### PR TITLE
RavenDB-18031 - Subscription does not send over new docs after restart of responsible node

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -226,7 +226,7 @@ namespace Raven.Client.Documents.Subscriptions
                     TcpConnectionHeaderMessage.OperationTypes.Subscription,
                     NegotiateProtocolVersionForSubscriptionAsync,
                     context,
-                    _options?.WorkerStreamTimeout, 
+                    _options?.ConnectionStreamTimeout, 
                     null
 #if TCP_CLIENT_CANCELLATIONTOKEN_SUPPORT
                     ,

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -226,7 +226,7 @@ namespace Raven.Client.Documents.Subscriptions
                     TcpConnectionHeaderMessage.OperationTypes.Subscription,
                     NegotiateProtocolVersionForSubscriptionAsync,
                     context,
-                    requestExecutor.DefaultTimeout, 
+                    _options?.WorkerStreamTimeout, 
                     null
 #if TCP_CLIENT_CANCELLATIONTOKEN_SUPPORT
                     ,
@@ -235,7 +235,7 @@ namespace Raven.Client.Documents.Subscriptions
                     ).ConfigureAwait(false);
 
                 _tcpClient = result.TcpClient;
-                _stream = result.Stream;
+                _stream = new StreamWithTimeout(result.Stream);
                 _supportedFeatures = result.SupportedFeatures;
 
                 _tcpClient.NoDelay = true;

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
@@ -96,6 +96,7 @@ namespace Raven.Client.Documents.Subscriptions
             Strategy = SubscriptionOpeningStrategy.OpenIfFree;
             MaxDocsPerBatch = 4096;
             TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5);
+            WorkerStreamTimeout = TimeSpan.FromSeconds(30);
             MaxErroneousPeriod = TimeSpan.FromMinutes(5);
             SendBufferSizeInBytes = DefaultSendBufferSizeInBytes;
             ReceiveBufferSizeInBytes = DefaultReceiveBufferSizeInBytes;
@@ -123,6 +124,11 @@ namespace Raven.Client.Documents.Subscriptions
         /// Cooldown time between connection retry. Default: 5 seconds
         /// </summary>
         public TimeSpan TimeToWaitBeforeConnectionRetry { get; set; }
+
+        /// <summary>
+        /// Timeout for writing or reading from worker stream. Default: 2 minutes
+        /// </summary>
+        public TimeSpan WorkerStreamTimeout { get; set; }
 
         /// <summary>
         /// Whether subscriber error should halt the subscription processing or not. Default: false

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
@@ -126,9 +126,21 @@ namespace Raven.Client.Documents.Subscriptions
         public TimeSpan TimeToWaitBeforeConnectionRetry { get; set; }
 
         /// <summary>
-        /// Timeout for writing or reading from worker stream. Default: 30 seconds
+        /// Timeout for writing or reading from worker stream. Default: 30 seconds.
+        /// Minimum value allowed: 15 seconds
         /// </summary>
-        public TimeSpan ConnectionStreamTimeout { get; set; }
+        public TimeSpan ConnectionStreamTimeout
+        {
+            get { return _connectionStreamTimeout; }
+            set
+            {
+                if (value < TimeSpan.FromSeconds(15))
+                    throw new ArgumentException("Value can't be smaller than 15 seconds.", nameof(ConnectionStreamTimeout));
+                _connectionStreamTimeout = value;
+            }
+        }
+
+        private TimeSpan _connectionStreamTimeout;
 
         /// <summary>
         /// Whether subscriber error should halt the subscription processing or not. Default: false

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
@@ -96,7 +96,7 @@ namespace Raven.Client.Documents.Subscriptions
             Strategy = SubscriptionOpeningStrategy.OpenIfFree;
             MaxDocsPerBatch = 4096;
             TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5);
-            WorkerStreamTimeout = TimeSpan.FromSeconds(30);
+            ConnectionStreamTimeout = TimeSpan.FromSeconds(30);
             MaxErroneousPeriod = TimeSpan.FromMinutes(5);
             SendBufferSizeInBytes = DefaultSendBufferSizeInBytes;
             ReceiveBufferSizeInBytes = DefaultReceiveBufferSizeInBytes;
@@ -128,7 +128,7 @@ namespace Raven.Client.Documents.Subscriptions
         /// <summary>
         /// Timeout for writing or reading from worker stream. Default: 30 seconds
         /// </summary>
-        public TimeSpan WorkerStreamTimeout { get; set; }
+        public TimeSpan ConnectionStreamTimeout { get; set; }
 
         /// <summary>
         /// Whether subscriber error should halt the subscription processing or not. Default: false

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerOptions.cs
@@ -126,7 +126,7 @@ namespace Raven.Client.Documents.Subscriptions
         public TimeSpan TimeToWaitBeforeConnectionRetry { get; set; }
 
         /// <summary>
-        /// Timeout for writing or reading from worker stream. Default: 2 minutes
+        /// Timeout for writing or reading from worker stream. Default: 30 seconds
         /// </summary>
         public TimeSpan WorkerStreamTimeout { get; set; }
 

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -155,7 +155,7 @@ namespace Raven.Client.Util
         private async Task<int> ReadAsyncWithTimeout(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             _readCts?.Dispose();
-            _readCts = _readCts == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _readCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _readCts.CancelAfter(_readTimeout);
 
             var read = await _stream.ReadAsync(buffer, offset, count, _readCts.Token).ConfigureAwait(false);
@@ -196,7 +196,7 @@ namespace Raven.Client.Util
         private Task WriteAsyncWithTimeout(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             _writeCts?.Dispose();
-            _writeCts = _writeCts == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _writeCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _writeCts.CancelAfter(_writeTimeout);
 
             return _stream.WriteAsync(buffer, offset, count, _writeCts.Token);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18031

### Additional description

Network stream's `ReadAsync()` function doesn't respect the timeout given to it. This causes severed connections between worker and server to wait on worker's `ReadAsync()` indefinitely, and the subscription to get stuck.
Wrapped the subscription worker's stream with `StreamWithTimout`.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No studio work required
