### PR TITLE
RavenDB-13106 semi-automate the rehsarding process

### DIFF
--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -16,6 +16,8 @@ namespace Raven.Client.Documents.Replication.Messages
 
         public ReplicationType ReplicationsType { get; set; }
 
+        public long MigrationIndex { get; set; }
+
         public enum ReplicationType
         {
             // External here as the default value to handle older servers, which aren't sending this field.

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -11,6 +11,7 @@ using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Documents.Commands.Attachments;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Binary;
@@ -88,7 +89,7 @@ namespace Raven.Server.Documents
         {
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
 
-            foreach (var result in GetItemsByBucket(context.Allocator, table, AttachmentsSchema.DynamicKeyIndexes[AttachmentsBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, AttachmentsSchema.DynamicKeyIndexes[AttachmentsBucketAndEtagSlice], bucket, etag))
             {
                 var attachment = TableValueToAttachment(context, ref result.Result.Reader);
 

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -10,6 +10,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -142,7 +143,7 @@ namespace Raven.Server.Documents
         {
             var table = context.Transaction.InnerTransaction.OpenTable(ConflictsSchema, ConflictsSlice);
 
-            foreach (var result in GetItemsByBucket(context.Allocator, table, ConflictsSchema.DynamicKeyIndexes[ConflictsBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, ConflictsSchema.DynamicKeyIndexes[ConflictsBucketAndEtagSlice], bucket, etag))
             {
                 yield return TableValueToConflictDocument(context, ref result.Result.Reader);
             }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions.Documents.Counters;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
@@ -128,7 +129,7 @@ namespace Raven.Server.Documents
         {
             var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
-            foreach (var result in GetItemsByBucket(context.Allocator, table, CountersSchema.DynamicKeyIndexes[CountersBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, CountersSchema.DynamicKeyIndexes[CountersBucketAndEtagSlice], bucket, etag))
             {
                 yield return CreateReplicationBatchItem(context, ref result.Result.Reader);
             }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1573,7 +1573,7 @@ namespace Raven.Server.Documents
             yield return TxMerger.TransactionPerformanceMetrics;
         }
 
-        private void OnDatabaseRecordChanged(DatabaseRecord record)
+        protected virtual void OnDatabaseRecordChanged(DatabaseRecord record)
         {
             DatabaseRecordChanged?.Invoke(record);
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -18,7 +18,6 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Replication;
-using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Storage.Layout;
@@ -45,7 +44,7 @@ namespace Raven.Server.Documents
     public unsafe class DocumentsStorage : IDisposable
     {
         public static readonly TableSchema DocsSchema = Schemas.Documents.Current;
-        public static readonly TableSchema CompressedDocsSchema = CurrentCompressed;
+        public static readonly TableSchema CompressedDocsSchema = Schemas.Documents.CurrentCompressed;
         public static readonly TableSchema TombstonesSchema = Schemas.Tombstones.Current;
         public static readonly TableSchema CollectionsSchema = Schemas.Collections.Current;
         public readonly DocumentDatabase DocumentDatabase;

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Replication.Messages;
+﻿using System;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TcpHandlers;
@@ -10,18 +11,14 @@ namespace Raven.Server.Documents.Replication.Incoming
 {
     public class IncomingMigrationReplicationHandler : IncomingReplicationHandler
     {
-        private readonly ReplicationLoader _parent;
         private readonly long _currentMigrationIndex;
-        private readonly ShardedDocumentDatabase _database;
 
         public const string MigrationTag = "MOVE";
 
         public IncomingMigrationReplicationHandler(TcpConnectionOptions options, ReplicationLatestEtagRequest replicatedLastEtag, ReplicationLoader parent,
             JsonOperationContext.MemoryBuffer bufferToCopy, ReplicationLatestEtagRequest.ReplicationType replicationType, long migrationIndex) : base(options, replicatedLastEtag, parent, bufferToCopy, replicationType)
         {
-            _parent = parent;
             _currentMigrationIndex = migrationIndex;
-            _database = parent.Database as ShardedDocumentDatabase;
         }
 
         protected override TransactionOperationsMerger.MergedTransactionCommand GetMergeDocumentsCommand(DataForReplicationCommand data, long lastDocumentEtag)
@@ -60,7 +57,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
-                _shardedDatabase = context.DocumentDatabase as ShardedDocumentDatabase;
+                _shardedDatabase = ShardedDocumentDatabase.CastToShardedDocumentDatabase(context.DocumentDatabase);
                
                 // TODO: delete current items in the bucket?
                 // TODO: handle the incoming properly

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.ServerWide.Commands;
 using Raven.Server.Documents.Replication.Senders;
@@ -25,7 +26,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         private void TryNotifySourceMigrationCompleted(DatabaseOutgoingReplicationHandler handler)
         {
-            var current = handler as OutgoingMigrationReplicationHandler;
+            var current = handler as OutgoingMigrationReplicationHandler ??
+                          throw new ArgumentException($"Handler must be of type 'OutgoingMigrationReplicationHandler', but is actually {handler.GetType().FullName}");
+
             var bucket = current.BucketMigrationNode.Bucket;
             var migrationIndex = current.BucketMigrationNode.MigrationIndex;
             var lastSentChangeVector = current.LastChangeVectorInBucket;

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
@@ -1,47 +1,60 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.ServerWide.Commands;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
     public class OutgoingMigrationReplicationHandler : DatabaseOutgoingReplicationHandler
     {
+        private readonly ShardedDocumentDatabase _database;
         public readonly BucketMigrationReplication BucketMigrationNode;
-        public OutgoingMigrationReplicationHandler(ReplicationLoader parent, DocumentDatabase database, BucketMigrationReplication node, TcpConnectionInfo connectionInfo) : base(parent, database, node, connectionInfo)
+        public string LastChangeVectorInBucket = null;
+
+        public OutgoingMigrationReplicationHandler(ReplicationLoader parent, ShardedDocumentDatabase database, BucketMigrationReplication node, TcpConnectionInfo connectionInfo) : base(parent, database, node, connectionInfo)
         {
+            _database = database;
             BucketMigrationNode = node;
+            SuccessfulReplication += (handler) =>
+            {
+                var current = handler as OutgoingMigrationReplicationHandler;
+                var bucket = current.BucketMigrationNode.Bucket;
+                var migrationIndex = current.BucketMigrationNode.MigrationIndex;
+                var lastSentChangeVector = current.LastChangeVectorInBucket;
+                
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal,
+                    "this is only best effort, this will not solve failovers / writting to a different node / writing after this");
+                if (_database.ShardedDocumentsStorage.HaveMoreDocumentsInBucket(bucket, lastSentChangeVector))
+                    return;
+
+                var task = current._parent._server.Sharding.SourceMigrationCompleted(_database.ShardedDatabaseName, bucket, migrationIndex, lastSentChangeVector,
+                    $"{bucket}@{migrationIndex}/{lastSentChangeVector}");
+
+                task.Wait(_database.DatabaseShutdown);
+
+                var result = task.Result;
+
+                var op = new WaitForIndexNotificationOperation(result.Index);
+                _database.DatabaseContext.AllNodesExecutor.ExecuteParallelForAllAsync(op).Wait(_database.DatabaseShutdown);
+            };
         }
 
         public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, Logger logger) => 
             new MigrationReplicationDocumentSender(stream, this, logger);
 
-        protected override void ProcessHandshakeResponse((ReplicationMessageReply.ReplyType ReplyType, ReplicationMessageReply Reply) response)
+        protected override DynamicJsonValue GetInitialHandshakeRequest()
         {
-            var request = new MigrationRequest
-            {
-                Database = Destination.Database,
-                Bucket = BucketMigrationNode.Bucket,
-                MigrationIndex = BucketMigrationNode.MigrationIndex
-            };
-
-            base.ProcessHandshakeResponse(response);
+            var request = base.GetInitialHandshakeRequest();
+            request[nameof(ReplicationLatestEtagRequest.MigrationIndex)] = BucketMigrationNode.MigrationIndex;
+            return request;
         }
 
         public override int GetHashCode() => BucketMigrationNode.GetHashCode();
-
-        public class MigrationRequest
-        {
-            public int Version;
-            public string Database;
-            public int Bucket;
-            public long MigrationIndex;
-        }
-
-        public class MigrationRequestResponse
-        {
-            public string LastBucketChangeVector;
-        }
     }
 }

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingMigrationReplicationHandler.cs
@@ -33,7 +33,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 if (_database.ShardedDocumentsStorage.HaveMoreDocumentsInBucket(bucket, lastSentChangeVector))
                     return;
 
-                var task = current._parent._server.Sharding.SourceMigrationCompleted(_database.ShardedDatabaseName, bucket, migrationIndex, lastSentChangeVector,
+                if (current.Server.Sharding.ManualMigration)
+                    return;
+
+                var task = current.Server.Sharding.SourceMigrationCompleted(_database.ShardedDatabaseName, bucket, migrationIndex, lastSentChangeVector,
                     $"{bucket}@{migrationIndex}/{lastSentChangeVector}");
 
                 task.Wait(_database.DatabaseShutdown);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1070,7 +1070,7 @@ namespace Raven.Server.Documents.Replication
                                     break;
 
                                 default:
-                                    _logger.Info($"Failed to dispose an unknown type '{instance?.GetType()}", e);
+                                    _logger.Info($"Failed to dispose an unknown type '{instance?.GetType().FullName}", e);
                                     break;
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1493,7 +1493,7 @@ namespace Raven.Server.Documents.Replication
                     outgoingReplication = new OutgoingExternalReplicationHandler(this, Database, externalNode, info);
                     break;
                 case BucketMigrationReplication migrationNode:
-                    outgoingReplication = new OutgoingMigrationReplicationHandler(this, Database as ShardedDocumentDatabase, migrationNode, info);
+                    outgoingReplication = new OutgoingMigrationReplicationHandler(this, ShardedDocumentDatabase.CastToShardedDocumentDatabase(Database), migrationNode, info);
                     break;
                 default:
                     throw new ArgumentException($"Unknown node type {node.GetType().FullName}");

--- a/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
@@ -28,8 +28,8 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected override IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentsOperationContext ctx, long etag, ReplicationStats stats, bool caseInsensitiveCounters)
         {
-            var database = ctx.DocumentDatabase as ShardedDocumentDatabase;
-            var documentsStorage = database.DocumentsStorage as ShardedDocumentsStorage;
+            var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(ctx.DocumentDatabase);
+            var documentsStorage = database.ShardedDocumentsStorage;
 
             var bucket = Destination.Bucket;
             _lastBatchChangeVector = ctx.GetChangeVector(string.Empty);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
@@ -1692,7 +1693,7 @@ namespace Raven.Server.Documents.Revisions
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
             
-            foreach (var result in GetItemsByBucket(context.Allocator, table, RevisionsSchema.DynamicKeyIndexes[RevisionsBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, RevisionsSchema.DynamicKeyIndexes[RevisionsBucketAndEtagSlice], bucket, etag))
             {
                 yield return TableValueToRevision(context, ref result.Result.Reader);
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Documents.Revisions
 
         public Table EnsureRevisionTableCreated(Transaction tx, CollectionName collection)
         {
-            var revisionsSchema = _documentsStorage.DocumentPut.DocumentsCompression.CompressRevisions ?
+            var revisionsSchema = _database.DocumentsCompression.CompressRevisions ?
                 CompressedRevisionsSchema :
                 RevisionsSchema;
 

--- a/src/Raven.Server/Documents/Schemas/Documents.cs
+++ b/src/Raven.Server/Documents/Schemas/Documents.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Schemas
                 Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
                 Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
                 Slice.From(ctx, "AllDocsEtags", ByteStringType.Immutable, out AllDocsEtagsSlice);
-                Slice.From(ctx, "DocsBucketAndEtag", ByteStringType.Immutable, out AllDocsBucketAndEtagSlice);
+                Slice.From(ctx, "AllDocsBucketAndEtag", ByteStringType.Immutable, out AllDocsBucketAndEtagSlice);
                 Slice.From(ctx, "CollectionDocsBucketAndEtag", ByteStringType.Immutable, out CollectionDocsBucketAndEtagSlice);
             }
 
@@ -93,6 +93,7 @@ namespace Raven.Server.Documents.Schemas
                     Name = AllDocsEtagsSlice
                 });
             }
+
             void DefineIndexesForDocsSchemaBase60(TableSchema docsSchema)
             {
                 DefineIndexesForDocsSchemaBase(docsSchema);
@@ -107,6 +108,7 @@ namespace Raven.Server.Documents.Schemas
                 docsSchema.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForDocuments,
+                    IsGlobal = false,
                     Name = CollectionDocsBucketAndEtagSlice
                 });
             }

--- a/src/Raven.Server/Documents/Schemas/Documents.cs
+++ b/src/Raven.Server/Documents/Schemas/Documents.cs
@@ -9,11 +9,11 @@ namespace Raven.Server.Documents.Schemas
         public static TableSchema Current => DocsSchemaBase60;
         public static TableSchema CurrentCompressed => CompressedDocsSchemaBase60;
 
-
         internal static readonly Slice DocsSlice;
         public static readonly Slice CollectionEtagsSlice;
         internal static readonly Slice AllDocsEtagsSlice;
-        internal static readonly Slice DocsBucketAndEtagSlice;
+        internal static readonly Slice AllDocsBucketAndEtagSlice;
+        internal static readonly Slice CollectionDocsBucketAndEtagSlice;
 
         internal static readonly TableSchema DocsSchemaBase60 = new TableSchema
         {
@@ -55,7 +55,8 @@ namespace Raven.Server.Documents.Schemas
                 Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
                 Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
                 Slice.From(ctx, "AllDocsEtags", ByteStringType.Immutable, out AllDocsEtagsSlice);
-                Slice.From(ctx, "DocsBucketAndEtag", ByteStringType.Immutable, out DocsBucketAndEtagSlice);
+                Slice.From(ctx, "DocsBucketAndEtag", ByteStringType.Immutable, out AllDocsBucketAndEtagSlice);
+                Slice.From(ctx, "CollectionDocsBucketAndEtag", ByteStringType.Immutable, out CollectionDocsBucketAndEtagSlice);
             }
 
             DefineIndexesForDocsSchemaBase(DocsSchemaBase);
@@ -100,7 +101,13 @@ namespace Raven.Server.Documents.Schemas
                 {
                     GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForDocuments,
                     IsGlobal = true,
-                    Name = DocsBucketAndEtagSlice
+                    Name = AllDocsBucketAndEtagSlice
+                });
+
+                docsSchema.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForDocuments,
+                    Name = CollectionDocsBucketAndEtagSlice
                 });
             }
         }

--- a/src/Raven.Server/Documents/Schemas/Tombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/Tombstones.cs
@@ -90,6 +90,7 @@ namespace Raven.Server.Documents.Schemas
                 TombstonesSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForTombstones,
+                    IsGlobal = false,
                     Name = CollectionTombstonesBucketAndEtagSlice
                 });
             }

--- a/src/Raven.Server/Documents/Schemas/Tombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/Tombstones.cs
@@ -16,6 +16,7 @@ namespace Raven.Server.Documents.Schemas
         internal static readonly Slice TombstonesPrefix;
         internal static readonly Slice DeletedEtagsSlice;
         internal static readonly Slice TombstonesBucketAndEtagSlice;
+        internal static readonly Slice CollectionTombstonesBucketAndEtagSlice;
 
         internal enum TombstoneTable
         {
@@ -35,10 +36,12 @@ namespace Raven.Server.Documents.Schemas
             using (StorageEnvironment.GetStaticContext(out var ctx))
             {
                 Slice.From(ctx, "AllTombstonesEtags", ByteStringType.Immutable, out AllTombstonesEtagsSlice);
-                Slice.From(ctx, "TombstonesBucketAndEtag", ByteStringType.Immutable, out TombstonesBucketAndEtagSlice);
                 Slice.From(ctx, "Tombstones", ByteStringType.Immutable, out TombstonesSlice);
                 Slice.From(ctx, CollectionName.GetTablePrefix(CollectionTableType.Tombstones), ByteStringType.Immutable, out TombstonesPrefix);
                 Slice.From(ctx, "DeletedEtags", ByteStringType.Immutable, out DeletedEtagsSlice);
+
+                Slice.From(ctx, "TombstonesBucketAndEtag", ByteStringType.Immutable, out TombstonesBucketAndEtagSlice);
+                Slice.From(ctx, "CollectionTombstonesBucketAndEtag", ByteStringType.Immutable, out CollectionTombstonesBucketAndEtagSlice);
             }
 
             DefineIndexesForTombstonesSchema(TombstonesSchemaBase);
@@ -82,6 +85,12 @@ namespace Raven.Server.Documents.Schemas
                     GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForTombstones,
                     IsGlobal = true,
                     Name = TombstonesBucketAndEtagSlice
+                });
+
+                TombstonesSchemaBase60.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = DocumentsStorage.GenerateBucketAndEtagIndexKeyForTombstones,
+                    Name = CollectionTombstonesBucketAndEtagSlice
                 });
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -62,6 +62,10 @@ public class ShardedDocumentDatabase : DocumentDatabase
     {
         // this called under lock
         base.OnDatabaseRecordChanged(record);
+
+        if (ServerStore.Sharding.ManualMigration)
+            return;
+
         var finishedMigrations = record.Sharding.BucketMigrations.Where(m => m.Value.Status == MigrationStatus.OwnershipTransferred);
         foreach (var finishedMigration in finishedMigrations)
         {

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -142,6 +142,8 @@ public class ShardedDocumentDatabase : DocumentDatabase
             $"{bucket}@{migrationIndex}-Cleaned-{ServerStore.NodeTag}");
     }
 
