### PR TITLE
RavenDB-17996 Avoid marking document as dirty if only read operations or no-op operations are performed on metadata in session API

### DIFF
--- a/src/Raven.Client/Json/MetadataAsDictionary.cs
+++ b/src/Raven.Client/Json/MetadataAsDictionary.cs
@@ -172,12 +172,22 @@ namespace Raven.Client.Json
             if (_metadata == null)
                 Initialize(_source);
             Debug.Assert(_metadata != null);
-            if (_metadata.Count > 0)
+            foreach (var item in _metadata)
             {
-                _metadata.Clear();
+                switch (item.Key)
+                {
+                    // skipping reserved properties
+                    case Constants.Documents.Metadata.Collection:
+                    case Constants.Documents.Metadata.Id:
+                    case Constants.Documents.Metadata.ChangeVector:
+                    case Constants.Documents.Metadata.LastModified:
+                    case Constants.Documents.Metadata.RavenClrType:
+                        continue;
+                }
+
+                _metadata.Remove(item);
                 _hasChanges = true;
             }
-
         }
 
         public bool Contains(KeyValuePair<string, object> item)

--- a/src/Raven.Client/Json/MetadataAsDictionary.cs
+++ b/src/Raven.Client/Json/MetadataAsDictionary.cs
@@ -16,6 +16,7 @@ namespace Raven.Client.Json
 
         private IDictionary<string, object> _metadata;
         private readonly BlittableJsonReaderObject _source;
+        private bool _hasChanges;
 
         internal MetadataAsDictionary(BlittableJsonReaderObject metadata, IMetadataDictionary parent, string parentKey)
             : this(metadata)
@@ -106,7 +107,11 @@ namespace Raven.Client.Json
                 if (_metadata == null)
                     Initialize(_source);
                 Debug.Assert(_metadata != null);
-                _metadata[key] = value;
+                if (_metadata.TryGetValue(key, out var currentValue) == false || currentValue.Equals(value) == false)
+                {
+                    _metadata[key] = value;
+                    _hasChanges = true;
+                }
             }
         }
 
@@ -118,7 +123,7 @@ namespace Raven.Client.Json
             return result;
         }
 
-        public bool Changed => _metadata != null;
+        public bool Changed => _metadata != null && _hasChanges;
 
         public int Count => _metadata?.Count ?? _source.Count;
 
@@ -149,6 +154,7 @@ namespace Raven.Client.Json
                 Initialize(_source);
             Debug.Assert(_metadata != null);
             _metadata.Add(item.Key, item.Value);
+            _hasChanges = true;
         }
 
         public void Add(string key, object value)
@@ -158,6 +164,7 @@ namespace Raven.Client.Json
 
             Debug.Assert(_metadata != null);
             _metadata.Add(key, value);
+            _hasChanges = true;
         }
 
         public void Clear()
@@ -165,7 +172,12 @@ namespace Raven.Client.Json
             if (_metadata == null)
                 Initialize(_source);
             Debug.Assert(_metadata != null);
-            _metadata.Clear();
+            if (_metadata.Count > 0)
+            {
+                _metadata.Clear();
+                _hasChanges = true;
+            }
+
         }
 
         public bool Contains(KeyValuePair<string, object> item)
@@ -205,7 +217,9 @@ namespace Raven.Client.Json
             if (_metadata == null)
                 Initialize(_source);
             Debug.Assert(_metadata != null);
-            return _metadata.Remove(item);
+            var result = _metadata.Remove(item);
+            _hasChanges |= result;
+            return result;
         }
 
         public bool Remove(string key)
@@ -213,7 +227,9 @@ namespace Raven.Client.Json
             if (_metadata == null)
                 Initialize(_source);
             Debug.Assert(_metadata != null);
-            return _metadata.Remove(key);
+            var result = _metadata.Remove(key);
+            _hasChanges |= result;
+            return result;
         }
 
         public bool TryGetValue(string key, out object value)

--- a/src/Raven.Client/Json/MetadataAsDictionary.cs
+++ b/src/Raven.Client/Json/MetadataAsDictionary.cs
@@ -107,7 +107,7 @@ namespace Raven.Client.Json
                 if (_metadata == null)
                     Initialize(_source);
                 Debug.Assert(_metadata != null);
-                if (_metadata.TryGetValue(key, out var currentValue) == false || currentValue.Equals(value) == false)
+                if (_metadata.TryGetValue(key, out var currentValue) == false || (currentValue != null && currentValue.Equals(value) == false) || (currentValue == null && value != null))
                 {
                     _metadata[key] = value;
                     _hasChanges = true;

--- a/test/SlowTests/Issues/RavenDB_17996.cs
+++ b/test/SlowTests/Issues/RavenDB_17996.cs
@@ -33,7 +33,12 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
                 
-                GetValues(id, store);
+                AssertRequestCountEqual(metadataFor => {
+                    foreach (var keyValue in metadataFor)
+                    {
+
+                    }
+                });
                 AssertRequestCountEqual(metadataFor => metadataFor["@collection"] = "Users");
                 AssertRequestCountEqual(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.Refresh));
                 AssertRequestCountEqual(metadataFor => metadataFor.Remove(new KeyValuePair<string, object>(Constants.Documents.Metadata.Refresh, "122123")));
