### PR TITLE
RavenDB-18260 Sharding - Queries - TimeLimitedQueryToken. Passing cancelation token from CreateTimeLimitedQueryToken() to query requests sent from orchestrator to shards.

### DIFF
--- a/src/Raven.Client/Documents/Queries/HashCalculator.cs
+++ b/src/Raven.Client/Documents/Queries/HashCalculator.cs
@@ -324,7 +324,7 @@ namespace Raven.Client.Documents.Queries
             }
         }
 
-        private void Write(BlittableJsonReaderObject json)
+        internal void Write(BlittableJsonReaderObject json)
         {
             _buffer.Write(json.BasePointer, json.Size);
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -38,6 +38,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
     protected abstract ValueTask HandleSuggestQuery(IndexQueryServerSide query, TQueryContext queryContext, long? existingResultEtag, OperationCancelToken token);
 
     protected abstract ValueTask<QueryResultServerSide<TQueryResult>> GetQueryResults(IndexQueryServerSide query, TQueryContext queryContext, long? existingResultEtag,
+        bool metadataOnly,
         OperationCancelToken token);
 
     protected override HttpMethod QueryMethod { get; }
@@ -92,7 +93,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
                     QueryResultServerSide<TQueryResult> result;
                     try
                     {
-                        result = await GetQueryResults(indexQuery, queryContext, existingResultEtag, token);
+                        result = await GetQueryResults(indexQuery, queryContext, existingResultEtag, metadataOnly, token);
                     }
                     catch (IndexDoesNotExistException)
                     {

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForGet.cs
@@ -108,7 +108,7 @@ internal class DatabaseQueriesHandlerProcessorForGet : AbstractQueriesHandlerPro
     }
 
     protected override async ValueTask<QueryResultServerSide<Document>> GetQueryResults(IndexQueryServerSide query, QueryOperationContext queryContext,
-        long? existingResultEtag, OperationCancelToken token)
+        long? existingResultEtag, bool metadataOnly, OperationCancelToken token)
     {
         return await RequestHandler.Database.QueryRunner.ExecuteQuery(query, queryContext, existingResultEtag, token).ConfigureAwait(false);
     }

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
@@ -1,19 +1,53 @@
 ﻿using System.Net.Http;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Sharding.Handlers;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Commands;
 
-public class ShardedQueryCommand : ShardedBaseCommand<QueryResult>
+public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObject, QueryResult>
 {
+    private readonly BlittableJsonReaderObject _query;
     private readonly string _indexName;
 
-    public ShardedQueryCommand(ShardedDatabaseRequestHandler handler, HttpMethod method, BlittableJsonReaderObject content, string indexName) : base(handler, method, Commands.Headers.Sharded, content)
+    public ShardedQueryCommand(ShardedDatabaseRequestHandler handler, BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName) : base(indexQuery, false, metadataOnly, indexEntriesOnly)
     {
+        _query = query;
         _indexName = indexName;
+
+        ModifyRequest = r =>
+        {
+            // TODO arek - this is temporaty solution, we need to refactor that
+
+            r.Headers.TryAddWithoutValidation(Constants.Headers.Sharded, "true");
+
+            var lastKnownClusterTransactionIndex = handler.GetStringFromHeaders(Constants.Headers.LastKnownClusterTransactionIndex);
+            if (lastKnownClusterTransactionIndex != null)
+                r.Headers.TryAddWithoutValidation(Constants.Headers.LastKnownClusterTransactionIndex, lastKnownClusterTransactionIndex);
+        };
+    }
+
+    protected override ulong GetQueryHash(JsonOperationContext ctx)
+    {
+        using (var hasher = new HashCalculator(ctx))
+        {
+            hasher.Write(_query);
+
+            return hasher.GetHash();
+        }
+    }
+
+    protected override HttpContent GetContent(JsonOperationContext ctx)
+    {
+        var queryToSend = _query.Clone(ctx);
+
+        return new BlittableJsonContent(async stream => await queryToSend.WriteJsonToAsync(stream));
     }
 
     public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
@@ -58,12 +58,13 @@ internal class ShardedQueriesHandlerProcessorForGet : AbstractQueriesHandlerProc
         throw new NotSupportedInShardingException("Suggestions are not supported");
     }
 
