### PR TITLE
RavenDB-19184 Fixing CPU stats on Cluster Dashboard after changing the type of internal CPU stats object

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/CpuUsageNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/CpuUsageNotificationSender.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Raven.Server.Commercial;
 using Raven.Server.NotificationCenter;
 using Raven.Server.Utils;
+using Raven.Server.Utils.Cpu;
 
 namespace Raven.Server.Dashboard.Cluster.Notifications
 {
@@ -50,7 +51,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
 
         protected override AbstractClusterDashboardNotification CreateNotification()
         {
-            var cpuInfo = _server.MetricCacher.GetValue<(double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)>(
+            var cpuInfo = _server.MetricCacher.GetValue<CpuUsageStats>(
                 MetricCacher.Keys.Server.CpuUsage);
 
             TryFillNodeLicenseLimits();

--- a/test/SlowTests/Issues/RavenDB-14342.cs
+++ b/test/SlowTests/Issues/RavenDB-14342.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
         }
 
         [LicenseRequiredFact]
-        public void ServerMonitoringTest()
+        public async Task ServerMonitoringTest()
         {
             DoNotReuseServer();
         
@@ -43,9 +43,19 @@ namespace SlowTests.Issues
             
                 using (var commands = store.Commands())
                 {
-                    var command = new ServerMonitoringCommand();
-                    commands.RequestExecutor.Execute(command, commands.Context);
-                    var metrics = command.Result;
+                    ServerMetrics metrics = null;
+
+                    // since RavenDB-19040 we're calculating the metrics as the background task
+                    // we need to wait for non default (empty) values
+
+                    await WaitForGreaterThanAsync(async () =>
+                    {
+                        var command = new ServerMonitoringCommand();
+                        await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
+                        metrics = command.Result;
+
+                        return metrics.Cpu.ProcessUsage;
+                    }, double.Epsilon);
                     
                     Assert.Equal(string.Join(";", Server.Configuration.Core.ServerUrls), string.Join(";", metrics.Config.ServerUrls));
                     Assert.Equal(ServerVersion.Version, metrics.ServerVersion);

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -28,8 +28,8 @@ namespace Tests.Infrastructure.TestMetrics
         private object CalculateMemoryInfoExtended()
             => MemoryInformation.GetMemoryInfo(_smapsReader, extended: true);
 
-        public (double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait) GetCpuUsage()
-            => GetValue<(double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)>(Keys.Server.CpuUsage);
+        public CpuUsageStats GetCpuUsage()
+            => GetValue<CpuUsageStats>(Keys.Server.CpuUsage);
 
         public MemoryInfoResult GetMemoryInfoExtended()
             => GetValue<MemoryInfoResult>(Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19184/No-CPU-on-Server-dashboard

### Additional description

The type was changed in https://github.com/ravendb/ravendb/pull/14677

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