+    public static ShardedDocumentDatabase CastToShardedDocumentDatabase(DocumentDatabase database) => database as ShardedDocumentDatabase ?? throw new ArgumentException($"Database {database.Name} must be sharded!");
+
     private class DeleteBucketCommand : TransactionOperationsMerger.MergedTransactionCommand
     {
         private readonly int _bucket;

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
@@ -54,21 +54,3 @@ public class ShardedDocumentPutAction : DocumentPutAction
             valueWritePosition[j + 1] = idSuffixPtr[j];
     }
 }
-
-public class BucketUnderMoveException : ConcurrencyException
-{
-    public BucketUnderMoveException()
-    {
-
-    }
-
-    public BucketUnderMoveException(string message) : base(message)
-    {
-
-    }
-
-    public BucketUnderMoveException(string message, Exception inner) : base(message, inner)
-    {
-
-    }
-}

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -1,16 +1,178 @@
 ﻿using System;
+using System.Collections.Generic;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Binary;
+using Sparrow.Json;
+using Sparrow.Server;
+using Sparrow.Utils;
+using Voron;
+using Voron.Data.Tables;
+using static Raven.Server.Documents.Schemas.Documents;
+using static Raven.Server.Documents.Schemas.Tombstones;
 
 namespace Raven.Server.Documents.Sharding;
 
