### PR TITLE
RavenDB-15744 Support logging toggling

### DIFF
--- a/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Http
 {
     internal static class ClusterTopologyLocalCache
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger("Client", typeof(ClusterTopologyLocalCache).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Client", typeof(ClusterTopologyLocalCache).FullName);
 
         private static void Clear(string path)
         {
@@ -27,8 +27,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not clear the persisted cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not clear the persisted cluster topology", e);
             }
         }
 
@@ -56,8 +56,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not understand the persisted cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not understand the persisted cluster topology", e);
                 return null;
             }
         }
@@ -94,8 +94,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not persist the cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not persist the cluster topology", e);
             }
         }
     }

--- a/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Http
 {
     internal static class DatabaseTopologyLocalCache
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger("Client", typeof(DatabaseTopologyLocalCache).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DatabaseTopologyLocalCache));
 
         private static void Clear(string path)
         {
@@ -26,8 +26,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not clear the persisted database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not clear the persisted database topology", e);
             }
         }
 
@@ -60,8 +60,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not understand the persisted database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not understand the persisted database topology", e);
                 return null;
             }
         }
@@ -83,8 +83,8 @@ namespace Raven.Client.Http
                 var existingTopology = await TryLoadAsync(path, context).ConfigureAwait(false);
                 if (existingTopology?.Etag >= topology.Etag)
                 {
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Skipping save topology with etag {topology.Etag} to cache " +
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Skipping save topology with etag {topology.Etag} to cache " +
                                      $"as the cache already have a topology with etag: {existingTopology.Etag}");
                     return;
                 }
@@ -118,8 +118,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not persist the database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not persist the database topology", e);
             }
         }
 

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Http
         public HttpCache(long maxSize)
         {
             _maxSize = maxSize;
-            _unmanagedBuffersPool = new UnmanagedBuffersPool(nameof(HttpCache), "Client");
+            _unmanagedBuffersPool = new UnmanagedBuffersPool(nameof(HttpCache));
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }
 

--- a/src/Raven.Server/Background/BackgroundWorkBase.cs
+++ b/src/Raven.Server/Background/BackgroundWorkBase.cs
@@ -14,10 +14,10 @@ namespace Raven.Server.Background
         private Task _currentTask;
         protected readonly Logger Logger;
 
-        protected BackgroundWorkBase(string resourceName, CancellationToken shutdown)
+        protected BackgroundWorkBase(Logger logger, CancellationToken shutdown)
         {
             _shutdown = shutdown;
-            Logger = LoggingSource.Instance.GetLogger(resourceName ?? "Server", GetType().FullName);
+            Logger = logger ?? LoggingSource.Instance.LoggersHolder.Generic.GetLogger(GetType().Name);
             Cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdown);
         }
 

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Commercial.LetsEncrypt;
 
 public class LetsEncryptSimulationHelper
 {
-    internal static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+    internal static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
 
     internal class UniqueResponseResponder : IStartup
     {

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Commercial
 {
     public class LicenseHelper
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseHelper>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseHelper>();
         public static readonly string LicenseStringConfigurationName = RavenConfiguration.GetKey(x => x.Licensing.License);
 
         private readonly ServerStore _serverStore;

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Commercial
 {
     public class LicenseManager : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
         private static readonly RSAParameters _rsaParameters;
         private readonly LicenseStorage _licenseStorage = new LicenseStorage();
         private Timer _leaseLicenseTimer;

--- a/src/Raven.Server/Commercial/OsInfoExtensions.cs
+++ b/src/Raven.Server/Commercial/OsInfoExtensions.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Commercial
 {
     public static class OsInfoExtensions
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("OsInfo");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
 
         public static OsInfo GetOsInfo()
         {

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Commercial
 {
     public static class SetupManager
     {
-        internal static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+        internal static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
         
         private static string BuildHostName(string nodeTag, string userDomain, string rootDomain)
         {

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Config
 #if !RVN
         internal static readonly RavenConfiguration Default = new RavenConfiguration("__default", ResourceType.Server);
 
-        private readonly Logger _logger;
+        private readonly Logger _logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenConfiguration>();
 
         private readonly string _customConfigPath;
 
@@ -107,8 +107,6 @@ namespace Raven.Server.Config
 
         private RavenConfiguration(string resourceName, ResourceType resourceType, string customConfigPath = null, bool skipEnvironmentVariables = false)
         {
-            _logger = LoggingSource.Instance.GetLogger<RavenConfiguration>(resourceName);
-
             ResourceName = resourceName;
             ResourceType = resourceType;
             _customConfigPath = customConfigPath;

--- a/src/Raven.Server/Dashboard/Cluster/AbstractClusterDashboardNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/AbstractClusterDashboardNotificationSender.cs
@@ -21,7 +21,8 @@ namespace Raven.Server.Dashboard.Cluster
         
         private DateTime _lastSentNotification = DateTime.MinValue;
 
-        protected AbstractClusterDashboardNotificationSender(int widgetId, ConnectedWatcher watcher, CancellationToken shutdown) : base(nameof(AbstractClusterDashboardNotificationSender), shutdown)
+        protected AbstractClusterDashboardNotificationSender(int widgetId, ConnectedWatcher watcher, CancellationToken shutdown) 
+            : base(null, shutdown)
         {
             _widgetId = widgetId;
             _watcher = watcher;

--- a/src/Raven.Server/Dashboard/DatabasesInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoNotificationSender.cs
@@ -17,9 +17,9 @@ namespace Raven.Server.Dashboard
         private readonly TimeSpan _notificationsThrottle;
         private DateTime _lastSentNotification = DateTime.MinValue;
 
-        public DatabasesInfoNotificationSender(string resourceName, ServerStore serverStore,
+        public DatabasesInfoNotificationSender(ServerStore serverStore,
             ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
-            : base(resourceName, shutdown)
+            : base(null, shutdown)
         {
             _serverStore = serverStore;
             _watchers = watchers;

--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -24,12 +24,11 @@ namespace Raven.Server.Dashboard
         private DateTime _lastSentNotification = DateTime.MinValue;
 
         public MachineResourcesNotificationSender(
-            string resourceName,
             RavenServer server,
             ConcurrentSet<ConnectedWatcher> watchers,
             TimeSpan notificationsThrottle,
             CancellationToken shutdown)
-            : base(resourceName, shutdown)
+            : base(null, shutdown)
         {
             _server = server;
             _watchers = watchers;

--- a/src/Raven.Server/Dashboard/ServerDashboardNotifications.cs
+++ b/src/Raven.Server/Dashboard/ServerDashboardNotifications.cs
@@ -11,11 +11,11 @@ namespace Raven.Server.Dashboard
             var options = new ServerDashboardOptions();
 
             var machineResourcesNotificationSender = 
-                new MachineResourcesNotificationSender(nameof(ServerStore), serverStore.Server, Watchers, options.MachineResourcesThrottle, shutdown);
+                new MachineResourcesNotificationSender(serverStore.Server, Watchers, options.MachineResourcesThrottle, shutdown);
             BackgroundWorkers.Add(machineResourcesNotificationSender);
 
             var databasesInfoNotificationSender = 
-                new DatabasesInfoNotificationSender(nameof(ServerStore), serverStore, Watchers, options.DatabasesInfoThrottle, shutdown);
+                new DatabasesInfoNotificationSender(serverStore, Watchers, options.DatabasesInfoThrottle, shutdown);
             BackgroundWorkers.Add(databasesInfoNotificationSender);
         }
     }

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
@@ -15,9 +15,9 @@ public class ThreadsInfoNotificationSender : BackgroundWorkBase
     private readonly ThreadsUsage _threadsUsage;
     private DateTime _lastSentNotification = DateTime.MinValue;
 
-    public ThreadsInfoNotificationSender(string resourceName,
-        ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
-        : base(resourceName, shutdown)
+    public ThreadsInfoNotificationSender(ConcurrentSet<ConnectedWatcher> watchers, 
+        TimeSpan notificationsThrottle, CancellationToken shutdown)
+        : base(null, shutdown)
     {
         _watchers = watchers;
         _notificationsThrottle = notificationsThrottle;

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
 using Raven.Server.NotificationCenter;
-using Raven.Server.ServerWide;
 
 namespace Raven.Server.Dashboard;
 
@@ -10,7 +9,7 @@ public class ThreadsInfoNotifications : NotificationsBase
     {
         var options = new ThreadsInfoOptions();
 
-        var threadsInfoNotificationSender = new ThreadsInfoNotificationSender(nameof(ServerStore), Watchers, options.ThreadsInfoThrottle, shutdown);
+        var threadsInfoNotificationSender = new ThreadsInfoNotificationSender(Watchers, options.ThreadsInfoThrottle, shutdown);
         BackgroundWorkers.Add(threadsInfoNotificationSender);
     }
 }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -15,7 +15,6 @@ using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -87,7 +86,6 @@ namespace Raven.Server.Documents
         {
             _documentDatabase = documentDatabase;
             _documentsStorage = documentDatabase.DocumentsStorage;
-            LoggingSource.Instance.GetLogger<AttachmentsStorage>(documentDatabase.Name);
 
             tx.CreateTree(AttachmentsSlice);
             AttachmentsSchema.Create(tx, AttachmentsMetadataSlice, 44);

--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -18,13 +18,12 @@ namespace Raven.Server.Documents
 
         private readonly DatabasesLandlord _databasesLandlord;
         private readonly ServerStore _serverStore;
-        private readonly Logger _logger;
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<CatastrophicFailureHandler>();
         
         public CatastrophicFailureHandler(DatabasesLandlord databasesLandlord, ServerStore serverStore)
         {
             _databasesLandlord = databasesLandlord;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<CatastrophicFailureHandler>("Server");
         }
 
         public bool TryGetStats(Guid environmentId, out FailureStats stats)
@@ -75,8 +74,8 @@ namespace Raven.Server.Documents
                     // exception in raising an alert can't prevent us from unloading a database
                 }
 
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"{title}. {message} (StackTrace='{stacktrace}')", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"{title}. {message} (StackTrace='{stacktrace}')", e);
 
                 // let it propagate the exception to the client first and do
                 // the internal failure handling e.g. Index.HandleIndexCorruption

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -22,9 +22,7 @@ namespace Raven.Server.Documents
 {
     public class CompactDatabaseTask
     {
-        private const string ResourceName = nameof(CompactDatabaseTask);
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<CompactDatabaseTask>(ResourceName);
-
+        private readonly Logger _logger;
         private readonly ServerStore _serverStore;
         private readonly string _database;
         private CancellationToken _token;
@@ -32,6 +30,7 @@ namespace Raven.Server.Documents
 
         public CompactDatabaseTask(ServerStore serverStore, string database, CancellationToken token)
         {
+            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(database);
             _serverStore = serverStore;
             _database = database;
             _token = token;
@@ -68,12 +67,12 @@ namespace Raven.Server.Documents
                     {
                         DisableIoMetrics = true
                     },
-                new CatastrophicFailureNotification((endId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}), StackTrace='{stacktrace}'", exception))))
+                new CatastrophicFailureNotification((endId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}), StackTrace='{stacktrace}'", exception)), _logger))
                 {
                     documentDatabase.ForTestingPurposes?.CompactionAfterDatabaseUnload?.Invoke();
 
                     InitializeOptions(src, configuration, documentDatabase, encryptionKey);
-                    DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(src, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, Logger);
+                    DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(src, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, _logger);
 
                     var basePath = configuration.Core.DataDirectory.FullPath;
                     compactDirectory = basePath + "-compacting";
@@ -107,10 +106,10 @@ namespace Raven.Server.Documents
                         {
                             DisableIoMetrics = true
                         },
-                        new CatastrophicFailureNotification((envId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}). StackTrace='{stacktrace}'", exception))))
+                        new CatastrophicFailureNotification((envId, path, exception, stacktrace) => throw new InvalidOperationException($"Failed to compact database {_database} ({path}). StackTrace='{stacktrace}'", exception)), _logger))
                     {
                         InitializeOptions(dst, configuration, documentDatabase, encryptionKey);
-                        DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(dst, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, Logger);
+                        DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(dst, configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Compaction, _logger);
 
                         _token.ThrowIfCancellationRequested();
                         StorageCompaction.Execute(src, (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)dst, progressReport =>

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -14,10 +14,6 @@ namespace Raven.Server.Documents
 {
     public class ConfigurationStorage : IDisposable
     {
-        private const string ResourceName = nameof(ConfigurationStorage);
-
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ConfigurationStorage>(ResourceName);
-
         public TransactionContextPool ContextPool { get; }
 
         public NotificationsStorage NotificationsStorage { get; }
@@ -36,8 +32,8 @@ namespace Raven.Server.Documents
             }
 
             var options = db.Configuration.Core.RunInMemory
-                ? StorageEnvironmentOptions.CreateMemoryOnly(path.FullPath, tempPath, db.IoChanges, db.CatastrophicFailureNotification)
-                : StorageEnvironmentOptions.ForPath(path.FullPath, tempPath, null, db.IoChanges, db.CatastrophicFailureNotification);
+                ? StorageEnvironmentOptions.CreateMemoryOnly(path.FullPath, tempPath, db.IoChanges, db.CatastrophicFailureNotification, db.Logger)
+                : StorageEnvironmentOptions.ForPath(path.FullPath, tempPath, null, db.IoChanges, db.CatastrophicFailureNotification, db.Logger);
 
             options.OnNonDurableFileSystemError += db.HandleNonDurableFileSystemError;
             options.OnRecoverableFailure += db.HandleRecoverableFailure;
@@ -63,9 +59,9 @@ namespace Raven.Server.Documents
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = db.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.MaxNumberOfRecyclableJournals = db.Configuration.Storage.MaxNumberOfRecyclableJournals;
 
-            DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, db.Configuration.Storage, db.Name, DirectoryExecUtils.EnvironmentType.Configuration, Logger);
+            DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, db.Configuration.Storage, db.Name, DirectoryExecUtils.EnvironmentType.Configuration, db.Logger);
 
-            NotificationsStorage = new NotificationsStorage(db.Name);
+            NotificationsStorage = new NotificationsStorage(db.Logger);
 
             OperationsStorage = new OperationsStorage();
 

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents
         {
             _documentDatabase = documentDatabase;
             _documentsStorage = documentDatabase.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<ConflictsStorage>(documentDatabase.Name);
+            _logger = documentDatabase.Logger;
 
             ConflictsSchema.Create(tx, ConflictsSlice, 32);
 

--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -12,8 +12,7 @@ namespace Raven.Server.Documents
 {
     public class DatabaseInfoCache
     {
-
-        protected readonly Logger Logger;
+        protected Logger Logger;
 
         private StorageEnvironment _environment;
 
@@ -23,7 +22,6 @@ namespace Raven.Server.Documents
 
         public DatabaseInfoCache()
         {
-            Logger = LoggingSource.Instance.GetLogger<DatabaseInfoCache>("Server");
             _databaseInfoSchema.DefineKey(new TableSchema.SchemaIndexDef
             {
                 StartIndex = 0,
@@ -33,6 +31,8 @@ namespace Raven.Server.Documents
 
         public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)
         {
+            Logger = environment.Logger;
+
             _environment = environment;
             _contextPool = contextPool;
 

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents
 
             Database = context.Database;
             ContextPool = Database.DocumentsStorage.ContextPool;
-            Logger = Database.Logger.GetLogger(GetType().Name);
+            Logger = Database.Logger;
 
             context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -20,7 +20,6 @@ namespace Raven.Server.Documents
     {
         protected DocumentsContextPool ContextPool;
         protected DocumentDatabase Database;
-        protected Logger Logger;
 
         public override void Init(RequestHandlerContext context)
         {
@@ -28,7 +27,7 @@ namespace Raven.Server.Documents
 
             Database = context.Database;
             ContextPool = Database.DocumentsStorage.ContextPool;
-            Logger = LoggingSource.Instance.GetLogger(Database.Name, GetType().FullName);
+            Logger = Database.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents
             _serverStore = serverStore;
             _databaseSemaphore = new SemaphoreSlim(_serverStore.Configuration.Databases.MaxConcurrentLoads);
             _concurrentDatabaseLoadTimeout = _serverStore.Configuration.Databases.ConcurrentLoadTimeout.AsTimeSpan;
-            _logger = LoggingSource.Instance.GetLogger<DatabasesLandlord>("Server");
+            _logger = serverStore.Server.Logger;
             CatastrophicFailureHandler = new CatastrophicFailureHandler(this, _serverStore);
         }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1631,8 +1631,8 @@ namespace Raven.Server.Documents
         {
             string title = $"Non Durable File System - {Name ?? "Unknown Database"}";
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"{title}. {e.Message}", e.Exception);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"{title}. {e.Message}", e.Exception);
 
             _serverStore?.NotificationCenter.Add(AlertRaised.Create(
                 Name,
@@ -1686,8 +1686,8 @@ namespace Raven.Server.Documents
 
             string message = $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}";
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"{title}. {message}", e.Exception);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"{title}. {message}", e.Exception);
 
             nc?.Add(AlertRaised.Create(Name,
                 title,
@@ -1755,8 +1755,8 @@ namespace Raven.Server.Documents
             var title = $"Recoverable Voron error in '{Name}' database";
             var message = $"Failure {e.FailureMessage} in the following environment: {e.EnvironmentPath}";
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"{title}. {message}", e.Exception);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"{title}. {message}", e.Exception);
 
             try
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -66,7 +66,8 @@ namespace Raven.Server.Documents
     {
         private readonly ServerStore _serverStore;
         private readonly Action<string> _addToInitLog;
-        private readonly Logger _logger;
+        public readonly SwitchLogger Logger;
+        public readonly SwitchLogger IndexesLogger;
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
         internal TestingStuff ForTestingPurposes;
 
@@ -101,7 +102,8 @@ namespace Raven.Server.Documents
         public DocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog)
         {
             Name = name;
-            _logger = LoggingSource.Instance.GetLogger<DocumentDatabase>(Name);
+            Logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(Name);
+            IndexesLogger = Logger.GetSubSwitchLogger("Indexes");
             _serverStore = serverStore;
             _addToInitLog = addToInitLog;
             StartTime = Time.GetUtcNow();
@@ -122,7 +124,7 @@ namespace Raven.Server.Documents
                 {
                     _addToInitLog("Creating db.lock file");
                     _fileLocker = new FileLocker(Configuration.Core.DataDirectory.Combine("db.lock").FullPath);
-                    _fileLocker.TryAcquireWriteLock(_logger);
+                    _fileLocker.TryAcquireWriteLock(Logger);
                 }
 
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
@@ -162,9 +164,9 @@ namespace Raven.Server.Documents
                 MetricCacher = new DatabaseMetricCacher(this);
                 TxMerger = new TransactionOperationsMerger(this, DatabaseShutdown);
                 ConfigurationStorage = new ConfigurationStorage(this);
-                NotificationCenter = new NotificationCenter.NotificationCenter(ConfigurationStorage.NotificationsStorage, Name, DatabaseShutdown, configuration);
+                NotificationCenter = new NotificationCenter.NotificationCenter(ConfigurationStorage.NotificationsStorage, Name, DatabaseShutdown, configuration, Logger);
                 HugeDocuments = new HugeDocuments(NotificationCenter, ConfigurationStorage.NotificationsStorage, Name, configuration.PerformanceHints.HugeDocumentsCollectionSize,
-                    configuration.PerformanceHints.HugeDocumentSize.GetValue(SizeUnit.Bytes));
+                    configuration.PerformanceHints.HugeDocumentSize.GetValue(SizeUnit.Bytes), Logger);
                 Operations = new Operations.Operations(Name, ConfigurationStorage.OperationsStorage, NotificationCenter, Changes,
                     Is32Bits ? TimeSpan.FromHours(12) : TimeSpan.FromDays(2));
                 DatabaseInfoCache = serverStore.DatabaseInfoCache;
@@ -373,9 +375,9 @@ namespace Raven.Server.Documents
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
-                            _logger.Info("An unhandled exception closed the cluster transaction task", e);
+                            Logger.Info("An unhandled exception closed the cluster transaction task", e);
                         }
                     }
                 }, DatabaseShutdown);
@@ -465,9 +467,9 @@ namespace Raven.Server.Documents
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsInfoEnabled)
+                    if (Logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Can't perform cluster transaction on database '{Name}'.", e);
+                        Logger.Info($"Can't perform cluster transaction on database '{Name}'.", e);
                     }
                 }
             }
@@ -497,9 +499,9 @@ namespace Raven.Server.Documents
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
+                if (Logger.IsInfoEnabled)
                 {
-                    _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
+                    Logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
                 }
                 await ExecuteClusterTransactionOneByOne(batch);
                 return batch;
@@ -584,9 +586,9 @@ namespace Raven.Server.Documents
             catch (Exception e)
             {
                 // nothing we can do
-                if (_logger.IsInfoEnabled)
+                if (Logger.IsInfoEnabled)
                 {
-                    _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
+                    Logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
                 }
             }
         }
@@ -653,8 +655,8 @@ namespace Raven.Server.Documents
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, $"Generating offline database info failed: {e}");
                 // if we encountered a catastrophic failure we might not be able to retrieve database info
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Failed to generate and store database info", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Failed to generate and store database info", e);
             }
 
             if (ForTestingPurposes == null || ForTestingPurposes.SkipDrainAllRequests == false)
@@ -676,7 +678,7 @@ namespace Raven.Server.Documents
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, $"Drained all requests. Took: {sp.Elapsed}");
             }
 
-            var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(DocumentDatabase)} {Name}");
+            var exceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {nameof(DocumentDatabase)} {Name}");
 
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Acquiring cluster lock");
 
@@ -685,8 +687,8 @@ namespace Raven.Server.Documents
 
             ForTestingPurposes?.DisposeLog?.Invoke(Name, $"Acquired cluster lock. Taken: {lockTaken}");
 
-            if (lockTaken == false && _logger.IsOperationsEnabled)
-                _logger.Operations("Failed to acquire lock during database dispose for cluster notifications. Will dispose rudely...");
+            if (lockTaken == false && Logger.IsOperationsEnabled)
+                Logger.Operations("Failed to acquire lock during database dispose for cluster notifications. Will dispose rudely...");
 
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Unsubscribing from storage space monitor");
             exceptionAggregator.Execute(() =>
@@ -860,6 +862,7 @@ namespace Raven.Server.Documents
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Finished dispose");
 
             exceptionAggregator.ThrowIfNeeded();
+            Logger.Dispose();
         }
 
         public DynamicJsonValue GenerateOfflineDatabaseInfo()
@@ -1010,8 +1013,8 @@ namespace Raven.Server.Documents
                     _nextIoMetricsCleanupTime = utcNow.Add(Configuration.Storage.IoMetricsCleanupInterval.AsTimeSpan);
                 }
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Ran idle operations for database '{Name}' in {mode} mode, took: {sp.ElapsedMilliseconds}ms");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Ran idle operations for database '{Name}' in {mode} mode, took: {sp.ElapsedMilliseconds}ms");
             }
             finally
             {
@@ -1103,7 +1106,7 @@ namespace Raven.Server.Documents
                     using (var zipStream = zipArchiveEntry.Open())
                     using (var outputStream = GetOutputStream(zipStream))
                     {
-                        var smugglerSource = new DatabaseSource(this, 0, 0, _logger);
+                        var smugglerSource = new DatabaseSource(this, 0, 0);
                         using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
                         {
                             var smugglerDestination = new StreamDestination(outputStream, documentsContext, smugglerSource);
@@ -1261,8 +1264,8 @@ namespace Raven.Server.Documents
 
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e);
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Got exception during StateChanged({index}).", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Got exception during StateChanged({index}).", e);
 
                 if (throwShutDown != null)
                     throw throwShutDown;
@@ -1299,8 +1302,8 @@ namespace Raven.Server.Documents
                     Debug.Assert(string.Equals(Name, record.DatabaseName, StringComparison.OrdinalIgnoreCase),
                         $"{Name} != {record.DatabaseName}");
 
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Starting to process record {index} (current {LastDatabaseRecordChangeIndex}) for {record.DatabaseName}.");
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Starting to process record {index} (current {LastDatabaseRecordChangeIndex}) for {record.DatabaseName}.");
 
                     try
                     {
@@ -1318,13 +1321,13 @@ namespace Raven.Server.Documents
 
                         LastDatabaseRecordChangeIndex = index;
 
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info($"Finish to process record {index} for {record.DatabaseName}.");
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Finish to process record {index} for {record.DatabaseName}.");
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info($"Encounter an error while processing record {index} for {record.DatabaseName}.", e);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Encounter an error while processing record {index} for {record.DatabaseName}.", e);
                         throw;
                     }
                 }
@@ -1336,7 +1339,7 @@ namespace Raven.Server.Documents
 
                         if (sp?.Elapsed > TimeSpan.FromSeconds(10))
                         {
-                            if (_logger.IsOperationsEnabled)
+                            if (Logger.IsOperationsEnabled)
                             {
                                 using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
                                 using (ctx.OpenReadTransaction())
@@ -1344,7 +1347,7 @@ namespace Raven.Server.Documents
                                     var logs = ServerStore.Engine.LogHistory.GetLogByIndex(ctx, index).Select(djv => ctx.ReadObject(djv, "djv").ToString());
                                     var msg =
                                         $"Lock held for a very long time {sp.Elapsed} in database {Name} for index {index} ({string.Join(", ", logs)})";
-                                    _logger.Operations(msg);
+                                    Logger.Operations(msg);
 
 #if !RELEASE
                                     Console.WriteLine(msg);
@@ -1379,8 +1382,8 @@ namespace Raven.Server.Documents
             if (LastDatabaseRecordChangeIndex > index)
             {
                 // index and LastDatabaseRecordIndex could have equal values when we transit from/to passive and want to update the tasks.
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Skipping record {index} (current {LastDatabaseRecordChangeIndex}) for {database} because it was already precessed.");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Skipping record {index} (current {LastDatabaseRecordChangeIndex}) for {database} because it was already precessed.");
                 return true;
             }
 
@@ -1392,8 +1395,8 @@ namespace Raven.Server.Documents
             if (LastValueChangeIndex > index)
             {
                 // index and LastDatabaseRecordIndex could have equal values when we transit from/to passive and want to update the tasks.
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Skipping value change for index {index} (current {LastValueChangeIndex}) for {database} because it was already precessed.");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Skipping value change for index {index} (current {LastValueChangeIndex}) for {database} because it was already precessed.");
                 return true;
             }
 
@@ -1736,8 +1739,8 @@ namespace Raven.Server.Documents
 
             string message = $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}";
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"{title}. {message}", e.Exception);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"{title}. {message}", e.Exception);
 
             nc?.Add(AlertRaised.Create(Name,
                 title,

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -184,7 +184,7 @@ namespace Raven.Server.Documents
         {
             DocumentDatabase = documentDatabase;
             _name = DocumentDatabase.Name;
-            _logger = LoggingSource.Instance.GetLogger<DocumentsStorage>(documentDatabase.Name);
+            _logger = documentDatabase.Logger;
             _addToInitLog = addToInitLog;
         }
 
@@ -242,7 +242,7 @@ namespace Raven.Server.Documents
 
             }
 
-            var options = GetStorageEnvironmentOptionsFromConfiguration(DocumentDatabase.Configuration, DocumentDatabase.IoChanges, DocumentDatabase.CatastrophicFailureNotification);
+            var options = GetStorageEnvironmentOptionsFromConfiguration(DocumentDatabase.Configuration, DocumentDatabase.IoChanges, DocumentDatabase.CatastrophicFailureNotification, _logger);
 
             options.OnNonDurableFileSystemError += DocumentDatabase.HandleNonDurableFileSystemError;
             options.OnRecoveryError += DocumentDatabase.HandleOnDatabaseRecoveryError;
@@ -281,21 +281,23 @@ namespace Raven.Server.Documents
             }
         }
 
-        public static StorageEnvironmentOptions GetStorageEnvironmentOptionsFromConfiguration(RavenConfiguration config, IoChangesNotifications ioChanges, CatastrophicFailureNotification catastrophicFailureNotification)
+        public static StorageEnvironmentOptions GetStorageEnvironmentOptionsFromConfiguration(RavenConfiguration config, IoChangesNotifications ioChanges, CatastrophicFailureNotification catastrophicFailureNotification, Logger logger)
         {
             if (config.Core.RunInMemory)
                 return StorageEnvironmentOptions.CreateMemoryOnly(
                     config.Core.DataDirectory.FullPath,
                     config.Storage.TempPath?.FullPath,
                     ioChanges,
-                    catastrophicFailureNotification);
+                    catastrophicFailureNotification,
+                    logger);
 
             return StorageEnvironmentOptions.ForPath(
                 config.Core.DataDirectory.FullPath,
                 config.Storage.TempPath?.FullPath,
                 null,
                 ioChanges,
-                catastrophicFailureNotification
+                catastrophicFailureNotification, 
+                logger
             );
         }
 

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -49,8 +49,7 @@ namespace Raven.Server.Documents.ETL
 
         public EtlLoader(DocumentDatabase database, ServerStore serverStore)
         {
-            Logger = LoggingSource.Instance.GetLogger(database.Name, GetType().FullName);
-
+            Logger = database.Logger;
             _database = database;
             _serverStore = serverStore;
 

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.ETL
             ConfigurationName = Configuration.Name;
             TransformationName = Transformation.Name;
             Name = $"{Configuration.Name}/{Transformation.Name}";
-            Logger = LoggingSource.Instance.GetLogger(database.Name, GetType().FullName);
+            Logger = database.Logger;
             Database = database;
             _serverStore = serverStore;
             Statistics = new EtlProcessStatistics(Tag, Name, Database.NotificationCenter);

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
         {
             _etl = etl;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger<RelationalDatabaseWriter>(_database.Name);
+            _logger = database.Logger;
             _providerFactory = GetDbProviderFactory(etl.Configuration);
             _commandBuilder = _providerFactory.InitializeCommandBuilder();
             _connection = _providerFactory.CreateConnection();

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -22,14 +22,10 @@ namespace Raven.Server.Documents.Expiration
         private const string DocumentsByRefresh = "DocumentsByRefresh";
 
         private readonly DocumentDatabase _database;
-        private readonly DocumentsStorage _documentsStorage;
-        private readonly Logger _logger;
 
         public ExpirationStorage(DocumentDatabase database, Transaction tx)
         {
             _database = database;
-            _documentsStorage = _database.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<ExpirationStorage>(database.Name);
 
             tx.CreateTree(DocumentsByExpiration);
             tx.CreateTree(DocumentsByRefresh);

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -34,7 +34,8 @@ namespace Raven.Server.Documents.Expiration
         public ExpirationConfiguration ExpirationConfiguration { get; }
         public RefreshConfiguration RefreshConfiguration { get; }
 
-        private ExpiredDocumentsCleaner(DocumentDatabase database, ExpirationConfiguration expirationConfiguration, RefreshConfiguration refreshConfiguration) : base(database.Name, database.DatabaseShutdown)
+        private ExpiredDocumentsCleaner(DocumentDatabase database, ExpirationConfiguration expirationConfiguration, RefreshConfiguration refreshConfiguration)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             ExpirationConfiguration = expirationConfiguration;
             RefreshConfiguration = refreshConfiguration;
@@ -81,7 +82,7 @@ namespace Raven.Server.Documents.Expiration
                     $"Expiration error in {database.Name}", msg,
                     AlertType.RevisionsConfigurationNotValid, NotificationSeverity.Error, database.Name));
 
-                var logger = LoggingSource.Instance.GetLogger<ExpiredDocumentsCleaner>(database.Name);
+                var logger = database.Logger;
                 if (logger.IsOperationsEnabled)
                     logger.Operations(msg, e);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
 using Raven.Client.ServerWide.Operations.Logs;
-using Raven.Server.Indexing;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
-using Sparrow.Server.Platform.Posix;
 using Sparrow.Utils;
+using Sparrow.Server.Platform.Posix;
+using Voron.Util;
 
 namespace Raven.Server.Documents.Handlers.Admin
 {
@@ -32,7 +36,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                     [nameof(GetLogsConfigurationResult.Path)] = ServerStore.Configuration.Logs.Path.FullPath,
                     [nameof(GetLogsConfigurationResult.UseUtcTime)] = ServerStore.Configuration.Logs.UseUtcTime,
                     [nameof(GetLogsConfigurationResult.RetentionTime)] = LoggingSource.Instance.RetentionTime,
-                    [nameof(GetLogsConfigurationResult.RetentionSize)] = LoggingSource.Instance.RetentionSize == long.MaxValue ? null : (object)LoggingSource.Instance.RetentionSize,
+                    [nameof(GetLogsConfigurationResult.RetentionSize)] =
+                        LoggingSource.Instance.RetentionSize == long.MaxValue ? null : (object)LoggingSource.Instance.RetentionSize,
                     [nameof(GetLogsConfigurationResult.Compress)] = LoggingSource.Instance.Compressing
                 };
 
@@ -76,6 +81,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 {
                     context.Filter.Add(filter, true);
                 }
+
                 foreach (var filter in HttpContext.Request.Query["except"])
                 {
                     context.Filter.Add(filter, false);
@@ -147,5 +153,103 @@ namespace Raven.Server.Documents.Handlers.Admin
                 await stream.CopyToAsync(ResponseBodyStream());
             }
         }
+
+        private IDisposable AcquireLockAndGetLoggers(out SwitchLogger generic, out SwitchLogger server)
+        {
+            var genericLogger = LoggingSource.Instance.LoggersHolder.Generic;
+            var serverLogger = Server.Logger;
+            Monitor.Enter(genericLogger);
+            Monitor.Enter(serverLogger);
+
+            generic = genericLogger;
+            server = serverLogger;
+            return new DisposableAction(() =>
+            {
+                Monitor.Exit(genericLogger);
+                Monitor.Exit(serverLogger);
+            });
+        }
+        
+        [RavenAction("/admin/loggers", "GET", AuthorizationStatus.Operator)]
+        public async Task GetAllLoggers()
+        {
+            using (AcquireLockAndGetLoggers(out var generic, out var server))
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                await using var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream());
+
+                lock (generic)
+                lock (server)
+                {
+                    var djv = new DynamicJsonValue
+                    {
+                        ["IsInfoEnabled"] = LoggingSource.Instance.IsInfoEnabled,
+                        ["IsOperationsEnabled"] = LoggingSource.Instance.IsOperationsEnabled,
+                        ["Loggers"] = new DynamicJsonValue {[generic.Name] = generic.ToJson(), [server.Name] = server.ToJson()}
+                    };
+                    var json = context.ReadObject(djv, "logs/loggers");
+                    writer.WriteObject(json);
+                }
+            }
+        }
+
+        [RavenAction("/admin/loggers/reset/all", "GET", AuthorizationStatus.Operator)]
+        public Task ResetAllLoggers()
+        {
+            using (AcquireLockAndGetLoggers(out var generic, out var server))
+            {
+                generic.Reset(true);
+                server.Reset(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        [RavenAction("/admin/loggers/set", "POST", AuthorizationStatus.Operator)]
+        public async Task SetLoggerMode()
+        {
+            using (AcquireLockAndGetLoggers(out var generic, out var server))
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            {
+                var input = await ctx.ReadForMemoryAsync(RequestBodyStream(), "SwitchLoggerConfiguration");
+                if (input.TryGet("Configuration", out BlittableJsonReaderObject json) == false)
+                    ThrowRequiredPropertyNameInRequest("Configuration");
+
+                var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(json);
+                if (configuration.Loggers.TryGetValue(generic.Name, out var genericBlittable))
+                {
+                    var genericConfiguration = JsonDeserializationServer.SwitchLoggerConfiguration(genericBlittable);
+                    genericConfiguration.Apply(generic);
+                }
+
+                if (configuration.Loggers.TryGetValue(server.Name, out var serverBlittable))
+                {
+                    var serverConfiguration = JsonDeserializationServer.SwitchLoggerConfiguration(serverBlittable);
+                    serverConfiguration.Apply(server);
+                }
+            }
+        }
+
+        internal class SwitchLoggerConfiguration
+        {
+            public LogMode? LogMode { get; set; }
+            public Dictionary<string, BlittableJsonReaderObject> Loggers { get; set; }
+
+            public void Apply(SwitchLogger switchLogger)
+            {
+                if (LogMode.HasValue)
+                    switchLogger.SetLoggerMode(LogMode.Value);
+
+                if (Loggers != null)
+                {
+                    foreach ((string name, BlittableJsonReaderObject blittable) in Loggers)
+                    {
+                        var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
+                        if (switchLogger.Loggers.TryGet(name, out var descendant))
+                            configuration.Apply(descendant);
+                    }
+                }
+            }
+        }
     }
 }
+

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Handlers
             var progress = new BulkInsertProgress();
             try
             {
-                var logger = LoggingSource.Instance.GetLogger<MergedInsertBulkCommand>(Database.Name);
+                var logger = Database.Logger;
                 IDisposable currentCtxReset = null, previousCtxReset = null;
 
                 try
@@ -511,7 +511,7 @@ namespace Raven.Server.Documents.Handlers
                 TotalSize = Commands.Sum(c => c.Document.Size),
                 Commands = Commands,
                 Database = database,
-                Logger = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name)
+                Logger = database.Logger
             };
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -59,8 +59,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             nameof(DatabaseRecord.TimeSeries)
         };
 
-        private Logger _logger = LoggingSource.Instance.GetLogger<ServerWideDebugInfoPackageHandler>("Server");
-
         [RavenAction("/admin/debug/remote-cluster-info-package", "GET", AuthorizationStatus.Operator)]
         public async Task GetClusterWideInfoPackageForRemote()
         {
@@ -324,8 +322,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var routes = DebugInfoPackageUtils.GetAuthorizedRoutes(Server, HttpContext, databaseName).Where(x => x.TypeOfRoute == routeType);
 
             var id = Guid.NewGuid();
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Creating Debug Package '{id}' for '{databaseName ?? "Server"}'.");
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Creating Debug Package '{id}' for '{databaseName ?? "Server"}'.");
 
             foreach (var route in routes)
             {
@@ -335,8 +333,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 Exception ex = null;
                 var sw = Stopwatch.StartNew();
 
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Started gathering debug info from '{route.Path}' for Debug Package '{id}'.");
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Started gathering debug info from '{route.Path}' for Debug Package '{id}'.");
 
                 try
                 {
@@ -350,8 +348,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 }
                 finally
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"Finished gathering debug info from '{route.Path}' for Debug Package '{id}'. Took: {(int)sw.Elapsed.TotalMilliseconds} ms",
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Finished gathering debug info from '{route.Path}' for Debug Package '{id}'. Took: {(int)sw.Elapsed.TotalMilliseconds} ms",
                             ex);
                 }
             }

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1116,7 +1116,7 @@ namespace Raven.Server.Documents.Handlers
                         writer.WriteEndArray();
                         if (indexDefinition.Reduce != null)
                         {
-                            using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("JavaScriptIndexTest", Database.Name))
+                            using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("JavaScriptIndexTest", Database.Logger))
                             {
                                 compiledIndex.SetBufferPoolForTestingPurposes(bufferPool);
                                 compiledIndex.SetAllocatorForTestingPurposes(context.Allocator);

--- a/src/Raven.Server/Documents/HugeDocuments.cs
+++ b/src/Raven.Server/Documents/HugeDocuments.cs
@@ -30,14 +30,14 @@ namespace Raven.Server.Documents
 
         private Timer _timer;
 
-        public HugeDocuments(NotificationCenter.NotificationCenter notificationCenter, NotificationsStorage notificationsStorage, string database, int maxCollectionSize, long maxWarnSize)
+        public HugeDocuments(NotificationCenter.NotificationCenter notificationCenter, NotificationsStorage notificationsStorage, string database, int maxCollectionSize, long maxWarnSize, Logger logger)
         {
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
             _maxWarnSize = maxWarnSize;
             _hugeDocs = new SizeLimitedConcurrentDictionary<Tuple<string, DateTime>, long>(maxCollectionSize);
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = logger;
         }
 
         public void AddIfDocIsHuge(Document doc)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2466,8 +2466,8 @@ namespace Raven.Server.Documents.Indexes
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations("Failed to get index error count", e);
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Failed to get index error count", e);
 
                     return 1;
                 }
@@ -4748,8 +4748,8 @@ namespace Raven.Server.Documents.Indexes
             }
             catch (Exception e)
             {
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations("Unable to complete optimization, index is not usable and may require reset of the index to recover", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Unable to complete optimization, index is not usable and may require reset of the index to recover", e);
 
                 throw;
             }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -108,7 +108,7 @@ namespace Raven.Server.Documents.Indexes
 
         private readonly Size MappedSizeLimitOn32Bits = new Size(8, SizeUnit.Megabytes);
 
-        protected Logger _logger;
+        public SwitchLogger Logger;
 
         internal LuceneIndexPersistence IndexPersistence;
 
@@ -335,7 +335,7 @@ namespace Raven.Server.Documents.Indexes
                 DocumentDatabase.Changes.OnIndexChange -= HandleIndexChange;
             }
 
-            var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(Index)} '{Name}'");
+            var exceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {nameof(Index)} '{Name}'");
 
             exceptionAggregator.Execute(() =>
             {
@@ -359,27 +359,29 @@ namespace Raven.Server.Documents.Indexes
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
 
             exceptionAggregator.ThrowIfNeeded();
+            Logger.Dispose();
         }
 
         public static Index Open(string path, DocumentDatabase documentDatabase, bool generateNewDatabaseId)
         {
-            var logger = LoggingSource.Instance.GetLogger<Index>(documentDatabase.Name);
 
             StorageEnvironment environment = null;
 
             var name = new DirectoryInfo(path).Name;
+            var indexLogger = documentDatabase.IndexesLogger.GetSubSwitchLogger(name);
+
             var indexPath = path;
 
             var indexTempPath =
                 documentDatabase.Configuration.Indexing.TempPath?.Combine(name);
 
             var options = StorageEnvironmentOptions.ForPath(indexPath, indexTempPath?.FullPath, null,
-                documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification);
+                documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, indexLogger);
             try
             {
                 InitializeOptions(options, documentDatabase, name);
 
-                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, logger);
+                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, indexLogger);
 
                 environment = StorageLoader.OpenEnvironment(options, StorageEnvironmentWithType.StorageEnvironmentType.Index);
 
@@ -611,7 +613,7 @@ namespace Raven.Server.Documents.Indexes
         {
             InitializeMetrics(configuration);
 
-            _logger = LoggingSource.Instance.GetLogger<Index>(documentDatabase.Name);
+            Logger = documentDatabase.IndexesLogger.GetSubSwitchLogger(Name);
             using (DrainRunningQueries())
             {
                 if (_initialized)
@@ -619,7 +621,7 @@ namespace Raven.Server.Documents.Indexes
 
                 var options = CreateStorageEnvironmentOptions(documentDatabase, configuration);
 
-                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, _logger);
+                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, Logger);
 
                 StorageEnvironment storageEnvironment = null;
                 try
@@ -657,12 +659,13 @@ namespace Raven.Server.Documents.Indexes
             var indexPath = configuration.StoragePath.Combine(name);
 
             var indexTempPath = configuration.TempPath?.Combine(name);
-            
+
+            var indexLogger = documentDatabase.IndexesLogger.GetSubSwitchLogger(name);
             var options = configuration.RunInMemory
                 ? StorageEnvironmentOptions.CreateMemoryOnly(indexPath.FullPath, indexTempPath?.FullPath ?? Path.Combine(indexPath.FullPath, "Temp"),
-                    documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification)
+                    documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, indexLogger)
                 : StorageEnvironmentOptions.ForPath(indexPath.FullPath, indexTempPath?.FullPath, null,
-                    documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification);
+                    documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, indexLogger);
 
             InitializeOptions(options, documentDatabase, name);
 
@@ -742,6 +745,7 @@ namespace Raven.Server.Documents.Indexes
             IndexingConfiguration configuration,
             PerformanceHintsConfiguration performanceHints)
         {
+            Logger ??= documentDatabase.IndexesLogger.GetSubSwitchLogger(Name);
             configuration.InitializeAnalyzers(documentDatabase.Name);
 
             if (_disposeOnce.Disposed)
@@ -768,10 +772,9 @@ namespace Raven.Server.Documents.Indexes
                 PerformanceHintsConfig = performanceHints;
 
                 _mre = new ThrottledManualResetEventSlim(Configuration.ThrottlingTimeInterval?.AsTimeSpan, timerManagement: ThrottledManualResetEventSlim.TimerManagement.Manual);
-                _logger = LoggingSource.Instance.GetLogger<Index>(documentDatabase.Name);
                 _environment = environment;
                 var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(Name);
-                _unmanagedBuffersPool = new UnmanagedBuffersPoolWithLowMemoryHandling($"Indexes//{safeName}");
+                _unmanagedBuffersPool = new UnmanagedBuffersPoolWithLowMemoryHandling(Name, Logger);
 
                 InitializeComponentsUsingEnvironment(documentDatabase, _environment);
 
@@ -1038,16 +1041,16 @@ namespace Raven.Server.Documents.Indexes
                         // we need to retry
                         ScheduleIndexingRun();
 
-                        if (_logger.IsOperationsEnabled)
-                            _logger.Operations($"Failed to send {nameof(PutRollingIndexCommand)} after finished indexing '{Definition.Name}' in node {nodeTag}.", e);
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations($"Failed to send {nameof(PutRollingIndexCommand)} after finished indexing '{Definition.Name}' in node {nodeTag}.", e);
                     }
                 });
 
             }
             catch (Exception e)
             {
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Failed to send {nameof(PutRollingIndexCommand)} after finished indexing '{Definition.Name}' in node {nodeTag}.", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Failed to send {nameof(PutRollingIndexCommand)} after finished indexing '{Definition.Name}' in node {nodeTag}.", e);
             }
         }
 
@@ -1055,8 +1058,8 @@ namespace Raven.Server.Documents.Indexes
         {
             try
             {
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Unexpected error in '{Name}' index. This should never happen.", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Unexpected error in '{Name}' index. This should never happen.", e);
 
                 DocumentDatabase.NotificationCenter.Add(AlertRaised.Create(DocumentDatabase.Name, $"Unexpected error in '{Name}' index",
                     "Unexpected error in indexing thread. See details.", AlertType.Indexing_UnexpectedIndexingThreadError, NotificationSeverity.Error,
@@ -1481,8 +1484,8 @@ namespace Raven.Server.Documents.Indexes
 
                         try
                         {
-                            if (_logger.IsInfoEnabled)
-                                _logger.Info($"Starting indexing for '{Name}'.");
+                            if (Logger.IsInfoEnabled)
+                                Logger.Info($"Starting indexing for '{Name}'.");
 
                             LastIndexingTime = stats.StartTime;
 
@@ -1563,13 +1566,13 @@ namespace Raven.Server.Documents.Indexes
                                         MaybeFinishRollingDeployment();
                                     }
 
-                                    if (_logger.IsInfoEnabled)
-                                        _logger.Info($"Finished indexing for '{Name}'.'");
+                                    if (Logger.IsInfoEnabled)
+                                        Logger.Info($"Finished indexing for '{Name}'.'");
                                 }
                                 catch (TimeoutException te)
                                 {
-                                    if (_logger.IsOperationsEnabled)
-                                        _logger.Operations($"Failed to open write transaction, indexing will be retried", te);
+                                    if (Logger.IsOperationsEnabled)
+                                        Logger.Operations($"Failed to open write transaction, indexing will be retried", te);
                                 }
                                 catch (VoronUnrecoverableErrorException ide)
                                 {
@@ -1631,8 +1634,8 @@ namespace Raven.Server.Documents.Indexes
                                 }
                                 catch (Exception e)
                                 {
-                                    if (_logger.IsInfoEnabled)
-                                        _logger.Info($"Could not update stats for '{Name}'.", e);
+                                    if (Logger.IsInfoEnabled)
+                                        Logger.Info($"Could not update stats for '{Name}'.", e);
                                 }
 
                                 if (ReplaceIfNeeded(batchCompleted, didWork) == ReplaceStatus.Succeeded)
@@ -1693,8 +1696,8 @@ namespace Raven.Server.Documents.Indexes
 
                             if (_scratchSpaceLimitExceeded)
                             {
-                                if (_logger.IsInfoEnabled)
-                                    _logger.Info(
+                                if (Logger.IsInfoEnabled)
+                                    Logger.Info(
                                         $"Indexing exceeded global limit for scratch space usage. Going to flush environment of '{Name}' index and forcing sync of data file");
 
                                 GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(storageEnvironment);
@@ -1820,8 +1823,8 @@ namespace Raven.Server.Documents.Indexes
             {
                 _mre.Set(ignoreThrottling: true); // try again
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Could not replace index '{Name}'.", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Could not replace index '{Name}'.", e);
 
                 return ReplaceStatus.Failed;
             }
@@ -1915,7 +1918,7 @@ namespace Raven.Server.Documents.Indexes
             if (currentPriority == newPriority)
                 return;
 
-            ThreadHelper.TrySetThreadPriority(newPriority, IndexingThreadName, _logger);
+            ThreadHelper.TrySetThreadPriority(newPriority, IndexingThreadName, Logger);
         }
 
         private void PersistIndexDefinition()
@@ -1928,8 +1931,8 @@ namespace Raven.Server.Documents.Indexes
             }
             catch (Exception e)
             {
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Failed to persist definition of '{Name}' index", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Failed to persist definition of '{Name}' index", e);
             }
         }
 
@@ -1966,9 +1969,9 @@ namespace Raven.Server.Documents.Indexes
                 _currentMaximumAllowedMemory = DefaultMaximumMemoryAllocation;
 
                 _allocatedAfterPreviousCleanup = indexingStats.TotalAllocated;
-                if (_logger.IsInfoEnabled)
+                if (Logger.IsInfoEnabled)
                 {
-                    _logger.Info($"Reduced the memory usage of index '{Name}' (mode:{mode}). " +
+                    Logger.Info($"Reduced the memory usage of index '{Name}' (mode:{mode}). " +
                                  $"Before: {new Size(allocatedBeforeCleanup, SizeUnit.Bytes)}, " +
                                  $"after: {new Size(_allocatedAfterPreviousCleanup, SizeUnit.Bytes)}");
                 }
@@ -1989,8 +1992,8 @@ namespace Raven.Server.Documents.Indexes
 
         internal void HandleAnalyzerErrors(IndexingStatsScope stats, IndexAnalyzerException iae)
         {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Analyzer error occurred for '{Name}'.", iae);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Analyzer error occurred for '{Name}'.", iae);
 
             stats.AddAnalyzerError(iae);
 
@@ -2004,8 +2007,8 @@ namespace Raven.Server.Documents.Indexes
 
         internal void HandleUnexpectedErrors(IndexingStatsScope stats, Exception e)
         {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Unexpected exception occurred for '{Name}'.", e);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Unexpected exception occurred for '{Name}'.", e);
 
             stats.AddUnexpectedError(e);
 
@@ -2019,8 +2022,8 @@ namespace Raven.Server.Documents.Indexes
 
         internal void HandleCriticalErrors(IndexingStatsScope stats, CriticalIndexingException e)
         {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Critical exception occurred for '{Name}'.", e);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Critical exception occurred for '{Name}'.", e);
 
             if (State == IndexState.Error)
                 return;
@@ -2030,8 +2033,8 @@ namespace Raven.Server.Documents.Indexes
 
         internal void HandleWriteErrors(IndexingStatsScope stats, IndexWriteException iwe)
         {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Write exception occurred for '{Name}'.", iwe);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Write exception occurred for '{Name}'.", iwe);
 
             stats.AddWriteError(iwe);
 
@@ -2045,8 +2048,8 @@ namespace Raven.Server.Documents.Indexes
 
         internal void HandleExcessiveNumberOfReduceErrors(IndexingStatsScope stats, ExcessiveNumberOfReduceErrorsException e)
         {
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Erroring index due to excessive number of reduce errors '{Name}'.", e);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Erroring index due to excessive number of reduce errors '{Name}'.", e);
 
             stats.AddExcessiveNumberOfReduceErrors(e);
 
@@ -2065,8 +2068,8 @@ namespace Raven.Server.Documents.Indexes
             {
                 var timeToWaitInMilliseconds = (int)Math.Min(Math.Pow(2, diskFullErrors), 30) * 1000;
 
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"After disk full error in index : '{Name}', " +
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"After disk full error in index : '{Name}', " +
                                        $"going to try flushing and syncing the environment to cleanup the storage. " +
                                        $"Will wait for flush for: {timeToWaitInMilliseconds}ms", dfe);
 
@@ -2074,8 +2077,8 @@ namespace Raven.Server.Documents.Indexes
                 return;
             }
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Disk full error occurred for '{Name}'. Setting index to errored state", dfe);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Disk full error occurred for '{Name}'. Setting index to errored state", dfe);
 
             if (State == IndexState.Error)
                 return;
@@ -2140,16 +2143,16 @@ namespace Raven.Server.Documents.Indexes
                     // we'll try to clear the scratch buffers to free up some memory
                     var timeToWaitInMilliseconds = (int)Math.Min(Math.Pow(2, outOfMemoryErrors), 30) * 1000;
 
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"After out of memory error in index : '{Name}', " +
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"After out of memory error in index : '{Name}', " +
                                            $"going to try flushing and syncing the environment to cleanup the scratch buffers. " +
                                            $"Will wait for flush for: {timeToWaitInMilliseconds}ms", exception);
 
                     FlushAndSync(storageEnvironment, timeToWaitInMilliseconds, false);
                 }
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Out of memory occurred for '{Name}'", exception);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Out of memory occurred for '{Name}'", exception);
 
                 DocumentDatabase.NotificationCenter.OutOfMemory.Add(_environment, exception);
             }
@@ -2159,8 +2162,8 @@ namespace Raven.Server.Documents.Indexes
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Failed out of memory exception handling for index '{Name}'", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Failed out of memory exception handling for index '{Name}'", e);
             }
         }
 
@@ -2168,8 +2171,8 @@ namespace Raven.Server.Documents.Indexes
         {
             stats.AddCorruptionError(e);
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Data corruption occurred for '{Name}'.", e);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Data corruption occurred for '{Name}'.", e);
 
             if (DocumentDatabase.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.TryGetStats(_environment.DbId, out var corruptionStats) &&
                 corruptionStats.WillUnloadDatabase)
@@ -2197,8 +2200,8 @@ namespace Raven.Server.Documents.Indexes
             }
             catch (Exception exception)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Unable to set the index {Name} to error state", exception);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Unable to set the index {Name} to error state", exception);
                 State = IndexState.Error; // just in case it didn't took from the SetState call
             }
         }
@@ -2210,8 +2213,8 @@ namespace Raven.Server.Documents.Indexes
 
             var message = failureInformation.GetErrorMessage();
 
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations(message);
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations(message);
 
             SetErrorState(message);
         }
@@ -2494,8 +2497,8 @@ namespace Raven.Server.Documents.Indexes
                 if (Definition.Priority == priority)
                     return;
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Changing priority for '{Name}' from '{Definition.Priority}' to '{priority}'.");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Changing priority for '{Name}' from '{Definition.Priority}' to '{priority}'.");
 
                 var oldPriority = Definition.Priority;
 
@@ -2544,13 +2547,13 @@ namespace Raven.Server.Documents.Indexes
                 {
                     _errorStateReason = null;
 
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info(message);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info(message);
                 }
                 else
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations(message + $" Error state reason: {_errorStateReason}");
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations(message + $" Error state reason: {_errorStateReason}");
                 }
 
                 var oldState = State;
@@ -2566,8 +2569,8 @@ namespace Raven.Server.Documents.Indexes
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"Failed to write {state} state of '{Name}' index to the storage", e);
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Failed to write {state} state of '{Name}' index to the storage", e);
 
                     if (ignoreWriteError == false)
                         throw;
@@ -2621,8 +2624,8 @@ namespace Raven.Server.Documents.Indexes
                 if (Definition.LockMode == mode)
                     return;
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(
+                if (Logger.IsInfoEnabled)
+                    Logger.Info(
                         $"Changing lock mode for '{Name}' from '{Definition.LockMode}' to '{mode}'.");
 
                 var oldLockMode = Definition.LockMode;
@@ -3417,8 +3420,8 @@ namespace Raven.Server.Documents.Indexes
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"Failed to change state of '{Name}' index from {IndexState.Idle} to {IndexState.Normal}. Proceeding with running the query.",
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Failed to change state of '{Name}' index from {IndexState.Idle} to {IndexState.Normal}. Proceeding with running the query.",
                             e);
                 }
             }
@@ -4442,7 +4445,7 @@ namespace Raven.Server.Documents.Indexes
                     allocated,
                     _environment.Options.RunningOn32Bits,
                     DocumentDatabase.ServerStore.Server.MetricCacher,
-                    _logger,
+                    Logger,
                     out var memoryUsage) == false)
                 {
                     Interlocked.Increment(ref _allocationCleanupNeeded);
@@ -4468,7 +4471,7 @@ namespace Raven.Server.Documents.Indexes
 
                     if (canContinue == false)
                     {
-                        if (_logger.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
                             var message = $"Stopping the batch because cannot budget additional memory. " +
                                           $"Current budget: {allocated}.";
@@ -4480,7 +4483,7 @@ namespace Raven.Server.Documents.Indexes
                                            $"{nameof(memoryUsage.PrivateMemory)} = {memoryUsage.PrivateMemory}";
                             }
 
-                            _logger.Info(message);
+                            Logger.Info(message);
                         }
 
                         HandleStoppedBatchesConcurrently(parameters.Stats, parameters.Count,
@@ -4579,8 +4582,8 @@ namespace Raven.Server.Documents.Indexes
             var message = $"Halting processing of batch after {count:#,#;;0} and waiting because of {reason}, " +
                           $"other indexes are currently completing and index {Name} will wait for them to complete";
             stats.RecordBatchCompletedReason(type, message);
-            if (_logger.IsInfoEnabled)
-                _logger.Info(message);
+            if (Logger.IsInfoEnabled)
+                Logger.Info(message);
             var timeout = _indexStorage.DocumentDatabase.Configuration.Indexing.MaxTimeForDocumentTransactionToRemainOpen.AsTimeSpan;
 
             while (true)
@@ -4595,8 +4598,8 @@ namespace Raven.Server.Documents.Indexes
                 if (canContinue())
                     break;
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"{Name} is still waiting for other indexes to complete their batches because there is a {reason} condition in action...");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"{Name} is still waiting for other indexes to complete their batches because there is a {reason} condition in action...");
             }
         }
         
@@ -4652,7 +4655,7 @@ namespace Raven.Server.Documents.Indexes
 
                         var environmentOptions = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)storageEnvironmentOptions;
                         var srcOptions = StorageEnvironmentOptions.ForPath(environmentOptions.BasePath.FullPath, environmentOptions.TempPath?.FullPath, null, DocumentDatabase.IoChanges,
-                            DocumentDatabase.CatastrophicFailureNotification);
+                            DocumentDatabase.CatastrophicFailureNotification, Logger);
 
                         InitializeOptions(srcOptions, DocumentDatabase, Name, schemaUpgrader: false);
 
@@ -4661,7 +4664,7 @@ namespace Raven.Server.Documents.Indexes
 
                         using (var compactOptions = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)
                             StorageEnvironmentOptions.ForPath(compactPath.FullPath, tempPath?.FullPath, null, DocumentDatabase.IoChanges,
-                                DocumentDatabase.CatastrophicFailureNotification))
+                                DocumentDatabase.CatastrophicFailureNotification, Logger))
                         {
                             InitializeOptions(compactOptions, DocumentDatabase, Name, schemaUpgrader: false);
 
@@ -4691,8 +4694,8 @@ namespace Raven.Server.Documents.Indexes
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations("Unable to complete compaction, index is not usable and may require reset of the index to recover", e);
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Unable to complete compaction, index is not usable and may require reset of the index to recover", e);
 
                     throw;
                 }
@@ -4787,7 +4790,7 @@ namespace Raven.Server.Documents.Indexes
 
                 var options = CreateStorageEnvironmentOptions(DocumentDatabase, Configuration);
 
