### PR TITLE
RavenDB-18523 - Unable to include counters, time series when including revisions

### DIFF
--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents.Includes
                   {
                       var bt = BlittableJsonTraverser.Default;
                       if (bt.TryRead(document.Data, path, out var singleOrMultipleCv, out var _) == false)
-                        throw new InvalidOperationException($"Field `{path}` inside `include revisions(..)` is invalid.");
+                        throw new InvalidOperationException($"Field `{path}` (which is mentioned inside `include revisions(..)`) is missing in document.");
 
                       switch (singleOrMultipleCv)
                       {

--- a/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
+++ b/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
@@ -121,8 +121,19 @@ namespace SlowTests.Tests.Linq
                     var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     if (includeCounters)
                     {
@@ -229,7 +240,10 @@ namespace SlowTests.Tests.Linq
                     var revision1 = session.Advanced.Revisions.Get<UserNested>(cvList[0]);
                     var revision2 = session.Advanced.Revisions.Get<UserNested>(cvList[1]);
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.Revisions.FirstRevision);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.Revisions.FirstRevision);
 
                     if (includeCounters)
                     {
@@ -321,8 +335,19 @@ namespace SlowTests.Tests.Linq
                     var revision3 = await asyncSession.Advanced.Revisions.GetAsync<User>(cvList[2]);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, asyncSession.Advanced.NumberOfRequests);
                 }
@@ -354,8 +379,11 @@ namespace SlowTests.Tests.Linq
                 {
                     var query = session.Load<User>(id, builder => builder.IncludeRevisions(x => x.ChangeVector));
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
-
                     Assert.NotNull(revision);
+                    Assert.Null(revision.FirstRevision);
+                    Assert.Null(revision.SecondRevision);
+                    Assert.Null(revision.ChangeVectors);
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -389,6 +417,9 @@ namespace SlowTests.Tests.Linq
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
                     Assert.NotNull(revision);
+                    Assert.Null(revision.FirstRevision);
+                    Assert.Null(revision.SecondRevision);
+                    Assert.Null(revision.ChangeVectors);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -419,19 +450,35 @@ namespace SlowTests.Tests.Linq
                     Assert.Equal(1, metadatas.Count);
 
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
+
+                    session.Advanced.Patch<User, string>(id, x => x.FirstRevision, changeVector);
+
                     session.SaveChanges();
+
+
                     cvList.Add(changeVector);
 
                     metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
+
                     cvList.Add(changeVector);
+
+                    session.Advanced.Patch<User, string>(id, x => x.SecondRevision, changeVector);
 
                     session.SaveChanges();
+
+
                     metadatas = session.Advanced.Revisions.GetMetadataFor(id);
+
                     changeVector = metadatas[0].GetString(Constants.Documents.Metadata.ChangeVector);
 
                     cvList.Add(changeVector);
+
+                    session.Advanced.Patch<User, string>(id, x => x.ThirdRevision, changeVector);
+
                     session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, cvList);
+
                     session.SaveChanges();
                 }
 
@@ -442,6 +489,21 @@ namespace SlowTests.Tests.Linq
                     var revision1 = session.Advanced.Revisions.Get<User>(cvList[0]);
                     var revision2 = session.Advanced.Revisions.Get<User>(cvList[1]);
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
+
+                    Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
+                    Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
+                    Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -510,6 +572,21 @@ namespace SlowTests.Tests.Linq
                     var revision1 = await session.Advanced.Revisions.GetAsync<User>(cvList[0]);
                     var revision2 = await session.Advanced.Revisions.GetAsync<User>(cvList[1]);
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
+
+                    Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
+                    Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
+                    Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -583,11 +660,41 @@ namespace SlowTests.Tests.Linq
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
                     var revisions = session.Advanced.Revisions.Get<User>(cvList);
 
-
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
+
                     Assert.NotNull(revisions);
+                    Assert.Equal(revisions.Count, 3);
+                    Assert.Contains(cvList[0], revisions.Keys);
+
+                    Assert.NotNull(cvList[0]);
+                    Assert.Equal(revisions[cvList[0]].FirstRevision, revision1.FirstRevision);
+                    Assert.Equal(revisions[cvList[0]].SecondRevision, revision1.SecondRevision);
+                    Assert.Equal(revisions[cvList[0]].ChangeVectors, revision1.ChangeVectors);
+
+                    Assert.Contains(cvList[1], revisions.Keys);
+                    Assert.NotNull(cvList[1]);
+                    Assert.Equal(revisions[cvList[1]].FirstRevision, revision2.FirstRevision);
+                    Assert.Equal(revisions[cvList[1]].SecondRevision, revision2.SecondRevision);
+                    Assert.Equal(revisions[cvList[1]].ChangeVectors, revision2.ChangeVectors);
+
+                    Assert.Contains(cvList[2], revisions.Keys);
+                    Assert.NotNull(cvList[2]);
+                    Assert.Equal(revisions[cvList[2]].FirstRevision, revision3.FirstRevision);
+                    Assert.Equal(revisions[cvList[2]].SecondRevision, revision3.SecondRevision);
+                    Assert.Equal(revisions[cvList[2]].ChangeVectors, revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -661,8 +768,35 @@ namespace SlowTests.Tests.Linq
                     var revisions = await session.Advanced.Revisions.GetAsync<User>(cvList);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revisions);
+                    Assert.Equal(revisions.Count, 3);
+                    Assert.Contains(cvList[0], revisions.Keys);
+
+                    Assert.NotNull(revisions[cvList[0]]);
+                    Assert.Equal(revisions[cvList[0]].FirstRevision, revision1.FirstRevision);
+                    Assert.Equal(revisions[cvList[0]].SecondRevision, revision1.SecondRevision);
+                    Assert.Equal(revisions[cvList[0]].ChangeVectors, revision1.ChangeVectors);
+
+                    Assert.Contains(cvList[1], revisions.Keys);
+                    Assert.NotNull(revisions[cvList[1]]);
+                    Assert.Equal(revisions[cvList[1]].FirstRevision, revision2.FirstRevision);
+                    Assert.Equal(revisions[cvList[1]].SecondRevision, revision2.SecondRevision);
+                    Assert.Equal(revisions[cvList[1]].ChangeVectors, revision2.ChangeVectors);
+
+                    Assert.Contains(cvList[2], revisions.Keys);
+                    Assert.NotNull(revisions[cvList[2]]);
+                    Assert.Equal(revisions[cvList[2]].FirstRevision, ex.FirstRevision);
+                    Assert.Equal(revisions[cvList[2]].SecondRevision, ex.SecondRevision);
+                    Assert.Null(revisions[cvList[2]].ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -679,8 +813,7 @@ namespace SlowTests.Tests.Linq
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User { Name = "Omer", },
-                        id);
+                    session.Store(new User { Name = "Omer", }, id);
                     session.SaveChanges();
 
                     var metadatas = session.Advanced.Revisions.GetMetadataFor(id);
@@ -688,6 +821,7 @@ namespace SlowTests.Tests.Linq
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
                     session.Advanced.Patch<User, List<string>>(id, x => x.ChangeVectors, new List<string> { changeVector });
+                    session.SaveChanges();
                 }
 
                 var dateTime = DateTime.Now.ToLocalTime();
@@ -698,11 +832,26 @@ namespace SlowTests.Tests.Linq
                         .IncludeRevisions(x => x.ChangeVector)
                         .IncludeRevisions(x => x.ChangeVectors));
 
-                    var revision = session.Advanced.Revisions.Get<User>(id, dateTime.ToUniversalTime());
-                    var revision2 = session.Advanced.Revisions.Get<User>(changeVector);
+                    var revision = session.Advanced.Revisions.Get<User>(changeVector);
+                    var revision2 = session.Advanced.Revisions.Get<User>(id, dateTime.ToUniversalTime());
                     Assert.NotNull(query);
