### PR TITLE
RavenDB-18935 - The test Sinks_should_not_update_hubs_change_vector2 …

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -225,6 +225,10 @@ namespace Raven.Client.ServerWide
             {
                 var myUrl = clusterTopology.GetUrlFromTag(myTag);
                 var repNode = WhoseTaskIsIt(state, new PromotableTask(myTag, myUrl, databaseName));
+                if (repNode == null)
+                {
+                    return destinations;
+                }
                 var repNodeUrl = clusterTopology.GetUrlFromTag(repNode);
 
                 destinations.Add(new InternalReplication


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18935/The-test-Sinksshouldnotupdatehubschangevector2-sometimes-results-in-having-empty-url

### Additional description

The test Sinks_should_not_update_hubs_change_vector2 sometimes results in having empty URL.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
