### PR TITLE
RavenDB-18990 Prevent from returning null page from GetFirst10AllocatedPages(). It's a method used for debug purposes only.

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -411,6 +411,9 @@ namespace Voron.Impl.Scratch
                     if (_parent._allocatedPages.TryGetValue(key, out var pageFromScratchBuffer) == false)
                         continue;
 
+                    if (pageFromScratchBuffer == null)
+                        continue;
+
                     pages.Add(pageFromScratchBuffer);
 
                     if (pages.Count == 10)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18990

### Additional description

It was happening that occasionally we were getting NRE:

```
System.NullReferenceException : Object reference not set to an instance of an object.

at Voron.Impl.Scratch.ScratchBufferPool.InfoForDebug(Int64 oldestActiveTransaction) in c:\Jenkins\workspace\Testsv52_Winx64_Debug\s\src\Voron\Impl\Scratch\ScratchBufferPool.cs:line 734
   at Voron.StorageEnvironment.GenerateDetailedReport(Transaction tx, Boolean includeDetails) in c:\Jenkins\workspace\Testsv52_Winx64_Debug\s\src\Voron\StorageEnvironment.cs:line 1115
   at SlowTests.Voron.Storage.StorageReportGenerationTests.TreeReportContainsInformationAboutMultiValueEntries(String[] keys, Int32 numberOfValuesPerKey) in c:\Jenkins\workspace\Testsv52_Winx64_Debug\s\test\SlowTests\Voron\Storage\StorageReportGenerationTests.cs:line 290
```

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing test will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
