### PR TITLE
RavenDB-19015: Replay traffic watch tool for queries

### DIFF
--- a/tools/Raven.Debug/LogTrafficWatch/TrafficWatchReplay.cs
+++ b/tools/Raven.Debug/LogTrafficWatch/TrafficWatchReplay.cs
@@ -158,8 +158,11 @@ namespace Raven.Debug.LogTrafficWatch
                         return;
                     }
 
+                    if (item.RequestUri == null) 
+                        continue;
+                    
                     var uri = UriReplace(item.RequestUri);
-                   
+                    
                     try
                     {
                         if (item.Type != TrafficWatchChangeType.Queries)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19015/Replay-traffic-watch-tool-for-queries

### Additional description

Add traffic watch replay tool for queries into `Raven.Debug`.

### Type of change

- New feature

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing