### PR TITLE
RavenDB-18657 - changing behavior of serialize/deserialize fields in client.

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace Raven.Client
 {
     public static class Constants
@@ -378,7 +376,6 @@ namespace Raven.Client
                 internal class Fields
                 {
                     internal const string PowerBIJsonFieldName = "json()";
-                    internal const BindingFlags FieldsReflectionBindingFlags = BindingFlags.Instance | BindingFlags.Public;
                 }
             }
 

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace Raven.Client
 {
     public static class Constants
@@ -376,6 +378,7 @@ namespace Raven.Client
                 internal class Fields
                 {
                     internal const string PowerBIJsonFieldName = "json()";
+                    internal const BindingFlags FieldsReflectionBindingFlags = BindingFlags.Instance | BindingFlags.Public;
                 }
             }
 

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3925,7 +3925,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
         protected bool Equals(FieldToFetch other)
         {
-            return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) && string.Equals(Alias, other.Alias, StringComparison.Ordinal);
+            return string.Equals(Name, other.Name, StringComparison.Ordinal) && string.Equals(Alias, other.Alias, StringComparison.Ordinal);
         }
 
         public override bool Equals(object obj)
@@ -3943,7 +3943,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         {
             unchecked
             {
-                return ((Name != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Name) : 0) * 397) ^ (Alias != null ? StringComparer.Ordinal.GetHashCode(Alias) : 0);
+                return ((Name != null ? StringComparer.Ordinal.GetHashCode(Name) : 0) * 397) ^ (Alias != null ? StringComparer.Ordinal.GetHashCode(Alias) : 0);
             }
         }
     }

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -227,7 +227,7 @@ namespace Raven.Client.Documents
             var results = queryable.Provider.CreateQuery<TResult>(ofType.Expression);
             var ravenQueryInspector = (RavenQueryInspector<TResult>)results;
 
-            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ToList();
+            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(BindingFlags.Instance | BindingFlags.Public).ToList();
             ravenQueryInspector.FieldsToFetch(membersList.Select(x => x.Name));
             return (IRavenQueryable<TResult>)results;
         }

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -227,7 +227,7 @@ namespace Raven.Client.Documents
             var results = queryable.Provider.CreateQuery<TResult>(ofType.Expression);
             var ravenQueryInspector = (RavenQueryInspector<TResult>)results;
 
-            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
+            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             ravenQueryInspector.FieldsToFetch(membersList.Select(x => x.Name));
             return (IRavenQueryable<TResult>)results;
         }

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -227,7 +227,7 @@ namespace Raven.Client.Documents
             var results = queryable.Provider.CreateQuery<TResult>(ofType.Expression);
             var ravenQueryInspector = (RavenQueryInspector<TResult>)results;
 
-            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(BindingFlags.Instance | BindingFlags.Public).ToList();
+            var membersList = ReflectionUtil.GetPropertiesAndFieldsFor<TResult>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
             ravenQueryInspector.FieldsToFetch(membersList.Select(x => x.Name));
             return (IRavenQueryable<TResult>)results;
         }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -569,7 +569,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -569,7 +569,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -569,7 +569,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -39,7 +39,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -39,7 +39,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(BindingFlags.Public | BindingFlags.Instance).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -39,7 +39,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
-            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(Constants.Documents.Querying.Fields.FieldsReflectionBindingFlags).ToList();
+            var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
             return SelectFields<TProjection>(new QueryData(fields, projections)

--- a/src/Raven.Client/Util/ReflectionUtil.cs
+++ b/src/Raven.Client/Util/ReflectionUtil.cs
@@ -18,6 +18,11 @@ namespace Raven.Client.Util
     /// </summary>
     internal static class ReflectionUtil
     {
+        internal static class BindingFlagsConstants
+        {
+            internal const BindingFlags QueryingFields = BindingFlags.Instance | BindingFlags.Public;
+        }
+
         private static Dictionary<Type, string> _fullNameCache = new Dictionary<Type, string>();
 
         /// <summary>

--- a/test/SlowTests/Issues/RavenDB-18657.cs
+++ b/test/SlowTests/Issues/RavenDB-18657.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Google.Apis.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18657 : RavenTestBase
+    {
+        public RavenDB_18657(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Get_Fields_With_Different_Casing()
+        {
+            using var store = GetDocumentStore();
+
+            var user = new User
+            {
+                Name = "Grisha",
+                name = "Shahar"
+            };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<User>().ProjectInto<User>();
+                var documentQuery = session.Advanced.DocumentQuery<User>().SelectFields<User>();
+                Assert.Equal("from 'Users' select Name, name", query.ToString()); // Name and name are public properties so it should contain them.
+                Assert.Equal("from 'Users' select Name, name", documentQuery.ToString());
+                var results = query.ToList();
+                Assert.Equal(user.Name, results.First().Name);
+                Assert.Equal(user.name, results.First().name);
+                results = documentQuery.ToList();
+                Assert.Equal(user.Name, results.First().Name);
+                Assert.Equal(user.name, results.First().name);
+            }
+        }
+
+        private class User
+        {
+            public string Name { get; set; }
+
+            public string name { get; set; }
+        }
+
+
+        [Fact]
+        public async Task DocumentQuery_RQL_Expression_Should_Not_Include_Private_Members()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Item(11, 22));
+                session.SaveChanges();
+            }
+
+            var index = new Item_Content();
+            await index.ExecuteAsync(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<Item, Item_Content>().ProjectInto<Item>();
+                var documentQuery = session.Advanced.DocumentQuery<Item, Item_Content>().SelectFields<Item>();
+                Assert.Equal("from index 'Item/Content' select Content", query.ToString()); // 'content', 'content2' are private so it should contain only 'Content'
+                Assert.Equal("from index 'Item/Content' select Content", documentQuery.ToString());
+                var l = query.ToList();
+                Assert.Equal(12, l.First().Content);
+                l = documentQuery.ToList();
+                Assert.Equal(12, l.First().Content);
+            }
+        }
+
+        public class Item
+        {
+
+            public Item()
+            {
+            }
+
+            public Item(int c, int c2)
+            {
+                content = c;
+                content2 = c2;
+            }
+
+            private int? content2
+            {
+                get;
+                set;
+            }
+
+            private int? content
+            {
+                get;
+                set;
+            }
+
+            public int? Content
+            {
+                get => content;
+                set => content = value == int.MinValue ? null : value;
+            }
+        }
+
+        private class Item_Content : AbstractIndexCreationTask<Item>
+        {
+            public Item_Content()
+            {
+                Map = (items) =>
+                    from item in items
+                    select new
+                    {
+                        Content = item.Content + 1
+                    };
+
+
+                Store(x => x.Content, FieldStorage.Yes);
+            }
+        }
+        
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18657/Failed-to-project-when-having-a-backing-private-field

### Additional description

Private fields won't be serialized/deserialized.
Public fields that have the same name in different cases (Ex: 'Content', 'coNtent', 'content', 'CONTENT') will be different fields in serialization/deserialization.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
