### PR TITLE
RavenDB-17872 - Get and update compare exchange metadata in the session.

### DIFF
--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -321,31 +321,16 @@ namespace Raven.Client.Documents.Session
                                 throw new InvalidOperationException("Value cannot be null.");
 
                             T entity = default;
-                            IMetadataDictionary metadata = null;
-                            if (_originalValue != null)
+                            if (_originalValue != null && _originalValue.Value != null)
                             {
-                                if (_originalValue.Value != null)
-                                {
-                                    var type = typeof(T);
-                                    if (type.IsPrimitive || type == typeof(string))
-                                        _originalValue.Value.TryGet(Constants.CompareExchange.ObjectFieldName, out entity);
-                                    else
-                                        entity = conventions.Serialization.DefaultConverter.FromBlittable<T>(_originalValue.Value, _key);
-                                }
-
-                                if (_originalValue.Metadata != null)
-                                {
-                                    metadata = new MetadataAsDictionary();
-                                    foreach (var kvp in _originalValue.Metadata)
-                                    {
-                                        var key = kvp.Key;
-                                        var val = kvp.Value;
-                                        metadata[key] = val;
-                                    }
-                                }
+                                var type = typeof(T);
+                                if (type.IsPrimitive || type == typeof(string))
+                                    _originalValue.Value.TryGet(Constants.CompareExchange.ObjectFieldName, out entity);
+                                else
+                                    entity = conventions.Serialization.DefaultConverter.FromBlittable<T>(_originalValue.Value, _key);
                             }
 
-                            var value = new CompareExchangeValue<T>(_key, _index, entity, metadata);
+                            var value = new CompareExchangeValue<T>(_key, _index, entity, _originalValue?.Metadata);
                             _value = value;
 
                             return value;

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -323,30 +323,16 @@ namespace Raven.Client.Documents.Session
 
                             T entity = default;
                             IMetadataDictionary metadata = null;
-                            if (_originalValue != null)
+                            if (_originalValue != null && _originalValue.Value != null)
                             {
-                                if (_originalValue.Value != null)
-                                {
-                                    var type = typeof(T);
-                                    if (type.IsPrimitive || type == typeof(string))
-                                        _originalValue.Value.TryGet(Constants.CompareExchange.ObjectFieldName, out entity);
-                                    else
-                                        entity = conventions.Serialization.DefaultConverter.FromBlittable<T>(_originalValue.Value, _key);
-                                }
-
-                                if (_originalValue.Metadata != null)
-                                {
-                                    metadata = new MetadataAsDictionary();
-                                    foreach (var kvp in _originalValue.Metadata)
-                                    {
-                                        var key = kvp.Key;
-                                        var val = kvp.Value;
-                                        metadata[key] = val;
-                                    }
-                                }
+                                var type = typeof(T);
+                                if (type.IsPrimitive || type == typeof(string))
+                                    _originalValue.Value.TryGet(Constants.CompareExchange.ObjectFieldName, out entity);
+                                else
+                                    entity = conventions.Serialization.DefaultConverter.FromBlittable<T>(_originalValue.Value, _key);
                             }
 
-                            var value = new CompareExchangeValue<T>(_key, _index, entity, metadata);
+                            var value = new CompareExchangeValue<T>(_key, _index, entity, _originalValue?.Metadata);
                             _value = value;
 
                             return value;
@@ -414,11 +400,11 @@ namespace Raven.Client.Documents.Session
                             if (metadata == null)
                             {
                                 metadataHasChanged = true;
-                                metadata = PrepareMetadataForPut(_key, _value.Metadata, conventions, context);
+                                metadata = PrepareMetadataForPut(_key, _value.Metadata, conventions, context); //create new metadata (because there wasn't any metadata before)
                             }
                             else
                             {
-                                metadataHasChanged = InMemoryDocumentSessionOperations.UpdateMetadataModifications(_value.Metadata, metadata);
+                                metadataHasChanged = InMemoryDocumentSessionOperations.UpdateMetadataModifications(_value.Metadata, metadata); //add modifications to the existing metadata
                             }
                         }
 

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -472,20 +472,26 @@ namespace Raven.Client.Documents.Session
 
             internal bool MetadataHasChanged(IMetadataDictionary oldMetadata, IMetadataDictionary newMetadata)
             {
-                if (newMetadata == null && oldMetadata == null)
+                if (newMetadata == null)
                 {
-                    return false;
+                    if (oldMetadata == null) // newMetadata == null && oldMetadata == null
+                    {
+                        return false;
+                    }
+                    else                    // newMetadata == null && oldMetadata != null
+                    {
+                        return true;
+                    }
                 }
-
-                if (newMetadata != null)
+                else
                 {
-                    if (oldMetadata == null)
+                    if (oldMetadata == null) // newMetadata != null && oldMetadata == null
                     {
                         return true;
                     }
                     else
                     {
-                        foreach (var key in newMetadata.Keys)
+                        foreach (var key in newMetadata.Keys) // newMetadata != null && oldMetadata != null
                         {
                             newMetadata.TryGetValue(key, out string newVal);
                             oldMetadata.TryGetValue(key, out string oldVal);
@@ -494,9 +500,9 @@ namespace Raven.Client.Documents.Session
                                 return true;
                             }
                         }
+                        return false;
                     }
                 }