-public class ShardedDocumentsStorage : DocumentsStorage
+public unsafe class ShardedDocumentsStorage : DocumentsStorage
 {
-    public ShardedDocumentsStorage(DocumentDatabase documentDatabase, Action<string> addToInitLog) 
+    private readonly ShardedDocumentDatabase _documentDatabase;
+
+    public ShardedDocumentsStorage(ShardedDocumentDatabase documentDatabase, Action<string> addToInitLog) 
         : base(documentDatabase, addToInitLog)
     {
+        _documentDatabase = documentDatabase;
     }
 
     protected override DocumentPutAction CreateDocumentPutAction()
     {
-        return new ShardedDocumentPutAction(this, DocumentDatabase);
+        return new ShardedDocumentPutAction(this, _documentDatabase);
+    }
+    
+    public IEnumerable<Document> GetDocumentsByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
+    {
+        var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+
+        foreach (var result in GetItemsByBucket(context.Allocator, table, DocsSchema.DynamicKeyIndexes[AllDocsBucketAndEtagSlice], bucket, etag))
+        {
+            yield return TableValueToDocument(context, ref result.Result.Reader);
+        }
+    }
+
+    public long DeleteBucket(DocumentsOperationContext context, int bucket, ChangeVector upTo)
+    {
+        var deleted = 0L;
+        foreach (var collectionName in _collectionsCache.Values)
+        {
+            deleted += DeleteItemsByBucketForDocuments(context, collectionName, bucket, upTo);
+            deleted += DeleteItemsByBucketForTombstones(context, collectionName, bucket, upTo);
+        }
+        
+        return deleted;
+    }
+
+    public ChangeVector GetLastChangeVectorInBucket(DocumentsOperationContext context, int bucket)
+    {
+        var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+        using (GetBucketAndEtagByteString(context.Allocator, bucket, long.MaxValue, out var buffer))
+        using (Slice.External(context.Allocator, buffer, buffer.Length, out var keySlice))
+        using (Slice.External(context.Allocator, buffer, buffer.Length - sizeof(long), out var prefix))
+        {
+            var result = table.SeekOneBackwardFrom(DocsSchema.DynamicKeyIndexes[AllDocsBucketAndEtagSlice], prefix, keySlice);
+            if (result == null)
+                return null;
+
+            var document = TableValueToDocument(context, ref result.Reader, DocumentFields.ChangeVector);
+            return context.GetChangeVector(document.ChangeVector);
+        }
+    }
+
+    public ChangeVector GetMergedChangeVectorInBucket(DocumentsOperationContext context, int bucket)
+    {
+        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal,
+            "Optimize this to calculate the merged change vector during insertion to the bucket");
+        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal,
+            "Extend this for all types not only docs");
+
+        var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+        var merged = context.GetChangeVector(string.Empty);
+        foreach (var result in GetItemsByBucket(context.Allocator, table, DocsSchema.DynamicKeyIndexes[AllDocsBucketAndEtagSlice], bucket, 0))
+        {
+            var document = TableValueToDocument(context, ref result.Result.Reader, DocumentFields.ChangeVector);
+            merged = merged.MergeWith(document.ChangeVector, context);
+        }
+
+        return merged;
+    }
+
+    public bool HaveMoreDocumentsInBucket(int bucket, string current)
+    {
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            var last = GetLastChangeVectorInBucket(context, bucket);
+            if (last == null)
+                return false;
+
+            var status = ChangeVector.GetConflictStatusForDatabase(last, context.GetChangeVector(current));
+            if (status == ConflictStatus.AlreadyMerged)
+                return false;
+
+            return true;
+        }
+    }
+
+    public IEnumerable<ReplicationBatchItem> GetTombstonesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
+    {
+        var table = new Table(TombstonesSchema, context.Transaction.InnerTransaction);
+
+        foreach (var result in GetItemsByBucket(context.Allocator, table, TombstonesSchema.DynamicKeyIndexes[TombstonesBucketAndEtagSlice], bucket, etag))
+        {
+            yield return TombstoneReplicationItem.From(context, TableValueToTombstone(context, ref result.Result.Reader));
+        }
+    }
+
+    public static IEnumerable<Table.SeekResult> GetItemsByBucket(ByteStringContext allocator, Table table,
+        TableSchema.DynamicKeyIndexDef dynamicIndex, int bucket, long etag)
+    {
+        using (GetBucketAndEtagByteString(allocator, bucket, etag, out var buffer))
+        using (Slice.External(allocator, buffer, buffer.Length, out var keySlice))
+        using (Slice.External(allocator, buffer, buffer.Length - sizeof(long), out var prefix))
+        {
+            foreach (var result in table.SeekForwardFromPrefix(dynamicIndex, keySlice, prefix, 0))
+            {
+                yield return result;
+            }
+        }
+    }
+
+    public const long MaxDocumentsToDeleteInBucket = 1024;
+
+    public static long DeleteItemsByBucket(DocumentsOperationContext context, Table table,
+        TableSchema.DynamicKeyIndexDef dynamicIndex, int changeVectorPosition, int bucket, ChangeVector upTo)
+    {
+        using (GetBucketByteString(context.Allocator, bucket, out var buffer))
+        using (Slice.External(context.Allocator, buffer, buffer.Length, out var prefix))
+        {
+            return table.DeleteForwardFrom(dynamicIndex, prefix, startsWith: true, MaxDocumentsToDeleteInBucket, shouldAbort: holder =>
+            {
+                var changeVector = TableValueToChangeVector(context, changeVectorPosition, ref holder.Reader);
+                var status = ChangeVectorUtils.GetConflictStatus(changeVector, upTo);
+                return status != ConflictStatus.AlreadyMerged;
+            });
+        }
+    }
+
+    public static long DeleteItemsByBucketForDocuments(DocumentsOperationContext context, CollectionName collection, int bucket, ChangeVector upTo)
+    {
+        var table = context.Transaction.InnerTransaction.OpenTable(DocsSchema, collection.GetTableName(CollectionTableType.Documents));
+        return DeleteItemsByBucket(context, table, DocsSchema.DynamicKeyIndexes[CollectionDocsBucketAndEtagSlice], (int)DocumentsTable.ChangeVector, bucket, upTo);
+    }
+
+    public static long DeleteItemsByBucketForTombstones(DocumentsOperationContext context, CollectionName collection, int bucket, ChangeVector upTo)
+    {
+        var table = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collection.GetTableName(CollectionTableType.Tombstones));
+        return DeleteItemsByBucket(context, table, TombstonesSchema.DynamicKeyIndexes[CollectionTombstonesBucketAndEtagSlice], (int)TombstoneTable.ChangeVector, bucket, upTo);
+    }
+
+    public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetBucketByteString(
+        ByteStringContext allocator, int bucket,
+        out ByteString buffer)
+    {
+        var scope = allocator.Allocate(sizeof(int), out buffer);
+        *(int*)buffer.Ptr = Bits.SwapBytes(bucket);
+
+        return scope;
+    }
+
+    public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetBucketAndEtagByteString(
+        ByteStringContext allocator, int bucket, long etag,
+        out ByteString buffer)
+    {
+        var scope = allocator.Allocate(sizeof(int) + sizeof(long), out buffer);
+        *(int*)buffer.Ptr = Bits.SwapBytes(bucket);
+        *(long*)(buffer.Ptr + sizeof(int)) = Bits.SwapBytes(etag);
+
+        return scope;
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
@@ -2247,7 +2248,7 @@ namespace Raven.Server.Documents.TimeSeries
         {
             var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
 
-            foreach (var result in DocumentsStorage.GetItemsByBucket(context.Allocator, table, TimeSeriesSchema.DynamicKeyIndexes[TimeSeriesBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, TimeSeriesSchema.DynamicKeyIndexes[TimeSeriesBucketAndEtagSlice], bucket, etag))
             {
                 yield return CreateTimeSeriesSegmentItem(context, ref result.Result.Reader);
             }
@@ -2325,7 +2326,7 @@ namespace Raven.Server.Documents.TimeSeries
         {
             var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
 
-            foreach (var result in DocumentsStorage.GetItemsByBucket(context.Allocator, table, DeleteRangesSchema.DynamicKeyIndexes[DeletedRangesBucketAndEtagSlice], bucket, etag))
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, DeleteRangesSchema.DynamicKeyIndexes[DeletedRangesBucketAndEtagSlice], bucket, etag))
             {
                 yield return CreateDeletedRangeItem(context, ref result.Result.Reader);
             }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -30,6 +30,7 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
@@ -3420,6 +3421,15 @@ namespace Raven.Server.ServerWide
                         break;
                     yield return def;
                 }
+            }
+        }
+
+        public ShardingConfiguration ReadShardingConfiguration<TTransaction>(TransactionOperationContext<TTransaction> context, string name)
+            where TTransaction : RavenTransaction
+        {
+            using (var raw = ReadRawDatabaseRecord(context, name))
+            {
+                return raw.Sharding.Value;
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Sharding
@@ -30,6 +31,13 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
             if (migration.MigrationIndex != MigrationIndex)
                 throw new InvalidOperationException($"Wrong migration index. Expected: '{MigrationIndex}', Actual: '{migration.MigrationIndex}'");
+
+            if (migration.Status == MigrationStatus.Moved)
+            {
+                // we got a write after we already moved
+                migration.LastSourceChangeVector = LastSentChangeVector;
+                return;
+            }
 
             if (migration.Status != MigrationStatus.Moving)
                 throw new InvalidOperationException($"Expected status is '{MigrationStatus.Moving}', Actual '{migration.Status}'");

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
         public Dictionary<string, long> LastSentEtag = new Dictionary<string, long>();
-        public Dictionary<BucketNumber, BucketReport> ReportPerBucket;
+        public Dictionary<int, BucketReport> ReportPerBucket = new Dictionary<int, BucketReport>();
 
         public class ObservedIndexStatus
         {
@@ -102,6 +102,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(DatabaseChangeVector)] = DatabaseChangeVector,
                 [nameof(LastCompletedClusterTransaction)] = LastCompletedClusterTransaction,
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
+                [nameof(ReportPerBucket)] = DynamicJsonValue.Convert(ReportPerBucket),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime
             };

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -430,6 +430,9 @@ namespace Raven.Server.ServerWide.Maintenance
 
         private void UpdateReshardingStatus(ClusterOperationContext context, RawDatabaseRecord rawRecord, Dictionary<string, ClusterNodeStatusReport> newStats, ref List<DestinationMigrationConfirmCommand> confirmCommands)
         {
+            if (_server.Server.ServerStore.Sharding.ManualMigration)
+                return;
+
             var databaseName = rawRecord.DatabaseName;
             var sharding = rawRecord.Sharding;
             var currentMigration = sharding.BucketMigrations.SingleOrDefault(pair => pair.Value.Status < MigrationStatus.OwnershipTransferred).Value;

--- a/src/Raven.Server/ServerWide/Maintenance/Sharding/BucketsMigrator.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/Sharding/BucketsMigrator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Maintenance.Sharding
 {
@@ -190,15 +191,27 @@ namespace Raven.Server.ServerWide.Maintenance.Sharding
     public class ShardReport
     {
         public ShardNumber Shard;
-        public Dictionary<BucketNumber, BucketReport> ReportPerBucket;
+        public Dictionary<int, BucketReport> ReportPerBucket;
         public long TotalSize => ReportPerBucket.Sum(r => r.Value.Size);
     }
 
-    public class BucketReport
+    public class BucketReport : IDynamicJson
     {
         public long Size;
         public long NumberOfDocuments;
         public DateTime LastAccess;
+        public string LastChangeVector;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Size)] = Size,
+                [nameof(NumberOfDocuments)] = NumberOfDocuments,
+                [nameof(LastAccess)] = LastAccess,
+                [nameof(LastChangeVector)] = LastChangeVector,
+            };
+        }
     }
 
     public class MigrationPolicy