+                    Assert.Null(query.FirstRevision);
+                    Assert.Null(query.SecondRevision);
+                    Assert.NotNull(query.ChangeVectors);
+                    Assert.NotNull(query.Name);
+
                     Assert.NotNull(revision);
+                    Assert.Null(revision.FirstRevision);
+                    Assert.Null(revision.SecondRevision);
+                    Assert.Null(revision.ChangeVectors);
+                    Assert.NotNull(revision.Name);
+
                     Assert.NotNull(revision2);
+                    Assert.Null(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.NotNull(revision2.ChangeVectors);
+                    Assert.NotNull(revision2.Name);
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -718,14 +867,15 @@ namespace SlowTests.Tests.Linq
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new User { Name = "Omer", },
-                        id);
+                    var user = new User { Name = "Omer", };
+                    await session.StoreAsync(user, id);
                     await session.SaveChangesAsync();
 
                     var metadatas = await session.Advanced.Revisions.GetMetadataForAsync(id);
                     Assert.Equal(1, metadatas.Count);
                     changeVector = metadatas.First().GetString(Constants.Documents.Metadata.ChangeVector);
                     session.Advanced.Patch<User, string>(id, x => x.ChangeVector, changeVector);
+                    await session.SaveChangesAsync();
                 }
 
                 var dateTime = DateTime.Now.ToLocalTime();
@@ -735,11 +885,29 @@ namespace SlowTests.Tests.Linq
                         .IncludeRevisions(dateTime)
                         .IncludeRevisions(x => x.ChangeVector));
 
-                    var revision = await session.Advanced.Revisions.GetAsync<User>(id, dateTime.ToUniversalTime());
-                    var revision2 = await session.Advanced.Revisions.GetAsync<User>(changeVector);
+                    var revision2 = await session.Advanced.Revisions.GetAsync<User>(id, dateTime.ToUniversalTime());
+                    var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector); //revision before 'ChangeVector' value chaged.
                     Assert.NotNull(query);
+                    Assert.Null(query.FirstRevision);
+                    Assert.Null(query.SecondRevision);
+                    Assert.Null(query.ChangeVectors);
+                    Assert.NotNull(query.ChangeVector);
+                    Assert.NotNull(query.Name);
+
                     Assert.NotNull(revision);
+                    Assert.Null(revision.FirstRevision);
+                    Assert.Null(revision.SecondRevision);
+                    Assert.Null(revision.ChangeVectors);
+                    Assert.Null(revision.ChangeVector);
+                    Assert.NotNull(revision.Name);
+
                     Assert.NotNull(revision2);
+                    Assert.Null(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+                    Assert.NotNull(revision2.ChangeVector);
+                    Assert.NotNull(revision2.Name);
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -776,7 +944,9 @@ namespace SlowTests.Tests.Linq
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
                     Assert.NotNull(users);
+                    Assert.Equal(users.Count, 1);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -812,7 +982,9 @@ namespace SlowTests.Tests.Linq
 
                     var revision = await asyncSession.Advanced.Revisions.GetAsync<User>(changeVector);
                     Assert.NotNull(users);
+                    Assert.Equal(users.Count, 1);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, asyncSession.Advanced.NumberOfRequests);
                 }
             }
