### PR TITLE
RavenDB-18915 - open the file with the correct file share flag

### DIFF
--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -382,7 +382,7 @@ namespace SlowTests.SparrowTests
                 var logs = logDirectory.GetFiles();
                 foreach (var fileInfo in logs)
                 {
-                    using var file = fileInfo.OpenRead();
+                    using var file = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
                     Stream stream;
                     if (fileInfo.Name.EndsWith(".log.gz"))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18915/SlowTestsSparrowTestsLoggingSourceTestsLoggingSourceWhileRetentionBySizeOnShouldKeepRetentionPolicycompressing-True

### Additional description

Open the file with the correct file share flag

### Type of change

- Bug fix

### How risky is the change?

- Low 