### PR TITLE
RavenDB-19157 - add the managed memory info to the information logs

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3109,7 +3109,7 @@ namespace Raven.Server.Documents.Indexes
 
                         FillQueryResult(resultToFill, isStale, query.Metadata, queryContext, indexContext);
 
-                        using (var reader = IndexPersistence.OpenIndexReader(indexTx.InnerTransaction))
+                        using (var reader = IndexPersistence.OpenIndexReader(indexTx.InnerTransaction, query))
                         {
                             using (var queryScope = query.Timings?.For(nameof(QueryTimingsScope.Names.Query)))
                             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -33,8 +33,10 @@ using Raven.Server.Indexing;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Sparrow.Utils;
 using Spatial4n.Core.Shapes;
 using Voron.Impl;
 using Query = Lucene.Net.Search.Query;
@@ -54,13 +56,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly IDisposable _releaseSearcher;
         private readonly IDisposable _releaseReadTransaction;
         private readonly int _maxNumberOfOutputsPerDocument;
+        private readonly MemoryInfo _memoryInfo;
 
         private readonly IState _state;
 
         private FastVectorHighlighter _highlighter;
         private FieldQuery _highlighterQuery;
 
-        public IndexReadOperation(Index index, LuceneVoronDirectory directory, IndexSearcherHolder searcherHolder, QueryBuilderFactories queryBuilderFactories, Transaction readTransaction)
+        public IndexReadOperation(Index index, LuceneVoronDirectory directory, IndexSearcherHolder searcherHolder, QueryBuilderFactories queryBuilderFactories, Transaction readTransaction, IndexQueryServerSide query)
             : base(index, LoggingSource.Instance.GetLogger<IndexReadOperation>(index._indexStorage.DocumentDatabase.Name))
         {
             try
@@ -78,6 +81,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _indexHasBoostedFields = index.HasBoostedFields;
             _releaseReadTransaction = directory.SetTransaction(readTransaction, out _state);
             _releaseSearcher = searcherHolder.GetSearcher(readTransaction, _state, out _searcher);
+
+            if (_logger.IsInfoEnabled && query != null)
+            {
+                _memoryInfo = new MemoryInfo
+                {
+                    AllocatedBefore = GC.GetAllocatedBytesForCurrentThread(), 
+                    ManagedThreadId = NativeMemory.CurrentThreadStats.ManagedThreadId,
+                    Query = query.Metadata.Query
+                };
+            }
         }
 
         public int EntriesCount()
@@ -847,6 +860,15 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _analyzer?.Dispose();
             _releaseSearcher?.Dispose();
             _releaseReadTransaction?.Dispose();
+
+            if (_memoryInfo != null && _memoryInfo.ManagedThreadId == NativeMemory.CurrentThreadStats.ManagedThreadId)
+            {
+                var diff = GC.GetAllocatedBytesForCurrentThread() - _memoryInfo.AllocatedBefore;
+                if (diff > 0)
+                {
+                    _logger.Info($"Query for index `{_indexName}` for query: `{_memoryInfo.Query}`, allocated: {new Size(diff, SizeUnit.Bytes)}");
+                }
+            }
         }
 
         internal static unsafe BlittableJsonReaderObject ParseJsonStringIntoBlittable(string json, JsonOperationContext context)
@@ -858,6 +880,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 blittableJson.BlittableValidation(); //precaution, needed because this is user input..
                 return blittableJson;
             }
+        }
+
+        private class MemoryInfo
+        {
+            public long AllocatedBefore { get; init; }
+            public int ManagedThreadId { get; init; }
+            public Queries.AST.Query Query { get; init; }
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -861,7 +861,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _releaseSearcher?.Dispose();
             _releaseReadTransaction?.Dispose();
 
-            if (_memoryInfo != null && _memoryInfo.ManagedThreadId == NativeMemory.CurrentThreadStats.ManagedThreadId)
+            if (_logger.IsInfoEnabled && _memoryInfo != null && _memoryInfo.ManagedThreadId == NativeMemory.CurrentThreadStats.ManagedThreadId)
             {
                 var diff = GC.GetAllocatedBytesForCurrentThread() - _memoryInfo.AllocatedBefore;
                 if (diff > 0)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -16,6 +16,7 @@ using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.TimeSeries;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.Counters;
 using Raven.Server.Documents.Indexes.Static.TimeSeries;
+using Raven.Server.Documents.Queries;
 using Raven.Server.Exceptions;
 using Raven.Server.Indexing;
 using Raven.Server.Utils;
@@ -443,12 +444,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 );
         }
 
-        public IndexReadOperation OpenIndexReader(Transaction readTransaction)
+        public IndexReadOperation OpenIndexReader(Transaction readTransaction, IndexQueryServerSide query = null)
         {
             CheckDisposed();
             CheckInitialized();
 
-            return new IndexReadOperation(_index, _directory, _indexSearcherHolder, _index._queryBuilderFactories, readTransaction);
+            return new IndexReadOperation(_index, _directory, _indexSearcherHolder, _index._queryBuilderFactories, readTransaction, query);
         }
 
         public IndexFacetedReadOperation OpenFacetedIndexReader(Transaction readTransaction)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19157/Log-the-managed-memory-usage-for-a-single-query

### Additional description

Add the managed memory info to the information logs

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing