### PR TITLE
RavenDB-19196  Setup Wizard: Provide default IP Address in Unsecure flow

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/wizard/unsecured.ts
+++ b/src/Raven.Studio/typescript/viewmodels/wizard/unsecured.ts
@@ -68,22 +68,23 @@ class unsecured extends setupStep {
         
         const initialIp = ipEntry.runningOnDocker ? "" : "127.0.0.1";
         
-        this.model.nodes().forEach(x => {
-            let ip = x.ips()[0];
-            if (!ip) {
-                ip = ipEntry.forIp(initialIp, false);
+        this.model.nodes().forEach(node => {
+            const firstIp = node.ips()[0].ip();
+
+            if (!firstIp) {
+                node.ips()[0] = ipEntry.forIp(initialIp, false);
             }
         });
     }
     
     compositionComplete() {
         super.compositionComplete();
+        const nodes = this.model.nodes();
 
-        if (this.model.nodes().length) {
+        if (nodes.length) {
+            const firstNode = nodes[0];
 
-            let firstNode = this.model.nodes()[0];
-
-            if (firstNode.ips().length === 0 ) {
+            if (firstNode.ips().length === 0) {
                 firstNode.ips.push(new ipEntry(true));
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19196

### Additional description
Auto-fill `127.0.0.1` IP address in unsecure flow


### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