-                return false;
             }
 
             public enum CompareExchangeValueState

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -492,17 +492,23 @@ namespace Raven.Client.Documents.Session
                     {
                         return true;
                     }
-                    else
+                    else // newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false
                     {
-                        foreach (var key in newMetadata.Keys) // newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false
+                        if(oldMetadata.Count != newMetadata.Count)
+                            return true;
+
+                        var keys = newMetadata.Keys.Union(oldMetadata.Keys);
+
+                        foreach (var key in keys) 
                         {
-                            newMetadata.TryGetValue(key, out string newVal);
-                            oldMetadata.TryGetValue(key, out string oldVal);
-                            if (oldVal != newVal)
+                            if (oldMetadata.TryGetValue(key, out string oldVal) == false ||
+                                newMetadata.TryGetValue(key, out string newVal) == false ||
+                                oldVal != newVal)
                             {
                                 return true;
                             }
                         }
+
                         return false;
                     }
                 }

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -472,26 +472,29 @@ namespace Raven.Client.Documents.Session
 
             internal bool MetadataHasChanged(IMetadataDictionary oldMetadata, IMetadataDictionary newMetadata)
             {
-                if (newMetadata == null)
+                bool oldMetadataNullOrEmpty = oldMetadata == null || oldMetadata.Count == 0;
+                bool newMetadataNullOrEmpty = newMetadata == null || newMetadata.Count == 0;
+
+                if (newMetadataNullOrEmpty)
                 {
-                    if (oldMetadata == null) // newMetadata == null && oldMetadata == null
+                    if (oldMetadataNullOrEmpty) // newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
                     {
                         return false;
                     }
-                    else                    // newMetadata == null && oldMetadata != null
+                    else                    // newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == false
                     {
                         return true;
                     }
                 }
                 else
                 {
-                    if (oldMetadata == null) // newMetadata != null && oldMetadata == null
+                    if (oldMetadataNullOrEmpty) // newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
                     {
                         return true;
                     }
                     else
                     {
-                        foreach (var key in newMetadata.Keys) // newMetadata != null && oldMetadata != null
+                        foreach (var key in newMetadata.Keys) // newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false
                         {
                             newMetadata.TryGetValue(key, out string newVal);
                             oldMetadata.TryGetValue(key, out string oldVal);

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -928,32 +928,31 @@ more responsive application.
 
         protected internal abstract ClusterTransactionOperationsBase GetClusterSession();
 
-        private static bool UpdateMetadataModifications(DocumentInfo documentInfo)
+        internal static bool UpdateMetadataModifications(IMetadataDictionary metadataDictionary, BlittableJsonReaderObject metadata)
         {
-            if ((documentInfo.MetadataInstance == null ||
-                ((MetadataAsDictionary)documentInfo.MetadataInstance).Changed == false) &&
-                (documentInfo.Metadata.Modifications == null ||
-                documentInfo.Metadata.Modifications.Properties.Count == 0))
+            if ((metadataDictionary == null ||
+                 ((MetadataAsDictionary)metadataDictionary).Changed == false) &&
+                (metadata?.Modifications == null ||
+                 metadata.Modifications.Properties.Count == 0))
                 return false;
 
-            if (documentInfo.Metadata.Modifications == null || documentInfo.Metadata.Modifications.Properties.Count == 0)
+            if (metadata.Modifications == null || metadata.Modifications.Properties.Count == 0)
             {
-                documentInfo.Metadata.Modifications = new DynamicJsonValue();
+                metadata.Modifications = new DynamicJsonValue();
             }
 
-            if (documentInfo.MetadataInstance != null)
+            if (metadataDictionary != null)
             {
-                foreach (var prop in documentInfo.MetadataInstance.Keys)
+                foreach (var prop in metadataDictionary.Keys)
                 {
-                    var result = documentInfo.MetadataInstance[prop];
-                    if(result is IMetadataDictionary md)
+                    var result = metadataDictionary[prop];
+                    if (result is IMetadataDictionary md)
                     {
                         result = HandleDictionaryObject(md);
                     }
-                    documentInfo.Metadata.Modifications[prop] =  result;
+                    metadata.Modifications[prop] = result;
                 }
             }
-
             return true;
         }
 
@@ -1066,7 +1065,7 @@ more responsive application.
                     if (IsDeleted(entity.Value.Id))
                         continue;
 
-                    var metadataUpdated = UpdateMetadataModifications(entity.Value);
+                    var metadataUpdated = UpdateMetadataModifications(entity.Value.MetadataInstance, entity.Value.Metadata);
 
                     var document = JsonConverter.ToBlittable(entity.Key, entity.Value);
 
@@ -1085,7 +1084,7 @@ more responsive application.
                         var beforeStoreEventArgs = new BeforeStoreEventArgs(this, entity.Value.Id, entity.Key);
                         onOnBeforeStore(this, beforeStoreEventArgs);
                         if (metadataUpdated || beforeStoreEventArgs.MetadataAccessed)
-                            metadataUpdated |= UpdateMetadataModifications(entity.Value);
+                            metadataUpdated |= UpdateMetadataModifications(entity.Value.MetadataInstance, entity.Value.Metadata);
                         if (beforeStoreEventArgs.MetadataAccessed ||
                             EntityChanged(document, entity.Value, null))
                         {
@@ -1263,7 +1262,7 @@ more responsive application.
         {
             foreach (var pair in DocumentsById)
             {
-                UpdateMetadataModifications(pair.Value);
+                UpdateMetadataModifications(pair.Value.MetadataInstance, pair.Value.Metadata);
                 var newObj = JsonConverter.ToBlittable(pair.Value.Entity, pair.Value);
                 EntityChanged(newObj, pair.Value, changes);
             }

--- a/test/SlowTests/Issues/RavenDB-17872.cs
+++ b/test/SlowTests/Issues/RavenDB-17872.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17872 : ClusterTestBase
+    {
+        public RavenDB_17872(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task TestCase()
+        {
+            using var store = GetDocumentStore();
+
+            const string id = "testObjs/0";
+            const string metadataPropName = "RandomProp";
+            const string metadataValue = "RandomValue";
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var entity = new TestObj();
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id, entity);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
+                // entity.Value.Prop = "Changed"; //without this line the session doesn't send an update to the compare exchange
+                entity.Metadata[metadataPropName] = metadataValue;
+                await session.SaveChangesAsync();
+            }
+
+            //The session doesn't set the metadata but it can be seen in the studio. 
+            // WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
+                Assert.Contains(metadataPropName, entity.Metadata.Keys);
+                Assert.Equal(metadataValue, entity.Metadata[metadataPropName]);
+            }
+        }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17872.cs
+++ b/test/SlowTests/Issues/RavenDB-17872.cs
@@ -35,7 +35,6 @@ namespace SlowTests.Issues
             const string metadataPropName = "RandomProp";
             const string metadataValue = "RandomValue";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -43,7 +42,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -72,7 +70,6 @@ namespace SlowTests.Issues
             const string metadataPropName = "RandomProp";
             const string metadataValue = "RandomValue";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -80,7 +77,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -88,7 +84,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged: newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false, and return false (same kvp's).
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -113,7 +108,6 @@ namespace SlowTests.Issues
             const string metadataPropName = "RandomProp";
             const string metadataValue = "RandomValue";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -121,7 +115,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -130,7 +123,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false, and return true (different kvp's).
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -153,7 +145,6 @@ namespace SlowTests.Issues
 
             const string id = "testObjs/0";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -161,7 +152,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -186,7 +176,6 @@ namespace SlowTests.Issues
             const string metadataPropName = "RandomProp";
             const string metadataValue = "RandomValue";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -194,7 +183,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -203,7 +191,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false, and return true (different kvp's).
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -230,7 +217,6 @@ namespace SlowTests.Issues
             const string metadataPropName = "RandomProp";
             const string metadataValue = "RandomValue";
 
-            // CompareExchangeSessionValue.MetadataHasChanged:  newMetadataNullOrEmpty == true && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = new TestObj();
@@ -238,7 +224,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == true
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);
@@ -248,7 +233,6 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            // * CompareExchangeSessionValue.MetadataHasChanged: case newMetadataNullOrEmpty == false && oldMetadataNullOrEmpty == false, and return true (different counts).
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(id);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17872/Get-and-update-compare-exchange-metadata-in-the-session

### Additional description

Fix - compare-exchange metadata can't be updated in the session.
### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
