### PR TITLE
RavenDB-19141 Fixing race condition in tests. We should rely on the n…

### DIFF
--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -584,6 +584,11 @@ namespace Voron
                 }
             }
 
+            public override int GetNumberOfJournalsForReuse()
+            {
+                return _journalsForReuse.Count;
+            }
+
             private void AttemptToReuseJournal(VoronPathSetting desiredPath, long desiredSize)
             {
                 lock (_journalsForReuse)
@@ -982,6 +987,11 @@ namespace Voron
             {
             }
 
+            public override int GetNumberOfJournalsForReuse()
+            {
+                return 0;
+            }
+
             protected override void Disposing()
             {
                 if (Disposed)
@@ -1237,6 +1247,8 @@ namespace Voron
         private long _maxScratchBufferSize;
 
         public abstract void TryStoreJournalForReuse(VoronPathSetting filename);
+
+        public abstract int GetNumberOfJournalsForReuse();
 
         private void TryDelete(string file)
         {

--- a/test/SlowTests/Voron/Issues/RavenDB_10225_Voron.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10225_Voron.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Voron.Issues
 
             var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
 
-            Assert.True(SpinWait.SpinUntil(() => new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length == 6,
+            Assert.True(SpinWait.SpinUntil(() => Env.Options.GetNumberOfJournalsForReuse() == 6,
                 TimeSpan.FromSeconds(30)));
 
             Env.Cleanup(tryCleanupRecycledJournals: true);

--- a/test/SlowTests/Voron/Issues/RavenDB_7097.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_7097.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Voron.Issues
 
             var journalPath = ((StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)Env.Options).JournalPath.FullPath;
 
-            Assert.True(SpinWait.SpinUntil(() => new DirectoryInfo(journalPath).GetFiles($"{StorageEnvironmentOptions.RecyclableJournalFileNamePrefix}*").Length == 6,
+            Assert.True(SpinWait.SpinUntil(() => Env.Options.GetNumberOfJournalsForReuse() == 6,
                 TimeSpan.FromSeconds(30)));
 
             Env.Dispose();


### PR DESCRIPTION
…umber of recyclable journals that we have on the in-memory list because TryCleanupRecycledJournals() and Dispose() operate on those. The problem was that we were renaming the files on the disk but updating in-memory list later so the cleanup didn't delete all recyclable files as we expected.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19141/SlowTestsVoronIssuesRavenDB10225VoronRecyclablejournalfilescanbedeletedonstoragecleanup
### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
