### PR TITLE
RavenDB-18427 Unexpected behavior for saving same entity with different id

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -688,7 +688,7 @@ more responsive application.
 
             if (DocumentsByEntity.TryGetValue(entity, out var value))
             {
-                if (id != null && value.Id.Equals(id) == false)
+                if (id != null && value.Id.Equals(id, StringComparison.OrdinalIgnoreCase) == false)
                     throw new InvalidOperationException($"Cannot store the same entity (id: {value.Id}) with a different id ({id})"); 
 
                 value.ChangeVector = changeVector ?? value.ChangeVector;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -688,6 +688,9 @@ more responsive application.
 
             if (DocumentsByEntity.TryGetValue(entity, out var value))
             {
+                if (id != null && value.Id.Equals(id) == false)
+                    throw new InvalidOperationException($"Cannot store the same entity (id: {value.Id}) with a different id ({id})"); 
+
                 value.ChangeVector = changeVector ?? value.ChangeVector;
                 value.ConcurrencyCheckMode = forceConcurrencyCheck;
                 return;

--- a/test/SlowTests/Issues/RavenDB-18427.cs
+++ b/test/SlowTests/Issues/RavenDB-18427.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18427 : RavenTestBase
+    {
+        public RavenDB_18427(ITestOutputHelper output) : base(output)
+        {
+        }
+        [Fact]
+        public void Store_Documents2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var user = new User { Name = "Foo/Bar" };
+                    session.Store(user, "foo");
+                    Assert.Throws<InvalidOperationException>(() => session.Store(user, "bar"));
+                    session.SaveChanges();
+
+                    var usersCount = session.Query<User>().Count();
+                    Assert.Equal(usersCount, 1);
+
+                    var user1 = session.Load<User>("foo");
+                    Assert.NotNull(user1);
+                    var user2 = session.Load<User>("bar");
+                    Assert.Null(user2);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-18427.cs
+++ b/test/SlowTests/Issues/RavenDB-18427.cs
@@ -28,6 +28,7 @@ namespace SlowTests.Issues
                 {
                     var user = new User { Name = "Foo/Bar" };
                     session.Store(user, "foo");
+                    session.Store(user, "Foo");
                     Assert.Throws<InvalidOperationException>(() => session.Store(user, "bar"));
                     session.SaveChanges();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18427/Unexpected-behavior-for-saving-same-entity-with-different-id

### Additional description

Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR.

### Type of change

- Bug fix

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
