### PR TITLE
RavenDB-19109 Add manual ways to disable indexes & databases

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -236,8 +236,8 @@ namespace Raven.Server.Documents
                 string disableMarkerPath = DocumentDatabase.Configuration.Core.DataDirectory.Combine("disable.marker").FullPath;
                 if (File.Exists(disableMarkerPath))
                 {
-                    throw new DatabaseDisabledException("Unable to open database: " + _name + ", it has been manually disabled via the file: '" + disableMarkerPath +"'." +
-                                                 "To re-enable, remove the disable.marker and reload the database.");
+                    throw new DatabaseDisabledException(
+                        $"Unable to open database: '{_name}', it has been manually disabled via the file: '{disableMarkerPath}'. To re-enable, remove the disable.marker and reload the database.");
                 }
 
             }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -659,6 +659,16 @@ namespace Raven.Server.Documents.Indexes
 
             var indexTempPath = configuration.TempPath?.Combine(name);
 
+            if (configuration.RunInMemory == false)
+            {
+                string disableMarkerPath = indexPath.Combine("disable.marker").FullPath;
+                if (File.Exists(disableMarkerPath))
+                {
+                    throw new IndexOpenException("Unable to open index: " + name + ", it has been manually disabled via the file: '" + disableMarkerPath +"'." +
+                                                 "To re-enable, remove the disable.marker file and enable indexing.");
+                }
+            }
+
             var options = configuration.RunInMemory
                 ? StorageEnvironmentOptions.CreateMemoryOnly(indexPath.FullPath, indexTempPath?.FullPath ?? Path.Combine(indexPath.FullPath, "Temp"),
                     documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19109 

### Additional description

Manual way to disable a database or an index via the file system.
Helps to do that if we have to disable a database without being able to run the server.

### Type of change

- New feature

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

https://issues.hibernatingrhinos.com/issue/RDoc-2244/Document-the-disablemarker-option-to-manually-disable-databases-indexes

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