@@ -73,8 +78,15 @@ namespace SlowTests.Issues
                 }
 
                 AssertRequestCountNotEqual(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.LastModified));
-                AssertRequestCountNotEqual(metadataFor => metadataFor.Remove(new KeyValuePair<string, object>(Constants.Documents.Metadata.LastModified, metadataFor[Constants.Documents.Metadata.LastModified])));
+                AssertRequestCountNotEqual(metadataFor =>
+                    metadataFor.Remove(
+                        new KeyValuePair<string, object>(Constants.Documents.Metadata.LastModified, metadataFor[Constants.Documents.Metadata.LastModified])));
                 AssertRequestCountNotEqual(metadataFor => metadataFor["@last-modified"] = "Users");
+                AssertRequestCountNotEqual(metadataFor =>
+                {
+                    metadataFor["@last-modified"] = null;
+                    metadataFor["@last-modified"] = "Users";
+                } );
                 AssertRequestCountNotEqual(metadataFor => metadataFor["@1234"] = "Users");
                 AssertRequestCountNotEqual(metadataFor => metadataFor.Add(new KeyValuePair<string, object>("@sfddfdsf", "fgffffg")));
                 AssertRequestCountNotEqual(metadataFor => metadataFor.Add("@ewewrewr", "fdsfdgfdg"));
@@ -96,26 +108,6 @@ namespace SlowTests.Issues
                     }
                 }
             }
-        }
-        private void GetValues(string id, DocumentStore store)
-        {
-            using (var session = store.OpenSession())
-            {
-                var entity = session.Load<User>(id);
-                var metadataFor = session.Advanced.GetMetadataFor(entity);
-
-                var requestsBefore = session.Advanced.NumberOfRequests;
-
-                foreach (var keyValue in metadataFor)
-                {
-
-                }
-
-                session.SaveChanges();
-
-                Assert.Equal(requestsBefore, session.Advanced.NumberOfRequests);
-            }
-            
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_17996.cs
+++ b/test/SlowTests/Issues/RavenDB_17996.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17996 : RavenTestBase
+    {
+        public RavenDB_17996(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Metadata_that_didnt_change_doesnt_cause_saveChanges()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string id;
+                using (var session = store.OpenSession())
+                {
+                    var user = new User();
+                    session.Store(user);
+                    id = user.Id;
+                    session.SaveChanges();
+                }
+                
+                GetValues(id, store);
+                AssertRequestCountEqual(metadataFor => metadataFor["@collection"] = "Users");
+                AssertRequestCountEqual(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.Refresh));
+                AssertRequestCountEqual(metadataFor => metadataFor.Remove(new KeyValuePair<string, object>(Constants.Documents.Metadata.Refresh, "122123")));
+                AssertRequestCountEqual(metadataFor => metadataFor.CopyTo(new System.Collections.Generic.KeyValuePair<string, object>[metadataFor.Count], 0));
+
+                void AssertRequestCountEqual(Action<IMetadataDictionary> action)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        var entity = session.Load<User>(id);
+                        var metadataFor = session.Advanced.GetMetadataFor(entity);
+
+                        var requestsBefore = session.Advanced.NumberOfRequests;
+
+                        action(metadataFor);
+
+                        session.SaveChanges();
+
+                        Assert.Equal(requestsBefore, session.Advanced.NumberOfRequests);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Metadata_that_changed_cause_saveChanges()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string id;
+                using (var session = store.OpenSession())
+                {
+                    var user = new User();
+                    session.Store(user);
+                    id = user.Id;
+                    session.SaveChanges();
+                }
+
+                AssertRequestCountNotEqual(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.LastModified));
+                AssertRequestCountNotEqual(metadataFor => metadataFor.Remove(new KeyValuePair<string, object>(Constants.Documents.Metadata.LastModified, metadataFor[Constants.Documents.Metadata.LastModified])));
+                AssertRequestCountNotEqual(metadataFor => metadataFor["@last-modified"] = "Users");
+                AssertRequestCountNotEqual(metadataFor => metadataFor["@1234"] = "Users");
+                AssertRequestCountNotEqual(metadataFor => metadataFor.Add(new KeyValuePair<string, object>("@sfddfdsf", "fgffffg")));
+                AssertRequestCountNotEqual(metadataFor => metadataFor.Add("@ewewrewr", "fdsfdgfdg"));
+
+                void AssertRequestCountNotEqual(Action<IMetadataDictionary> action)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        var entity = session.Load<User>(id);
+                        var metadataFor = session.Advanced.GetMetadataFor(entity);
+
+                        var requestsBefore = session.Advanced.NumberOfRequests;
+
+                        action(metadataFor);
+
+                        session.SaveChanges();
+
+                        Assert.NotEqual(requestsBefore, session.Advanced.NumberOfRequests);
+                    }
+                }
+            }
+        }
+        private void GetValues(string id, DocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var entity = session.Load<User>(id);
+                var metadataFor = session.Advanced.GetMetadataFor(entity);
+
+                var requestsBefore = session.Advanced.NumberOfRequests;
+
+                foreach (var keyValue in metadataFor)
+                {
+
+                }
+
+                session.SaveChanges();
+
+                Assert.Equal(requestsBefore, session.Advanced.NumberOfRequests);
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17996

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