-                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, DocumentDatabase.Configuration.Storage, DocumentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, _logger);
+                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, DocumentDatabase.Configuration.Storage, DocumentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, Logger);
 
                 try
                 {

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents.Indexes
             _index = index;
             _contextPool = contextPool;
             DocumentDatabase = database;
-            _logger = LoggingSource.Instance.GetLogger<IndexStorage>(DocumentDatabase.Name);
+            _logger = _index.Logger;
 
             var referencedCollections = index.GetReferencedCollections();
             if (referencedCollections != null)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents.Indexes
         {
             _documentDatabase = documentDatabase;
             _serverStore = serverStore;
-            Logger = LoggingSource.Instance.GetLogger<IndexStore>(_documentDatabase.Name);
+            Logger = documentDatabase.IndexesLogger;
 
             var stoppedConcurrentIndexBatches = _documentDatabase.Configuration.Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory;
             StoppedConcurrentIndexBatches = new SemaphoreSlim(stoppedConcurrentIndexBatches);

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -11,8 +11,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 {
     public class MapReduceIndexingContext : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MapReduceResultsStore>("MapReduceIndexingContext");
-
         internal static Slice LastMapResultIdKey;
 
         public FixedSizeTree DocumentMapEntries;
@@ -53,18 +51,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (MapPhaseTree.Llt.Environment.Options.IsCatastrophicFailureSet)
                 return; // avoid re-throwing it
 
-            try
-            {
-                using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
-                    *(long*)ptr = NextMapResultId;
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info("Failed to store next map result id", e);
-
-                throw;
-            }
+            using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
+                *(long*)ptr = NextMapResultId;
         }
 
         public unsafe void Initialize(Tree mapEntriesTree)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _indexStorage = indexStorage;
             _metrics = metrics;
             _mapReduceContext = mapReduceContext;
-            _logger = LoggingSource.Instance.GetLogger<ReduceMapResultsBase<T>>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         static ReduceMapResultsBase()
@@ -153,7 +153,17 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
 
             WriteLastEtags(indexContext);
-            _mapReduceContext.StoreNextMapResultId();
+            try
+            {
+                _mapReduceContext.StoreNextMapResultId();
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info("Failed to store next map result id", e);
+                throw;
+            }
+            
 
             return (false, Index.CanContinueBatchResult.None);
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             QueryBuilderFactories queryBuilderFactories,
             Transaction readTransaction,
             DocumentDatabase documentDatabase)
-            : base(index, LoggingSource.Instance.GetLogger<IndexFacetedReadOperation>(documentDatabase.Name))
+            : base(index, index.Logger)
         {
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private FieldQuery _highlighterQuery;
 
         public IndexReadOperation(Index index, LuceneVoronDirectory directory, IndexSearcherHolder searcherHolder, QueryBuilderFactories queryBuilderFactories, Transaction readTransaction, IndexQueryServerSide query)
-            : base(index, LoggingSource.Instance.GetLogger<IndexReadOperation>(index._indexStorage.DocumentDatabase.Name))
+            : base(index, index.Logger)
         {
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexWriteOperation.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private byte[] _buffer;
 
         public IndexWriteOperation(Index index, LuceneVoronDirectory directory, LuceneDocumentConverterBase converter, Transaction writeTransaction, LuceneIndexPersistence persistence)
-            : base(index, LoggingSource.Instance.GetLogger<IndexWriteOperation>(index._indexStorage.DocumentDatabase.Name))
+            : base(index, index.Logger)
         {
             _converter = converter;
             DocumentDatabase = index._indexStorage.DocumentDatabase;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         public LuceneIndexPersistence(Index index)
         {
             _index = index;
-            _logger = LoggingSource.Instance.GetLogger<LuceneIndexPersistence>(index.DocumentDatabase.Name);
+            _logger = index.Logger;
             _suggestionsDirectories = new Dictionary<string, LuceneVoronDirectory>();
             _suggestionsIndexSearcherHolders = new Dictionary<string, IndexSearcherHolder>();
             _disposeOnce = new DisposeOnce<SingleAttempt>(() =>
@@ -148,7 +148,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
             _fields = fields.ToDictionary(x => x.Name, x => x);
 
-            _indexSearcherHolder = new IndexSearcherHolder(CreateIndexSearcher, _index._indexStorage.DocumentDatabase);
+            _indexSearcherHolder = new IndexSearcherHolder(CreateIndexSearcher, _index.Logger);
 
             foreach (var field in _fields)
             {
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     continue;
 
                 string fieldName = field.Key;
-                _suggestionsIndexSearcherHolders[fieldName] = new IndexSearcherHolder(state => new IndexSearcher(_suggestionsDirectories[fieldName], true, state), _index._indexStorage.DocumentDatabase);
+                _suggestionsIndexSearcherHolders[fieldName] = new IndexSearcherHolder(state => new IndexSearcher(_suggestionsDirectories[fieldName], true, state), _index.Logger);
             }
 
             IndexSearcher CreateIndexSearcher(IState state)
@@ -527,7 +527,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     var snapshotter = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
                     var writer = new LuceneSuggestionIndexWriter(field, _suggestionsDirectories[field],
                                         snapshotter, IndexWriter.MaxFieldLength.UNLIMITED,
-                        _index, state);
+                        _index, state, _logger);
 
                     _suggestionsIndexWriters[field] = writer;
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _indexReaderWarmer = indexReaderWarmer;
             _index = index;
 
-            _logger = LoggingSource.Instance.GetLogger<LuceneIndexWriter>(index.DocumentDatabase.Name);
+            _logger = index.Logger;
             RecreateIndexWriter(state);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly IState _state;
 
         public LuceneSuggestionIndexReader(Index index, LuceneVoronDirectory directory, IndexSearcherHolder searcherHolder, Transaction readTransaction)
-            : base(index, LoggingSource.Instance.GetLogger<LuceneSuggestionIndexReader>(index._indexStorage.DocumentDatabase.Name))
+            : base(index, index.Logger)
         {
             _releaseReadTransaction = directory.SetTransaction(readTransaction, out _state);
             _releaseSearcher = searcherHolder.GetSearcher(readTransaction, _state, out _searcher);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
@@ -37,14 +37,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         public Analyzer Analyzer => _indexWriter?.Analyzer;
 
-        public LuceneSuggestionIndexWriter(string field, LuceneVoronDirectory directory, SnapshotDeletionPolicy snapshotter, IndexWriter.MaxFieldLength maxFieldLength, Index index, IState state)
+        public LuceneSuggestionIndexWriter(string field, LuceneVoronDirectory directory, SnapshotDeletionPolicy snapshotter, IndexWriter.MaxFieldLength maxFieldLength, Index index, IState state, Logger logger)
         {
             _directory = directory;
             _indexDeletionPolicy = snapshotter;
             _maxFieldLength = maxFieldLength;
             _index = index;
             _field = field;
-            _logger = LoggingSource.Instance.GetLogger<LuceneSuggestionIndexWriter>(_index.DocumentDatabase.Name);
+            _logger = logger;
 
             RecreateIndexWriter(state);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Indexes.Static
     [SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalse")]
     public static class IndexCompiler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(IndexCompiler).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(IndexCompiler));
 
         internal static readonly bool EnableDebugging = false; // for debugging purposes (mind https://issues.hibernatingrhinos.com/issue/RavenDB-6960)
 

--- a/src/Raven.Server/Documents/Indexes/Static/NuGet/ProjectContext.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/NuGet/ProjectContext.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Indexes.Static.NuGet
 {
     public class ProjectContext : INuGetProjectContext
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServer>("NuGet");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenServer>();
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
 

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
@@ -29,8 +29,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             _mapReduceContext = mapReduceContext;
             _documentsStorage = documentsStorage;
             _indexStorage = indexStorage;
-            _logger = LoggingSource.Instance
-                .GetLogger<CleanupDocuments>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         public string Name => "Cleanup";

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -27,8 +27,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             _mapReduceContext = mapReduceContext;
             _configuration = configuration;
             _indexStorage = indexStorage;
-            _logger = LoggingSource.Instance
-                .GetLogger<MapDocuments>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         public string Name => "Map";

--- a/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
+++ b/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
@@ -10,20 +10,19 @@ namespace Raven.Server.Documents.Patch
     public class AdminJsConsole
     {
         private readonly DocumentDatabase _database;
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<AdminJsConsole>("Server");
+        public readonly Logger Log;
         private readonly RavenServer _server;
 
         public AdminJsConsole(RavenServer server, DocumentDatabase database)
         {
             _server = server;
             _database = database;
+            Log = database != null ? database.Logger : server.Logger;
             if (Log.IsOperationsEnabled)
             {
-                if (database != null)
-                    Log.Operations($"AdminJSConsole : Preparing to execute database script for \"{database.Name}\"");
-                else
-                    Log.Operations("AdminJSConsole : Preparing to execute server script");
-
+                Log.Operations(database != null
+                    ? $"AdminJSConsole : Preparing to execute database script for \"{database.Name}\""
+                    : "AdminJSConsole : Preparing to execute server script");
             }
         }
 

--- a/src/Raven.Server/Documents/Patch/PatchConflict.cs
+++ b/src/Raven.Server/Documents/Patch/PatchConflict.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Patch
 
         public PatchConflict(DocumentDatabase database, IReadOnlyList<DocumentConflict> docs)
         {
-            _logger = LoggingSource.Instance.GetLogger<PatchConflict>(database.Name);
+            _logger = database.Logger;
             _database = database;
 
             foreach (var doc in docs)

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         private readonly string _taskName;
         internal PeriodicBackupRunner.TestingStuff _forTestingPurposes;
         private readonly DateTime _startTimeUtc;
-        public BackupTask(DocumentDatabase database, BackupParameters backupParameters, BackupConfiguration configuration, Logger logger, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
+        public BackupTask(DocumentDatabase database, BackupParameters backupParameters, BackupConfiguration configuration, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
         {
             _database = database;
             _taskName = backupParameters.Name;
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             _backupToLocalFolder = backupParameters.BackupToLocalFolder;
             _tempBackupPath = backupParameters.TempBackupPath;
             _configuration = configuration;
-            _logger = logger;
+            _logger = database.Logger;
             _isServerWide = backupParameters.Name?.StartsWith(ServerWideBackupConfiguration.NamePrefix, StringComparison.OrdinalIgnoreCase) ?? false;
             _isBackupEncrypted = IsBackupEncrypted(_database, _configuration);
             _forTestingPurposes = forTestingPurposes;
@@ -647,7 +647,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_backupToLocalFolder)
             {
                 var sp = Stopwatch.StartNew();
-                var localRetentionPolicy = new LocalRetentionPolicyRunner(_retentionPolicyParameters, _configuration.LocalSettings.FolderPath);
+                var localRetentionPolicy = new LocalRetentionPolicyRunner(_retentionPolicyParameters, _configuration.LocalSettings.FolderPath, _logger);
                 localRetentionPolicy.Execute();
                 sp.Stop();
                 status.LocalRetentionDurationInMs = sp.ElapsedMilliseconds;
@@ -751,7 +751,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             using (var outputStream = GetOutputStream(fileStream))
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value, startRaftIndex.Value, _logger);
+                var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value, startRaftIndex.Value);
                 var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource);
                 var smuggler = new DatabaseSmuggler(_database,
                     smugglerSource,

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -138,7 +138,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new GlacierRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new GlacierRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -155,7 +155,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new FtpRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new FtpRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -197,7 +197,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new GoogleCloudRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new GoogleCloudRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             _database = database;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<PeriodicBackupRunner>(_database.Name);
+            _logger = database.Logger;
             _cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
             _tempBackupPath = BackupUtils.GetBackupTempPath(_database.Configuration, "PeriodicBackupTemp");
 
@@ -414,7 +414,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         Name = periodicBackup.Configuration.Name
                     };
 
-                    var backupTask = new BackupTask(_database, backupParameters, periodicBackup.Configuration, _logger, _forTestingPurposes);
+                    var backupTask = new BackupTask(_database, backupParameters, periodicBackup.Configuration, _forTestingPurposes);
                     periodicBackup.CancelToken = backupTask.TaskCancelToken;
 
                     periodicBackup.RunningTask = new PeriodicBackup.RunningBackupTask

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
     public abstract class RestoreBackupTaskBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RestoreBackupTaskBase>("Server");
+        private readonly Logger _logger;
 
         private readonly ServerStore _serverStore;
         private readonly string _nodeTag;
@@ -59,6 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             OperationCancelToken operationCancelToken)
         {
             _serverStore = serverStore;
+            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(restoreFromConfiguration.DatabaseName);
             RestoreFromConfiguration = restoreFromConfiguration;
             _nodeTag = nodeTag;
             _operationCancelToken = operationCancelToken;
@@ -272,8 +273,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     var addToInitLog = new Action<string>(txt => // init log is not save in mem during RestoreBackup
                     {
                         var msg = $"[RestoreBackup] {DateTime.UtcNow} :: Database '{databaseName}' : {txt}";
-                        if (Logger.IsInfoEnabled)
-                            Logger.Info(msg);
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info(msg);
                     });
 
                     var configuration = _serverStore
@@ -370,8 +371,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             }
             catch (Exception e)
             {
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations("Failed to restore database", e);
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations("Failed to restore database", e);
 
                 var alert = AlertRaised.Create(
                     RestoreFromConfiguration.DatabaseName,
@@ -544,7 +545,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                 // validate free space
                 var snapshotSize = zip.Entries.Sum(entry => entry.Length);
-                BackupHelper.AssertFreeSpaceForSnapshot(restorePath.FullPath, snapshotSize, "restore a backup", Logger);
+                BackupHelper.AssertFreeSpaceForSnapshot(restorePath.FullPath, snapshotSize, "restore a backup", _logger);
 
                 foreach (var zipEntries in zip.Entries.GroupBy(x => x.FullName.Substring(0, x.FullName.Length - x.Name.Length)))
                 {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             OperationCancelToken operationCancelToken)
         {
             _serverStore = serverStore;
-            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(restoreFromConfiguration.DatabaseName);
+                
             RestoreFromConfiguration = restoreFromConfiguration;
             _nodeTag = nodeTag;
             _operationCancelToken = operationCancelToken;
@@ -71,6 +71,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             if (ResourceNameValidator.IsValidResourceName(RestoreFromConfiguration.DatabaseName, dataDirectoryThatWillBeUsed, out string errorMessage) == false)
                 throw new InvalidOperationException(errorMessage);
 
+            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(restoreFromConfiguration.DatabaseName);
+            
             _serverStore.EnsureNotPassiveAsync().Wait(_operationCancelToken.Token);
 
             ClusterTopology clusterTopology;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -364,8 +364,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         // we failed to load the database after restore, we don't want to fail the entire restore process since it will delete the database if we throw here
                         result.AddError($"Failed to load the database after restore, {e}");
 
-                        if (Logger.IsOperationsEnabled)
-                            Logger.Operations($"Failed to load the database '{databaseName}' after restore", e);
+                        if (_logger.IsOperationsEnabled)
+                            _logger.Operations($"Failed to load the database '{databaseName}' after restore", e);
                     }
 
                     return result;

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.Documents.PeriodicBackup.Restore;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -16,8 +17,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         private string _continuationToken = null;
 
-        public AzureRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, IRavenAzureClient client)
-            : base(parameters)
+        public AzureRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, IRavenAzureClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -7,10 +8,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
     {
         private readonly RavenFtpClient _client;
 
-        protected override string Name => "Glacier";
+        protected override string Name => "Ftp";
 
-        public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client)
-            : base(parameters)
+        public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/GlacierRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/GlacierRetentionPolicyRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -10,8 +11,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Glacier";
 
-        public GlacierRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsGlacierClient client)
-            : base(parameters)
+        public GlacierRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsGlacierClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/GoogleCloudRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/GoogleCloudRetentionPolicyRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -10,8 +11,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Google Cloud";
 
-        public GoogleCloudRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenGoogleCloudClient client)
-            : base(parameters)
+        public GoogleCloudRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenGoogleCloudClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/LocalRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/LocalRetentionPolicyRunner.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Voron.Util.Settings;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
@@ -14,8 +15,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Local";
 
-        public LocalRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, string folderPath)
-            : base(parameters)
+        public LocalRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, string folderPath, Logger logger)
+            : base(parameters, logger)
         {
             _folderPath = PathUtil.ToFullPath(folderPath);
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
     public abstract class RetentionPolicyRunnerBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RetentionPolicyRunnerBase>("BackupTask");
+        private readonly Logger _logger;
 
         private readonly RetentionPolicy _retentionPolicy;
         private readonly string _databaseName;
@@ -21,13 +21,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
         private readonly Action<string> _onProgress;
         protected CancellationToken CancellationToken;
 
-        protected RetentionPolicyRunnerBase(RetentionPolicyBaseParameters parameters)
+        protected RetentionPolicyRunnerBase(RetentionPolicyBaseParameters parameters, Logger logger)
         {
             _retentionPolicy = parameters.RetentionPolicy;
             _databaseName = parameters.DatabaseName;
             _isFullBackup = parameters.IsFullBackup;
             _onProgress = parameters.OnProgress;
             CancellationToken = parameters.CancellationToken;
+            _logger = logger;
         }
 
         protected abstract GetFoldersResult GetSortedFolders();
@@ -91,21 +92,21 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
                 var message = $"Found {foldersToDelete.Count:#,#} backups to delete, took: {sp.ElapsedMilliseconds:#,#}ms";
                 _onProgress.Invoke(message);
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(message);
+                if (_logger.IsInfoEnabled)
+                    _logger.Info(message);
 
                 sp.Restart();
                 DeleteFolders(foldersToDelete);
 
                 message = $"Deleted {foldersToDelete.Count:#,#} backups, took: {sp.ElapsedMilliseconds:#,#}ms";
                 _onProgress.Invoke(message);
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(message);
+                if (_logger.IsInfoEnabled)
+                    _logger.Info(message);
             }
             catch (NotSupportedException)
             {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Retention Policy for {Name} isn't currently supported");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Retention Policy for {Name} isn't currently supported");
             }
             catch (OperationCanceledException)
             {
@@ -117,8 +118,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
                 var message = $"Failed to run Retention Policy for {Name}";
                 _onProgress.Invoke($"{message}. Error: {e.Message}");
 
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Failed to run Retention Policy for {Name}", e);
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Failed to run Retention Policy for {Name}", e);
             }
         }
 
@@ -134,8 +135,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
                 var folderDetails = RestorePointsBase.ParseFolderName(folderName);
                 if (folderDetails.BackupTimeAsString == null)
                 {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Failed to get backup date time for folder: {folder}");
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Failed to get backup date time for folder: {folder}");
                     continue;
                 }
 
@@ -146,8 +147,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
                         DateTimeStyles.None,
                         out var backupTime) == false)
                 {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Failed to parse backup date time for folder: {folder}");
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Failed to parse backup date time for folder: {folder}");
                     continue;
                 }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/S3RetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/S3RetentionPolicyRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
@@ -17,8 +18,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         private string _folderContinuationToken = null;
 
-        public S3RetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsS3Client client)
-            : base(parameters)
+        public S3RetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsS3Client client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/Queries/GraphQueryOrderByFieldComparer.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryOrderByFieldComparer.cs
@@ -12,14 +12,14 @@ namespace Raven.Server.Documents.Queries
         private string _alias;
         private BlittablePath _path;
         private int _order;
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<GraphQueryOrderByFieldComparer>("GraphQueryOrderByFieldComparer");
+        private readonly Logger _logger;
         private readonly string _databaseName;
         private readonly string _query;
         private string _xId = Unknown;
         private string _yId = Unknown;
         private const string Unknown = "Unknown";
 
-        public GraphQueryOrderByFieldComparer(OrderByField field, string databaseName, string query)
+        public GraphQueryOrderByFieldComparer(OrderByField field, string databaseName, string query, Logger logger)
         {
             _databaseName = databaseName;
             _query = query;
@@ -30,6 +30,7 @@ namespace Raven.Server.Documents.Queries
             _alias = fieldName.Substring(0, indexOfDot);
             _path = new BlittablePath(fieldName.Substring(indexOfDot + 1, fieldName.Length - indexOfDot - 1));
             _field = field;
+            _logger = logger;
         }
 
 
@@ -266,9 +267,9 @@ namespace Raven.Server.Documents.Queries
 
         private int LogMissmatchTypesReturnOrder(object xResult, object yResult)
         {
-            if (Log.IsInfoEnabled)
+            if (_logger.IsInfoEnabled)
             {
-                Log.Info($"Database: {_databaseName} Graph Query: {_query} Document Ids:({_xId},{_yId}), Got unexpected types to compare: {xResult} of type {xResult.GetType().Name} and {yResult} of type {yResult.GetType().Name}, this may yield unexpected query ordering.");
+                _logger.Info($"Database: {_databaseName} Graph Query: {_query} Document Ids:({_xId},{_yId}), Got unexpected types to compare: {xResult} of type {xResult.GetType().Name} and {yResult} of type {yResult.GetType().Name}, this may yield unexpected query ordering.");
             }
 
             return _order;
@@ -279,12 +280,12 @@ namespace Raven.Server.Documents.Queries
     {
         private List<GraphQueryOrderByFieldComparer> _comparers;
 
-        public GraphQueryMultipleFieldsComparer(IEnumerable<OrderByField> fields, string databaseName, string query)
+        public GraphQueryMultipleFieldsComparer(IEnumerable<OrderByField> fields, string databaseName, string query, Logger logger)
         {
             _comparers = new List<GraphQueryOrderByFieldComparer>();
             foreach (var field in fields)
             {
-                _comparers.Add(new GraphQueryOrderByFieldComparer(field, databaseName, query));
+                _comparers.Add(new GraphQueryOrderByFieldComparer(field, databaseName, query, logger));
             }
         }
 

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -22,15 +22,18 @@ using Raven.Server.Utils.Features;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Queries
 {
     public partial class GraphQueryRunner : AbstractQueryRunner
     {
         private readonly HashSet<StringSegment> _mapReduceAliases = new HashSet<StringSegment>();
+        private readonly Logger _logger;
 
         public GraphQueryRunner(DocumentDatabase database) : base(database)
         {
+            _logger = database.Logger;
         }
 
         public class EdgeDebugInfo
@@ -216,12 +219,12 @@ namespace Raven.Server.Documents.Queries
         {
             if (orderBy.Length == 1)
             {
-                var orderByFieldSorter = new GraphQueryOrderByFieldComparer(orderBy.First(), databaseName, query);
+                var orderByFieldSorter = new GraphQueryOrderByFieldComparer(orderBy.First(), databaseName, query, _logger);
                 matches.Sort(orderByFieldSorter);
                 return;
             }
 
-            var orderByMltipleFieldsSorter = new GraphQueryMultipleFieldsComparer(orderBy, databaseName, query);
+            var orderByMltipleFieldsSorter = new GraphQueryMultipleFieldsComparer(orderBy, databaseName, query, _logger);
             matches.Sort(orderByMltipleFieldsSorter);
         }
 

--- a/src/Raven.Server/Documents/Queries/LiveRunningQueriesCollector.cs
+++ b/src/Raven.Server/Documents/Queries/LiveRunningQueriesCollector.cs
@@ -14,7 +14,8 @@ namespace Raven.Server.Documents.Queries
         private readonly HashSet<string> _dbNames;
 
         public LiveRunningQueriesCollector(ServerStore serverStore, HashSet<string> dbNames)
-            : base(serverStore.ServerShutdown, "Server")
+            : base(serverStore.ServerShutdown, 
+                serverStore.Server.Logger)
         {
             _dbNames = dbNames;
             _serverStore = serverStore;

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Replication
         {
             _conflictResolver = conflictResolver;
             _database = database;
-            _log = LoggingSource.Instance.GetLogger<ConflictManager>(_database.Name);
+            _log = database.Logger;
         }
 
         public unsafe void HandleConflictForDocument(

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.Replication
 
             CertificateThumbprint = options.Certificate?.Thumbprint;
 
-            _log = LoggingSource.Instance.GetLogger<IncomingReplicationHandler>(_database.Name);
+            _log = _database.Logger;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
 
             _conflictManager = new ConflictManager(_database, _parent.ConflictResolver);
@@ -1637,7 +1637,7 @@ namespace Raven.Server.Documents.Replication
                 ReplicatedItems = replicationItems,
                 ReplicatedAttachmentStreams = replicatedAttachmentStreams,
                 SupportedFeatures = SupportedFeatures,
-                Logger = LoggingSource.Instance.GetLogger<IncomingReplicationHandler>(database.Name)
+                Logger = database.Logger
             };
 
             return new IncomingReplicationHandler.MergedDocumentReplicationCommand(dataForReplicationCommand, LastEtag, Mode);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -109,7 +109,7 @@ namespace Raven.Server.Documents.Replication
 
             Destination = node;
             ReplicationType = external ? ReplicationLatestEtagRequest.ReplicationType.External : ReplicationLatestEtagRequest.ReplicationType.Internal;
-            _log = LoggingSource.Instance.GetLogger<OutgoingReplicationHandler>(_database.Name);
+            _log = _database.Logger;
             _tcpConnectionOptions = tcpConnectionOptions ??
                                     new TcpConnectionOptions { DocumentDatabase = database, Operation = TcpConnectionHeaderMessage.OperationTypes.Replication };
             _connectionInfo = connectionInfo;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -258,7 +258,7 @@ namespace Raven.Server.Documents.Replication
 
             var config = Database.Configuration.Replication;
             var reconnectTime = config.RetryReplicateAfter.AsTimeSpan;
-            _log = LoggingSource.Instance.GetLogger<ReplicationLoader>(Database.Name);
+            _log = database.Logger;
             _reconnectAttemptTimer = new Timer(state => ForceTryReconnectAll(),
                 null, reconnectTime, reconnectTime);
             MinimalHeartbeatInterval = (int)config.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
@@ -841,7 +841,7 @@ namespace Raven.Server.Documents.Replication
                 return;
 
             ConflictSolverConfig = record.ConflictSolverConfig;
-            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _log);
+            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this);
             Task.Run(() => ConflictResolver.RunConflictResolversOnce(record.ConflictSolverConfig, index));
             _isInitialized.Raise();
         }

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -29,12 +29,12 @@ namespace Raven.Server.Documents.Replication
 
         internal Dictionary<string, ScriptResolver> ScriptConflictResolversCache = new Dictionary<string, ScriptResolver>();
 
-        public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader, Logger log)
+        public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader)
         {
             _replicationLoader = replicationLoader ??
                 throw new ArgumentNullException($"{nameof(ResolveConflictOnReplicationConfigurationChange)} must have replicationLoader instance");
             _database = _replicationLoader.Database;
-            _log = log;
+            _log = _database.Logger;
         }
 
         public long ConflictsCount => _database.DocumentsStorage?.ConflictsStorage?.ConflictsCount ?? 0;
@@ -527,8 +527,7 @@ namespace Raven.Server.Documents.Replication
         public ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
             var resolver = new ResolveConflictOnReplicationConfigurationChange(
-                database.ReplicationLoader,
-                LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name));
+                database.ReplicationLoader);
 
             return new ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand(
                 database.DocumentsStorage.ConflictsStorage,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Revisions
         {
             _database = database;
             _documentsStorage = _database.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<RevisionsStorage>(database.Name);
+            _logger = database.Logger;
             Operations = new RevisionsOperations(_database);
             ConflictConfiguration = new RevisionsConfiguration
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -45,8 +45,7 @@ namespace Raven.Server.Documents.Subscriptions
         {
             _db = db;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<SubscriptionStorage>(db.Name);
-
+            _logger = db.Logger;
             _concurrentConnectionsSemiSemaphore = new SemaphoreSlim(db.Configuration.Subscriptions.MaxNumberOfConcurrentConnections);
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionDocumentsFetcher.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionDocumentsFetcher.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents.TcpHandlers
             SubscriptionPatchDocument patch)
         {
             _db = db;
-            _logger = LoggingSource.Instance.GetLogger<SubscriptionDocumentsFetcher>(db.Name);
+            _logger = db.Logger;
             _maxBatchSize = maxBatchSize;
             _subscriptionId = subscriptionId;
             _remoteEndpoint = remoteEndpoint;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
@@ -25,7 +25,8 @@ namespace Raven.Server.Documents.TimeSeries
 
         private readonly TimeSpan _checkFrequency;
 
-        public TimeSeriesPolicyRunner(DocumentDatabase database, TimeSeriesConfiguration configuration) : base(database.Name, database.DatabaseShutdown)
+        public TimeSeriesPolicyRunner(DocumentDatabase database, TimeSeriesConfiguration configuration)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             _database = database;
             Configuration = configuration;
@@ -79,7 +80,7 @@ namespace Raven.Server.Documents.TimeSeries
                         AlertType.RevisionsConfigurationNotValid, NotificationSeverity.Error, database.Name));
                 }
 
-                var logger = LoggingSource.Instance.GetLogger<TimeSeriesPolicyRunner>(database.Name);
+                var logger = database.Logger;
                 if (logger.IsOperationsEnabled)
                     logger.Operations(msg, e);
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -124,8 +124,8 @@ namespace Raven.Server.Documents.TimeSeries
             tx.CreateTree(DeletedRangesKey);
 
             Stats = new TimeSeriesStats(this, tx);
+            _logger = documentDatabase.Logger;
             Rollups = new TimeSeriesRollups(_documentDatabase);
-            _logger = LoggingSource.Instance.GetLogger<TimeSeriesStorage>(documentDatabase.Name);
         }
 
         public static DateTime ExtractDateTimeFromKey(Slice key)

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents
 
         private readonly HashSet<ITombstoneAware> _subscriptions = new HashSet<ITombstoneAware>();
 
