### PR TITLE
RavenDB-19145:  Add CancellationToken to GetDocumentsStartingWith method

### DIFF
--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -230,10 +230,10 @@ namespace Raven.Server.Documents.Queries
                         countQuery = true;
                         _query.PageSize = int.MaxValue;
                     }
-
+                    
                     documents = _isAllDocsCollection
-                        ? _documents.GetDocumentsStartingWith(_context, _startsWith, null, null, _startAfterId, _start, _query.PageSize, fields: _fields) 
-                        : _documents.GetDocumentsStartingWith(_context, _startsWith, _startAfterId, _start, _query.PageSize, _collection, _skippedResults, _fields);
+                        ? _documents.GetDocumentsStartingWith(_context, _startsWith, null, null, _startAfterId, _start, _query.PageSize, null, fields: _fields, _token) 
+                        : _documents.GetDocumentsStartingWith(_context, _startsWith, _startAfterId, _start, _query.PageSize, _collection, _skippedResults,  _fields, _token);
 
                     if (countQuery)
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19145/Cannot-kill-a-collection-query

### Additional description

There was no interruption of the process of `GetDocumentsStartingWith`.
Now it has.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