@@ -229,21 +242,5 @@ namespace Raven.Server.ServerWide.Maintenance.Sharding
         public static implicit operator int(ShardNumber value) => value._value;
         public override string ToString() => _value.ToString();
 
-    }
-
-    public struct BucketNumber
-    {
-        private int _value = 0;
-
-        public BucketNumber(int value)
-        {
-            _value = value;
-        }
-
-        public static implicit operator BucketNumber(int value) => new BucketNumber(value: value);
-
-        public static implicit operator int(BucketNumber value) => value._value;
-
-        public override string ToString() => _value.ToString();
     }
 }

--- a/src/Raven.Server/ServerWide/Maintenance/Sharding/ShardMigrationResult.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/Sharding/ShardMigrationResult.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.ServerWide.Maintenance.Sharding
 
         public int SourceShard;
         public int DestinationShard;
-        public BucketNumber Bucket;
+        public int Bucket;
 
         public StartBucketMigrationCommand GetMigrationCommand => new StartBucketMigrationCommand(Bucket, SourceShard, DestinationShard, Database, RaftId);
 

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -7,6 +7,7 @@ namespace Raven.Server.ServerWide
     public class ShardingStore
     {
         private readonly ServerStore _server;
+        public bool ManualMigration = false;
 
         public ShardingStore(ServerStore server)
         {

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Raven.Client.Util;
-using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Commands.Sharding;
 
 namespace Raven.Server.ServerWide
@@ -13,33 +12,28 @@ namespace Raven.Server.ServerWide
         {
             _server = server;
         }
-
         
-        public Task<(long Index, object Result)> StartBucketMigration(string database, int bucket, int fromShard, int toShard)
+        public Task<(long Index, object Result)> StartBucketMigration(string database, int bucket, int fromShard, int toShard, string raftId = null)
         {
-            var cmd = new StartBucketMigrationCommand(bucket, fromShard, toShard, database, RaftIdGenerator.NewId());
-
+            var cmd = new StartBucketMigrationCommand(bucket, fromShard, toShard, database, raftId ?? RaftIdGenerator.NewId());
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> SourceMigrationCompleted(string database, int bucket, long migrationIndex, string lastChangeVector)
+        public Task<(long Index, object Result)> SourceMigrationCompleted(string database, int bucket, long migrationIndex, string lastChangeVector, string raftId = null)
         {
-            var cmd = new SourceMigrationSendCompletedCommand(bucket, migrationIndex, lastChangeVector, database, RaftIdGenerator.NewId());
-
+            var cmd = new SourceMigrationSendCompletedCommand(bucket, migrationIndex, lastChangeVector, database, raftId ?? RaftIdGenerator.NewId());
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> DestinationMigrationConfirm(string database, int bucket, long migrationIndex)
+        public Task<(long Index, object Result)> DestinationMigrationConfirm(string database, int bucket, long migrationIndex, string raftId = null)
         {
-            var cmd = new DestinationMigrationConfirmCommand(bucket, migrationIndex, _server.NodeTag, database, RaftIdGenerator.NewId());
-
+            var cmd = new DestinationMigrationConfirmCommand(bucket, migrationIndex, _server.NodeTag, database, raftId ?? RaftIdGenerator.NewId());
             return _server.SendToLeaderAsync(cmd);
         }
 
-        public Task<(long Index, object Result)> SourceMigrationCleanup(string database, int bucket, long migrationIndex)
+        public Task<(long Index, object Result)> SourceMigrationCleanup(string database, int bucket, long migrationIndex, string raftId = null)
         {
-            var cmd = new SourceMigrationCleanupCommand(bucket, migrationIndex, _server.NodeTag, database, RaftIdGenerator.NewId());
-
+            var cmd = new SourceMigrationCleanupCommand(bucket, migrationIndex, _server.NodeTag, database, raftId ?? RaftIdGenerator.NewId());
             return _server.SendToLeaderAsync(cmd);
         }
     }

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
         public bool Update(UpdateStep step)
         {
-            InsertIndexValuesFor(step, DocsSchemaBase60, DocsBucketAndEtagSlice,
+            InsertIndexValuesFor(step, DocsSchemaBase60, AllDocsBucketAndEtagSlice,
                 fixedSizeIndex: DocsSchemaBase60.FixedSizeIndexes[AllDocsEtagsSlice],
                 etagPosition: (int)DocumentsTable.Etag);
 

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Utils
         }
 
         //do not use this directly, we might mutate the slice buffer here.
-        private static unsafe int GetBucketFromSlice(Slice lowerId)
+        public static unsafe int GetBucketFromSlice(Slice lowerId)
         {
             byte* buffer = lowerId.Content.Ptr;
             int size = lowerId.Size;

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Sparrow.Collections;
 using Sparrow.Extensions;
 using Sparrow.Utils;
@@ -122,6 +123,27 @@ namespace Sparrow.Json.Parsing
             {
                 var json = kvp.Value as IDynamicJson;
                 djv[kvp.Key] = json == null ? (object)kvp.Value : json.ToJson();
+            }
+            return djv;
+        }
+
+        public static DynamicJsonValue Convert<TK, TV>(IDictionary<TK, TV> dictionary)
+        {
+            if (dictionary == null)
+                return null;
+
+            // if (typeof(TK).IsPrimitive == false)
+            {
+                var mi = typeof(TK).GetMethod(nameof(ToString), types: Type.EmptyTypes);
+                if (mi.GetBaseDefinition().DeclaringType == mi.DeclaringType)
+                    throw new InvalidOperationException($"{typeof(TK).FullName} must override 'ToString'");
+            }
+
+            var djv = new DynamicJsonValue();
+            foreach (var kvp in dictionary)
+            {
+                var json = kvp.Value as IDynamicJson;
+                djv[kvp.Key.ToString()] = json == null ? (object)kvp.Value : json.ToJson();
             }
             return djv;
         }

--- a/test/FastTests/Sharding/RavenDB-17760.cs
+++ b/test/FastTests/Sharding/RavenDB-17760.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
@@ -59,7 +60,7 @@ namespace FastTests.Sharding
                     using (shardedDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        var docs = shardedDb.DocumentsStorage.GetDocumentsByBucketFrom(context, buckets[i], etag: 0).ToList();
+                        var docs = shardedDb.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, buckets[i], etag: 0).ToList();
                         if (docs.Count == 0)
                             continue;
 
@@ -68,7 +69,7 @@ namespace FastTests.Sharding
                         Assert.True(docs.Select(d => d.Id).All(s => s.EndsWith($"suffix{i}")));
 
                         var fromEtag = docs[70].Etag;
-                        docs = shardedDb.DocumentsStorage.GetDocumentsByBucketFrom(context, buckets[i], etag: fromEtag).ToList();
+                        docs = shardedDb.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, buckets[i], etag: fromEtag).ToList();
                         Assert.Equal(30, docs.Count);
                         break;
                     }
@@ -102,7 +103,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -163,14 +164,14 @@ namespace FastTests.Sharding
                 await session.SaveChangesAsync();
             }
 
-            DocumentDatabase db = null;
+            ShardedDocumentDatabase db = null;
             var dbs = await Task.WhenAll(Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(store.Database));
             foreach (var shard in dbs)
             {
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -197,7 +198,7 @@ namespace FastTests.Sharding
 
                 using (context.OpenReadTransaction())
                 {
-                    var tombstones = db.DocumentsStorage.GetTombstonesByBucketFrom(context, bucket, etag: 0).ToList();
+                    var tombstones = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(context, bucket, etag: 0).ToList();
                     var expected = 20; 
                     Assert.Equal(expected, tombstones.Count);
 
@@ -215,7 +216,7 @@ namespace FastTests.Sharding
 
 
                     var fromEtag = tombstones[12].Etag;
-                    tombstones = db.DocumentsStorage.GetTombstonesByBucketFrom(context, bucket, etag: fromEtag).ToList();
+                    tombstones = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(context, bucket, etag: fromEtag).ToList();
                     expected = 8;
                     Assert.Equal(expected, tombstones.Count);
                 }
@@ -261,7 +262,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -344,7 +345,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -423,7 +424,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -511,7 +512,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 
@@ -603,7 +604,7 @@ namespace FastTests.Sharding
                 using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
+                    var docs = shard.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
                     if (docs.Count == 0)
                         continue;
 

--- a/test/SlowTests/Issues/IAsyncDocumentSessionExtensionsTest.cs
+++ b/test/SlowTests/Issues/IAsyncDocumentSessionExtensionsTest.cs
@@ -128,7 +128,7 @@ namespace SlowTests.Issues
                             count++;
                             tmp = DateTime.ParseExact(reader.Current.Metadata[Constants.Documents.Metadata.LastModified].ToString(), "yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'",
                                 CultureInfo.InvariantCulture, DateTimeStyles.None);
-                            Assert.True(lastModified > tmp);
+                            Assert.True(lastModified >= tmp);
                             lastModified = tmp;
                             Assert.IsType<User>(reader.Current.Document);
                         }

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -230,9 +230,11 @@ namespace SlowTests.Sharding.Backup
                 }));
 
                 // wait for backups to complete
