### PR TITLE
RavenDB-19146 - Collection query is running on for a VERY long time

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -726,52 +726,47 @@ namespace Raven.Server.Documents
             return lastEtag;
         }
 
-        public IEnumerable<Document> GetDocumentsStartingWith(DocumentsOperationContext context, string idPrefix,  string startAfterId,
+        public IEnumerable<Document> GetDocumentsStartingWith(DocumentsOperationContext context, string idPrefix, string startAfterId,
             long start, long take, string collection, Reference<long> skippedResults, DocumentFields fields = DocumentFields.All)
         {
-            int alreadyReturnedDocumentsCount = 0;
-            int lastLoadedDocumentsCount;
             var isAllDocs = collection == Constants.Documents.Collections.AllDocumentsCollection;
             var requestedDataField = fields.HasFlag(DocumentFields.Data);
             if (isAllDocs == false && requestedDataField == false)
                 fields |= DocumentFields.Data;
-            
-            do
+
+            // we request ALL documents that start with `idPrefix` and filter it here by the collection name
+            foreach (var doc in GetDocumentsStartingWith(context, idPrefix, null, null, startAfterId, start, take: long.MaxValue, fields: fields))
             {
-                lastLoadedDocumentsCount = 0;
-                foreach (var doc in GetDocumentsStartingWith(context, idPrefix, null, null, startAfterId, start, take, fields: fields))
+                if (isAllDocs)
                 {
-                    lastLoadedDocumentsCount++;
-                    if (isAllDocs)
-                    {
-                        yield return doc;
-                        continue;
-                    }
-
-                    if (IsCollectionMatch(doc, collection) == false)
-                    {
-                        skippedResults.Value++;
-                        doc.Dispose();
-                        continue;
-                    }
-
-                    if (requestedDataField == false)
-                    {
-                        doc.Data.Dispose();
-                        doc.Data = null;
-                    }
-
-                    alreadyReturnedDocumentsCount++;
-                    yield return doc;
-
-                    if (alreadyReturnedDocumentsCount >= take)
+                    if (take-- < 0)
                         break;
 
+                    yield return doc;
+                    continue;
                 }
 
-                start += take;
+                if (IsCollectionMatch(doc, collection) == false)
+                {
+                    skippedResults.Value++;
+                    doc.Dispose();
+                    continue;
+                }
+
+                if (requestedDataField == false)
+                {
+                    doc.Data.Dispose();
+                    doc.Data = null;
+                }
+
+                if (take-- <= 0)
+                {
+                    doc.Dispose();
+                    break;
+                }
+
+                yield return doc;
             }
-            while (alreadyReturnedDocumentsCount != take && lastLoadedDocumentsCount > 0);
 
             static bool IsCollectionMatch(Document doc, string collection)
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -734,49 +734,52 @@ namespace Raven.Server.Documents
             if (isAllDocs == false && requestedDataField == false)
                 fields |= DocumentFields.Data;
 
-            // we request ALL documents that start with `idPrefix` and filter it here by the collection name
-            foreach (var doc in GetDocumentsStartingWith(context, idPrefix, null, null, startAfterId, start, take: long.MaxValue, fields: fields))
+            using (var lzv = context.GetLazyString(collection))
             {
-                if (isAllDocs)
+                // we request ALL documents that start with `idPrefix` and filter it here by the collection name
+                foreach (var doc in GetDocumentsStartingWith(context, idPrefix, null, null, startAfterId, start, take: long.MaxValue, fields: fields))
                 {
-                    if (take-- < 0)
+                    if (isAllDocs)
+                    {
+                        if (take-- < 0)
+                            break;
+
+                        yield return doc;
+                        continue;
+                    }
+
+                    if (IsCollectionMatch(doc, lzv) == false)
+                    {
+                        skippedResults.Value++;
+                        doc.Dispose();
+                        continue;
+                    }
+
+                    if (requestedDataField == false)
+                    {
+                        doc.Data.Dispose();
+                        doc.Data = null;
+                    }
+
+                    if (take-- <= 0)
+                    {
+                        doc.Dispose();
                         break;
+                    }
 
                     yield return doc;
-                    continue;
                 }
-
-                if (IsCollectionMatch(doc, collection) == false)
-                {
-                    skippedResults.Value++;
-                    doc.Dispose();
-                    continue;
-                }
-
-                if (requestedDataField == false)
-                {
-                    doc.Data.Dispose();
-                    doc.Data = null;
-                }
-
-                if (take-- <= 0)
-                {
-                    doc.Dispose();
-                    break;
-                }
-
-                yield return doc;
             }
 
-            static bool IsCollectionMatch(Document doc, string collection)
+            bool IsCollectionMatch(Document doc, LazyStringValue lzv)
             {
                 if (doc.TryGetMetadata(out var metadata) == false)
                     return false;
 
-                if (metadata.TryGet(Constants.Documents.Metadata.Collection, out string c) == false)
+                if (metadata.TryGet(Constants.Documents.Metadata.Collection, out LazyStringValue c) == false)
                     return false;
 
-                if (string.Equals(c, collection, StringComparison.OrdinalIgnoreCase) == false)
+                if (c == null || lzv.EqualsOrdinalIgnoreCase(c) == false)
                     return false;
 
                 return true;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -735,7 +735,7 @@ namespace Raven.Server.Documents
             if (isAllDocs == false && requestedDataField == false)
                 fields |= DocumentFields.Data;
 
-            using (var lzv = context.GetLazyString(collection))
+            using (var collectionAsLazyString = context.GetLazyString(collection))
             {
                 // we request ALL documents that start with `idPrefix` and filter it here by the collection name
                 foreach (var doc in GetDocumentsStartingWith(context, idPrefix, null, null, startAfterId, start, take: long.MaxValue, fields: fields))
@@ -749,7 +749,7 @@ namespace Raven.Server.Documents
                         continue;
                     }
 
-                    if (IsCollectionMatch(doc, lzv) == false)
+                    if (IsCollectionMatch(doc) == false)
                     {
                         skippedResults.Value++;
                         doc.Dispose();
@@ -770,28 +770,28 @@ namespace Raven.Server.Documents
 
                     yield return doc;
                 }
-            }
 
-            bool IsCollectionMatch(Document doc, LazyStringValue lzv)
-            {
-                if (doc.TryGetMetadata(out var metadata) == false)
-                    return false;
-
-                if (metadata.TryGet(Constants.Documents.Metadata.Collection, out LazyStringValue c) == false)
-                    return false;
-
-                if (c != null)
+                bool IsCollectionMatch(Document doc)
                 {
-                    if (lzv.EqualsOrdinalIgnoreCase(c) == false)
+                    if (doc.TryGetMetadata(out var metadata) == false)
                         return false;
-                }
-                else
-                {
-                    if (isEmptyCollection == false)
-                        return false;
-                }
 
-                return true;
+                    if (metadata.TryGet(Constants.Documents.Metadata.Collection, out LazyStringValue c) == false)
+                        return false;
+
+                    if (c != null)
+                    {
+                        if (collectionAsLazyString.EqualsOrdinalIgnoreCase(c) == false)
+                            return false;
+                    }
+                    else
+                    {
+                        if (isEmptyCollection == false)
+                            return false;
+                    }
+
+                    return true;
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -730,6 +730,7 @@ namespace Raven.Server.Documents
             long start, long take, string collection, Reference<long> skippedResults, DocumentFields fields = DocumentFields.All)
         {
             var isAllDocs = collection == Constants.Documents.Collections.AllDocumentsCollection;
+            var isEmptyCollection = collection == Constants.Documents.Collections.EmptyCollection;
             var requestedDataField = fields.HasFlag(DocumentFields.Data);
             if (isAllDocs == false && requestedDataField == false)
                 fields |= DocumentFields.Data;
@@ -779,8 +780,16 @@ namespace Raven.Server.Documents
                 if (metadata.TryGet(Constants.Documents.Metadata.Collection, out LazyStringValue c) == false)
                     return false;
 
-                if (c == null || lzv.EqualsOrdinalIgnoreCase(c) == false)
-                    return false;
+                if (c != null)
+                {
+                    if (lzv.EqualsOrdinalIgnoreCase(c) == false)
+                        return false;
+                }
+                else
+                {
+                    if (isEmptyCollection == false)
+                        return false;
+                }
 
                 return true;
             }

--- a/test/SlowTests/Issues/RavenDB-19146.cs
+++ b/test/SlowTests/Issues/RavenDB-19146.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Dynamic;
+using FastTests;
+using Raven.Client;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19146 : RavenTestBase
+    {
+        public RavenDB_19146(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Can_Use_StartsWith_In_Empty_Collection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string id = "test";
+                using (var session = store.OpenSession())
+                {
+                    var expando = new ExpandoObject();
+                    session.Store(expando, id);
+
+                    var metadata = session.Advanced.GetMetadataFor((ExpandoObject)expando);
+                    metadata[Constants.Documents.Metadata.Collection] = null;
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Advanced
+                        .RawQuery<dynamic>($"from @empty where startsWith(id(), '{id[0]}')")
+                        .ToList();
+
+                    Assert.Equal(1, results.Count);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19146/Collection-query-is-running-on-for-a-VERY-long-time

### Additional description

- fix collection query that was running for a long time (we did O(n^n) operations).
- handle the case of `@empty` collection

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
