### PR TITLE
RavenDB-12430: As doesn't take into account the projection

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -112,7 +112,7 @@ namespace Raven.Client.Documents.Linq
                     _highlightings,
                     _isMapReduce,
                     _conventions,
-                    FieldsToFetch?.Count == 0 ? null : FieldsToFetch);
+                    FieldsToFetch);
 
             ravenQueryProvider.Customize(_customizeQuery);
 

--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -48,9 +48,11 @@ namespace Raven.Client.Documents.Linq
             QueryStatistics queryStatistics,
             LinqQueryHighlightings highlightings,
             bool isMapReduce,
-            DocumentConventions conventions)
+            DocumentConventions conventions,
+            HashSet<FieldToFetch> fieldsToFetch = null
+            )
         {
-            FieldsToFetch = new HashSet<FieldToFetch>();
+            FieldsToFetch = fieldsToFetch ?? new HashSet<FieldToFetch>();
             OriginalQueryType = originalQueryType;
 
             _queryGenerator = queryGenerator;
@@ -102,14 +104,15 @@ namespace Raven.Client.Documents.Linq
                 return this;
 
             var ravenQueryProvider = new RavenQueryProvider<TS>(
-                _queryGenerator,
-                _indexName,
-                _collectionName,
-                OriginalQueryType,
-                _queryStatistics,
-                _highlightings,
-                _isMapReduce,
-                _conventions);
+                    _queryGenerator,
+                    _indexName,
+                    _collectionName,
+                    OriginalQueryType,
+                    _queryStatistics,
+                    _highlightings,
+                    _isMapReduce,
+                    _conventions,
+                    FieldsToFetch?.Count == 0 ? null : FieldsToFetch);
 
             ravenQueryProvider.Customize(_customizeQuery);
 

--- a/test/FastTests/Issues/RavenDB-12430.cs
+++ b/test/FastTests/Issues/RavenDB-12430.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_12430 : RavenTestBase
+    {
+        public RavenDB_12430(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void AsExtensionShouldTakeIntoAccountProjection()
+        {
+            using (var store = GetDocumentStore())
+            using (IDocumentSession session = store.OpenSession())
+            {
+                var withoutAsExtension = session.Query<Order>().ProjectInto<Result>();
+                var withAsExtension = session.Query<Order>().ProjectInto<Result>().As<BlittableJsonReaderObject>();
+
+                Assert.True(withAsExtension is IQueryable<BlittableJsonReaderObject>);
+                Assert.Equal(withoutAsExtension.ToString(), "from 'Orders' select Company, Employee");
+                Assert.Equal(withoutAsExtension.ToString(), withAsExtension.ToString());
+            }
+        }
+
+        public class Result
+        {
+            public string Company { get; set; }
+            public string Employee { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Issues/RavenDB-12430.cs
+++ b/test/FastTests/Issues/RavenDB-12430.cs
@@ -29,7 +29,7 @@ namespace FastTests.Issues
             }
         }
 
-        public class Result
+        private class Result
         {
             public string Company { get; set; }
             public string Employee { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-12430/As-doesnt-take-into-account-the-projection

### Additional description

`session.Query<Order>().ProjectInto<Orders.Result>().As<BlittableJsonReaderObject>().ToString();`
Result:
Was:  `from Orders`
Now: `from 'Orders' select Company, Employee`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed