### PR TITLE
RavenDB-18829 Making sure that we are not still deleting before addin…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17311.cs
+++ b/test/SlowTests/Issues/RavenDB-17311.cs
@@ -66,6 +66,12 @@ namespace SlowTests.Issues
 
                 Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "John Doe", 30_000));
 
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    var record = await src.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(src.Database));
+                    return record.DeletionInProgress.Count;
+                }, 0);
+
                 var addResult = await src.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(src.Database, node: mentor));
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(addResult.RaftCommandIndex, TimeSpan.FromSeconds(30));
 


### PR DESCRIPTION
…g the node back to the db group (we were getting 'Can't add node A to database 'CanRemoveAndReAddNodeToDbWhileUpdatingEtlProcessState' topology because it is currently being deleted from node 'A').

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18829

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