-    protected override async ValueTask<QueryResultServerSide<BlittableJsonReaderObject>> GetQueryResults(IndexQueryServerSide query, TransactionOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
+    protected override async ValueTask<QueryResultServerSide<BlittableJsonReaderObject>> GetQueryResults(IndexQueryServerSide query,
+        TransactionOperationContext queryContext, long? existingResultEtag, bool metadataOnly, OperationCancelToken token)
     {
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal,
             @"RavenDB-19071 what do we do with: var diagnostics = GetBoolValueQueryString(""diagnostics"", required: false) ?? false");
 
-        _queryProcessor = new ShardedQueryProcessor(queryContext, RequestHandler, query);
+        _queryProcessor = new ShardedQueryProcessor(queryContext, RequestHandler, query, metadataOnly, indexEntriesOnly: false, token: token.Token);
 
         _queryProcessor.Initialize(out _);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForExport.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForExport.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Smuggler
                 writer.WriteInteger(ServerVersion.Build);
                 
                 // we execute one by one so requests will not timeout since the export can take long
-                for (var shardNumber = 0; shardNumber < RequestHandler.DatabaseContext.NumberOfShardNodes; shardNumber++)
+                for (var shardNumber = 0; shardNumber < RequestHandler.DatabaseContext.ShardCount; shardNumber++)
                 {
                     var smuggler = new DatabaseSmuggler(
                         (_, nodeTag) => RequestHandler.DatabaseContext.Operations.GetChanges(new ShardedDatabaseIdentifier(nodeTag, shardNumber)),

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
         private async ValueTask<(IEnumerator<BlittableJsonReaderObject>, StreamQueryStatistics)> ExecuteQueryAsync(TransactionOperationContext context, IndexQueryServerSide query, string debug, bool ignoreLimit, OperationCancelToken token)
         {
-            var queryProcessor = new ShardedQueryStreamProcessor(context, RequestHandler, query);
+            var queryProcessor = new ShardedQueryStreamProcessor(context, RequestHandler, query, token.Token);
             if (queryProcessor.IsMapReduce())
                 throw new NotSupportedInShardingException("MapReduce is not supported in sharded streaming queries");
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.ServerWide.Context;
@@ -8,7 +9,7 @@ namespace Raven.Server.Documents.Sharding.Queries
 {
     internal class ShardedQueryStreamProcessor : ShardedQueryProcessor
     {
-        public ShardedQueryStreamProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler parent, IndexQueryServerSide query) : base(context, parent, query)
+        public ShardedQueryStreamProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, IndexQueryServerSide query, CancellationToken token) : base(context, requestHandler, query, false, false, token)
         {
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -88,8 +88,6 @@ namespace Raven.Server.Documents.Sharding
 
         public string DatabaseName => _record.DatabaseName;
 
-        public int NumberOfShardNodes => _record.Sharding.Shards.Length;
-
         public char IdentityPartsSeparator => _record.Client?.IdentityPartsSeparator ?? Constants.Identities.DefaultSeparator;
 
         public bool Encrypted => _record.Encrypted;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18260/Sharding-Queries-TimeLimitedQueryToken

### Additional description

- Passing cancellation token generated by `CreateTimeLimitedQueryToken()` which was introduced in https://github.com/ravendb/ravendb/pull/14460 to query requests sent to shards.

- Making abstraction of query command so `ShardedBaseCommand` is based on in instead of inheriting from `ShardedBaseCommand<QueryResult>`

- Further refactoring of `ShardedQueryProcessor` will be handled in separate PR since we have dedicated issue for that (RavenDB-19084)

### Type of change

- Feature impl for sharding
- Refactoring

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