-                var backupsDone = await Sharding.Backup.WaitForBackupsToComplete(new[] { store1, store2 });
+                var backupsDone = await Sharding.Backup.WaitForBackupToComplete(store1);
+                var backupsDone2 = await Backup.WaitForBackupToComplete(store2);
 
                 Assert.True(WaitHandle.WaitAll(backupsDone, TimeSpan.FromMinutes(2)));
+                Assert.True(WaitHandle.WaitAll(backupsDone2, TimeSpan.FromMinutes(2)));
 
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(2, dirs.Length);

--- a/test/SlowTests/Sharding/BucketMigration/BucketsMigratorTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/BucketsMigratorTests.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Sharding.BucketMigration
                 shards[shardNumber] ??= new ShardReport
                 {
                     Shard = shardNumber,
-                    ReportPerBucket = new Dictionary<BucketNumber, BucketReport>()
+                    ReportPerBucket = new Dictionary<int, BucketReport>()
                 };
 
                 shards[shardNumber].ReportPerBucket[bucket] = new BucketReport

--- a/test/SlowTests/Sharding/Client/Operations/GetSuggestConflictResolutionOperationTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetSuggestConflictResolutionOperationTests.cs
@@ -71,7 +71,7 @@ namespace SlowTests.Sharding.Client.Operations
                 await session.SaveChangesAsync();
             }
 
