### PR TITLE
RavenDB-19173 Fixing tests that failed during nightly builds only

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -1076,6 +1076,8 @@ namespace SlowTests.Authentication
                     ("GET", "/setup/ips"),                              // only available in setup mode
                     ("POST", "/setup/hosts"),                           // only available in setup mode
                     ("POST", "/setup/unsecured"),                       // only available in setup mode
+                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
+                    ("POST", "/setup/continue/unsecured"),               // only available in setup mode
                     ("POST", "/setup/secured"),                         // only available in setup mode
                     ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
                     ("POST", "/setup/letsencrypt"),                     // only available in setup mode
@@ -1136,7 +1138,7 @@ namespace SlowTests.Authentication
             }
         }
 
-        [NightlyBuildMultiplatformFact(RavenArchitecture.AllX64)]
+        [MultiplatformFact(RavenArchitecture.AllX64)]
         public void Routes_ClusterAdmin()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1172,6 +1174,8 @@ namespace SlowTests.Authentication
                     ("GET", "/setup/ips"),                              // only available in setup mode
                     ("POST", "/setup/hosts"),                           // only available in setup mode
                     ("POST", "/setup/unsecured"),                       // only available in setup mode
+                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
+                    ("POST", "/setup/continue/unsecured"),               // only available in setup mode
                     ("POST", "/setup/secured"),                         // only available in setup mode
                     ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
                     ("POST", "/setup/letsencrypt"),                     // only available in setup mode


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19173

### Additional description

Routes were supposed to be skipped in tests. It relates to https://github.com/ravendb/ravendb/pull/14309

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing test will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
