### PR TITLE
RavenDB-19076 Filter returns same amount as query against index.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19076.cs
+++ b/test/SlowTests/Issues/RavenDB-19076.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using FastTests;
+using Nest;
+using Orders;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19076 : RavenTestBase
+{
+    public RavenDB_19076(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ExplorationQueryShouldReturnSameAmountOfResultsAsLuceneWhenFilterOnPrimitiveTypes()
+    {
+        using var store = GetDocumentStore();
+        store.Maintenance.Send(new CreateSampleDataOperation());
+        {
+            using var session = store.OpenSession();
+
+            var explorationQueryResults = GetResultPaging("from 'Orders' order by OrderedAt filter ShippedAt != null");
+            var indexQueryResults = GetResultPaging("from 'Orders' where ShippedAt != null order by OrderedAt");
+            for (int index = 0; index < indexQueryResults.Count; index++)
+            {
+                Order indexItem = indexQueryResults[index];
+                Assert.Equal(indexItem.Id, explorationQueryResults[index].Id);
+            }
+
+            Assert.Equal(indexQueryResults.Count, explorationQueryResults.Count);
+            List<Order> GetResultPaging(string query)
+            {
+                var pagging = new List<Order>();
+                int pageNumber = 0;
+                int pageSize = 101;
+                int skippedResults = 0;
+                List<Order> results;
+                do
+                {
+                    results = session.Advanced.RawQuery<Orders.Order>(query)
+                        .Statistics(out QueryStatistics stats)
+                        .Skip((pageNumber * pageSize) + skippedResults)
+                        .Take(pageSize)
+                        .ToList();
+
+                    pagging.AddRange(results);
+                    skippedResults += stats.SkippedResults;
+                    pageNumber++;
+                } while (results.Count > 0);
+
+                return pagging;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19076

### Additional description

Results are correct but the studio shows an invalid number of results. It takes it from the Lucene query but we don't filter the whole collection, so it should count the results as we do in unbounded queries.
### Type of change

- Test

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