-            var db = await GetShardedDocumentDatabase(store.Database, bucket);
+            var db = await Sharding.GetShardedDocumentDatabaseForBucketAsync(store.Database, bucket);
 
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
@@ -102,29 +102,6 @@ namespace SlowTests.Sharding.Client.Operations
 
                 context.Transaction.Commit();
             }
-        }
-
-        private async Task<DocumentDatabase> GetShardedDocumentDatabase(string databaseName, int bucket)
-        {
-            DocumentDatabase db = null;
-            var dbs = await Task.WhenAll(Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(databaseName));
-            foreach (var shard in dbs)
-            {
-                using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    var docs = shard.DocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0).ToList();
-                    if (docs.Count == 0)
-                        continue;
-
-                    db = shard;
-                    break;
-                }
-            }
-
-            Assert.NotNull(db);
-
-            return db;
         }
     }
 }

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -24,9 +24,11 @@ namespace SlowTests.Sharding.Cluster
         [RavenFact(RavenTestCategory.Sharding)]
         public async Task CanMoveOneBucketManually()
         {
-            // TODO: once wired, disable the observer
+            DoNotReuseServer();
             using (var store = Sharding.GetDocumentStore())
             {
+                Server.ServerStore.Sharding.ManualMigration = true;
+
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
 
                 var id = "foo/bar";

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -1,18 +1,21 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using FastTests.Sharding;
 using Orders;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Utils;
 using SlowTests.Core.Utils.Entities;
+using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Sharding.Cluster
 {
-    public class ReshardingTests : RavenTestBase
+    public class ReshardingTests : ClusterTestBase
     {
         public ReshardingTests(ITestOutputHelper output) : base(output)
         {
@@ -82,34 +85,18 @@ namespace SlowTests.Sharding.Cluster
         {
             using (var store = Sharding.GetDocumentStore())
             {
-                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Attachments | DatabaseItemType.CounterGroups | DatabaseItemType.RevisionDocuments));
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents /*| DatabaseItemType.Attachments | DatabaseItemType.CounterGroups | DatabaseItemType.RevisionDocuments*/));
 
                 var id = "orders/830-A";
+                var oldLocation = await Sharding.GetShardNumber(store, id);
                
-                var bucket = ShardHelper.GetBucket(id);
-                var location = ShardHelper.GetShardNumber(record.Sharding.BucketRanges, bucket);
-                var newLocation = (location + 1) % record.Sharding.Shards.Length;
-                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, location)))
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, oldLocation)))
                 {
                     var order = await session.LoadAsync<Order>(id);
                     Assert.NotNull(order);
                 }
 