-        public TombstoneCleaner(DocumentDatabase documentDatabase) : base(documentDatabase.Name, documentDatabase.DatabaseShutdown)
+        public TombstoneCleaner(DocumentDatabase documentDatabase) : base(documentDatabase.Logger, documentDatabase.DatabaseShutdown)
         {
             _documentDatabase = documentDatabase;
             _numberOfTombstonesToDeleteInBatch = _documentDatabase.Is32Bits
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents
 
         public TombstoneCleaner.DeleteTombstonesCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var log = LoggingSource.Instance.GetLogger<TombstoneCleaner.DeleteTombstonesCommand>(database.Name);
+            var log = database.Logger;
             var command = new TombstoneCleaner.DeleteTombstonesCommand(Tombstones, MinAllDocsEtag, MinAllTimeSeriesEtag, MinAllCountersEtag, NumberOfTombstonesToDeleteInBatch ?? long.MaxValue, database, log);
             return command;
         }

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents
         public TransactionOperationsMerger(DocumentDatabase parent, CancellationToken shutdown)
         {
             _parent = parent;
-            _log = LoggingSource.Instance.GetLogger<TransactionOperationsMerger>(_parent.Name);
+            _log = parent.Logger;
             _shutdown = shutdown;
 
             _maxTimeToWaitForPreviousTxInMs = _parent.Configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTx.AsTimeSpan.TotalMilliseconds;

--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -193,7 +193,7 @@ namespace Raven.Server.Indexing
             if (state == null)
                 throw new ArgumentNullException(nameof(s));
 
-            return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
+            return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary, _environment.Logger);
         }
 
         public IDisposable SetTransaction(Transaction tx, out IState state)

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Indexing
 {
     public class VoronIndexOutput : BufferedIndexOutput
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LuceneVoronDirectory>("VoronIndexOutput");
+        private readonly Logger _logger;
 
         private readonly TempFileCache _fileCache;
         private readonly string _name;
@@ -24,13 +24,14 @@ namespace Raven.Server.Indexing
 
         private Stream StreamToUse => _ms ?? _file;
 
-        public VoronIndexOutput(
-            TempFileCache fileCache,
+        public VoronIndexOutput(TempFileCache fileCache,
             string name,
             Transaction tx,
             string tree,
-            IndexOutputFilesSummary indexOutputFilesSummary)
+            IndexOutputFilesSummary indexOutputFilesSummary, 
+            Logger logger)
         {
+            _logger = logger;
             _fileCache = fileCache;
             _name = name;
             _tree = tree;
@@ -151,8 +152,8 @@ namespace Raven.Server.Indexing
             }
             catch (Exception e)
             {
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations($"Failed to copy the file: {_name}", e);
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"Failed to copy the file: {_name}", e);
 
                 _indexOutputFilesSummary.SetWriteError();
 

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -209,6 +209,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, BackupConfiguration> BackupConfiguration = GenerateJsonDeserializationRoutine<BackupConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, AdminLogsHandler.SwitchLoggerConfiguration> SwitchLoggerConfiguration = GenerateJsonDeserializationRoutine<AdminLogsHandler.SwitchLoggerConfiguration>();
+
         public class Parameters
         {
             private Parameters()

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Monitoring.Snmp
 
         private readonly SemaphoreSlim _locker = new SemaphoreSlim(1, 1);
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<SnmpWatcher>("Server");
+        private readonly Logger _logger;
 
         private readonly RavenServer _server;
 
@@ -49,6 +49,7 @@ namespace Raven.Server.Monitoring.Snmp
 
         public SnmpWatcher(RavenServer server)
         {
+            _logger = server.Logger;
             _server = server;
             _server.ServerStore.LicenseManager.LicenseChanged += OnLicenseChanged;
         }
@@ -169,8 +170,8 @@ namespace Raven.Server.Monitoring.Snmp
                 }
                 catch (Exception e)
                 {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations($"Failed to update the SNMP mapping for database: {databaseName}", e);
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Failed to update the SNMP mapping for database: {databaseName}", e);
                 }
                 finally
                 {
@@ -193,7 +194,7 @@ namespace Raven.Server.Monitoring.Snmp
 
             var messageHandlerFactory = new MessageHandlerFactory(handlers);
 
-            var factory = new SnmpApplicationFactory(new SnmpLogger(Logger), objectStore, membershipProvider, messageHandlerFactory);
+            var factory = new SnmpApplicationFactory(new SnmpLogger(), objectStore, membershipProvider, messageHandlerFactory);
 
             var listener = new Listener();
 
@@ -245,8 +246,9 @@ namespace Raven.Server.Monitoring.Snmp
             engine.Listener.AddBinding(new IPEndPoint(IPAddress.Any, server.Configuration.Monitoring.Snmp.Port));
             engine.Listener.ExceptionRaised += (sender, e) =>
             {
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations("SNMP error: " + e.Exception.Message, e.Exception);
+                var logger = server.Logger;
+                if (logger.IsOperationsEnabled)
+                    logger.Operations("SNMP error: " + e.Exception.Message, e.Exception);
             };
 
             return engine;
@@ -569,8 +571,8 @@ namespace Raven.Server.Monitoring.Snmp
                 if (missingDatabases?.Count > 0)
                     msg += $" missing databases: {string.Join(", ", missingDatabases)}";
 
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations(msg, e);
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations(msg, e);
             }
             finally
             {
@@ -619,17 +621,12 @@ namespace Raven.Server.Monitoring.Snmp
 
         private class SnmpLogger : ILogger
         {
-            private readonly Logger _logger;
-
-            public SnmpLogger(Logger logger)
-            {
-                _logger = logger;
-            }
+            private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<SnmpLogger>();
 
             public void Log(ISnmpContext context)
             {
 #if DEBUG
-                if (_logger.IsInfoEnabled)
+                if (Logger.IsInfoEnabled)
                     return;
 
                 var builder = new StringBuilder();
@@ -651,7 +648,7 @@ namespace Raven.Server.Monitoring.Snmp
                     builder.AppendLine(string.Format("OID: {0}. Response: {1}", oid, responseData?.ToString()));
                 }
 
-                _logger.Info(builder.ToString());
+                Logger.Info(builder.ToString());
 #endif
             }
         }

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
         private Stats _latest;
 
         public DatabaseStatsSender(DocumentDatabase database, NotificationCenter notificationCenter)
-            : base(database.Name, database.DatabaseShutdown)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             _database = database;
             _notificationCenter = notificationCenter;

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/PostponedNotificationsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/PostponedNotificationsSender.cs
@@ -6,6 +6,7 @@ using Raven.Client.Util;
 using Raven.Server.Background;
 using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Collections;
+using Sparrow.Logging;
 using Sparrow.Server;
 
 namespace Raven.Server.NotificationCenter.BackgroundWork
@@ -16,9 +17,9 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
         private readonly ConcurrentSet<ConnectedWatcher> _watchers;
         private AsyncManualResetEvent _event;
 
-        public PostponedNotificationsSender(string resourceName, NotificationsStorage notificationsStorage,
-            ConcurrentSet<ConnectedWatcher> watchers, CancellationToken shutdown)
-            : base(resourceName, shutdown)
+        public PostponedNotificationsSender(NotificationsStorage notificationsStorage,
+            ConcurrentSet<ConnectedWatcher> watchers, Logger logger, CancellationToken shutdown)
+            : base(logger, shutdown)
         {
             _notificationsStorage = notificationsStorage;
             _watchers = watchers;

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardConnection.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.NotificationCenter.Handlers
     {
         private const int WelcomeMessageId = -1;
         
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ClusterDashboardConnection>(nameof(ClusterDashboardConnection));
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ClusterDashboardConnection>();
 
         private readonly CanAccessDatabase _canAccessDatabase;
         private readonly ClusterDashboardNotifications _clusterDashboardNotifications;

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
@@ -25,8 +25,6 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ClusterDashboardHandler : ServerNotificationHandlerBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ClusterDashboardHandler>("Server");
-
         [RavenAction("/cluster-dashboard/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task Watch()
         {

--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ProxyWebSocketConnection : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ProxyWebSocketConnection>(nameof(ProxyWebSocketConnection));
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ProxyWebSocketConnection>();
 
         private readonly CancellationTokenSource _cts;
         private readonly Uri _remoteWebSocketUri;

--- a/src/Raven.Server/NotificationCenter/Handlers/ServerDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ServerDashboardHandler.cs
@@ -11,8 +11,6 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ServerDashboardHandler : ServerNotificationHandlerBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ServerDashboardHandler>("Server");
-
         [RavenAction("/server-dashboard/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task Get()
         {

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void AddWarning(string indexName, WarnIndexOutputsPerDocument.WarningDetails indexOutputsWarning)

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.NotificationCenter
 
         private static readonly Slice ByPostponedUntil;
 
-        protected readonly Logger Logger;
+        private readonly Logger _logger;
 
         private StorageEnvironment _environment;
 
@@ -40,9 +40,9 @@ namespace Raven.Server.NotificationCenter
             }
         }
 
-        public NotificationsStorage(string resourceName)
+        public NotificationsStorage(Logger logger)
         {
-            Logger = LoggingSource.Instance.GetLogger<NotificationsStorage>(resourceName);
+            _logger = logger;
 
             _actionsSchema.DefineKey(new TableSchema.SchemaIndexDef
             {
@@ -101,8 +101,8 @@ namespace Raven.Server.NotificationCenter
                     }
                 }
 
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Saving notification '{notification.Id}'.");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Saving notification '{notification.Id}'.");
 
                 using (var json = context.ReadObject(notification.ToJson(), "notification", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 using (var tx = context.OpenWriteTransaction())
@@ -242,8 +242,8 @@ namespace Raven.Server.NotificationCenter
                 }
             }
 
-            if (deleteResult && Logger.IsInfoEnabled)
-                Logger.Info($"Deleted notification '{id}'.");
+            if (deleteResult && _logger.IsInfoEnabled)
+                _logger.Info($"Deleted notification '{id}'.");
 
             return deleteResult;
 

--- a/src/Raven.Server/NotificationCenter/Paging.cs
+++ b/src/Raven.Server/NotificationCenter/Paging.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void Add(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration, long totalDocumentsSizeInBytes)

--- a/src/Raven.Server/NotificationCenter/RequestLatency.cs
+++ b/src/Raven.Server/NotificationCenter/RequestLatency.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void AddHint(long duration, string action, string query)

--- a/src/Raven.Server/NotificationCenter/SlowWriteNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/SlowWriteNotifications.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.NotificationCenter
             _notificationsStorage = notificationsStorage;
             _database = database;
             _slowWrites = new ConcurrentDictionary<string, SlowWritesDetails.SlowWriteInfo>();
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void Add(string path, double dataSizeInMb, double durationInSec)

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -31,7 +31,7 @@ namespace Raven.Server
 {
     public class Program
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<Program>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<Program>();
 
         public static unsafe int Main(string[] args)
         {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -419,7 +419,7 @@ namespace Raven.Server.Rachis
             Timeout.TimeoutPeriod = _rand.Next(timeout / 3 * 2, timeout);
         }
 
-        public unsafe void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, out long clusterTopologyEtag)
+        public unsafe void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, out long clusterTopologyEtag, SwitchLogger clusterLogger)
         {
             try
             {
@@ -444,7 +444,7 @@ namespace Raven.Server.Rachis
 
                     RequestSnapshot = GetSnapshotRequest(context);
 
-                    Log = LoggingSource.Instance.GetLogger<RachisConsensus>(_tag);
+                    Log = clusterLogger.GetLogger(_tag);
                     LogsTable.Create(tx.InnerTransaction, EntriesSlice, 16);
 
                     CurrentTerm = ReadTerm(context);

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Rachis.Remote
             _context = JsonOperationContext.ShortTermSingleUse();
             _releaseBuffer = _context.GetMemoryBuffer(out _buffer);
             _disposeOnce = new DisposeOnce<SingleAttempt>(DisposeInternal);
-            _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{src} > {dest}");
+            _log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger($"{src} > {dest}");
             RegisterConnection(dest, term, caller);
         }
 
@@ -433,7 +433,7 @@ namespace Raven.Server.Rachis.Remote
                 var rachisHello = JsonDeserializationRachis<RachisHello>.Deserialize(json);
                 _src = rachisHello.DebugSourceIdentifier ?? "unknown";
                 _destTag = rachisHello.DebugDestinationIdentifier ?? _destTag;
-                _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{_src} > {_destTag}");
+                _log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger($"{_src} > {_destTag}");
                 _info.Destination = _destTag;
 
                 return rachisHello;

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -45,7 +45,7 @@ namespace Raven.Server
         private RequestRouter _router;
         private RavenServer _server;
         private int _requestId;
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenServerStartup>();
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
@@ -221,9 +221,9 @@ namespace Raven.Server
                 }
                 catch (Exception internalException)
                 {
-                    if (_logger.IsOperationsEnabled)
+                    if (Logger.IsOperationsEnabled)
                     {
-                        _logger.Operations($"Error during error handling of a failed request. Original error: {e}", internalException);
+                        Logger.Operations($"Error during error handling of a failed request. Original error: {e}", internalException);
                     }
 
                     throw;
@@ -245,9 +245,9 @@ namespace Raven.Server
                     requestHandlerContext.Database?.Metrics.Requests.UpdateDuration(requestDuration);
                 }
 
-                if (_logger.IsInfoEnabled && SkipHttpLogging == false)
+                if (Logger.IsInfoEnabled && SkipHttpLogging == false)
                 {
-                    _logger.Info($"{context.Request.Method} {context.Request.Path.Value}{context.Request.QueryString.Value} - {context.Response.StatusCode} - {(sp?.ElapsedMilliseconds ?? 0):#,#;;0} ms", exception);
+                    Logger.Info($"{context.Request.Method} {context.Request.Path.Value}{context.Request.QueryString.Value} - {context.Response.StatusCode} - {(sp?.ElapsedMilliseconds ?? 0):#,#;;0} ms", exception);
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
+++ b/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.ServerWide.BackgroundTasks
     {
         private const string ApiRavenDbNet = "https://api.ravendb.net";
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(LatestVersionCheck).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(typeof(LatestVersionCheck).FullName);
 
         public static LatestVersionCheck Instance = new LatestVersionCheck();
 

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.ServerWide
         public static int CurrentClusterMinimalVersion => _currentClusterMinimalVersion;
         private static int _currentClusterMinimalVersion;
 
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger(typeof(ClusterCommandsVersionManager).FullName, typeof(ClusterCommandsVersionManager).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(ClusterCommandsVersionManager));
 
         public static readonly IReadOnlyDictionary<string, int> ClusterCommandsVersions = new Dictionary<string, int>
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 _token = _cts.Token;
                 _readStatusUpdateDebugString = $"ClusterMaintenanceServer/{ClusterTag}/UpdateState/Read-Response in term {term}";
                 _name = $"Heartbeats supervisor from {_parent._server.NodeTag} to {ClusterTag} in term {term}";
-                _log = LoggingSource.Instance.GetLogger<ClusterNode>(_name);
+                _log = _parent._server.Server.ClusterLogger;
             }
 
             public void Start()
@@ -224,7 +224,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     {
                         if (_log.IsInfoEnabled)
                         {
-                            _log.Info($"Exception occurred while collecting info from {ClusterTag}. Task is closed.", e);
+                            _log.Info($"{_name}: Exception occurred while collecting info from {ClusterTag}. Task is closed.", e);
                         }
                         // we don't want to crash the process so we don't propagate this exception.
                     }
@@ -243,7 +243,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     if (_log.IsInfoEnabled)
                     {
                         _log.Info(
-                            $"Warning: TCP timeout is lower than the receive from worker timeout ({tcpTimeout} < {receiveFromWorkerTimeout}), " +
+                            $"{_name}: Warning: TCP timeout is lower than the receive from worker timeout ({tcpTimeout} < {receiveFromWorkerTimeout}), " +
                             "this could affect the cluster observer's decisions.");
                     }
                 }
@@ -306,7 +306,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                                     if (_log.IsInfoEnabled)
                                     {
-                                        _log.Info("Exception occurred while reading the report from the connection", e);
+                                        _log.Info($"{_name}: Exception occurred while reading the report from the connection", e);
                                     }
 
                                     ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),
@@ -339,7 +339,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                         if (_log.IsInfoEnabled)
                         {
-                            _log.Info($"Exception was thrown while collecting info from {ClusterTag}", e);
+                            _log.Info($"{_name}: Exception was thrown while collecting info from {ClusterTag}", e);
                         }
 
                         ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),
@@ -398,7 +398,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 // expected timeout
                 if (_log.IsInfoEnabled)
                 {
-                    _log.Info("Timeout occurred while collecting info report.");
+                    _log.Info($"{_name}: Timeout occurred while collecting info report.");
                 }
 
                 ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.ServerWide.Maintenance
             _cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
             _token = _cts.Token;
             _server = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<ClusterMaintenanceWorker>(serverStore.NodeTag);
+            _logger = serverStore.Server.ClusterLogger;
             _name = $"Heartbeats worker connection to leader {leader} in term {term}";
             _temporaryDirtyMemoryAllowedPercentage = _server.Server.ServerStore.Configuration.Memory.TemporaryDirtyMemoryAllowedPercentage;
 
@@ -74,7 +74,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 {
                     if (_logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Exception occurred while collecting info from {_server.NodeTag}. Task is closed.", e);
+                        _logger.Info($"{_server.NodeTag}: Exception occurred while collecting info from {_server.NodeTag}. Task is closed.", e);
                     }
                     // we don't want to crash the process so we don't propagate this exception.
                 }
@@ -117,13 +117,13 @@ namespace Raven.Server.ServerWide.Maintenance
                     {
                         if (_logger.IsInfoEnabled)
                         {
-                            _logger.Info("The tcp connection was closed, so we exit the maintenance work.");
+                            _logger.Info($"{_server.NodeTag}: The tcp connection was closed, so we exit the maintenance work.");
                         }
                         return;
                     }
                     if (_logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Exception occurred while collecting info from {_server.NodeTag}", e);
+                        _logger.Info($"{_server.NodeTag}: Exception occurred while collecting info from {_server.NodeTag}", e);
                     }
                 }
                 finally

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -67,7 +67,7 @@ namespace Raven.Server.ServerWide.Maintenance
             _engine = engine;
             _term = term;
             _contextPool = contextPool;
-            _logger = LoggingSource.Instance.GetLogger<ClusterObserver>(_nodeTag);
+            _logger = server.Server.ClusterLogger;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
 
             var config = server.Configuration.Cluster;
@@ -174,7 +174,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (_logger.IsInfoEnabled)
             {
-                _logger.Info(message, e);
+                _logger.Info($"{_nodeTag}: {message}", e);
             }
         }
 

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.ServerWide
 {
     public class RavenTransaction : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenTransaction>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenTransaction>();
 
         public Transaction InnerTransaction;
 

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.ServerWide
     {
         public static readonly byte[] EncryptionContext = Encoding.UTF8.GetBytes("Secrets!");
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<SecretProtection>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<SecretProtection>();
         private readonly Lazy<byte[]> _serverMasterKey;
         private readonly SecurityConfiguration _config;
         private const int MaxDeveloperCertificateValidityDurationInMonths = 4;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -93,9 +93,7 @@ namespace Raven.Server.ServerWide
     /// </summary>
     public class ServerStore : IDisposable
     {
-        private const string ResourceName = nameof(ServerStore);
-
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ServerStore>(ResourceName);
+        private readonly Logger Logger;
 
         public const string LicenseStorageKey = "License/Key";
 
@@ -143,6 +141,7 @@ namespace Raven.Server.ServerWide
 
         public ServerStore(RavenConfiguration configuration, RavenServer server)
         {
+            Logger = server.Logger;
             // we want our servers to be robust get early errors about such issues
             MemoryInformation.EnableEarlyOutOfMemoryChecks = true;
 
@@ -156,9 +155,9 @@ namespace Raven.Server.ServerWide
 
             DatabasesLandlord = new DatabasesLandlord(this);
 
-            _notificationsStorage = new NotificationsStorage(ResourceName);
+            _notificationsStorage = new NotificationsStorage(Logger);
 
-            NotificationCenter = new NotificationCenter.NotificationCenter(_notificationsStorage, null, ServerShutdown, configuration);
+            NotificationCenter = new NotificationCenter.NotificationCenter(_notificationsStorage, null, ServerShutdown, configuration, server.Logger);
 
             ServerDashboardNotifications = new ServerDashboardNotifications(this, ServerShutdown);
 
@@ -587,11 +586,11 @@ namespace Raven.Server.ServerWide
             StorageEnvironmentOptions options;
             if (Configuration.Core.RunInMemory)
             {
-                options = StorageEnvironmentOptions.CreateMemoryOnly(null, null, null, CatastrophicFailureNotification);
+                options = StorageEnvironmentOptions.CreateMemoryOnly(null, null, null, CatastrophicFailureNotification, Logger);
             }
             else
             {
-                options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, CatastrophicFailureNotification);
+                options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, CatastrophicFailureNotification, Logger);
                 var secretKey = Path.Combine(path.FullPath, "secret.key.encrypted");
                 if (File.Exists(secretKey))
                 {
@@ -795,7 +794,7 @@ namespace Raven.Server.ServerWide
             _engine.BeforeAppendToRaftLog = BeforeAppendToRaftLog;
 
             var myUrl = GetNodeHttpServerUrl();
-            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, out _lastClusterTopologyIndex);
+            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, out _lastClusterTopologyIndex, _server.ClusterLogger);
 
             SorterCompilationCache.Instance.AddServerWideItems(this);
             AnalyzerCompilationCache.Instance.AddServerWideItems(this);
@@ -3219,8 +3218,7 @@ namespace Raven.Server.ServerWide
 
             try
             {
-                await TestConnectionHandler.ConnectToClientNodeAsync(_server, connectionInfo.Result, Engine.TcpConnectionTimeout,
-                    LoggingSource.Instance.GetLogger("testing-connection", "testing-connection"), database, result, ServerShutdown);
+                await TestConnectionHandler.ConnectToClientNodeAsync(_server, connectionInfo.Result, Engine.TcpConnectionTimeout, database, result, ServerShutdown);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
 {
     internal static class TcpNegotiationSyncExtensions
     {
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger("TCP Negotiation", typeof(TcpNegotiation).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(TcpNegotiation));
 
         internal static TcpConnectionHeaderMessage.SupportedFeatures NegotiateProtocolVersion(this TcpNegotiation.SyncTcpNegotiation syncTcpNegotiation, JsonOperationContext context, Stream stream, TcpNegotiateParameters parameters)
         {

--- a/src/Raven.Server/ServerWide/UnmanagedBuffersPoolWithLowMemoryHandling.cs
+++ b/src/Raven.Server/ServerWide/UnmanagedBuffersPoolWithLowMemoryHandling.cs
@@ -1,11 +1,12 @@
 ﻿using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 
 namespace Raven.Server.ServerWide
 {
     public class UnmanagedBuffersPoolWithLowMemoryHandling : UnmanagedBuffersPool, ILowMemoryHandler
     {
-        public UnmanagedBuffersPoolWithLowMemoryHandling(string debugTag, string databaseName = null) : base(debugTag, databaseName)
+        public UnmanagedBuffersPoolWithLowMemoryHandling(string debugTag, Logger logger = null) : base(debugTag, logger)
         {
             LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
         }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Smuggler.Documents
         {
             _database = database;
             _token = token;
-            _log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+            _log = database.Logger;
             _duplicateDocsHandler = new DuplicateDocsHandler(_database);
         }
 
@@ -1669,7 +1669,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public MergedBatchPutCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                var log = database.Logger;
                 var command = new MergedBatchPutCommand(database, BuildType, log)
                 {
                     IsRevision = IsRevision
@@ -1821,7 +1821,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 public MergedBatchFixDocumentMetadataCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
                 {
-                    var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                    var log = database.Logger;
                     var command = new MergedBatchFixDocumentMetadataCommand(database, log);
 
                     foreach (var id in Ids)
@@ -1904,7 +1904,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public MergedBatchDeleteRevisionCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                var log = database.Logger;
                 var command = new MergedBatchDeleteRevisionCommand(database, log);
 
                 foreach (var id in Ids)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -22,7 +22,6 @@ using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Iteration;
 using Raven.Server.Utils.Enumerators;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Voron;
 
 namespace Raven.Server.Smuggler.Documents
@@ -35,7 +34,6 @@ namespace Raven.Server.Smuggler.Documents
 
         private readonly long _startDocumentEtag;
         private readonly long _startRaftIndex;
-        private readonly Logger _logger;
         private IDisposable _returnContext;
         private IDisposable _returnServerContext;
         private DocumentsTransaction _disposeTransaction;
@@ -67,12 +65,11 @@ namespace Raven.Server.Smuggler.Documents
 
         private readonly SmugglerSourceType _type;
 
-        public DatabaseSource(DocumentDatabase database, long startDocumentEtag, long startRaftIndex, Logger logger)
+        public DatabaseSource(DocumentDatabase database, long startDocumentEtag, long startRaftIndex)
         {
             _database = database;
             _startDocumentEtag = startDocumentEtag;
             _startRaftIndex = startRaftIndex;
-            _logger = logger;
             _type = _startDocumentEtag == 0 ? SmugglerSourceType.FullExport : SmugglerSourceType.IncrementalExport;
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -194,7 +194,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
         {
             using (token)
             {
-                var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex, Logger);
+                var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex);
                 await using (var outputStream = GetOutputStream(ResponseBodyStream(), options))
                 {
                     var destination = new StreamDestination(outputStream, context, source);

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Smuggler.Documents
             _peepingTomStream = new PeepingTomStream(stream, context);
             _context = context;
             _database = database;
-            _log = LoggingSource.Instance.GetLogger<StreamSource>(database.Name);
+            _log = database.Logger;
         }
 
         public async Task<SmugglerInitializeResult> InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result)

--- a/src/Raven.Server/Storage/StorageSpaceMonitor.cs
+++ b/src/Raven.Server/Storage/StorageSpaceMonitor.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Storage
     {
         private static readonly TimeSpan CheckFrequency = TimeSpan.FromMinutes(10);
 
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<StorageSpaceMonitor>(nameof(StorageSpaceMonitor));
+        private readonly Logger _logger;
         private readonly LinkedList<DocumentDatabase> _databases = new LinkedList<DocumentDatabase>();
 
         private readonly object _runLock = new object();
@@ -31,6 +31,7 @@ namespace Raven.Server.Storage
 
         public StorageSpaceMonitor(NotificationCenter.NotificationCenter notificationCenter)
         {
+            _logger = notificationCenter.Logger;
             _notificationCenter = notificationCenter;
 
             _timer = new Timer(Run, null, CheckFrequency, CheckFrequency);

--- a/src/Raven.Server/TrafficWatch/TrafficWatchConnection.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchConnection.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.TrafficWatch
 
     internal class TrafficWatchConnection
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<TrafficWatchConnection>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<TrafficWatchConnection>();
 
         private readonly WebSocket _webSocket;
         private readonly JsonOperationContext _context;

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -19,8 +19,6 @@ namespace Raven.Server.TrafficWatch
 {
     public class TrafficWatchHandler : RequestHandler
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger<TrafficWatchHandler>("Server");
-
         [RavenAction("/admin/traffic-watch", "GET", AuthorizationStatus.Operator)]
         public async Task TrafficWatchWebsockets()
         {
@@ -41,8 +39,8 @@ namespace Raven.Server.TrafficWatch
                     }
                     catch (Exception ex)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error encountered in TrafficWatch handler", ex);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error encountered in TrafficWatch handler", ex);
 
                         try
                         {
@@ -62,8 +60,8 @@ namespace Raven.Server.TrafficWatch
                         }
                         catch (Exception)
                         {
-                            if (_logger.IsInfoEnabled)
-                                _logger.Info("Failed to send the error in TrafficWatch handler to the client", ex);
+                            if (Logger.IsInfoEnabled)
+                                Logger.Info("Failed to send the error in TrafficWatch handler to the client", ex);
                         }
                     }
                 }

--- a/src/Raven.Server/Utils/AffinityHelper.cs
+++ b/src/Raven.Server/Utils/AffinityHelper.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Utils
     public class AffinityHelper
     {
         private static readonly ConcurrentSet<PoolOfThreads.PooledThread> _customAffinityThreads = new ConcurrentSet<PoolOfThreads.PooledThread>();
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger<AffinityHelper>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<AffinityHelper>();
 
         public static void SetProcessAffinity(Process process, int cores, long? processAffinityMask, out long currentlyAssignedCores)
         {
@@ -123,8 +123,8 @@ namespace Raven.Server.Utils
                 {
                     if (retries-- == 0)
                     {
-                        if (_logger.IsOperationsEnabled)
-                            _logger.Operations("Failed to set thread affinity", e);
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations("Failed to set thread affinity", e);
                         return false;
                     }
 

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Utils
     {
         private const int BitsPerByte = 8;
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(CertificateUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(typeof(CertificateUtils).FullName);
 
         internal static bool CertHasKnownIssuer(X509Certificate2 userCertificate, X509Certificate2 knownCertificate, SecurityConfiguration securityConfiguration, out string issuerPinningHash)
         {

--- a/src/Raven.Server/Utils/Cpu/CpuHelper.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuHelper.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Utils.Cpu
 {
     public static class CpuHelper
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(CpuHelper));
 
         internal static ICpuUsageCalculator GetOSCpuUsageCalculator()
         {

--- a/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
@@ -21,7 +21,8 @@ namespace Raven.Server.Utils.Cpu
     internal abstract class CpuUsageCalculator<T> : ICpuUsageCalculator where T : ProcessInfo
     {
         private readonly (double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait) _emptyCpuUsage = (0.0, 0.0, (double?)null);
-        protected readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
+        protected readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MachineResources>();
+
         private readonly object _locker = new object();
 
         protected (double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)? LastCpuUsage;

--- a/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
@@ -12,8 +12,9 @@ namespace Raven.Server.Utils.Cpu
 {
     public class CpuUsageExtensionPoint : IDisposable
     {
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MachineResources>();
+
         private readonly JsonContextPool _contextPool;
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
         private readonly NotificationCenter.NotificationCenter _notificationCenter;
         private readonly ProcessStartInfo _startInfo;
         private readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
@@ -239,9 +240,9 @@ namespace Raven.Server.Utils.Cpu
 
         private void NotifyWarning(string warningMsg, Exception e = null)
         {
-            if (_logger.IsOperationsEnabled)
+            if (Logger.IsOperationsEnabled)
             {
-                _logger.Operations(warningMsg, e);
+                Logger.Operations(warningMsg, e);
             }
 
             try

--- a/src/Raven.Server/Utils/Metrics/MetricsScheduler.cs
+++ b/src/Raven.Server/Utils/Metrics/MetricsScheduler.cs
@@ -22,13 +22,12 @@ namespace Raven.Server.Utils.Metrics
 
         private readonly ConcurrentSet<WeakReference<Ewma>> _scheduledEwmaActions = new ConcurrentSet<WeakReference<Ewma>>();
 
-        private readonly Logger _logger;
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MetricsScheduler>();
 
         public static readonly MetricsScheduler Instance = new MetricsScheduler();
 
         private MetricsScheduler()
         {
-            _logger = LoggingSource.Instance.GetLogger<MetricsScheduler>("Server");
             _tickIntervalInNanoseconds = Clock.NanosecondsInSecond;
             _schedulerThread = new Thread(SchedulerTicking)
             {
@@ -63,8 +62,8 @@ namespace Raven.Server.Utils.Metrics
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error occurred during MetricsScheduler ticking of a single Metric action", e);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error occurred during MetricsScheduler ticking of a single Metric action", e);
                     }
                 }
 
@@ -83,8 +82,8 @@ namespace Raven.Server.Utils.Metrics
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error occurred during MetricsScheduler ticking of a single EWMA action", e);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error occurred during MetricsScheduler ticking of a single EWMA action", e);
                     }
                 }
 

--- a/src/Raven.Server/Utils/Pipes.cs
+++ b/src/Raven.Server/Utils/Pipes.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Utils
     public class Pipes
     {
 #if !RVN
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<Pipes>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<Pipes>();
 #endif
 
         public const string AdminConsolePipePrefix = "raven-control-pipe-";

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Utils
         });
 
         public static PoolOfThreads GlobalRavenThreadPool => _globalRavenThreadPool.Value;
-        private static Logger _log = LoggingSource.Instance.GetLogger<PoolOfThreads>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<PoolOfThreads>();
 
         public int TotalNumberOfThreads;
 
@@ -217,9 +217,9 @@ namespace Raven.Server.Utils
                 }
                 catch (Exception e)
                 {
-                    if (_log.IsOperationsEnabled)
+                    if (Logger.IsOperationsEnabled)
                     {
-                        _log.Operations($"An uncaught exception occurred in '{_name}' and killed the process", e);
+                        Logger.Operations($"An uncaught exception occurred in '{_name}' and killed the process", e);
                     }
 
                     throw;
@@ -273,12 +273,12 @@ namespace Raven.Server.Utils
                 var currentPriority = ThreadHelper.GetThreadPriority();
                 if (currentPriority != ThreadPriority.Normal)
                 {
-                    if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, _log) == false)
+                    if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, Logger) == false)
                     {
                         // if we can't reset it, better just kill it
-                        if (_log.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
-                            _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {currentPriority}, we'll let it exit");
+                            Logger.Info($"Unable to set this thread priority to normal, since we don't want its priority of {currentPriority}, we'll let it exit");
                         }
 
                         return false;

--- a/src/Raven.Server/Utils/Stats/DatabaseAwareLivePerformanceCollector.cs
+++ b/src/Raven.Server/Utils/Stats/DatabaseAwareLivePerformanceCollector.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Utils.Stats
     {
         protected readonly DocumentDatabase Database;
 
-        protected DatabaseAwareLivePerformanceCollector(DocumentDatabase database): base(database.DatabaseShutdown, database.Name)
+        protected DatabaseAwareLivePerformanceCollector(DocumentDatabase database): base(database.DatabaseShutdown, database.Logger)
         {
             Database = database;
         }

--- a/src/Raven.Server/Utils/Stats/LivePerformanceCollector.cs
+++ b/src/Raven.Server/Utils/Stats/LivePerformanceCollector.cs
@@ -17,11 +17,11 @@ namespace Raven.Server.Utils.Stats
         private readonly CancellationTokenSource _cts;
         private Task _task;
 
-        protected readonly Logger Logger;
+        private readonly Logger _logger;
 
-        protected LivePerformanceCollector(CancellationToken parentCts, string loggingSource)
+        protected LivePerformanceCollector(CancellationToken parentCts, Logger logger)
         {
-            Logger = LoggingSource.Instance.GetLogger(loggingSource, GetType().FullName);
+            _logger = logger;
 
             _cts = CancellationTokenSource.CreateLinkedTokenSource(parentCts);
         }
@@ -100,7 +100,7 @@ namespace Raven.Server.Utils.Stats
 
             _cts.Cancel();
 
-            var exceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {GetType().Name}");
+            var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {GetType().Name}");
 
             exceptionAggregator.Execute(() =>
             {

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Utils
 {
     public class ThreadsUsage
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("ThreadsUsage");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ThreadsUsage>();
         private (long TotalProcessorTimeTicks, long TimeTicks) _processTimes;
         private Dictionary<int, long> _threadTimesInfo = new Dictionary<int, long>();
 

--- a/src/Raven.Server/Utils/WindowsServiceRunner.cs
+++ b/src/Raven.Server/Utils/WindowsServiceRunner.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Utils
 
     internal class RavenWin32Service : IWin32Service
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenWin32Service>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenWin32Service>();
 
         private RavenServer _ravenServer;
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -75,6 +75,7 @@ namespace Raven.Server.Web
         public virtual void Init(RequestHandlerContext context)
         {
             _context = context;
+            Logger = Server.Logger;
         }
 
         protected Stream TryGetRequestFromStream(string itemName)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -30,6 +30,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Web
 {
@@ -40,6 +41,8 @@ namespace Raven.Server.Web
         public const string PageSizeParameter = "pageSize";
 
         private RequestHandlerContext _context;
+
+        protected Logger Logger;
 
         protected HttpContext HttpContext
         {

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -8,7 +8,6 @@ namespace Raven.Server.Web
         public override void Init(RequestHandlerContext context)
         {
             base.Init(context);
-            Logger = Server.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
         }

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -8,6 +8,7 @@ namespace Raven.Server.Web
         public override void Init(RequestHandlerContext context)
         {
             base.Init(context);
+            Logger = Server.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
         }

--- a/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
+++ b/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Web.Studio
 {
     public class DataDirectoryInfo
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<DataDirectoryInfo>("DataDirectoryInfo");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<DataDirectoryInfo>();
 
         private readonly ServerStore _serverStore;
         private readonly string _path;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -62,8 +62,6 @@ namespace Raven.Server.Web.System
 {
     public class AdminDatabasesHandler : ServerRequestHandler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<AdminDatabasesHandler>("Server");
-
         [RavenAction("/admin/databases", "GET", AuthorizationStatus.Operator)]
         public async Task Get()
         {
@@ -1148,7 +1146,13 @@ namespace Raven.Server.Web.System
                         catch (Exception e)
                         {
                             if (Logger.IsOperationsEnabled)
-                                Logger.Operations("Compaction process failed", e);
+                            {
+                                Logger.Operations($"Compaction process failed. " +
+                                                  $"{nameof(compactSettings.DatabaseName)}:\"{compactSettings.DatabaseName}\", " +
+                                                  $"{nameof(compactSettings.Documents)}:\"{compactSettings.Documents}\", " +
+                                                  $"{nameof(compactSettings.Indexes)}:\"{(compactSettings.Indexes != null ? string.Join(", ", compactSettings.Indexes) : null)}\""
+                                    , e);
+                            }
 
                             throw;
                         }

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -30,6 +30,7 @@ using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Web.System

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -30,15 +30,12 @@ using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Web.System
 {
     public sealed class DatabasesHandler : RequestHandler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<DatabasesHandler>("Server");
-
         [RavenAction("/databases", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Databases()
         {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -466,7 +466,7 @@ namespace Raven.Server.Web.System
                         Name = backupName
                     };
 
-                    var backupTask = new BackupTask(Database, backupParameters, backupConfiguration, Logger);
+                    var backupTask = new BackupTask(Database, backupParameters, backupConfiguration);
                     var threadName = $"Backup thread {backupName} for database '{Database.Name}'";
 
                     var t = Database.Operations.AddOperation(

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        public static async Task ConnectToClientNodeAsync(RavenServer server, TcpConnectionInfo tcpConnectionInfo, TimeSpan timeout, Logger log, string database,
+        public static async Task ConnectToClientNodeAsync(RavenServer server, TcpConnectionInfo tcpConnectionInfo, TimeSpan timeout, string database,
             NodeConnectionTestResult result, CancellationToken token = default)
         {
             List<string> negLogs = new();

--- a/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
+++ b/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
@@ -19,7 +19,7 @@ namespace Sparrow.Server.LowMemory
 {
     public static class CheckPageFileOnHdd
     {
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger("Server", typeof(CheckPageFileOnHdd).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Memory.GetLogger(nameof(CheckPageFileOnHdd));
 
         private const string PageFileName = "pagefile.sys";
 
@@ -482,7 +482,8 @@ namespace Sparrow.Server.LowMemory
             }
             catch (Exception ex)
             {
-                Log.Info("Error while trying to determine if hdd swaps instead of ssd on linux, ignoring this check and assuming no hddswap", ex);
+                if(Log.IsInfoEnabled)
+                    Log.Info("Error while trying to determine if hdd swaps instead of ssd on linux, ignoring this check and assuming no hddswap", ex);
                 // ignore
                 return null;
             }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -18,7 +18,7 @@ namespace Sparrow.LowMemory
 {
     public static class MemoryInformation
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MemoryInfoResult>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<MemoryInfoResult>();
 
         private static readonly ConcurrentQueue<Tuple<long, DateTime>> MemByTime = new ConcurrentQueue<Tuple<long, DateTime>>();
         private static DateTime _memoryRecordsSet;

--- a/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
+++ b/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
@@ -10,7 +10,7 @@ namespace Sparrow.Platform.Posix
 {
     internal static class KernelVirtualFileSystemUtils
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(KernelVirtualFileSystemUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger(nameof(KernelVirtualFileSystemUtils));
         private static readonly ConcurrentSet<string> IsOldFileAlert = new ConcurrentSet<string>();
 
         public static long? ReadNumberFromCgroupFile(string fileName)

--- a/src/Sparrow.Server/Utils/DiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter.cs
@@ -18,7 +18,7 @@ namespace Sparrow.Server.Utils
     internal class DiskStatsGetter : IDiskStatsGetter
     {
         private readonly TimeSpan _minInterval;
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(DiskStatsGetter).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DiskStatsGetter));
 
         private readonly ConcurrentDictionary<string, Task<PrevInfo>> _previousInfo = new ConcurrentDictionary<string, Task<PrevInfo>>();
 

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -12,7 +12,7 @@ namespace Sparrow.Server.Utils
 {
     public static class DiskUtils
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(DiskUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DiskUtils));
 
         // from https://github.com/dotnet/corefx/blob/9c06da6a34fcefa6fb37776ac57b80730e37387c/src/Common/src/System/IO/PathInternal.Windows.cs#L52
         public const short WindowsMaxPath = short.MaxValue;

--- a/src/Sparrow.Server/Utils/TaskExecutor.cs
+++ b/src/Sparrow.Server/Utils/TaskExecutor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Sparrow.Logging;
 using Sparrow.Utils;
 
 namespace Sparrow.Server.Utils
@@ -103,6 +104,7 @@ namespace Sparrow.Server.Utils
 
         private class RunOnce
         {
+            private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RunOnce>();
             private WaitCallback _callback;
 
             public RunOnce(WaitCallback callback)
@@ -125,9 +127,8 @@ namespace Sparrow.Server.Utils
                 }
                 catch (Exception e)
                 {
-                    var logger = Logging.LoggingSource.Instance.GetLogger<RunOnce>("TaskExecutor");
-                    if (logger.IsOperationsEnabled)
-                        logger.Operations("Failed to execute task", e);
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Failed to execute task", e);
                 }
             }
         }

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -13,7 +13,7 @@ namespace Sparrow.Json
         where T : JsonOperationContext
     {
         private readonly object _locker = new object();
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<JsonContextPoolBase<T>>("Memory");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<JsonContextPoolBase<T>>();
 
         private bool _disposed;
 

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -12,20 +12,20 @@ namespace Sparrow.Json
 {
     public unsafe class UnmanagedBuffersPool : IDisposable
     {
-        protected readonly string _debugTag;
+        private static readonly Logger StaticLogger = LoggingSource.Instance.GetLogger<UnmanagedBuffersPool>("Client");
 
-        protected readonly string _databaseName;
+        private readonly string _debugTag;
 
-        private static readonly Logger _log = LoggingSource.Instance.GetLogger<UnmanagedBuffersPool>("Client");
+        private  readonly Logger _log;
 
         private readonly ConcurrentStack<AllocatedMemoryData>[] _freeSegments;
 
         private bool _isDisposed;
 
-        public UnmanagedBuffersPool(string debugTag, string databaseName = null)
+        public UnmanagedBuffersPool(string debugTag, Logger logger = null)
         {
             _debugTag = debugTag;
-            _databaseName = databaseName ?? string.Empty;
+            _log = logger ?? StaticLogger;;
             _freeSegments = new ConcurrentStack<AllocatedMemoryData>[32];
             for (int i = 0; i < _freeSegments.Length; i++)
             {
@@ -40,7 +40,7 @@ namespace Sparrow.Json
 
             var size = FreeAllPooledMemory();
             if (_log.IsInfoEnabled && size > 0)
-                _log.Info($"{_debugTag}: HandleLowMemory freed {new Size(size, SizeUnit.Bytes)} in {_debugTag}");
+                _log.Info($"HandleLowMemory freed {new Size(size, SizeUnit.Bytes)} in {_debugTag}");
         }
 
         private long FreeAllPooledMemory()

--- a/src/Sparrow/Logging/LogAvailability.cs
+++ b/src/Sparrow/Logging/LogAvailability.cs
@@ -1,0 +1,41 @@
+namespace Sparrow.Logging;
+
+public class LogAvailability
+{
+    public bool IsInfoEnabled;
+    public bool IsOperationsEnabled;
+
+    public LogAvailability()
+    {
+            
+    }
+        
+    public LogAvailability(LogMode logMode)
+    {
+        InternalSetMode(logMode);
+    }
+        
+    public LogMode GetMode()
+    {
+        return IsInfoEnabled
+            ? LogMode.Information
+            : IsOperationsEnabled
+                ? LogMode.Operations
+                : LogMode.None;
+    }
+
+    protected void InternalSetMode(LogMode logMode)
+    {
+        IsOperationsEnabled = (logMode & LogMode.Operations) == LogMode.Operations;
+        IsInfoEnabled = (logMode & LogMode.Information) == LogMode.Information;
+    }
+}
+
+internal class LoggingSourceLogAvailability : LogAvailability
+{
+    public void SetMode(LogMode logMode)
+    {
+        InternalSetMode(logMode);
+    }
+}
+

--- a/src/Sparrow/Logging/LogEntry.cs
+++ b/src/Sparrow/Logging/LogEntry.cs
@@ -10,5 +10,7 @@ namespace Sparrow.Logging
         public string Logger;
         public string Message;
         public Exception Exception;
+        
+        public LogMode? OverrideWriteMode { get; set; }
     }
 }

--- a/src/Sparrow/Logging/LogMessageEntry.cs
+++ b/src/Sparrow/Logging/LogMessageEntry.cs
@@ -10,6 +10,7 @@ namespace Sparrow.Logging
         public LogMode Type;
         public MemoryStream Data;
         public TaskCompletionSource<object> Task;
+        public LogMode? OverrideWriteMode;
 
         public readonly List<WebSocket> WebSocketsList = new List<WebSocket>();
 

--- a/src/Sparrow/Logging/LoggersCollection.cs
+++ b/src/Sparrow/Logging/LoggersCollection.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sparrow.Logging
+{
+    public class LoggersCollection : IEnumerable<(string, SwitchLogger)>, IDisposable
+    {
+        private readonly SwitchLogger _parent;
+        private readonly ConcurrentDictionary<string, SwitchLogger> _loggers = new ConcurrentDictionary<string, SwitchLogger>(StringComparer.OrdinalIgnoreCase);
+
+        public int Count => _loggers.Count;
+        
+        public LoggersCollection(LoggingSource collectionOfLoggers, SwitchLogger parent)
+        {
+            _parent = parent;
+        }
+
+        public bool TryGet(string name, out SwitchLogger value) => _loggers.TryGetValue(name, out value);
+        public SwitchLogger GetOrAdd(string name)
+        {
+            return _loggers.GetOrAdd(name, _ =>
+                {
+                    var source = _parent.Source != null ? $"{_parent.Source}.{_parent.Name}" : _parent.Name;
+                    return new SwitchLogger(parent: _parent, source, name);
+                }
+               );
+        }
+
+        public void TryRemove(string name)
+        {
+            if (_loggers.TryRemove(name, out var holder))
+                holder.Dispose();
+        }
+
+        public void TryUpdateMode(string name, LogMode mode)
+        {
+            if(_loggers.TryGetValue(name, out var switchLogger))
+                switchLogger.UpdateMode(mode);
+        }
+
+        public IEnumerator<(string, SwitchLogger)> GetEnumerator()
+        {
+            foreach (var keyValue in _loggers)
+            {
+                yield return (keyValue.Key, keyValue.Value);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Dispose()
+        {
+            foreach (SwitchLogger logger in _loggers.Values.ToArray())
+            {
+                logger.Dispose();
+            }
+        }
+    }
+}

--- a/src/Sparrow/Logging/LoggersHolder.cs
+++ b/src/Sparrow/Logging/LoggersHolder.cs
@@ -1,0 +1,23 @@
+using Sparrow.Json.Parsing;
+
+namespace Sparrow.Logging;
+
+public class LoggersHolder
+{
+    private const string Root = null;
+
+    private readonly SwitchLogger _rootLogger;
+        
+    public LoggersHolder(LoggingSource loggingSource)
+    {
+        _rootLogger = new SwitchLogger(loggingSource, Root);
+        
+        Generic = _rootLogger.GetSubSwitchLogger("Generic");
+        Memory = Generic.GetSubSwitchLogger("Memory");
+    }
+
+    public readonly SwitchLogger Generic;
+    public readonly SwitchLogger Memory;
+    
+    public DynamicJsonValue ToJson() => _rootLogger.ToJson();
+}

--- a/src/Sparrow/Logging/LoggingSource.cs
+++ b/src/Sparrow/Logging/LoggingSource.cs
@@ -55,11 +55,12 @@ namespace Sparrow.Logging
         private readonly MultipleUseFlag _keepLogging = new MultipleUseFlag(true);
         private int _logNumber = -1;
         private DateTime _today;
-        private bool _isInfoEnabled;
-        private bool _isOperationsEnabled;
 
-        public bool IsInfoEnabled => _isInfoEnabled; 
-        public bool IsOperationsEnabled => _isOperationsEnabled;
+        private readonly LoggingSourceLogAvailability _logAvailability = new LoggingSourceLogAvailability();
+        public LogAvailability LogAvailability => _logAvailability;
+
+        public bool IsInfoEnabled => LogAvailability.IsInfoEnabled; 
+        public bool IsOperationsEnabled => LogAvailability.IsOperationsEnabled;
 
         private Stream _additionalOutput;
 
@@ -89,15 +90,15 @@ namespace Sparrow.Logging
         public bool Compressing => _compressLoggingThread != null;
 
 
-        private (bool Info, bool Operation) CalculateIsLogEnabled(LogMode? logMode = null)
+        private void SetLogAvailability(LogMode? logMode = null)
         {
-            if (_listeners.IsEmpty == false || _pipeSink != null) 
-                return (true, true);
-            
+            if (_listeners.IsEmpty == false || _pipeSink != null)
+            {
+                logMode = LogMode.Information;
+            }
+
             logMode ??= LogMode;
-            var info = (logMode & LogMode.Information) == LogMode.Information;
-            var operation = (logMode & LogMode.Operations) == LogMode.Operations;
-            return (info, operation);
+            _logAvailability.SetMode(logMode.Value);
         }
         
         public async Task Register(WebSocket source, WebSocketContext context, CancellationToken token)
@@ -114,7 +115,7 @@ namespace Sparrow.Logging
                 }
                 else
                 {
-                    (_isInfoEnabled, _isOperationsEnabled) = (true, true);
+                    _logAvailability.SetMode(LogMode);
                 }
             }
 
@@ -173,6 +174,7 @@ namespace Sparrow.Logging
             _localState = new LightWeightThreadLocal<LocalThreadWriterState>(GenerateThreadWriterState);
             _freePooledMessageEntries = new LimitedConcurrentSet<LogMessageEntry>[Environment.ProcessorCount];
             _activePoolMessageEntries = new LimitedConcurrentSet<LogMessageEntry>[Environment.ProcessorCount];
+            LoggersHolder = new LoggersHolder(this);
             for (int i = 0; i < _freePooledMessageEntries.Length; i++)
             {
                 _freePooledMessageEntries[i] = new LimitedConcurrentSet<LogMessageEntry>(1000);
@@ -185,6 +187,10 @@ namespace Sparrow.Logging
             SetupLogMode(logMode, path, retentionTime, retentionSize, compress);
         }
 
+        public void SetupLogMode(LogMode logMode)
+        {
+            SetupLogMode(logMode, _path, RetentionTime, RetentionSize, Compressing);
+        }
         public void SetupLogMode(LogMode logMode, string path, TimeSpan? retentionTime, long? retentionSize, bool compress)
         {
             SetupLogMode(logMode, path, retentionTime ?? TimeSpan.MaxValue, retentionSize ?? long.MaxValue, compress);
@@ -200,9 +206,9 @@ namespace Sparrow.Logging
                     Task.Run(() => SetupLogMode(logMode, path, retentionTime, retentionSize, compress));
                     return;
                 }
-                (bool info, bool operation) old = (_isInfoEnabled, _isOperationsEnabled);
-                (_isInfoEnabled, _isOperationsEnabled) = CalculateIsLogEnabled(logMode);
-                if (_isInfoEnabled == old.info && _isOperationsEnabled == old.operation && LogMode == logMode && path == _path && retentionTime == RetentionTime && compress == Compressing)
+                (bool info, bool operation) old = (LogAvailability.IsInfoEnabled, LogAvailability.IsOperationsEnabled);
+                SetLogAvailability(logMode);
+                if (LogAvailability.IsInfoEnabled == old.info && LogAvailability.IsOperationsEnabled == old.operation && LogMode == logMode && path == _path && retentionTime == RetentionTime && compress == Compressing)
                     return;
                 LogMode = logMode;
                 _path = path;
@@ -237,7 +243,7 @@ namespace Sparrow.Logging
             _keepLogging.Raise();
             _loggingThread = new Thread(BackgroundLogger) {IsBackground = true, Name = _name + " Thread"};
             _loggingThread.Start();
-            if (compress)
+            if (compress && LogMode != LogMode.None)
             {
                 _compressLoggingThread = new Thread(BackgroundLoggerCompress) {IsBackground = true, Name = _name + "Log Compression Thread"};
                 _compressLoggingThread.Start();
@@ -548,6 +554,7 @@ namespace Sparrow.Logging
             item.Data = state.ForwardingStream.Destination;
             Debug.Assert(item.Data != null);
             item.Type = entry.Type;
+            item.OverrideWriteMode = entry.OverrideWriteMode;
             
             _activePoolMessageEntries[currentProcessNumber].Enqueue(item, 128);
 
@@ -601,6 +608,8 @@ namespace Sparrow.Logging
             return new Logger(this, source, logger);
         }
 
+        public readonly LoggersHolder LoggersHolder;
+        
         private void BackgroundLogger()
         {
             NativeMemory.EnsureRegistered();
@@ -705,8 +714,7 @@ namespace Sparrow.Logging
         {
             try
             {
-                _isInfoEnabled = false;
-                _isOperationsEnabled = false;
+                _logAvailability.SetMode(LogMode.None);
 
                 foreach (var queue in _activePoolMessageEntries)
                 {
@@ -717,7 +725,7 @@ namespace Sparrow.Logging
             }
             finally
             {
-                (_isInfoEnabled, _isOperationsEnabled) = CalculateIsLogEnabled();
+                SetLogAvailability();
             }
         }
 
@@ -836,7 +844,7 @@ namespace Sparrow.Logging
             }
             else
             {
-                (_isInfoEnabled, _isOperationsEnabled) = (true, true);
+                _logAvailability.SetMode(LogMode.Information);
             }
         }
 
@@ -849,7 +857,7 @@ namespace Sparrow.Logging
             }
             else
             {
-                (_isInfoEnabled, _isOperationsEnabled) = CalculateIsLogEnabled();
+                SetLogAvailability();
             }
         }
 
@@ -858,24 +866,21 @@ namespace Sparrow.Logging
             item.Data.TryGetBuffer(out var bytes);
             Debug.Assert(bytes.Array != null);
 
-            if (item.Type == LogMode.Operations && LogMode != LogMode.None || (LogMode & LogMode.Information) == LogMode.Information)
+            try
             {
-                file.Write(bytes.Array, bytes.Offset, bytes.Count);
-                _additionalOutput?.Write(bytes.Array, bytes.Offset, bytes.Count);
-                if (item.Task != null)
+                var logMode = item.OverrideWriteMode ?? LogMode;
+                if (item.Type == LogMode.Operations && logMode != LogMode.None || (logMode & LogMode.Information) == LogMode.Information)
                 {
-                    try
+                    file.Write(bytes.Array, bytes.Offset, bytes.Count);
+                    _additionalOutput?.Write(bytes.Array, bytes.Offset, bytes.Count);
+                    if (item.Task != null)
                     {
                         file.Flush();
                         _additionalOutput?.Flush();
                     }
-                    finally
-                    {
-                        item.Task.TrySetResult(null);
-                    }
                 }
             }
-            else
+            finally
             {
                 item.Task?.TrySetResult(null);
             }
@@ -972,7 +977,7 @@ namespace Sparrow.Logging
             }
             else
             {
-                (_isInfoEnabled, _isOperationsEnabled) = CalculateIsLogEnabled();
+                SetLogAvailability();
             }
         }
 

--- a/src/Sparrow/Logging/SwitchLogger.cs
+++ b/src/Sparrow/Logging/SwitchLogger.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Sparrow.Json.Parsing;
+
+namespace Sparrow.Logging;
+
+public class SwitchLogger : Logger, IDisposable
+{
+    private LogAvailability _logAvailability; 
+        
+    public readonly LoggersCollection Loggers;
+
+    public SwitchLogger(LoggingSource loggingSource, string name) : 
+        base(loggingSource, null, name)
+    {
+        Loggers = new LoggersCollection(LoggingSource, this);
+        _logAvailability = loggingSource.LogAvailability;
+    }
+    
+    public SwitchLogger(SwitchLogger parent, string source, string name) : 
+        base(parent, source, name)
+    {
+        Loggers = new LoggersCollection(LoggingSource, this);
+        _logAvailability = parent._logAvailability;
+    }
+
+    public override bool IsInfoEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get { return _logAvailability.IsInfoEnabled; }
+    }
+
+    public override bool IsOperationsEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get { return _logAvailability.IsOperationsEnabled; }
+    }
+
+    public Logger GetLogger<T>() => GetLogger(typeof(T).Name);
+    public Logger GetLogger(string name) => new Logger(this, $"{Source}.{name}", name);
+    
+    public SwitchLogger GetSubSwitchLogger(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new InvalidOperationException($"{nameof(name)} {nameof(string.IsNullOrEmpty)}");
+
+        return Loggers.GetOrAdd(name);
+    }
+
+    public bool IsReset() => _logAvailability == LoggingSource.LogAvailability;
+
+    public LogMode GetLogMode() => _logAvailability.GetMode();
+
+    public void SetLoggerMode(LogMode mode) => _logAvailability = new LogAvailability(mode);
+
+    public void Dispose()
+    {
+        Loggers.Dispose();
+        Parent.Loggers.TryRemove(Name);
+    }
+
+    public void UpdateMode(LogMode mode)
+    {
+        _logAvailability = new LogAvailability
+        {
+            IsInfoEnabled = (mode & LogMode.Operations) == LogMode.Operations,
+            IsOperationsEnabled = (mode & LogMode.Information) == LogMode.Information
+        };
+    }
+    public void Reset(bool recursively)
+    {
+        _logAvailability = LoggingSource.LogAvailability;
+        if (recursively)
+        {
+            foreach ((_, SwitchLogger switchLogger) in Loggers.ToArray())
+            {
+                switchLogger.Reset(true);
+            }
+        }
+    }
+
+    protected override LogMode? GetOverrideWriteMode()
+    {
+        return IsReset() == false ? GetLogMode() : null;
+    }
+    
+    public DynamicJsonValue ToJson()
+    {
+        var ret = new DynamicJsonValue
+        {
+            [nameof(Name)] = Name,
+            [nameof(Source)] = Source,
+            
+            [nameof(IsReset)] = IsReset(),
+            [nameof(IsInfoEnabled)] = IsInfoEnabled,
+            [nameof(IsOperationsEnabled)] = IsOperationsEnabled,
+        };
+        var loggers = Loggers.ToArray();
+        if (loggers.Any())
+        {
+            var json = new DynamicJsonValue();
+            foreach ((var name, var logger) in loggers)
+            {
+                json[name] = logger.ToJson();
+            }
+            ret[nameof(Loggers)] = json;
+        }
+        
+        return ret;
+    }
+}

--- a/src/Sparrow/Utils/NativeMemoryCleaner.cs
+++ b/src/Sparrow/Utils/NativeMemoryCleaner.cs
@@ -9,8 +9,7 @@ namespace Sparrow.Utils
 {
     public class NativeMemoryCleaner<TStack, TPooledItem> : IDisposable where TPooledItem : PooledItem where TStack : StackHeader<TPooledItem>
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<NativeMemoryCleaner<TStack, TPooledItem>>("Memory");
-
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<NativeMemoryCleaner<TStack, TPooledItem>>();
         private readonly object _lock = new object();
         private readonly Func<object, ICollection<TStack>> _getContextsFromCleanupTarget;
         private readonly SharedMultipleUseFlag _lowMemoryFlag;

--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -45,7 +45,7 @@ namespace Voron
 
         private readonly ConcurrentDictionary<uint, MountPointInfo> _mountPoints = new ConcurrentDictionary<uint, MountPointInfo>();
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<GlobalFlushingBehavior>("Global Flusher");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<GlobalFlushingBehavior>();
 
         private class MountPointInfo
         {
@@ -73,9 +73,9 @@ namespace Voron
                         if (_envsToSync.Count == 0)
                             continue;
 
-                        if (_log.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
-                            _log.Info($"Starting force sync with {_envsToSync.Count:#,#} items to sync after a period of no activity");
+                            Logger.Info($"Starting force sync with {_envsToSync.Count:#,#} items to sync after a period of no activity");
                         }
 
                         // sync after 5 seconds if no flushing occurred
@@ -91,9 +91,9 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
+                if (Logger.IsOperationsEnabled)
                 {
-                    _log.Operations("Catastrophic failure in Voron environment flushing", e);
+                    Logger.Operations("Catastrophic failure in Voron environment flushing", e);
                 }
 
                 // wait for the message to be flushed to the logs
@@ -171,8 +171,8 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
-                    _log.Operations($"Failed to sync data file for {storageEnvironment.Options.BasePath}", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Failed to sync data file for {storageEnvironment.Options.BasePath}", e);
                 storageEnvironment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
             }
         }
@@ -239,8 +239,8 @@ namespace Voron
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsOperationsEnabled)
-                            _log.Operations($"Failed to flush {storageEnvironment.Options.BasePath}", e);
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations($"Failed to flush {storageEnvironment.Options.BasePath}", e);
 
                         storageEnvironment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
                     }

--- a/src/Voron/GlobalPrefetchingBehavior.cs
+++ b/src/Voron/GlobalPrefetchingBehavior.cs
@@ -29,8 +29,8 @@ namespace Voron.Impl
             return prefetcher;
         });
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<GlobalPrefetchingBehavior>("Global Prefetcher");
-         
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<GlobalPrefetchingBehavior>();
+
         public readonly BlockingCollection<PrefetchRanges> CommandQueue = new BlockingCollection<PrefetchRanges>(128);
 
         private unsafe void VoronPrefetcher()
@@ -80,9 +80,9 @@ namespace Voron.Impl
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
+                if (Logger.IsOperationsEnabled)
                 {
-                    _log.Operations("Catastrophic failure in Voron prefetcher ", e);
+                    Logger.Operations("Catastrophic failure in Voron prefetcher ", e);
                 }
 
                 // Note that we intentionally don't have error handling here.

--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -23,7 +23,7 @@ namespace Voron.Impl
         private readonly object _locker = new object();
 
         public static EncryptionBuffersPool Instance = new EncryptionBuffersPool();
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<EncryptionBuffersPool>("Memory");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<EncryptionBuffersPool>();
         private const int MaxNumberOfPagesToCache = 128; // 128 * 8K = 1 MB, beyond that, we'll not both
         private readonly MultipleUseFlag _isLowMemory = new MultipleUseFlag();
         private readonly MultipleUseFlag _isExtremelyLowMemory = new MultipleUseFlag();

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -33,7 +33,7 @@ namespace Voron.Impl.Journal
 
         private readonly FastList<PagePosition> _unusedPages;
         private readonly ContentionLoggingLocker _locker2;
-        private Logger _logger;
+        private readonly Logger _logger;
 
         public JournalFile(StorageEnvironment env, IJournalWriter journalWriter, long journalNumber)
         {
@@ -43,7 +43,7 @@ namespace Voron.Impl.Journal
             _journalWriter = journalWriter;
             _writePosIn4Kb = 0;
             _unusedPages = new FastList<PagePosition>();
-            _logger = LoggingSource.Instance.GetLogger<JournalFile>(JournalWriter.FileName.FullPath);
+            _logger = env.Logger;
             _locker2 = new ContentionLoggingLocker(_logger, JournalWriter.FileName.FullPath);
         }
 

--- a/src/Voron/Impl/Journal/JournalWriter.cs
+++ b/src/Voron/Impl/Journal/JournalWriter.cs
@@ -38,7 +38,7 @@ namespace Voron.Impl.Journal
         {
             _options = options;
             FileName = filename;
-            _log = LoggingSource.Instance.GetLogger<JournalWriter>(options.BasePath.FullPath);
+            _log = options.Logger;
 
             var result = Pal.rvn_open_journal_for_writes(filename.FullPath, mode, size, options.SupportDurabilityFlags, out _writeHandle, out var actualSize, out var error);
             if (result != PalFlags.FailCodes.Success)
@@ -66,7 +66,7 @@ namespace Voron.Impl.Journal
                 if (error == ERROR_WORKING_SET_QUOTA && _log.IsOperationsEnabled && _workingSetQuotaLogged == false)
                 {
                     _log.Operations(
-                        $"We managed to accomplish journal write although we got {nameof(ERROR_WORKING_SET_QUOTA)} under the covers and wrote data in 4KB chunks");
+                        $"We managed to accomplish journal write although we got {nameof(ERROR_WORKING_SET_QUOTA)} under the covers and wrote data in 4KB chunks. FileName {FileName}");
 
                     _workingSetQuotaLogged = true;
                 }

--- a/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
+++ b/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
@@ -27,7 +27,7 @@ namespace Voron.Impl.Journal
             _options = options;
             _lazyTransactionPager = CreateBufferPager();
             _transactionPersistentContext = new TransactionPersistentContext(true);
-            _log = LoggingSource.Instance.GetLogger<LazyTransactionBuffer>(options.BasePath.FullPath);
+            _log = options.Logger;
         }
 
         private AbstractPager CreateBufferPager()
@@ -97,7 +97,7 @@ namespace Voron.Impl.Journal
                     writeToJournalDuration = journalFile.Write(_firstPositionInJournalFile.Value, src, _lastUsed4Kbs);
                     if (_log.IsInfoEnabled)
                     {
-                        _log.Info($"Writing lazy transaction buffer with {_lastUsed4Kbs / 4:#,#0} kb took {sp.Elapsed}");
+                        _log.Info($"Writing lazy transaction buffer with {_lastUsed4Kbs / 4:#,#0} kb took {sp.Elapsed}. {nameof(_options)} {_options}");
                     }
                     ZeroLazyTransactionBufferIfNeeded(tempTx);
                 }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -73,7 +73,7 @@ namespace Voron.Impl.Journal
         {
             _env = env;
             _is32Bit = env.Options.ForceUsing32BitsPager || PlatformDetails.Is32Bits;
-            _logger = LoggingSource.Instance.GetLogger<WriteAheadJournal>(Path.GetFileName(env.ToString()));
+            _logger = env.Logger;
             _dataPager = _env.Options.DataPager;
             _currentJournalFileSize = env.Options.InitialLogFileSize;
             _headerAccessor = env.HeaderAccessor;
@@ -761,7 +761,7 @@ namespace Voron.Impl.Journal
                     {
                         if (_waj._logger.IsOperationsEnabled)
                         {
-                            _waj._logger.Operations("Could not allocate enough space to apply pages to data file", e);
+                            _waj._logger.Operations($"Could not allocate enough space to apply pages to data file. Environment {_waj._env}", e);
                         }
                         // on 32 bits systems, we likely run out of address space, nothing that we can do, this should
                         // be handled by the 32 bits pager.
@@ -771,7 +771,7 @@ namespace Voron.Impl.Journal
                     {
                         if (_waj._logger.IsOperationsEnabled)
                         {
-                            _waj._logger.Operations("The disk is full!", diskFullEx);
+                            _waj._logger.Operations($"The disk is full!. Environment {_waj._env}", diskFullEx);
                         }
                         _waj._env.HandleDataDiskFullException(diskFullEx);
                         return;
@@ -820,12 +820,12 @@ namespace Voron.Impl.Journal
                             UpdateJournalStateUnderWriteTransactionLock(txw, journalSnapshots, lastProcessedJournal, lastFlushedTransactionId);
 
                             if (_waj._logger.IsInfoEnabled)
-                                _waj._logger.Info($"Updated journal state under write tx lock (txId: {txw.Id}) after waiting for {sp.Elapsed}");
+                                _waj._logger.Info($"Updated journal state under write tx lock (txId: {txw.Id}) after waiting for {sp.Elapsed}. Environment {_waj._env}");
                         }
                         catch (Exception e)
                         {
                             if (_waj._logger.IsOperationsEnabled)
-                                _waj._logger.Operations($"Failed to update journal state under write tx lock (waited - {sp.Elapsed})", e);
+                                _waj._logger.Operations($"Failed to update journal state under write tx lock (waited - {sp.Elapsed}). Environment {_waj._env}", e);
 
                             edi = ExceptionDispatchInfo.Capture(e);
                             throw;
@@ -936,7 +936,7 @@ namespace Voron.Impl.Journal
                     if (_waj._logger.IsInfoEnabled)
                     {
                         _waj._logger.Info($"Detected {unusedJournals.Count} unused journals after flush ({nameof(lastFlushedTransactionId)} - {lastFlushedTransactionId}, {nameof(lastFlushedTransactionIdThatWontReadFromJournal)} - {lastFlushedTransactionIdThatWontReadFromJournal}). " +
-                                          $"Journals to delete: {string.Join(',' , unusedJournals.Select(x => x.Number.ToString()))}");
+                                          $"Journals to delete: {string.Join(',' , unusedJournals.Select(x => x.Number.ToString()))}. Environment {_waj._env}");
                     }
 
                     foreach (var unused in unusedJournals)
@@ -1189,7 +1189,7 @@ namespace Voron.Impl.Journal
                         if (_parent._waj._logger.IsInfoEnabled)
                         {
                             var sizeInKb = (_parent._waj._dataPager.NumberOfAllocatedPages * Constants.Storage.PageSize) / Constants.Size.Kilobyte;
-                            _parent._waj._logger.Info($"Sync of {sizeInKb:#,#0} kb file with {_currentTotalWrittenBytes / Constants.Size.Kilobyte:#,#0} kb dirty in {sp.Elapsed}");
+                            _parent._waj._logger.Info($"Sync of {sizeInKb:#,#0} kb file with {_currentTotalWrittenBytes / Constants.Size.Kilobyte:#,#0} kb dirty in {sp.Elapsed}. Environment {_parent._waj._env}");
                         }
                     }
                 }
@@ -1420,9 +1420,9 @@ namespace Voron.Impl.Journal
                     }
 
                     if (_waj._logger.IsInfoEnabled)
-                        _waj._logger.Info($"Flushed {pagesToWrite.Count:#,#} pages to { _waj._dataPager.FileName} with {written / Constants.Size.Kilobyte:#,#} kb in {sp.Elapsed}");
+                        _waj._logger.Info($"Flushed {pagesToWrite.Count:#,#} pages to { _waj._dataPager.FileName} with {written / Constants.Size.Kilobyte:#,#} kb in {sp.Elapsed}. Environment {_waj._env}");
                     else if (_waj._logger.IsOperationsEnabled && sp.Elapsed > _waj._dataPager.Options.LongRunningFlushingWarning)
-                        _waj._logger.Operations($"Very long data flushing. It took {sp.Elapsed} to flush {pagesToWrite.Count:#,#} pages to { _waj._dataPager.FileName} with {written / Constants.Size.Kilobyte:#,#} kb");
+                        _waj._logger.Operations($"Very long data flushing. It took {sp.Elapsed} to flush {pagesToWrite.Count:#,#} pages to { _waj._dataPager.FileName} with {written / Constants.Size.Kilobyte:#,#} kb. Environment {_waj._env}");
 
                     Interlocked.Add(ref _totalWrittenButUnsyncedBytes, written);
                 }
@@ -1647,7 +1647,7 @@ namespace Voron.Impl.Journal
                     if (_logger.IsInfoEnabled)
                     {
                         _logger.Info(
-                            $"Preparing to write tx {tx.Id} to journal with {journalEntry.NumberOfUncompressedPages:#,#} pages ({(journalEntry.NumberOfUncompressedPages * Constants.Storage.PageSize) / Constants.Size.Kilobyte:#,#} kb) in {sp.Elapsed} with {Math.Round(journalEntry.NumberOf4Kbs * 4d, 1):#,#.#;;0} kb compressed.");
+                            $"Preparing to write tx {tx.Id} to journal with {journalEntry.NumberOfUncompressedPages:#,#} pages ({(journalEntry.NumberOfUncompressedPages * Constants.Storage.PageSize) / Constants.Size.Kilobyte:#,#} kb) in {sp.Elapsed} with {Math.Round(journalEntry.NumberOf4Kbs * 4d, 1):#,#.#;;0} kb compressed. Environment {_env}");
                     }
 
                     if (tx.IsLazyTransaction && _lazyTransactionBuffer == null)
@@ -1660,7 +1660,7 @@ namespace Voron.Impl.Journal
                         _lazyTransactionBuffer?.WriteBufferToFile(CurrentFile, tx);
                         CurrentFile = NextFile(journalEntry.NumberOf4Kbs);
                         if (_logger.IsInfoEnabled)
-                            _logger.Info($"New journal file created {CurrentFile.Number:D19}");
+                            _logger.Info($"New journal file created {CurrentFile.Number:D19}. Environment {_env}");
                     }
 
                     tx._forTestingPurposes?.ActionToCallJustBeforeWritingToJournal?.Invoke();
@@ -1672,7 +1672,7 @@ namespace Voron.Impl.Journal
                     _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
 
                     if (_logger.IsInfoEnabled)
-                        _logger.Info($"Writing {journalEntry.NumberOf4Kbs * 4:#,#} kb to journal {CurrentFile.Number:D19} took {sp.Elapsed}");
+                        _logger.Info($"Writing {journalEntry.NumberOf4Kbs * 4:#,#} kb to journal {CurrentFile.Number:D19} took {sp.Elapsed}. Environment {_env}");
 
                     journalFilePath = CurrentFile.JournalWriter.FileName.FullPath;
 
@@ -2076,7 +2076,7 @@ namespace Voron.Impl.Journal
                 _logger.Operations(
                     $"Compression buffer: {_compressionPager} has reached size {new Size(_compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize, SizeUnit.Bytes)} which is more than the maximum size " +
                     $"of {new Size(maxSize, SizeUnit.Bytes)}. Will trim it now to the max size allowed. If this is happen on a regular basis," +
-                    " consider raising the limit (MaxScratchBufferSize option control it), since it can cause performance issues");
+                    $" consider raising the limit (MaxScratchBufferSize option control it), since it can cause performance issues. Environment {_env}");
             }
 
             _lastCompressionBufferReduceCheck = DateTime.UtcNow;

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -23,7 +23,7 @@ namespace Voron.Impl.Paging
 {
     public abstract unsafe class AbstractPager : IDisposable, ILowMemoryHandler
     {
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<AbstractPager>("AbstractPager");
+        protected readonly Logger Logger;
         private readonly StorageEnvironmentOptions _options;
 
         public static ConcurrentDictionary<string, uint> PhysicalDrivePerMountCache = new ConcurrentDictionary<string, uint>();
@@ -236,6 +236,7 @@ namespace Voron.Impl.Paging
 
         protected AbstractPager(StorageEnvironmentOptions options, bool canPrefetchAhead, bool usePageProtection = false) : this()
         {
+            Logger = options.Logger;
             DisposeOnceRunner = new DisposeOnce<SingleAttempt>(() =>
             {
                 if (FileName?.FullPath != null)
@@ -431,8 +432,8 @@ namespace Voron.Impl.Paging
             {
                 try
                 {
-                    if (Log.IsInfoEnabled)
-                        Log.Info("AbstractPager finalizer was called (leak?), and 'DisposeOnceRunner.Dispose' threw exception", e);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info("AbstractPager finalizer was called (leak?), and 'DisposeOnceRunner.Dispose' threw exception", e);
                 }
                 catch
                 {
@@ -443,8 +444,8 @@ namespace Voron.Impl.Paging
             {
                 try
                 {
-                    if (Log.IsInfoEnabled)
-                        Log.Info("AbstractPager finalizer was called although GC.SuppressFinalize should have been called", new InvalidOperationException("Leak in "));
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info("AbstractPager finalizer was called although GC.SuppressFinalize should have been called", new InvalidOperationException("Leak in "));
                 }
                 catch
                 {

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -25,7 +25,6 @@ namespace Voron.Impl.Paging
         public override string ToString() => FileName?.FullPath ?? "";
         protected override string GetSourceName() => $"mmf64: {FileName?.FullPath}";
         private long _totalAllocationSize;
-        private readonly Logger _logger;
         private readonly SafeMmapHandle _handle;
 
         public RvnMemoryMapPager(StorageEnvironmentOptions options, VoronPathSetting file, long? initialFileSize = null, bool canPrefetchAhead = true, bool usePageProtection = false, bool deleteOnClose = false)
@@ -34,7 +33,6 @@ namespace Voron.Impl.Paging
             DeleteOnClose = deleteOnClose;
             FileName = file;
             var copyOnWriteMode = options.CopyOnWriteMode && FileName.FullPath.EndsWith(Constants.DatabaseFilename);
-            _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
 
             if (initialFileSize.HasValue == false || initialFileSize.Value == 0) 
                 initialFileSize = Math.Max(SysInfo.PageSize * 16, 64 * 1024);
@@ -150,10 +148,10 @@ namespace Voron.Impl.Paging
             if (_handle.FailCode == FailCodes.Success)
                 return;
 
-            if (_logger.IsInfoEnabled)
+            if (Logger.IsInfoEnabled)
             {
-                _logger.Info($"Unable to dispose handle for {FileName.FullPath} (ignoring). rc={_handle.FailCode}. DeleteOnClose={DeleteOnClose}, "
-                             + $"errorCode={PalHelper.GetNativeErrorString(_handle.ErrorNo, "Unable to dispose handle for {FileName.FullPath} (ignoring).", out _)}",
+                Logger.Info($"Unable to dispose handle for {FileName.FullPath} (ignoring). rc={_handle.FailCode}. DeleteOnClose={DeleteOnClose}, "
+                             + $"errorCode={PalHelper.GetNativeErrorString(_handle.ErrorNo, $"Unable to dispose handle for {FileName.FullPath} (ignoring).", out _)}",
                     new IOException($"Unable to dispose handle for {FileName.FullPath} (ignoring)."));
             }
         }
@@ -219,8 +217,8 @@ namespace Voron.Impl.Paging
             if (rvn_protect_range(start, (long)size, ProtectRange.Protect, out var errorCode) == 0)
                 return;
 
-            if (_logger.IsInfoEnabled)
-                _logger.Info($"Unable to protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Protect, errorCode={errorCode}");
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Unable to protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Protect, errorCode={errorCode}");
         }
 
         internal override void UnprotectPageRange(byte* start, ulong size, bool force = false)
@@ -232,8 +230,8 @@ namespace Voron.Impl.Paging
             if (rvn_protect_range(start, (long)size, ProtectRange.Unprotect, out var errorCode) == 0)
                 return;
 
-            if (_logger.IsInfoEnabled)
-                _logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
         }
     }
 }

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -59,7 +59,7 @@ namespace Voron.Impl.Scratch
 
         public ScratchBufferPool(StorageEnvironment env)
         {
-            _logger = LoggingSource.Instance.GetLogger<ScratchBufferPool>(Path.GetFileName(env.ToString()));
+            _logger = env.Logger;
 
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
@@ -575,7 +575,7 @@ namespace Voron.Impl.Scratch
                             if (_logger.IsInfoEnabled)
                             {
                                 _logger.Info(
-                                    $"Cleanup of {nameof(ScratchBufferPool)} removed: {removedInactive} inactive scratches and {removedInactiveRecycled} inactive from the recycle area");
+                                    $"Cleanup of {nameof(ScratchBufferPool)} removed: {removedInactive} inactive scratches and {removedInactiveRecycled} inactive from the recycle area. env {_env}");
                             }
 
                             _forTestingPurposes?.ActionToCallDuringCleanupRightAfterRemovingInactiveScratches?.Invoke();

--- a/src/Voron/Platform/Posix/PosixAbstractPager.cs
+++ b/src/Voron/Platform/Posix/PosixAbstractPager.cs
@@ -17,7 +17,7 @@ namespace Voron.Platform.Posix
 
         private readonly bool _supportsUnmapping;
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<PosixAbstractPager>("PosixAbstractPager");
+        private readonly Logger _log;
 
         public override int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
         {
@@ -45,6 +45,7 @@ namespace Voron.Platform.Posix
             : base(options, canPrefetchAhead, usePageProtection: usePageProtection)
         {
             _supportsUnmapping = supportsUnmapping;
+            _log = options.Logger;
         }
 
         public override unsafe void ReleaseAllocationInfo(byte* baseAddress, long size)

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -32,7 +32,6 @@ namespace Voron.Platform.Win32
         private readonly Win32NativeFileAccess _access;
         private readonly MemoryMappedFileAccess _memoryMappedFileAccess;
         private readonly bool _copyOnWriteMode;
-        private readonly Logger _logger;
         public override long TotalAllocationSize => _totalAllocationSize;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -55,10 +54,7 @@ namespace Voron.Platform.Win32
             bool usePageProtection = false)
             : base(options, !fileAttributes.HasFlag(Win32NativeFileAttributes.Temporary), usePageProtection)
         {
-            SYSTEM_INFO systemInfo;
-            GetSystemInfo(out systemInfo);
             FileName = file;
-            _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
 
             _access = access;
             _copyOnWriteMode = Options.CopyOnWriteMode && FileName.FullPath.EndsWith(Constants.DatabaseFilename);
@@ -94,14 +90,14 @@ namespace Voron.Platform.Win32
                 if (PhysicalDrivePerMountCache.TryGetValue(drive, out UniquePhysicalDriveId) == false)
                     UniquePhysicalDriveId = GetPhysicalDriveId(drive);
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Physical drive '{drive}' unique id = '{UniquePhysicalDriveId}' for file '{file}'");
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Physical drive '{drive}' unique id = '{UniquePhysicalDriveId}' for file '{file}'");
             }
             catch (Exception ex)
             {
                 UniquePhysicalDriveId = 0;
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Failed to determine physical drive Id for drive letter '{drive}', file='{file}'", ex);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Failed to determine physical drive Id for drive letter '{drive}', file='{file}'", ex);
             }
 
             var streamAccessType = _access == Win32NativeFileAccess.GenericRead

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -113,7 +113,7 @@ namespace Voron
 
         private readonly ConcurrentQueue<TemporaryPage> _tempPagesPool = new ConcurrentQueue<TemporaryPage>();
         public bool Disposed;
-        private readonly Logger _log;
+        public readonly Logger Logger;
         public static int MaxConcurrentFlushes = 10; // RavenDB-5221
         public int TimeToSyncAfterFlushInSec;
 
@@ -133,7 +133,7 @@ namespace Voron
             {
                 SelfReference.Owner = this;
                 SelfReference.WeekReference = new WeakReference<StorageEnvironment>(this);
-                _log = LoggingSource.Instance.GetLogger<StorageEnvironment>(options.BasePath.FullPath);
+                Logger = options.Logger;
                 _options = options;
                 _dataPager = options.DataPager;
                 _freeSpaceHandling = new FreeSpaceHandling();
@@ -184,8 +184,8 @@ namespace Voron
 
         ~StorageEnvironment()
         {
-            if (_log.IsOperationsEnabled)
-                _log.Operations($"Finalizer of storage environment was called. Env: {this}");
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Finalizer of storage environment was called. Env: {this}");
 
             try
             {
@@ -193,8 +193,8 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled) 
-                    _log.Operations($"Failed to dispose storage environment via finalizer. Env: {this}", e);
+                if (Logger.IsOperationsEnabled) 
+                    Logger.Operations($"Failed to dispose storage environment via finalizer. Env: {this}", e);
             }
         }
 
@@ -257,9 +257,9 @@ namespace Voron
 
                 string message = $"{nameof(IdleFlushTimer)} failed (numberOfFailures: {numberOfFailures}), unable to schedule flush / syncs of data file. Will be restarted on new write transaction";
 
-                if (env._log.IsOperationsEnabled)
+                if (env.Logger.IsOperationsEnabled)
                 {
-                    env._log.Operations(message, e);
+                    env.Logger.Operations($"{message}. Env {env}", e);
                 }
 
                 try
@@ -1389,8 +1389,8 @@ namespace Voron
             {
                 var oldMode = Options.TransactionsMode;
 
-                if (_log.IsOperationsEnabled)
-                    _log.Operations($"Setting transaction mode to {mode}. Old mode is {oldMode}");
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Setting transaction mode to {mode}. Old mode is {oldMode}. Env {this}");
 
                 if (oldMode == mode)
                     return TransactionsModeResult.ModeAlreadySet;

--- a/test/SlowTests/SparrowTests/LogTestsHelper.cs
+++ b/test/SlowTests/SparrowTests/LogTestsHelper.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow;
+
+namespace SlowTests.SparrowTests;
+
+public class LogTestsHelper
+{
+    public class DummyWebSocket : WebSocket
+    {
+        private bool _close;
+        TaskCompletionSource<WebSocketReceiveResult> _tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        public string LogsReceived { get; private set; } = "";
+
+        public void Close() => _close = true;
+
+        public Func<Task<WebSocketReceiveResult>> ReceiveAsyncFunc { get; set; }
+
+        public override void Abort()
+        {
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override void Dispose()
+        {
+            _tcs.TrySetResult(new WebSocketReceiveResult(1, WebSocketMessageType.Text, true, WebSocketCloseStatus.NormalClosure, string.Empty));
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) => ReceiveAsyncFunc != null ? ReceiveAsyncFunc() : _tcs.Task;
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            if (_close)
+                throw new Exception("Closed");
+            LogsReceived += Encodings.Utf8.GetString(buffer.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public override WebSocketCloseStatus? CloseStatus { get; }
+        public override string CloseStatusDescription { get; }
+        public override WebSocketState State { get; }
+        public override string SubProtocol { get; }
+    }
+
+}

--- a/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
+++ b/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
@@ -117,33 +117,40 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            var bLogger = aLogger.GetSubSwitchLogger("B");
-            var cLogger = bLogger.GetSubSwitchLogger("C");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                var bLogger = aLogger.GetSubSwitchLogger("B");
+                var cLogger = bLogger.GetSubSwitchLogger("C");
 
-            var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
-            var contest = JsonOperationContext.ShortTermSingleUse();
-            var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
-            var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
+                var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
+                var contest = JsonOperationContext.ShortTermSingleUse();
+                var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
+                var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
 
 
-            Assert.True(aLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
-            Assert.True(cLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(aLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(cLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            Assert.True(bLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(bLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            configuration.Apply(aLogger);
+                configuration.Apply(aLogger);
 
-            Assert.True(aLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
-            Assert.True(cLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(aLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(cLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
         }
 
         [Fact]
@@ -162,12 +169,19 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            aLogger.SetLoggerMode(LogMode.Information);
-            var bLogger = aLogger.GetSubSwitchLogger("B");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                aLogger.SetLoggerMode(LogMode.Information);
+                var bLogger = aLogger.GetSubSwitchLogger("B");
 
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
         }
 
         [Fact]
@@ -186,26 +200,33 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            aLogger.SetLoggerMode(LogMode.Information);
-            var bLogger = aLogger.GetSubSwitchLogger("B");
-            var cLogger = bLogger.GetSubSwitchLogger("C");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                aLogger.SetLoggerMode(LogMode.Information);
+                var bLogger = aLogger.GetSubSwitchLogger("B");
+                var cLogger = bLogger.GetSubSwitchLogger("C");
 
-            Assert.False(aLogger.IsReset());
-            Assert.True(aLogger.IsInfoEnabled);
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
-            Assert.False(cLogger.IsReset());
-            Assert.True(cLogger.IsInfoEnabled);
+                Assert.False(aLogger.IsReset());
+                Assert.True(aLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(cLogger.IsReset());
+                Assert.True(cLogger.IsInfoEnabled);
 
-            aLogger.Reset(true);
+                aLogger.Reset(true);
 
-            Assert.True(aLogger.IsReset());
-            Assert.Equal(LogMode.None, aLogger.GetLogMode());
-            Assert.True(bLogger.IsReset());
-            Assert.Equal(LogMode.None, bLogger.GetLogMode());
-            Assert.True(cLogger.IsReset());
-            Assert.Equal(LogMode.None, cLogger.GetLogMode());
+                Assert.True(aLogger.IsReset());
+                Assert.Equal(LogMode.None, aLogger.GetLogMode());
+                Assert.True(bLogger.IsReset());
+                Assert.Equal(LogMode.None, bLogger.GetLogMode());
+                Assert.True(cLogger.IsReset());
+                Assert.Equal(LogMode.None, cLogger.GetLogMode());
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
 
         }
 
@@ -223,76 +244,84 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
-
-            var logger = new SwitchLogger(loggingSource, "A");
-
-            var shouldContainList = new List<string>();
-            var shouldNotContainList = new List<string>();
-
-            //Without listeners
+            try
             {
-                await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
 
-                logger.SetLoggerMode(LogMode.None);
-                await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-            
-                logger.SetLoggerMode(LogMode.Operations);
-                await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+                var logger = new SwitchLogger(loggingSource, "A");
 
-                logger.SetLoggerMode(LogMode.Information);
-                await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                var shouldContainList = new List<string>();
+                var shouldNotContainList = new List<string>();
+
+                //Without listeners
+                {
+                    await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                    logger.SetLoggerMode(LogMode.None);
+                    await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Operations);
+                    await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Information);
+                    await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                }
+
+                //With listeners
+                using (var socket = new LogTestsHelper.DummyWebSocket())
+                {
+                    var context = new LoggingSource.WebSocketContext();
+                    _ = loggingSource.Register(socket, context, CancellationToken.None);
+
+                    loggingSource.SetupLogMode(LogMode.Information);
+                    await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                    logger.SetLoggerMode(LogMode.None);
+                    await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Operations);
+                    await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Information);
+                    await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                }
+
+                //To be sure all logs where written to file
+                var lastLineLogger = loggingSource.GetLogger("Test", "Test");
+                await lastLineLogger.InfoWithWait("");
+
+                var actualLogContent = await File.ReadAllTextAsync(logFile);
+                foreach (var msg in shouldContainList)
+                {
+                    Assert.Contains(msg, actualLogContent);
+                }
+
+                foreach (var msg in shouldNotContainList)
+                {
+                    Assert.DoesNotContain(msg, actualLogContent);
+                }
+
+                async Task AddLog(string msg, bool shouldContain)
+                {
+                    var list = shouldContain ? shouldContainList : shouldNotContainList;
+
+                    var subLogger = logger.GetLogger("test");
+                    list.Add(msg);
+                    if (logger.IsInfoEnabled)
+                        logger.Info(msg);
+
+                    var subLoggerMsg = $"subLogger {msg}";
+                    list.Add(subLoggerMsg);
+                    if (subLogger.IsInfoEnabled)
+                        subLogger.Info(subLoggerMsg);
+
+                    var waitLogger = loggingSource.GetLogger("", "");
+                    await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+                }
             }
-            
-            //With listeners
-            using(var socket = new LogTestsHelper.DummyWebSocket())
+            finally
             {
-                var context = new LoggingSource.WebSocketContext();
-                _ = loggingSource.Register(socket, context, CancellationToken.None);
-                
-                loggingSource.SetupLogMode(LogMode.Information);
-                await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
-
-                logger.SetLoggerMode(LogMode.None);
-                await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-            
-                logger.SetLoggerMode(LogMode.Operations);
-                await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-
-                logger.SetLoggerMode(LogMode.Information);
-                await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
-            }
-
-            //To be sure all logs where written to file
-            var lastLineLogger = loggingSource.GetLogger("Test", "Test");
-            await lastLineLogger.InfoWithWait("");
-            
-            var actualLogContent = await File.ReadAllTextAsync(logFile);
-            foreach (var msg in shouldContainList)
-            {            
-                Assert.Contains(msg, actualLogContent);
-            }
-            foreach (var msg in shouldNotContainList)
-            {            
-                Assert.DoesNotContain(msg, actualLogContent);
-            }
-
-            async Task AddLog(string msg, bool shouldContain)
-            {
-                var list = shouldContain ? shouldContainList : shouldNotContainList;
-
-                var subLogger = logger.GetLogger("test");
-                list.Add(msg);
-                if (logger.IsInfoEnabled)
-                    logger.Info(msg);
-                
-                var subLoggerMsg = $"subLogger {msg}";
-                list.Add(subLoggerMsg);
-                if(subLogger.IsInfoEnabled)
-                    subLogger.Info(subLoggerMsg);
-
-                var waitLogger = loggingSource.GetLogger("", "");
-                await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+                loggingSource.EndLogging();
             }
         }
 

--- a/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
+++ b/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
@@ -1,0 +1,301 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Json;
+using SlowTests.Issues;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SparrowTests
+{
+    public class LoggersTogglingTests : RavenTestBase
+    {
+        public LoggersTogglingTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenRequestAllLogger_ShouldGetLoggersWithCurrentState()
+        {
+            using var server = GetNewServer();
+            server.Logger.SetLoggerMode(LogMode.Information);
+            using var store = new DocumentStore {Urls = new[] {server.WebUrl}, Database = "Random"}.Initialize();
+            var client = store.GetRequestExecutor().HttpClient;
+            var response = await client.GetAsync(store.Urls.First() + "/admin/loggers");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsStringAsync();
+            var loggers = JsonConvert.DeserializeObject<JObject>(result);
+            Assert.NotNull(loggers);
+            Assert.True(loggers["Loggers"]["Server"][nameof(Logger.IsInfoEnabled)].Value<bool>());
+
+            //We want the client to be able to get the result of "/admin/loggers" configure it and send it back to "/admin/loggers/set"
+            //We don't want to change generic loggers while they are common to all test
+            loggers["Loggers"].Value<JObject>().Property("Generic").Remove();
+            var data = new StringContent(JsonConvert.SerializeObject(new {Configuration = loggers}), Encoding.UTF8, "application/json");
+            var setResponse = await client.PostAsync(store.Urls.First() + "/admin/loggers/set", data);
+            Assert.Equal(HttpStatusCode.OK, setResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenRequestSetServerLoggerToInfo_ShouldServerLoggerBeSetToInfo()
+        {
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options {Server = server});
+
+            var client = store.GetRequestExecutor().HttpClient;
+
+            var configuration = new {Loggers = new {Server = new {LogMode = LogMode.Information}}};
+
+            var data = new StringContent(JsonConvert.SerializeObject(new {Configuration = configuration}), Encoding.UTF8, "application/json");
+            var setResponse = await client.PostAsync(store.Urls.First() + "/admin/loggers/set", data);
+
+            Assert.Equal(HttpStatusCode.OK, setResponse.StatusCode);
+            Assert.Equal(LogMode.Information, server.Logger.GetLogMode());
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenAddAndRemoveDatabaseAndIndex_ShouldContainsEquivalentSwitches()
+        {
+            using var server = GetNewServer();
+            Assert.True(server.Logger.IsReset());
+
+            Assert.True(server.Logger.Loggers.TryGet("Databases", out var databasesSwitchLogger));
+            Assert.True(databasesSwitchLogger.IsReset());
+
+            string databaseName;
+            using (var store = GetDocumentStore(new Options {Server = server}))
+            {
+                databaseName = store.Database;
+                var index = new SampleIndex();
+                await index.ExecuteAsync(store);
+
+                Assert.True(databasesSwitchLogger.Loggers.TryGet(store.Database, out var databaseSwitchLogger));
+                Assert.True(databaseSwitchLogger.IsReset());
+
+                Assert.True(databaseSwitchLogger.Loggers.TryGet("Indexes", out var indexesSwitchLogger));
+                Assert.True(indexesSwitchLogger.IsReset());
+
+                Assert.True(indexesSwitchLogger.Loggers.TryGet(index.IndexName, out var indexSwitchLogger));
+                Assert.True(indexSwitchLogger.IsReset());
+
+                await store.Maintenance.SendAsync(new DeleteIndexOperation(index.IndexName));
+                Assert.False(indexesSwitchLogger.Loggers.TryGet(index.IndexName, out _));
+            }
+
+            Assert.False(databasesSwitchLogger.Loggers.TryGet(databaseName, out _));
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenApplyConfiguration_ShouldSetOnlyConfiguredSwitch()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+            var cLogger = bLogger.GetSubSwitchLogger("C");
+
+            var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
+            var contest = JsonOperationContext.ShortTermSingleUse();
+            var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
+            var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
+
+
+            Assert.True(aLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+            Assert.True(cLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            Assert.True(bLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            configuration.Apply(aLogger);
+
+            Assert.True(aLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+            Assert.True(cLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenCreateNewFromSetLogger_ShouldSetTheNew()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            aLogger.SetLoggerMode(LogMode.Information);
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenReset_ShouldResetSwitches()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            aLogger.SetLoggerMode(LogMode.Information);
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+            var cLogger = bLogger.GetSubSwitchLogger("C");
+
+            Assert.False(aLogger.IsReset());
+            Assert.True(aLogger.IsInfoEnabled);
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+            Assert.False(cLogger.IsReset());
+            Assert.True(cLogger.IsInfoEnabled);
+
+            aLogger.Reset(true);
+
+            Assert.True(aLogger.IsReset());
+            Assert.Equal(LogMode.None, aLogger.GetLogMode());
+            Assert.True(bLogger.IsReset());
+            Assert.Equal(LogMode.None, bLogger.GetLogMode());
+            Assert.True(cLogger.IsReset());
+            Assert.Equal(LogMode.None, cLogger.GetLogMode());
+
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenSwitchLoggerIsDifferentFromLoggingSource_ShouldUseSwitchLoggerConfiguration()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(suffix: "Logs", forceCreateDir: true);
+
+            var loggingSource = new LoggingSource(
+                LogMode.Information,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
+
+            var logger = new SwitchLogger(loggingSource, "A");
+
+            var shouldContainList = new List<string>();
+            var shouldNotContainList = new List<string>();
+
+            //Without listeners
+            {
+                await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                logger.SetLoggerMode(LogMode.None);
+                await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+            
+                logger.SetLoggerMode(LogMode.Operations);
+                await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                logger.SetLoggerMode(LogMode.Information);
+                await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+            }
+            
+            //With listeners
+            using(var socket = new LogTestsHelper.DummyWebSocket())
+            {
+                var context = new LoggingSource.WebSocketContext();
+                _ = loggingSource.Register(socket, context, CancellationToken.None);
+                
+                loggingSource.SetupLogMode(LogMode.Information);
+                await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                logger.SetLoggerMode(LogMode.None);
+                await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+            
+                logger.SetLoggerMode(LogMode.Operations);
+                await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                logger.SetLoggerMode(LogMode.Information);
+                await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+            }
+
+            //To be sure all logs where written to file
+            var lastLineLogger = loggingSource.GetLogger("Test", "Test");
+            await lastLineLogger.InfoWithWait("");
+            
+            var actualLogContent = await File.ReadAllTextAsync(logFile);
+            foreach (var msg in shouldContainList)
+            {            
+                Assert.Contains(msg, actualLogContent);
+            }
+            foreach (var msg in shouldNotContainList)
+            {            
+                Assert.DoesNotContain(msg, actualLogContent);
+            }
+
+            async Task AddLog(string msg, bool shouldContain)
+            {
+                var list = shouldContain ? shouldContainList : shouldNotContainList;
+
+                var subLogger = logger.GetLogger("test");
+                list.Add(msg);
+                if (logger.IsInfoEnabled)
+                    logger.Info(msg);
+                
+                var subLoggerMsg = $"subLogger {msg}";
+                list.Add(subLoggerMsg);
+                if(subLogger.IsInfoEnabled)
+                    subLogger.Info(subLoggerMsg);
+
+                var waitLogger = loggingSource.GetLogger("", "");
+                await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        private static string GetTestName([CallerMemberName] string memberName = "") => memberName;
+    }
+}

--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -577,7 +577,7 @@ namespace SlowTests.SparrowTests
 
             var logger = new Logger(loggingSource, "Source" + name, "Logger" + name);
             var tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var socket = new MyDummyWebSocket();
+            var socket = new LogTestsHelper.DummyWebSocket();
             socket.ReceiveAsyncFunc = () => tcs.Task;
             var context = new LoggingSource.WebSocketContext();
 
@@ -721,7 +721,7 @@ namespace SlowTests.SparrowTests
 
             var logger = new Logger(loggingSource, "Source" + name, "Logger" + name);
             var tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var socket = new MyDummyWebSocket();
+            var socket = new LogTestsHelper.DummyWebSocket();
             socket.ReceiveAsyncFunc = () => tcs.Task;
             var context = new LoggingSource.WebSocketContext();
 
@@ -745,45 +745,6 @@ namespace SlowTests.SparrowTests
             var logContent = await File.ReadAllTextAsync(logFile);
             Assert.DoesNotContain(uniqForOperation, logContent);
             Assert.DoesNotContain(uniqForInformation, logContent);
-        }
-
-        private class MyDummyWebSocket : WebSocket
-        {
-            private bool _close;
-            public string LogsReceived { get; private set; } = "";
-
-            public void Close() => _close = true;
-
-            public Func<Task<WebSocketReceiveResult>> ReceiveAsyncFunc { get; set; } = () => Task.FromResult(new WebSocketReceiveResult(1, WebSocketMessageType.Text, true));
-
-            public override void Abort()
-            {
-            }
-
-            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
-            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
-            public override void Dispose()
-            {
-            }
-
-            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) => ReceiveAsyncFunc();
-
-            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
-            {
-                if (_close)
-                    throw new Exception("Closed");
-                LogsReceived += Encodings.Utf8.GetString(buffer.ToArray());
-                return Task.CompletedTask;
-            }
-
-            public override WebSocketCloseStatus? CloseStatus { get; }
-            public override string CloseStatusDescription { get; }
-            public override WebSocketState State { get; }
-            public override string SubProtocol { get; }
         }
 
         private static string GetTestName([CallerMemberName] string memberName = "") => memberName;

--- a/test/SlowTests/Tests/TempFileCacheTests.cs
+++ b/test/SlowTests/Tests/TempFileCacheTests.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Indexing;
+using Sparrow.Logging;
 using Sparrow.Server;
 using Voron;
 using Voron.Exceptions;
@@ -27,7 +28,9 @@ namespace SlowTests.Tests
         public void Can_reuse_files_for_cache()
         {
             var path = new VoronPathSetting(NewDataPath());
-            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+
+            var logger = LoggingSource.Instance.GetLogger<TempFileCacheTests>("Test");
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null, logger);
 
             using (File.Create(TempFileCache.GetTempFileName(environment)))
             {
@@ -43,7 +46,8 @@ namespace SlowTests.Tests
         public void Skip_files_that_are_in_use()
         {
             var path = new VoronPathSetting(NewDataPath());
-            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null, logger);
 
             for (var i = 0; i < TempFileCache.MaxFilesToKeepInCache; i++)
             {

--- a/test/SlowTests/Voron/Storage/Files.cs
+++ b/test/SlowTests/Voron/Storage/Files.cs
@@ -6,6 +6,7 @@
 
 using System.IO;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,7 +32,8 @@ namespace SlowTests.Voron.Storage
         [Fact]
         public void TemporaryPathTest()
         {
-            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null, logger);
 
             Assert.Equal(DataDir, options.BasePath.FullPath);
             Assert.Equal(DataDir + "Temp", options.TempPath.FullPath);
@@ -51,7 +53,8 @@ namespace SlowTests.Voron.Storage
         [Fact]
         public void ScratchLocationWithTemporaryPathSpecified()
         {
-            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null, logger);
             using (var env = new StorageEnvironment(options))
             {
                 var scratchFile = Path.Combine(DataDir, StorageEnvironmentOptions.ScratchBufferName(0));

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -204,7 +204,7 @@ namespace Tests.Infrastructure
             serverStore.Initialize();
             var rachis = new RachisConsensus<CountingStateMachine>(serverStore, seed);
             var storageEnvironment = new StorageEnvironment(server);
-            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], out _);
+            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], out _, serverStore.Server.ClusterLogger);
             rachis.OnDispose += (sender, args) =>
             {
                 serverStore.Dispose();

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -89,7 +89,7 @@ namespace FastTests
         {
             LicenseManager.IgnoreProcessorAffinityChanges = ignore;
         }
-
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<TestBase>(nameof(TestBase));
         static unsafe TestBase()
         {
             IgnoreProcessorAffinityChanges(ignore: true);
@@ -638,7 +638,7 @@ namespace FastTests
             if (_concurrentTestsSemaphoreTaken.Lower())
                 ConcurrentTestsSemaphore.Release();
 
-            var exceptionAggregator = new ExceptionAggregator("Could not dispose test");
+            var exceptionAggregator = new ExceptionAggregator(Logger, "Could not dispose test");
 
             var testOutcomeAnalyzer = new TestOutcomeAnalyzer(Context);
             var shouldSaveDebugPackage = testOutcomeAnalyzer.ShouldSaveDebugPackage();
@@ -677,7 +677,6 @@ namespace FastTests
             ServersForDisposal = null;
 
             RavenTestHelper.DeletePaths(_localPathsToDelete, exceptionAggregator);
-
             exceptionAggregator.ThrowIfNeeded();
         }
 

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -66,7 +66,7 @@ namespace Voron.Recovery
 
         private StorageEnvironmentOptions CreateOptions()
         {
-            var result = StorageEnvironmentOptions.ForPath(_config.DataFileDirectory, null, null, null, null);
+            var result = StorageEnvironmentOptions.ForPath(_config.DataFileDirectory);
             result.CopyOnWriteMode = _copyOnWrite;
             result.ManualFlushing = true;
             result.ManualSyncing = true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15744/Support-logging-toggling

### Additional description
* Only the server side has the ability to switch off/on the loggers
* The switch loggers have a hierarchy, parent - children. (the current structure is present in "Switch loggers structure")
* Setting switch logger will not affect its already existing children
* A new child will be set as its parent 
* Setup the Logging source will affect only "reset" loggers.


Switch loggers structure:
```
 Generic: 
  Name: "Generic"
  Loggers" 
   - Name: "Memory"
 Server: 
  - Name: "Server"
   Loggers: 
   - Name: "Databases"
    Loggers: 
     - Name: "DB1"
      Loggers: 
       - Name: "Indexes"
         Loggers": 
          - Name: "Index1"
          - Name: "Index2"
     - Name: "DB2"
   - Name: "Cluster"
```
### Type of change
- New feature

### How risky is the change?
- High

### Backward compatibility
- Non-breaking change

### Is it a platform-specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- UI work can be added