@@ -858,6 +1030,10 @@ namespace SlowTests.Tests.Linq
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
+                    Assert.NotNull(query);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -903,6 +1079,7 @@ namespace SlowTests.Tests.Linq
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -942,7 +1119,10 @@ namespace SlowTests.Tests.Linq
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
                     Assert.NotNull(query);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -980,7 +1160,10 @@ namespace SlowTests.Tests.Linq
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
                     Assert.NotNull(query);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1036,7 +1219,10 @@ select Foo(u)"
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1091,7 +1277,10 @@ select Foo(u)"
                         .ToListAsync();
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1143,7 +1332,10 @@ select Foo(u)"
                         .ToList();
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1192,7 +1384,10 @@ select Foo(u)"
                         .ToList();
 
                     var revision = session.Advanced.Revisions.Get<User>("users/rhino", getRevisionBefore);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1241,7 +1436,10 @@ select Foo(u)"
                         .ToListAsync();
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>("users/Rhino", getRevisionBefore);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1293,7 +1491,10 @@ select Foo(u)"
                         .ToList();
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1346,7 +1547,10 @@ select Foo(u)"
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1435,8 +1639,19 @@ select Foo(u)"
 
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     if (session.Advanced.NumberOfRequests != 1)
                         WaitForUserToContinueTheTest(store);
@@ -1520,8 +1735,19 @@ select Foo(u)"
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -1567,7 +1793,10 @@ select Foo(u)"
 
                     var revision = session.Advanced.Revisions.Get<User>(changeVector);
 
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1612,7 +1841,10 @@ select Foo(u)"
 
                     var revision = await session.Advanced.Revisions.GetAsync<User>(changeVector);
 
+                    Assert.Equal(query.Count, 1);
+                    Assert.NotNull(query[0].Name);
                     Assert.NotNull(revision);
+                    Assert.NotNull(revision.Name);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }
@@ -1687,8 +1919,19 @@ select Foo(u)"
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -1761,8 +2004,19 @@ select Foo(u)"
                     var revision3 = session.Advanced.Revisions.Get<User>(cvList[2]);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -1834,8 +2088,19 @@ select Foo(u)"
                     var revision3 = await session.Advanced.Revisions.GetAsync<User>(cvList[2]);
 
                     Assert.NotNull(revision1);
+                    Assert.Null(revision1.FirstRevision);
+                    Assert.Null(revision1.SecondRevision);
+                    Assert.Null(revision1.ChangeVectors);
+
                     Assert.NotNull(revision2);
+                    Assert.NotNull(revision2.FirstRevision);
+                    Assert.Null(revision2.SecondRevision);
+                    Assert.Null(revision2.ChangeVectors);
+
                     Assert.NotNull(revision3);
+                    Assert.NotNull(revision3.FirstRevision);
+                    Assert.NotNull(revision3.SecondRevision);
+                    Assert.Null(revision3.ChangeVectors);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
@@ -1867,7 +2132,7 @@ select Foo(u)"
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
 
-                    Assert.Contains("Field `x.SecondRevision` inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.SecondRevision` (which is mentioned inside `include revisions(..)`) is missing in document."
                         , error.Message);
                 }
 
@@ -1880,7 +2145,7 @@ select Foo(u)"
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToList());
 
-                    Assert.Contains("Field `x.ThirdRevision` inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.ThirdRevision` (which is mentioned inside `include revisions(..)`) is missing in document."
                         , error.Message);
                 }
             }
@@ -1911,7 +2176,7 @@ select Foo(u)"
                         .RawQuery<User>("from Users as u include revisions(u.FirstRevision, x.SecondRevision)")
                         .ToList());
 
-                    Assert.Contains("Field `x.SecondRevision` inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.SecondRevision` (which is mentioned inside `include revisions(..)`) is missing in document."
                         , error.Message);
                 }
 
@@ -1924,7 +2189,7 @@ select Foo(u)"
                         .AddParameter("p2", "x.ThirdRevision")
                         .ToListAsync());
 
-                    Assert.Contains("Field `x.ThirdRevision` inside `include revisions(..)` is invalid."
+                    Assert.Contains("Field `x.ThirdRevision` (which is mentioned inside `include revisions(..)`) is missing in document."
                         , error.Message);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18523/Unable-to-include-counters-time-series-when-including-revisions

### Additional description

The original issue - Unable to include counters, time series when including revisions.
The issue reopenned - to fix include revisions tests that didn't make sure that the required changes happened in DB for the include revisions testing,
 and to make exception message more accurate for the studio.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