-                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, location, newLocation);
-
-                var exists = WaitForDocument<Order>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, newLocation));
-                Assert.True(exists);
-
-                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
-                {
-                    var order = await session.LoadAsync<Order>(id);
-                    var changeVector = session.Advanced.GetChangeVectorFor(order);
-                    await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector);
-                }
-
-                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index);
-                await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+                await Sharding.Resharding.MoveShardForId(store, id);
 
                 // the document will be written to the new location
                 using (var session = store.OpenAsyncSession())
@@ -119,13 +106,20 @@ namespace SlowTests.Sharding.Cluster
                     await session.SaveChangesAsync();
                 }
 
-                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, location)))
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, oldLocation)))
                 {
                     var order = await session.LoadAsync<Order>(id);
-                    Assert.Equal("employees/1-A", order.Employee);
+                    Assert.Null(order);
                 }
 
-                WaitForUserToContinueTheTest(store);
+                var newLocation = await Sharding.GetShardNumber(store, id);
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
+                {
+                    var order = await session.LoadAsync<Order>(id);
+                    Assert.NotNull(order);
+                }
+
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "assert for everything");
             }
         }
 
@@ -162,11 +156,7 @@ namespace SlowTests.Sharding.Cluster
                 using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
                 {
                     var user = await session.LoadAsync<User>(id);
-                    var changeVector = session.Advanced.GetChangeVectorFor(user);
-                    //await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector);
                 }
-
-                //await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index);
 
                 // the document will be written to the new location
                 using (var session = store.OpenAsyncSession())
@@ -180,6 +170,129 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var user = await session.LoadAsync<User>(id);
                     Assert.Equal("Original shard", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanMoveBucketWhileWriting()
+        {
+            using var store = Sharding.GetDocumentStore();
+
+            var writes = Task.Run(() =>
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                    }, "users/1-A");
+                    session.SaveChanges();
+                }
+
+                for (int i = 0; i < 100; i++)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User
+                        {
+                        }, $"num-{i}$users/1-A");
+                        session.SaveChanges();
+                    }
+                }
+            });
+            
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+
+            await writes;
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    var q = await session.Query<User>().ToListAsync();
+                    return q.Count;
+                }
+            }, 101);
+
+            var expectedShard = await Sharding.GetShardNumber(store, "users/1-A");
+            for (int shard = 0; shard < 3; shard++)
+            {
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, shard)))
+                {
+                    var q = await session.Query<User>().ToListAsync();
+                    Assert.Equal(expectedShard == shard ? 101 : 0, q.Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanMoveBucketWhileWriting2()
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                Server = cluster.Leader
+            });
+
+            var writes = Task.Run(() =>
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Count = 10
+                    }, "users/1-A");
+                    session.SaveChanges();
+                }
+
+                for (int i = 0; i < 100; i++)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User
+                        {
+                            Count = 666
+                        },"users/");
+                        session.SaveChanges();
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User
+                        {
+                            Count = 10
+                        }, $"num-{i}$users/1-A");
+                        session.SaveChanges();
+                    }
+                }
+            });
+            
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+            await Sharding.Resharding.MoveShardForId(store, "users/1-A");
+
+            await writes;
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    var q = await session.Query<User>().Where(u => u.Count == 10, exact: true).ToListAsync();
+                    return q.Count;
+                }
+            }, 101);
+
+            var expectedShard = await Sharding.GetShardNumber(store, "users/1-A");
+            for (int shard = 0; shard < 3; shard++)
+            {
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, shard)))
+                {
+                    var q = await session.Query<User>().Where(u => u.Count == 10, exact: true).ToListAsync();
+                    Assert.Equal(expectedShard == shard ? 101 : 0, q.Count);
                 }
             }
         }

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -608,7 +608,9 @@ public partial class RavenTestBase
                     using (var ctx = JsonOperationContext.ShortTermSingleUse())
                     {
                         var sharding = store.Conventions.Serialization.DefaultConverter.ToBlittable(record.Sharding, ctx).ToString();
-                        throw new InvalidOperationException($"Failed to completed the migration for {id}{Environment.NewLine}{sharding}{Environment.NewLine}", e);
+                        throw new InvalidOperationException(
+                            $"Failed to completed the migration for {id}{Environment.NewLine}{sharding}{Environment.NewLine}{_parent.Cluster.CollectLogsFromNodes(servers ?? new List<RavenServer> { _parent.Server })}",
+                            e);
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13106

### Additional description

This PR continue the work on the core implementation of resharding.
We still manually specify which bucket we should move where, but for that point onward everything else is handled by raven.

The flow is the following
1. Manually start migration be specifying which bucket to move
2. Database record is updated with a new `BukcetMigration` with the status of `Moving`
3. The source shard starts a replication to the destination shard and start moving the bucket
4. After the source sent all docs it sends a command to change the status to `Moved` with the reached change vector. 
(The connection will remain open and will continue to send move docs for this bucket when arrived)
6. The cluster observer monitor the destination shards and for each node reaching the marked change vector we will issue a command to try and transfer the ownership, when all nodes reach that change vector the status will be change to `OwnershipTrasferred` and the buckets mapping will be modified.
7. All sources will start purging the moved bucket, once all of them are done the migration is completed and deleted from the database record.

Also included:
- Moving sharding stuff to `ShardedDocumentDatabase` or `ShardedDocumentsStorage`
- New _local_ Voron index to handle the bucket's deletion 

NOT in this PR:
- Handle proper bucket deletion https://issues.hibernatingrhinos.com/issue/RavenDB-19197
- Handle writes to the wrong shard https://issues.hibernatingrhinos.com/issue/RavenDB-19241

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
