### PR TITLE
RavenDB-18796: make sure to dispose subscription state on subscription delete

### DIFF
--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1459,7 +1459,7 @@ namespace SlowTests.Client.Subscriptions
             await store.Subscriptions.DeleteAsync(name);
 
             var db = await Databases.GetDocumentDatabaseInstanceFor(server, store);
-            await AssertWaitForExceptionAsync<KeyNotFoundException>(async () => db.SubscriptionStorage.GetSubscriptionStateById(state.SubscriptionId), interval: 1000);
+            await AssertWaitForExceptionAsync<KeyNotFoundException>(async () => await Task.Run(() => db.SubscriptionStorage.GetSubscriptionStateById(state.SubscriptionId)), interval: 1000);
         }
 
         private class IdleDatabaseStatistics

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1427,6 +1427,41 @@ namespace SlowTests.Client.Subscriptions
             }, true, timeout: 60000, interval: 1000), $"WaitForValue=>LastRecentlyUsed");
         }
 
+        [Fact]
+        public async Task DeletingSubscriptionShouldRemoveItsState()
+        {
+            using var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "1000000",
+                    [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1000000",
+                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+                }
+            });
+
+            using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
+            var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = "from Users", Name = "Subscription0" });
+            var state = await store.Subscriptions.GetSubscriptionStateAsync(name);
+          
+
+            var connections = new CountdownEvent(5);
+            var tasks = new List<Task>();
+            for (int i = 0; i < 5; i++)
+            {
+                var subsWorker1 = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(name) { Strategy = SubscriptionOpeningStrategy.Concurrent });
+                subsWorker1.OnEstablishedSubscriptionConnection += () => { connections.Signal(); };
+                tasks.Add(subsWorker1.Run(_ => { }));
+            }
+
+            connections.Wait(_reasonableWaitTime);
+
+            await store.Subscriptions.DeleteAsync(name);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(server, store);
+            await AssertWaitForExceptionAsync<KeyNotFoundException>(async () => db.SubscriptionStorage.GetSubscriptionStateById(state.SubscriptionId), interval: 1000);
+        }
+
         private class IdleDatabaseStatistics
         {
             public string MaxIdleTime { get; set; }

--- a/test/Tests.Infrastructure/RavenTestBase.Databases.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Databases.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server;
 using Raven.Server.Documents;
 using Voron;
 
@@ -25,6 +26,11 @@ public partial class RavenTestBase
         public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(IDocumentStore store, string database = null)
         {
             return _parent.Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+        }
+
+        public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(RavenServer server, IDocumentStore store, string database = null)
+        {
+            return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
         }
 
         public async Task SetDatabaseId(DocumentStore store, Guid dbId)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -375,7 +375,12 @@ namespace FastTests
 
         protected static async Task WaitAndAssertForValueAsync<T>(Func<Task<T>> act, T expectedVal, int timeout = 15000, int interval = 100)
         {
-            var val = await WaitForPredicateAsync(t => t.Equals(expectedVal), act, timeout, interval);
+            var val = await WaitForPredicateAsync(t =>
+            {
+                if (t == null)
+                    return expectedVal == null;
+                return t.Equals(expectedVal);
+            }, act, timeout, interval);
             Assert.Equal(expectedVal, val);
         }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18796

### Additional description

The subscription state was kept after subscription delete, and was cleaned only on IdleOperations run.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

no
