### PR TITLE
RavenDB-13965 Warn about huge documents

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -262,7 +262,7 @@ class genUtils {
         return asArray ? [newRes, sizes[i]] : newRes + " " + sizes[i];
     }
 
-    static getSizeInBytesAsUTF8(input: string) {
+    static getSizeInBytesAsUTF8(input: string): number {
         let result = 0;
         let isQuoted = false;
         let prevChar: any = 0;

--- a/src/Raven.Studio/typescript/models/database/documents/document.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/document.ts
@@ -1,6 +1,10 @@
 import documentMetadata = require("models/database/documents/documentMetadata");
+import genUtils = require("common/generalUtils");
 
 class document implements documentBase {
+    
+    static readonly hugeSizeInBytesDefault = 10_485_760; // 10 MB
+    static readonly hugeSizeFormatted = genUtils.formatBytesToSize(document.hugeSizeInBytesDefault);
     
     static readonly customColumnName = "@@x => x.getId()@@";
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -70,7 +70,6 @@ class editDocument extends viewModelBase {
     documentItemType: KnockoutComputed<string>;
     
     documentText = ko.observable("");
-    documentTextOrg = ko.observable("");
     documentTextRight = ko.observable("");
     
     documentTextStash = ko.observable<string>("");
@@ -432,19 +431,12 @@ class editDocument extends viewModelBase {
                 }
 
                 const docText = genUtils.stringify(docDto);
-                const textSizeInByes = genUtils.getSizeInBytesAsUTF8(docText);
+                this.documentText(docText);
                 
+                const textSizeInByes = genUtils.getSizeInBytesAsUTF8(docText);
                 this.isHugeDocument(textSizeInByes > document.hugeSizeInBytesDefault);
                 
-                if (this.isHugeDocument() && !this.ignoreHugeDocument()) {
-                    this.documentTextOrg(docText);
-                    this.documentText(null);
-                    this.hugeTextSize(textSizeInByes);
-                } else {
-                    this.documentTextOrg(null);
-                    this.documentText(docText);
-                    this.hugeTextSize(0);
-                }
+                this.hugeTextSize(this.isHugeDocument() && !this.ignoreHugeDocument() ? textSizeInByes : 0);
             }
         });
 
@@ -677,7 +669,7 @@ class editDocument extends viewModelBase {
     }
     
     downloadDocument() {
-        fileDownloader.downloadAsJson(this.documentTextOrg(), this.document().getId());
+        fileDownloader.downloadAsJson(this.documentText(), this.document().getId());
     }
     
     viewRaw() {
@@ -1067,7 +1059,7 @@ class editDocument extends viewModelBase {
             .done((rightDoc: document) => {
                 const wasDirty = this.dirtyFlag().isDirty();
                 
-                this.documentTextStash(this.documentText() || this.documentTextOrg());
+                this.documentTextStash(this.documentText());
                 
                 const leftDoc = this.document();
                 const leftDocDto = leftDoc.toDiffDto();

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -159,17 +159,17 @@
                     <div class="absolute-center padding padding-lg bg-info">
                         <div class="padding">
                             <span data-bind="text: documentItemType"></span> size is <strong data-bind="text: computedDocumentSize"></strong>.<br /><br />
-                            Having huge documents may impact indexing, querying and other database tasks.<br />
-                            Documents greater than <strong data-bind="text: constructor.hugeSizeFormatted"></strong> may not perform well in the browser.
+                            Having huge documents impacts indexing, querying and other database tasks.<br />
+                            Your browser may not perfrom well if you open the <span data-bind="text: documentItemType"></span> in this view.
                         </div>
                         <div class="padding text-left">
                             Select how to continue: <br />
                         </div>
                         <div class="padding text-center">
                             <button class="btn btn-warning" 
-                                    data-bind="click: reLoadDocument, attr: { title: 'Click to continue & load the ' + documentItemType().toLowerCase() + ' in this edit view' }, css: { 'btn-spinner': isBusy }">
-                                <i class="icon-upload"></i>
-                                <span><span data-bind="text: isBusy() ? 'Loading... ' : 'Load '"></span><span data-bind="text: documentItemType().toLowerCase(), visible: !isBusy()"></span></span>
+                                    data-bind="click: reLoadDocument, attr: { title: 'Click to open the ' + documentItemType().toLowerCase() + ' in this edit view' }, css: { 'btn-spinner': isBusy }">
+                                <i class="icon-preview"></i>
+                                <span><span data-bind="text: isBusy() ? 'Loading... ' : 'Open '"></span><span data-bind="text: documentItemType().toLowerCase(), visible: !isBusy()"></span></span>
                             </button>
                             <button class="btn btn-success"
                                     data-bind="click: viewRaw, attr: { title: 'Click to view the raw content for the ' + documentItemType().toLowerCase() }, disable: isBusy">

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -23,7 +23,9 @@
                             <a href="#" class="copy-button" title="Copy document Id" data-bind="click: copyDocumentIdToClipboard"><i class="icon-copy"></i></a>
                             <span data-bind="visible: inReadOnlyMode() && !isDeleteRevision()" class="text-primary revision flex-noshrink"> | REVISION</span>
                             <span data-bind="visible: inReadOnlyMode() && isDeleteRevision()" class="text-primary revision flex-noshrink"> | DELETED REVISION</span>
-                            <a target="_blank" href="#" title="Show raw output" class="flex-noshrink margin-left margin-left-sm" data-bind="attr: { href: rawJsonUrl }, visible: !isDeleteRevision()"><i class="icon-json"></i></a>
+                            <a target="_blank" href="#" title="Click to view the raw content of the document" class="flex-noshrink margin-left margin-left-sm"
+                               data-bind="attr: { href: rawJsonUrl }, visible: !isDeleteRevision()"><i class="icon-json"></i>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -57,7 +59,7 @@
                         <span>Save</span>
                     </button>
                     <button type="button" class="clone-btn btn btn-default"
-                            data-bind="click: tryCreateClone, enable: !isCreatingNewDocument(), visible: !isDeleteRevision() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
+                            data-bind="click: tryCreateClone, enable: !showHugeDocumentWarning() && !isCreatingNewDocument(), visible: !isDeleteRevision() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
                         <i class="icon-clone"></i>
                         <span>Clone</span>
                     </button>
@@ -73,7 +75,7 @@
                 </div>
                 <div class="pull-right-sm" data-bind="visible: !isDeleteRevision()">
                     <div class="btn-group" data-bind="visible: !inDiffMode()">
-                        <button type="button" class="btn btn-default" data-bind="click: copyDocumentBodyToClipboard" title="Copy document content to clipboard">
+                        <button type="button" class="btn btn-default" data-bind="click: copyDocumentBodyToClipboard, enable: !showHugeDocumentWarning()" title="Copy document content to clipboard">
                             <i class="icon-copy-to-clipboard"></i>
                             <span>Copy to Clipboard</span>
                         </button>
@@ -141,7 +143,7 @@
             <div class="left-editor">
                 <pre id="docEditor" class="form-control absolute-fill"
                      data-bind="aceEditor: { code: documentText, fontSize:'16px', lang: 'ace/mode/raven_document', readOnly: inReadOnlyMode() || inDiffMode() || isReadOnlyAccess() },
-                                disable: isBusy, validationOptions: { errorsAsTitle: false }, validationElement: documentText, visible: !isDeleteRevision()"></pre>
+                                disable: isBusy, validationOptions: { errorsAsTitle: false }, validationElement: documentText, visible: !isDeleteRevision() && !showHugeDocumentWarning()"></pre>
                 <div class="absolute-fill" data-bind="visible: isDeleteRevision()">
                     <div class="absolute-center padding padding-lg bg-info text-center">
                         <i class="icon-trash icon-xl"></i>
@@ -150,6 +152,35 @@
                         <div>@metadata flags: <strong data-bind="text: metadata().flags"></strong>
                         </div>
                         <div class="margin-top-lg">Go to <a href="#" class="text-revisions" data-bind="click: _.partial(connectedDocuments.activateRevisions, true)">REVISIONS</a> to see entire document history
+                        </div>
+                    </div>
+                </div>
+                <div class="absolute-fill" data-bind="visible: showHugeDocumentWarning()">
+                    <div class="absolute-center padding padding-lg bg-info">
+                        <div class="padding">
+                            <span data-bind="text: documentItemType"></span> size is <strong data-bind="text: computedDocumentSize"></strong>.<br /><br />
+                            Having huge documents may impact indexing, querying and other database tasks.<br />
+                            Documents greater than <strong data-bind="text: constructor.hugeSizeFormatted"></strong> may not perform well in the browser.
+                        </div>
+                        <div class="padding text-left">
+                            Select how to continue: <br />
+                        </div>
+                        <div class="padding text-center">
+                            <button class="btn btn-warning" 
+                                    data-bind="click: reLoadDocument, attr: { title: 'Click to continue & load the ' + documentItemType().toLowerCase() + ' in this edit view' }, css: { 'btn-spinner': isBusy }">
+                                <i class="icon-upload"></i>
+                                <span><span data-bind="text: isBusy() ? 'Loading... ' : 'Load '"></span><span data-bind="text: documentItemType().toLowerCase(), visible: !isBusy()"></span></span>
+                            </button>
+                            <button class="btn btn-success"
+                                    data-bind="click: viewRaw, attr: { title: 'Click to view the raw content for the ' + documentItemType().toLowerCase() }, disable: isBusy">
+                                <i class="icon-json"></i>
+                                <span>View raw content</span>
+                            </button>
+                            <button class="btn btn-info"
+                                    data-bind="click: downloadDocument, attr: { title: 'Click to download the ' + documentItemType().toLowerCase() + ' in your browser' }, disable: isBusy">
+                                <i class="icon-export"></i>
+                                <span>Download <span data-bind="text: documentItemType().toLowerCase()"></span></span>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -249,6 +280,7 @@
                         <span data-placement="left" data-toggle="tooltip" data-html="true" data-animation="true"
                              data-bind="tooltipText: $root.documentSizeHtml()">
                             <span data-bind="text: $root.computedDocumentSize()"></span>
+                            <i class="icon-warning text-warning margin-left-xs" data-bind="visible: $root.isHugeDocument"></i>
                         </span>
                     </dd>
                 </dl>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-13965

### Additional description
Detect when opening a huge document.
Disable editor and show warning.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
