### PR TITLE
RavenDB-19025 Corax - implement Update() on the index, to avoid delet…

### DIFF
--- a/src/Corax/IndexEntry/IndexEntryReader.cs
+++ b/src/Corax/IndexEntry/IndexEntryReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -18,7 +19,7 @@ namespace Corax;
  *  tuple<long, double, string>: <length:variable_size><string_table_ptr:sizeof(int)><long_ptr:variable_size><double[X]:sizeof(double)>
  *                               <strings[X]:sequence><string_length_table[X]:var_int>
  */
-public unsafe ref struct IndexEntryReader
+public ref struct IndexEntryReader
 {
     private const int Invalid = unchecked((int)0xFFFF_FFFF);
     private readonly Span<byte> _buffer;
@@ -509,8 +510,9 @@ public unsafe ref struct IndexEntryReader
         ushort knownFieldsCount = (ushort)(header.KnownFieldCount >> 2);
         IndexEntryTableEncoding encoding = (IndexEntryTableEncoding)(header.KnownFieldCount & 0b11);
 
-        int encodeSize = TableEncodingLookupTable[(int)encoding];    
-        int locationOffset = buffer.Length - (knownFieldsCount * encodeSize) + field * encodeSize;
+        int encodeSize = TableEncodingLookupTable[(int)encoding];
+        Debug.Assert(header.Length == (int)header.Length);
+        int locationOffset = (int)header.Length - (knownFieldsCount * encodeSize) + field * encodeSize;
 
         int offset;
         switch (encoding)

--- a/src/Corax/IndexEntry/IndexEntryReader.cs
+++ b/src/Corax/IndexEntry/IndexEntryReader.cs
@@ -28,6 +28,8 @@ public unsafe ref struct IndexEntryReader
 
     public int Length => (int)MemoryMarshal.Read<uint>(_buffer);
 
+    public Span<byte> Buffer => _buffer;
+
     public IndexEntryReader(Span<byte> buffer)
     {
         _buffer = buffer;

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -70,12 +70,14 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     public IndexEntryReader GetReaderFor(long id)
     {
-        return GetReaderFor(_transaction, ref _lastPage, id);
+        return GetReaderFor(_transaction, ref _lastPage, id, out _);
     }
 
-    public static IndexEntryReader GetReaderFor(Transaction transaction, ref Page page, long id)
+    public static IndexEntryReader GetReaderFor(Transaction transaction, ref Page page, long id, out int rawSize)
     {
-        var data = Container.MaybeGetFromSamePage(transaction.LowLevelTransaction, ref page, id).ToSpan();
+        var item = Container.MaybeGetFromSamePage(transaction.LowLevelTransaction, ref page, id);
+        rawSize = item.Length;
+        var data = item.ToSpan();
         int size = ZigZagEncoding.Decode<int>(data, out var len);
         return new IndexEntryReader(data.Slice(size + len));
     }

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -459,7 +459,7 @@ namespace Corax
 
                     while (iterator.ReadNext())
                     {
-                        Debug.Assert((fieldType & IndexEntryFieldType.Tuple) == 0);
+                        Debug.Assert((fieldType & IndexEntryFieldType.Tuple) == 0, "(fieldType & IndexEntryFieldType.Tuple) == 0");
                         
                         if ((fieldType & IndexEntryFieldType.HasNulls) != 0 && (iterator.IsEmpty || iterator.IsNull))
                         {
@@ -593,7 +593,7 @@ namespace Corax
                 Span<byte> localValue = stackalloc byte[Constants.Terms.MaxLength];
                 value.Slice(0, Constants.Terms.MaxLength).CopyTo(localValue);
                 int hexSize = Numbers.FillAsHex(localValue.Slice(hashStartingPoint), hash);
-                Debug.Assert(Constants.Terms.MaxLength == hashStartingPoint + hexSize);
+                Debug.Assert(Constants.Terms.MaxLength == hashStartingPoint + hexSize, "Constants.Terms.MaxLength == hashStartingPoint + hexSize");
 
                 return Slice.From(context, localValue, ByteStringType.Mutable, out slice);
             }
@@ -964,7 +964,7 @@ namespace Corax
                 ReadOnlySpan<byte> termsSpan = term.AsSpan();
                 if (fieldTree.TryGetNextValue(termsSpan, out var existing, out var encodedKey) == false)
                 {
-                    Debug.Assert(entries.Removals.Count == 0);
+                    Debug.Assert(entries.Removals.Count == 0, "entries.Removals.Count == 0");
                     AddNewTerm(entries.Additions, tmpBuf, out termId);
                     fieldTree.Add(termsSpan, termId, encodedKey);
                     continue;
@@ -1133,7 +1133,7 @@ namespace Corax
                 using var _ = fieldTree.Read(term, out var result);
                 if (result.HasValue == false)
                 {
-                    Debug.Assert(entries.Removals.Count == 0);
+                    Debug.Assert(entries.Removals.Count == 0, "entries.Removals.Count == 0");
                     AddNewTerm(entries.Additions, tmpBuf, out termId);
                     fieldTree.Add(term, termId);
                     continue;
@@ -1164,7 +1164,7 @@ namespace Corax
                 long termId;
                 if (result.Size == 0) // no existing value
                 {
-                    Debug.Assert(entries.Removals.Count == 0);
+                    Debug.Assert(entries.Removals.Count == 0, "entries.Removals.Count == 0");
                     AddNewTerm(entries.Additions, tmpBuf, out termId);
                     fieldTree.Add(term, termId);
                     continue;
@@ -1210,7 +1210,7 @@ namespace Corax
 
         private void AddNewTerm(List<long> additions, Span<byte> tmpBuf, out long termId, bool sortingNeeded = true)
         {
-            Debug.Assert(additions.Count > 0);
+            Debug.Assert(additions.Count > 0, "additions.Count > 0");
             // common for unique values (guid, date, etc)
             if (additions.Count == 1)
             {

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -34,7 +34,7 @@ namespace Corax
     {
         Single = 0,
         
-        EnsureIsSingleMask = -4,
+        EnsureIsSingleMask = 0b11,
         
         Small = 1,
         Set = 2

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -33,6 +33,9 @@ namespace Corax
     public enum TermIdMask : long
     {
         Single = 0,
+        
+        EnsureIsSingleMask = -4,
+        
         Small = 1,
         Set = 2
     }
@@ -133,7 +136,9 @@ namespace Corax
             {
                 return Index(id, data);
             }
-            if((entryId & ~0b00) == 0) 
+            // if there is more than a single entry for this key, delete & index from scratch
+            // this is checked by calling code, but cheap to do this here as well.
+            if((entryId & (long)TermIdMask.EnsureIsSingleMask) != 0)
             {
                 RecordDeletion(entryId);
                 return Index(id, data);
@@ -172,8 +177,6 @@ namespace Corax
             id.AsSpan().CopyTo(space);
             space = space.Slice(id.Size);
             data.CopyTo(space);
-
-            
             return entryId;
         }
 
@@ -206,7 +209,7 @@ namespace Corax
                     bool oldHasIterator = oldEntryReader.TryReadMany(fieldBinding.FieldId, out var oldIterator);
                     bool newHasIterator = newEntryReader.TryReadMany(fieldBinding.FieldId, out var newIterator);
                     bool areEqual = oldHasIterator == newHasIterator;
-                    while (areEqual)
+                    while (true)
                     {
                         oldHasIterator = oldIterator.ReadNext();
                         newHasIterator = newIterator.ReadNext();
@@ -263,7 +266,7 @@ namespace Corax
                     bool oldHasIterator = oldEntryReader.TryReadManySpatialPoint(fieldBinding.FieldId, out var oldIterator);
                     bool newHasIterator = newEntryReader.TryReadManySpatialPoint(fieldBinding.FieldId, out var newIterator);
                     bool areEqual = oldHasIterator == newHasIterator;
-                    while (areEqual)
+                    while (true)
                     {
                         oldHasIterator = oldIterator.ReadNext();
                         newHasIterator = newIterator.ReadNext();

--- a/src/Raven.Client/Util/Size.cs
+++ b/src/Raven.Client/Util/Size.cs
@@ -4,41 +4,25 @@ namespace Raven.Client.Util
 {
     public class Size
     {
-        private static readonly string ZeroHumaneSize = Humane(0);
-
         public Size()
         {
-            HumaneSize = ZeroHumaneSize;
+            SizeInBytes = 0;
         }
-
+        
         public Size(long sizeInBytes)
         {
             SizeInBytes = sizeInBytes;
         }
 
-        private long _sizeInBytes;
+        public long SizeInBytes { get; set; }
 
-        public long SizeInBytes
-        {
-            get
-            {
-                return _sizeInBytes;
-            }
-
-            set
-            {
-                _sizeInBytes = value;
-                HumaneSize = Humane(value);
-            }
-        }
-
-        public string HumaneSize { get; private set; }
+        public string HumaneSize => Humane(SizeInBytes);
 
         public static string Humane(long? size)
         {
             if (size == null)
                 return null;
-
+            
             var absSize = Math.Abs(size.Value);
             const double GB = 1024 * 1024 * 1024;
             const double MB = 1024 * 1024;

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Documents.Indexes
                 if (it.MoveNext() == false)
                 {
                     writer.Value.Delete(indexItem.LowerId, stats);
-                    return 0; // not results at all
+                    return 0; // no results at all
                 }
 
                 var first = it.Current;

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -94,7 +94,8 @@ namespace Raven.Server.Documents.Indexes
                 if (it.MoveNext() == false)
                 {
                     // we have just _one_ entry for the map, can try to optimize
-                    writer.Value.UpdateDocument(indexItem.LowerId, indexItem.LowerSourceDocumentId, first, stats, indexContext);
+                    writer.Value.UpdateDocument(Raven.Client.Constants.Documents.Indexing.Fields.DocumentIdFieldName,
+                        indexItem.LowerId, indexItem.LowerSourceDocumentId, first, stats, indexContext);
                     return 1;
                 }
                 else

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -84,7 +84,10 @@ namespace Raven.Server.Documents.Indexes
             try
             {
                 if (it.MoveNext() == false)
+                {
+                    writer.Value.Delete(indexItem.LowerId, stats);
                     return 0; // not results at all
+                }
 
                 var first = it.Current;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -77,8 +77,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             using(scope)
             using (Stats.AddStats.Start())
             {
-                _indexWriter.Update(Constants.Documents.Indexing.Fields.DocumentIdFieldName,
-                    key.AsSpan(), lowerId, data.ToSpan());
+                const string id = Constants.Documents.Indexing.Fields.DocumentIdFieldName;
+                if (data.Length == 0)
+                {
+                    Delete(key, stats);
+                    return;
+                }
+                
+                _indexWriter.Update(id, key.AsSpan(), lowerId, data.ToSpan());
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract void Optimize();
 
-        public abstract void UpdateDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,
+        public abstract void UpdateDocument(string keyFieldName, LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,
             JsonOperationContext indexContext);
 
         public abstract void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
@@ -21,6 +21,9 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract void Optimize();
 
+        public abstract void UpdateDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,
+            JsonOperationContext indexContext);
+
         public abstract void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,
             JsonOperationContext indexContext);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public override void UpdateDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats, JsonOperationContext indexContext)
+        public override void UpdateDocument(string keyFieldName, LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats, JsonOperationContext indexContext)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -136,6 +136,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
+        public override void UpdateDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats, JsonOperationContext indexContext)
+        {
+            throw new NotSupportedException();
+        }
+
         public override void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats, JsonOperationContext indexContext)
         {
             EnsureValidStats(stats);

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -127,7 +127,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue);
+                Debug.Assert(HasValue, "ByteString.HasValue");
                 EnsureIsNotBadPointer();
 
                 return _pointer->Flags;
@@ -139,7 +139,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue);
+                Debug.Assert(HasValue, "ByteString.HasValue");
                 EnsureIsNotBadPointer();
 
                 return _pointer->Ptr;
@@ -168,7 +168,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue);
+                Debug.Assert(HasValue, "ByteString.HasValue");
                 EnsureIsNotBadPointer();
 
                 return (_pointer->Flags & ByteStringType.Mutable) != 0;
@@ -180,7 +180,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue);
+                Debug.Assert(HasValue, "ByteString.HasValue");
                 EnsureIsNotBadPointer();
 
                 return (_pointer->Flags & ByteStringType.External) != 0;
@@ -229,7 +229,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue);
+                Debug.Assert(HasValue, "ByteString.HasValue");
                 EnsureIsNotBadPointer();
 
                 return *(_pointer->Ptr + (sizeof(byte) * index));
@@ -238,7 +238,7 @@ namespace Sparrow.Server
 
         public void CopyTo(int from, byte* dest, int offset, int count)
         {
-            Debug.Assert(HasValue);
+            Debug.Assert(HasValue, "ByteString.HasValue");
 
             if (from + count > _pointer->Length)
                 throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
@@ -249,7 +249,7 @@ namespace Sparrow.Server
 
         public void CopyTo(byte* dest)
         {
-            Debug.Assert(HasValue);
+            Debug.Assert(HasValue, "ByteString.HasValue");
 
             EnsureIsNotBadPointer();
             Memory.Copy(dest, _pointer->Ptr, _pointer->Length);
@@ -257,7 +257,7 @@ namespace Sparrow.Server
 
         public void CopyTo(byte[] dest)
         {
-            Debug.Assert(HasValue);
+            Debug.Assert(HasValue, "ByteString.HasValue");
 
             EnsureIsNotBadPointer();
             fixed (byte* p = dest)
@@ -282,7 +282,7 @@ namespace Sparrow.Server
                 if (this.Key >> 16 != _pointer->Key >> 16)
                     throw new InvalidOperationException("The owner context for the ByteString and the unmanaged storage are different. Make sure you havent killed the allocator and kept a reference to the ByteString outside of its scope.");
 
-                Debug.Assert((this.Key & 0x0000000FFFFFFFF) != (_pointer->Key & 0x0000000FFFFFFFF));
+                Debug.Assert((this.Key & 0x0000000FFFFFFFF) != (_pointer->Key & 0x0000000FFFFFFFF), "(this.Key & 0x0000000FFFFFFFF) != (_pointer->Key & 0x0000000FFFFFFFF)");
                 throw new InvalidOperationException("The key for the ByteString and the unmanaged storage are different. This is a dangling pointer. Check your .Release() statements and aliases in the calling code.");                                    
             }
         }
@@ -294,7 +294,7 @@ namespace Sparrow.Server
 
         public void CopyTo(int from, byte[] dest, int offset, int count)
         {
-            Debug.Assert(HasValue);
+            Debug.Assert(HasValue, "ByteString.HasValue");
 
             if (from + count > _pointer->Length)
                 throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
@@ -812,7 +812,7 @@ namespace Sparrow.Server
             _externalFastPoolCount = 0;
             _externalCurrentLeft = (int)(_externalCurrent.End - _externalCurrent.Start) / ByteStringContext.ExternalAlignedSize;
 
-            Debug.Assert(_wholeSegments.Count >= 2);
+            Debug.Assert(_wholeSegments.Count >= 2, "_wholeSegments.Count >= 2");
             // We need to make ensure that the _internalCurrent is linked to an unmanaged segment
             var index = _wholeSegments.Count - 1;
             if (_wholeSegments[index] == _externalCurrent)
@@ -989,7 +989,7 @@ namespace Sparrow.Server
                 allocationUnit += sizeof(long) - allocationUnit % sizeof(long);
 
             // All allocation units are 32 bits aligned. If not we will have a performance issue.
-            Debug.Assert(allocationUnit % sizeof(int) == 0);
+            Debug.Assert(allocationUnit % sizeof(int) == 0, "allocationUnit % sizeof(int) == 0");
 
             _currentlyAllocated += allocationUnit;
 
@@ -1129,7 +1129,7 @@ namespace Sparrow.Server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ByteString Create(void* ptr, int length, int size, ByteStringType type = ByteStringType.Immutable)
         {
-            Debug.Assert(length <= size - sizeof(ByteStringStorage));
+            Debug.Assert(length <= size - sizeof(ByteStringStorage), "length <= size - sizeof(ByteStringStorage)");
 
             var basePtr = (ByteStringStorage*)ptr;
             basePtr->Flags = type;
@@ -1211,7 +1211,7 @@ namespace Sparrow.Server
                 ThrowObjectDisposed();
 
 #if DEBUG
-            Debug.Assert(value.Generation == Generation);
+            Debug.Assert(value.Generation == Generation, "value.Generation == Generation");
 #endif
             Debug.Assert(value._pointer != null, "Pointer cannot be null. You have a defect in your code.");
             if (value._pointer == null) // this is a safe-guard on Release, it is better to not release the memory than fail

--- a/src/Sparrow/Utils/ZstdLib.cs
+++ b/src/Sparrow/Utils/ZstdLib.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using Sparrow.Platform;
@@ -157,17 +158,26 @@ namespace Sparrow.Utils
                               *       requires explicitly allowing such size at streaming decompression stage. */
         };
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AssertZstdSuccess(UIntPtr v)
         {
-            if (ZSTD_isError(v) == 0)
+            ulong code = v.ToUInt64();
+            if (ZSTD_Error_maxCode > code)
                 return;
 
+            RaiseError(v);
+        }
+
+        private static void RaiseError(UIntPtr v)
+        {
             throw new InvalidOperationException(Marshal.PtrToStringAnsi(ZSTD_getErrorName(v)));
         }
+        const ulong ZSTD_Error_maxCode = unchecked(0UL - 120L);
 
         private static void AssertSuccess(UIntPtr v, CompressionDictionary dictionary)
         {
-            if (ZSTD_isError(v) == 0)
+            ulong code = v.ToUInt64();
+            if (ZSTD_Error_maxCode > code)
                 return;
 
             string ptrToStringAnsi = Marshal.PtrToStringAnsi(ZSTD_getErrorName(v));

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -1096,6 +1096,8 @@ namespace Voron.Data.CompactTrees
         [Conditional("DEBUG")]
         private void VerifySizeOf(ref CursorState p)
         {
+            if (p.Header == null)
+                return; // page may have been released
             var actualFreeSpace = p.ComputeFreeSpace();
             if (p.Header->FreeSpace != actualFreeSpace)
             {

--- a/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
+++ b/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Text;
+using Corax;
+using Corax.Queries;
+using FastTests.Voron;
+using Sparrow.Json;
+using Sparrow.Server;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public unsafe class OptimizedUpdatesOnIndexes : StorageTest
+{
+    public OptimizedUpdatesOnIndexes(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanUpdateAndNotDelete()
+    {
+        var fields = CreateKnownFields(Allocator);
+        byte[] buffer = new byte[1024];
+        long oldId; 
+        using (var indexWriter = new IndexWriter(Env, fields))
+        {
+            var entry = new IndexEntryWriter(Allocator, fields);
+            entry.Write(0, Encoding.UTF8.GetBytes("cars/1"));
+            entry.Write(1, Encoding.UTF8.GetBytes("Lightning"));
+            entry.Write(2, Encoding.UTF8.GetBytes("12"));
+            entry.Finish(out var entrySpan);
+
+            using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
+            var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
+            oldId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
+            
+            indexWriter.Commit();
+        }
+
+        using (var indexSearcher = new IndexSearcher(Env, fields))
+        {
+            var termQuery = indexSearcher.TermQuery("Age", "12");
+            var ids = new long[16];
+            var read = termQuery.Fill(ids);
+            Assert.Equal(1, read);
+            Assert.Equal(oldId, ids[0]);
+        }
+
+        long newId;
+        using (var indexWriter = new IndexWriter(Env, fields))
+        {
+            var entry = new IndexEntryWriter(Allocator, fields);
+            entry.Write(0, Encoding.UTF8.GetBytes("cars/1"));
+            entry.Write(1, Encoding.UTF8.GetBytes("Lightning"));
+            entry.Write(2, Encoding.UTF8.GetBytes("13"));
+            entry.Finish(out var entrySpan);
+
+            using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
+            var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
+            newId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
+            
+            indexWriter.Commit();
+        }
+        Assert.Equal(oldId, newId);
+        
+        using (var indexSearcher = new IndexSearcher(Env, fields))
+        {
+            var termQuery = indexSearcher.TermQuery("Age", "12");
+            var ids = new long[16];
+            var read = termQuery.Fill(ids);
+            Assert.Equal(0, read);
+            termQuery = indexSearcher.TermQuery("Age", "13");
+            ids = new long[16];
+            read = termQuery.Fill(ids);
+            Assert.Equal(1, read);
+            Assert.Equal(oldId, ids[0]);
+        }
+
+    }
+    
+    private IndexFieldsMapping CreateKnownFields(ByteStringContext ctx)
+    {
+        Slice.From(ctx, "id()", ByteStringType.Immutable, out Slice idSlice);
+        Slice.From(ctx, "Name", ByteStringType.Immutable, out Slice nameSlice);
+        Slice.From(ctx, "Age", ByteStringType.Immutable, out Slice ageSlice);
+
+        return new IndexFieldsMapping(ctx)
+            .AddBinding(0, idSlice)
+            .AddBinding(1, nameSlice)
+            .AddBinding(2, ageSlice);
+    }
+
+}


### PR DESCRIPTION
…e / insert cycle if we can avoid it

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19025 

### Additional description

When indexing the same thing, skip updating the index.
When indexing *similar* things, only update modified values.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- 
### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
