### PR TITLE
RavenDB-19209 To check that query relay on PropertyNameConverter to g…

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -372,6 +372,20 @@ namespace Raven.Client.Documents.Conventions
         }
 #endif
 
+        public string GetConvertedPropertyNameFor(MemberInfo member)
+        {
+            var converter = PropertyNameConverter;
+            if (converter == null)
+                return member.Name;
+            
+            //do not use convention for types in system namespaces
+            if (member.DeclaringType?.Namespace?.StartsWith("System") == true ||
+                member.DeclaringType?.Namespace?.StartsWith("Microsoft") == true)
+                return member.Name;
+
+            return converter(member);
+        }
+
         public Func<MemberInfo, string> PropertyNameConverter
         {
             get => _propertyNameConverter;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBuilder.cs
@@ -182,12 +182,12 @@ namespace Raven.Client.Documents.Indexes
                 if (PatternForOutputReduceToCollectionReferences != null)
                     indexDefinition.PatternForOutputReduceToCollectionReferences = ConvertPatternForOutputReduceToCollectionReferencesToString(PatternForOutputReduceToCollectionReferences);
 
-                var indexes = ConvertToStringDictionary(Indexes);
-                var stores = ConvertToStringDictionary(Stores);
-                var analyzers = ConvertToStringDictionary(Analyzers);
-                var suggestionsOptions = ConvertToStringSet(SuggestionsOptions).ToDictionary(x => x, x => true);
-                var termVectors = ConvertToStringDictionary(TermVectors);
-                var spatialOptions = ConvertToStringDictionary(SpatialIndexes);
+                var indexes = ConvertToStringDictionary(conventions,Indexes);
+                var stores = ConvertToStringDictionary(conventions,Stores);
+                var analyzers = ConvertToStringDictionary(conventions,Analyzers);
+                var suggestionsOptions = ConvertToStringSet(conventions, SuggestionsOptions).ToDictionary(x => x, x => true);
+                var termVectors = ConvertToStringDictionary(conventions,TermVectors);
+                var spatialOptions = ConvertToStringDictionary(conventions,SpatialIndexes);
 
                 foreach (var indexesString in IndexesStrings)
                 {
@@ -365,23 +365,23 @@ namespace Raven.Client.Documents.Indexes
             }
         }
 
-        private static IDictionary<string, TValue> ConvertToStringDictionary<TValue>(IEnumerable<KeyValuePair<Expression<Func<TReduceResult, object>>, TValue>> input)
+        private static IDictionary<string, TValue> ConvertToStringDictionary<TValue>(DocumentConventions conventions, IEnumerable<KeyValuePair<Expression<Func<TReduceResult, object>>, TValue>> input)
         {
             var result = new Dictionary<string, TValue>();
             foreach (var value in input)
             {
-                var propertyPath = value.Key.ToPropertyPath('_');
+                var propertyPath = value.Key.ToPropertyPath(conventions, '_');
                 result[propertyPath] = value.Value;
             }
             return result;
         }
 
-        private static ISet<string> ConvertToStringSet(IEnumerable<Expression<Func<TReduceResult, object>>> input)
+        private static ISet<string> ConvertToStringSet(DocumentConventions conventions, IEnumerable<Expression<Func<TReduceResult, object>>> input)
         {
             var result = new HashSet<string>();
             foreach (var value in input)
             {
-                var propertyPath = value.ToPropertyPath('_');
+                var propertyPath = value.ToPropertyPath(conventions,'_');
                 result.Add(propertyPath);
             }
             return result;

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -151,7 +151,8 @@ namespace Raven.Client.Documents.Linq
 
             string path;
 
-            switch (memberExpression.Member.Name)
+            string memberName = _conventions.GetConvertedPropertyNameFor(memberExpression.Member);
+            switch (memberName)
             {
                 case "Value":
                     // we truncate the nullable .Value because in json all values are nullable
@@ -178,19 +179,19 @@ namespace Raven.Client.Documents.Linq
                 mi.Member.DeclaringType != null && 
                 mi.Member.DeclaringType.IsGenericType &&
                 mi.Member.DeclaringType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)
-                )
+               )
             {
-                path = mi.Expression + "." + memberExpression.Member.Name;
+                path = mi.Expression + "." + memberName;
             }
             else if (memberExpression.Expression is MethodCallExpression methodCallExpression &&
                      methodCallExpression.Method.Name == "get_Item")
             {
-                path = GetPath(memberExpression.Expression, isFilterActive).Path + "." + memberExpression.Member.Name;
+                path = GetPath(memberExpression.Expression, isFilterActive).Path + "." + memberName;
                 isNested = true;
             }
             else
             {
-                path = memberExpression.ToString();
+                path = memberExpression.Expression +"." + memberName;
             }
 
             AssertNoComputation(memberExpression);

--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -126,13 +126,13 @@ namespace Raven.Client.Documents.Linq
 
         public IRavenQueryable<T> Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, out Highlightings highlightings)
         {
-            return Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, out highlightings);
+            return Highlight(path.ToPropertyPath(_conventions), fragmentLength, fragmentCount, out highlightings);
         }
 
         public IRavenQueryable<T> Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, HighlightingOptions options,
             out Highlightings highlightings)
         {
-            return Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, options, out highlightings);
+            return Highlight(path.ToPropertyPath(_conventions), fragmentLength, fragmentCount, options, out highlightings);
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents
         /// <returns></returns>
         public static IRavenQueryable<TResult> Include<TResult>(this IQueryable<TResult> source, Expression<Func<TResult, object>> path)
         {
-            return source.Include(path.ToPropertyPath());
+            return source.Include(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions));
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Raven.Client.Documents
             var queryInspector = (IRavenQueryInspector)source;
             var conventions = queryInspector.Session.Conventions;
 
-            return Include(source, IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), conventions));
+            return Include(source, IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), conventions));
         }
         
         /// <summary>
@@ -172,7 +172,7 @@ namespace Raven.Client.Documents
 
         public static IAggregationQuery<T> AggregateBy<T>(this IQueryable<T> source, Action<IFacetBuilder<T>> builder)
         {
-            var f = new FacetBuilder<T>();
+            var f = new FacetBuilder<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions);
             builder.Invoke(f);
 
             return source.AggregateBy(f.Facet);
@@ -252,7 +252,7 @@ namespace Raven.Client.Documents
         /// </summary>
         public static ISuggestionQuery<T> SuggestUsing<T>(this IQueryable<T> source, Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions);
             builder?.Invoke(f);
 
             return source.SuggestUsing(f.Suggestion);
@@ -1114,7 +1114,7 @@ namespace Raven.Client.Documents
 
         public static IRavenQueryable<T> Spatial<T>(this IQueryable<T> source, Expression<Func<T, object>> path, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
-            return source.Spatial(path.ToPropertyPath(), clause);
+            return source.Spatial(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), clause);
         }
 
         public static IRavenQueryable<T> Spatial<T>(this IQueryable<T> source, string fieldName, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
@@ -1130,7 +1130,7 @@ namespace Raven.Client.Documents
 
         public static IRavenQueryable<T> Spatial<T>(this IQueryable<T> source, Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
-            return source.Spatial(field(DynamicSpatialFieldFactory<T>.Instance), clause);
+            return source.Spatial(field(new DynamicSpatialFieldFactory<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions)), clause);
         }
 
         public static IRavenQueryable<T> Spatial<T>(this IQueryable<T> source, DynamicSpatialField field, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
@@ -1146,7 +1146,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            return source.OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            return source.OrderByDistance(field(new DynamicSpatialFieldFactory<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions)), latitude, longitude);
         }
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, DynamicSpatialField field, double latitude, double longitude)
@@ -1167,7 +1167,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, Expression<Func<T, object>> path, double latitude, double longitude, double roundFactor)
         {
-            return source.OrderByDistance(path.ToPropertyPath(), latitude, longitude, roundFactor);
+            return source.OrderByDistance(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), latitude, longitude, roundFactor);
         }
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, string fieldName, double latitude, double longitude)
         {
@@ -1192,7 +1192,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            return source.OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            return source.OrderByDistance(field(new DynamicSpatialFieldFactory<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions)), shapeWkt);
         }
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, DynamicSpatialField field, string shapeWkt)
@@ -1208,7 +1208,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, Expression<Func<T, object>> path, string shapeWkt)
         {
-            return source.OrderByDistance(path.ToPropertyPath(), shapeWkt);
+            return source.OrderByDistance(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), shapeWkt);
         }
 
         public static IOrderedQueryable<T> OrderByDistance<T>(this IQueryable<T> source, string fieldName, string shapeWkt)
@@ -1224,7 +1224,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            return source.OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            return source.OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions)), latitude, longitude);
         }
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, DynamicSpatialField field, double latitude, double longitude)
@@ -1247,7 +1247,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, Expression<Func<T, object>> path, double latitude, double longitude, double roundFactor)
         {
-            return source.OrderByDistanceDescending(path.ToPropertyPath(), latitude, longitude, roundFactor);
+            return source.OrderByDistanceDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), latitude, longitude, roundFactor);
         }
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, string fieldName, double latitude, double longitude)
@@ -1272,7 +1272,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            return source.OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            return source.OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions)), shapeWkt);
         }
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, DynamicSpatialField field, string shapeWkt)
@@ -1292,7 +1292,7 @@ namespace Raven.Client.Documents
         }
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, Expression<Func<T, object>> path, string shapeWkt, double roundFactor)
         {
-            return source.OrderByDistanceDescending(path.ToPropertyPath(), shapeWkt, roundFactor);
+            return source.OrderByDistanceDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), shapeWkt, roundFactor);
         }
 
         public static IOrderedQueryable<T> OrderByDistanceDescending<T>(this IQueryable<T> source, string fieldName, string shapeWkt)
@@ -1317,7 +1317,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, Expression<Func<T, object>> path, string sorterName)
         {
-            return source.OrderBy(path.ToPropertyPath(), sorterName);
+            return source.OrderBy(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), sorterName);
         }
 
         public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, string path, string sorterName)
@@ -1333,7 +1333,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, Expression<Func<T, object>> path, OrderingType ordering = OrderingType.String)
         {
-            return source.OrderBy(path.ToPropertyPath(), ordering);
+            return source.OrderBy(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), ordering);
         }
 
         public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, string path, OrderingType ordering = OrderingType.String)
@@ -1350,7 +1350,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, Expression<Func<T, object>> path, string sorterName)
         {
-            return source.OrderByDescending(path.ToPropertyPath(), sorterName);
+            return source.OrderByDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), sorterName);
         }
 
         public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, string path, string sorterName)
@@ -1369,7 +1369,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, Expression<Func<T, object>> path, OrderingType ordering = OrderingType.String)
         {
-            return source.OrderByDescending(path.ToPropertyPath(), ordering);
+            return source.OrderByDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), ordering);
         }
 
         public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, string path, OrderingType ordering = OrderingType.String)
@@ -1385,7 +1385,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, Expression<Func<T, object>> path, string sorterName)
         {
-            return source.ThenBy(path.ToPropertyPath(), sorterName);
+            return source.ThenBy(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), sorterName);
         }
 
         public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, string path, string sorterName)
@@ -1401,7 +1401,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, Expression<Func<T, object>> path, OrderingType ordering = OrderingType.String)
         {
-            return source.ThenBy(path.ToPropertyPath(), ordering);
+            return source.ThenBy(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), ordering);
         }
 
         public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, string path, OrderingType ordering = OrderingType.String)
@@ -1417,7 +1417,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, Expression<Func<T, object>> path, string sorterName)
         {
-            return source.ThenByDescending(path.ToPropertyPath(), sorterName);
+            return source.ThenByDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), sorterName);
         }
 
         public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, string path, string sorterName)
@@ -1433,7 +1433,7 @@ namespace Raven.Client.Documents
 
         public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, Expression<Func<T, object>> path, OrderingType ordering = OrderingType.String)
         {
-            return source.ThenByDescending(path.ToPropertyPath(), ordering);
+            return source.ThenByDescending(path.ToPropertyPath(((IRavenQueryProvider)source.Provider).QueryGenerator.Conventions), ordering);
         }
 
         public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, string path, OrderingType ordering = OrderingType.String)

--- a/src/Raven.Client/Documents/Queries/Facets/AggregationDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/AggregationDocumentQuery.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IAggregationDocumentQuery<T> AndAggregateBy(Action<IFacetBuilder<T>> builder = null)
         {
-            var f = new FacetBuilder<T>();
+            var f = new FacetBuilder<T>(_source.Conventions);
             builder?.Invoke(f);
 
             return AndAggregateBy(f.Facet);

--- a/src/Raven.Client/Documents/Queries/Facets/AggregationQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/AggregationQuery.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IAggregationQuery<T> AndAggregateBy(Action<IFacetBuilder<T>> builder = null)
         {
-            var f = new FacetBuilder<T>();
+            var f = new FacetBuilder<T>(((IRavenQueryProvider)_source.Provider).QueryGenerator.Conventions);
             builder?.Invoke(f);
 
             return AndAggregateBy(f.Facet);

--- a/src/Raven.Client/Documents/Queries/Facets/AsyncAggregationDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/AsyncAggregationDocumentQuery.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IAsyncAggregationDocumentQuery<T> AndAggregateBy(Action<IFacetBuilder<T>> builder = null)
         {
-            var f = new FacetBuilder<T>();
+            var f = new FacetBuilder<T>(_source.Conventions);
             builder?.Invoke(f);
 
             return AndAggregateBy(f.Facet);

--- a/src/Raven.Client/Documents/Queries/Facets/Facet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/Facet.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session.Tokens;
 using Raven.Client.Extensions;
 using Sparrow.Json;
@@ -8,13 +9,17 @@ namespace Raven.Client.Documents.Queries.Facets
 {
     public class Facet : FacetBase
     {
+        internal FacetBase _parent;
+
         /// <summary>
         /// Name of field the facet aggregate on
         /// </summary>
         public string FieldName { get; set; }
 
-        internal override FacetToken ToFacetToken(Func<object, string> addQueryParameter)
+        internal override FacetToken ToFacetToken(DocumentConventions conventions, Func<object, string> addQueryParameter)
         {
+            if (_parent != null)
+                return _parent.ToFacetToken(conventions, addQueryParameter);
             return FacetToken.Create(this, addQueryParameter);
         }
 
@@ -45,17 +50,18 @@ namespace Raven.Client.Documents.Queries.Facets
         {
             return new Facet
             {
-                FieldName = other.FieldName.ToPropertyPath('_'),
+                FieldName = other.FieldName.ToPropertyPath(DocumentConventions.Default, '_'),
                 Options = other.Options,
                 Aggregations = other.Aggregations,
-                DisplayFieldName = other.DisplayFieldName
+                DisplayFieldName = other.DisplayFieldName,
+                _parent = other
             };
         }
 
-        internal override FacetToken ToFacetToken(Func<object, string> addQueryParameter)
+        internal override FacetToken ToFacetToken(DocumentConventions conventions,Func<object, string> addQueryParameter)
         {
             var facet = (Facet)this;
-            return facet.ToFacetToken(addQueryParameter);
+            return facet.ToFacetToken(conventions, addQueryParameter);
         }
     }
 }

--- a/src/Raven.Client/Documents/Queries/Facets/FacetBase.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session.Tokens;
 using Sparrow.Json;
 
@@ -29,7 +30,7 @@ namespace Raven.Client.Documents.Queries.Facets
             set => _displayFieldName = value;
         }
 
-        internal abstract FacetToken ToFacetToken(Func<object, string> addQueryParameter);
+        internal abstract FacetToken ToFacetToken(DocumentConventions conventions, Func<object, string> addQueryParameter);
 
         internal static void Fill(FacetBase facet, BlittableJsonReaderObject json)
         {

--- a/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Queries.Facets
@@ -33,6 +34,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
     internal class FacetBuilder<T> : IFacetBuilder<T>, IFacetOperations<T>
     {
+        private readonly DocumentConventions _conventions;
         private RangeFacet<T> _range;
         private Facet _default;
         private readonly HashSet<string> _rqlKeywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -46,6 +48,11 @@ namespace Raven.Client.Documents.Queries.Facets
             "INCLUDE",
             "UPDATE"
         };
+
+        public FacetBuilder(DocumentConventions conventions)
+        {
+            _conventions = conventions;
+        }
 
         public IFacetOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths)
         {
@@ -70,7 +77,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IFacetOperations<T> ByField(Expression<Func<T, object>> path)
         {
-            return ByField(path.ToPropertyPath('_'));
+            return ByField(path.ToPropertyPath(_conventions,'_'));
         }
 
         public IFacetOperations<T> ByField(string fieldName)
@@ -117,7 +124,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
             aggregations.Add(new FacetAggregationField
             {
-                Name = path.ToPropertyPath(), 
+                Name = path.ToPropertyPath(_conventions), 
                 DisplayName = displayName
             });
 
@@ -131,7 +138,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
             aggregations.Add(new FacetAggregationField
             {
-                Name = path.ToPropertyPath(),
+                Name = path.ToPropertyPath(_conventions),
                 DisplayName = displayName
             });
             return this;
@@ -144,7 +151,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
             aggregations.Add(new FacetAggregationField
             {
-                Name = path.ToPropertyPath(),
+                Name = path.ToPropertyPath(_conventions),
                 DisplayName = displayName
             });
             return this;
@@ -157,7 +164,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
             aggregations.Add(new FacetAggregationField
             {
-                Name = path.ToPropertyPath(),
+                Name = path.ToPropertyPath(_conventions),
                 DisplayName = displayName
             });
             return this;

--- a/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session.Tokens;
 using Sparrow.Extensions;
 using Sparrow.Json;
@@ -28,10 +30,10 @@ namespace Raven.Client.Documents.Queries.Facets
         /// </summary>
         public List<string> Ranges { get; set; }
 
-        internal override FacetToken ToFacetToken(Func<object, string> addQueryParameter)
+        internal override FacetToken ToFacetToken(DocumentConventions conventions, Func<object, string> addQueryParameter)
         {
             if (_parent != null)
-                return _parent.ToFacetToken(addQueryParameter);
+                return _parent.ToFacetToken(conventions, addQueryParameter);
             return FacetToken.Create(this, addQueryParameter);
         }
 
@@ -67,35 +69,50 @@ namespace Raven.Client.Documents.Queries.Facets
         /// </summary>
         public List<Expression<Func<T, bool>>> Ranges { get; set; }
 
-        internal override FacetToken ToFacetToken(Func<object, string> addQueryParameter)
+        internal override FacetToken ToFacetToken(DocumentConventions conventions, Func<object, string> addQueryParameter)
         {
-            return FacetToken.Create(this, addQueryParameter);
+            return FacetToken.Create(this, addQueryParameter, conventions);
         }
 
         public static implicit operator RangeFacet(RangeFacet<T> other)
         {
-            var ranges = other.Ranges.Select(Parse).ToList();
+            var ranges = other.Ranges.Select(r => Parse(r, DocumentConventions.Default)).ToList();
 
             return new RangeFacet(other)
             {
                 Ranges = ranges,
                 Options = other.Options,
                 Aggregations = other.Aggregations,
-                DisplayFieldName = other.DisplayFieldName
+                DisplayFieldName = other.DisplayFieldName,
             };
         }
 
         public static string Parse(Expression<Func<T, bool>> expr)
         {
-            return Parse(null, expr, null);
+            return Parse(expr, DocumentConventions.Default);
+        }
+        
+        public static string Parse(Expression<Func<T, bool>> expr, DocumentConventions documentConventions)
+        {
+            return Parse(null, expr, null, documentConventions);
         }
 
         public static string Parse(string prefix, LambdaExpression expr)
         {
-            return Parse(prefix, expr, null);
+            return Parse(prefix, expr, DocumentConventions.Default);
+        }
+        
+        public static string Parse(string prefix, LambdaExpression expr, DocumentConventions documentConventions)
+        {
+            return Parse(prefix, expr, null, documentConventions);
         }
 
         public static string Parse(string prefix, LambdaExpression expr, Func<object, string> addQueryParameter)
+        {
+            return Parse(prefix, expr, addQueryParameter, DocumentConventions.Default);
+        }
+        
+        public static string Parse(string prefix, LambdaExpression expr, Func<object, string> addQueryParameter, DocumentConventions documentConventions)
         {
             if (expr.Body is MethodCallExpression mce)
             {
@@ -104,7 +121,7 @@ namespace Raven.Client.Documents.Queries.Facets
                     if (mce.Arguments[0] is MemberExpression src &&
                         mce.Arguments[1] is LambdaExpression le)
                     {
-                        return Parse(GetFieldName(prefix, src), le);
+                        return Parse(GetFieldName(prefix, src, documentConventions), le, documentConventions);
                     }
                 }
                 throw new InvalidOperationException("Don't know how to translate expression to facets: " + expr);
@@ -115,7 +132,7 @@ namespace Raven.Client.Documents.Queries.Facets
 
             if (leftExpression is MemberExpression me)
             {
-                var fieldName = GetFieldName(prefix, me);
+                var fieldName = GetFieldName(prefix, me, documentConventions);
                 var subExpressionValue = ParseSubExpression(operation);
                 var expression = GetStringRepresentation(fieldName, operation.NodeType, subExpressionValue, addQueryParameter);
                 return expression;
@@ -137,8 +154,8 @@ namespace Raven.Client.Documents.Queries.Facets
                 throw new InvalidOperationException("Expressions on both sides of '&&' must point to range field. E.g. x => x.Age > 18 && x.Age < 99");
             }
 
-            var leftFieldName = GetFieldName(prefix, leftMember);
-            var rightFieldName = GetFieldName(prefix, rightMember);
+            var leftFieldName = GetFieldName(prefix, leftMember, documentConventions);
+            var rightFieldName = GetFieldName(prefix, rightMember, documentConventions);
 
             if (leftFieldName != rightFieldName)
             {
@@ -166,20 +183,22 @@ namespace Raven.Client.Documents.Queries.Facets
             throw new InvalidOperationException("Members in sub-expression(s) are not the correct types (expected '<', '<=', '>' or '>=')");
         }
 
-        private static string GetFieldName(string prefix, MemberExpression left)
+        private static string GetFieldName(string prefix, MemberExpression left, DocumentConventions conventions)
         {
             if (Nullable.GetUnderlyingType(left.Member.DeclaringType) != null)
-                return GetFieldName(prefix, ((MemberExpression)left.Expression));
+                return GetFieldName(prefix, ((MemberExpression)left.Expression), conventions);
 
+            string memberName = conventions.GetConvertedPropertyNameFor(left.Member);
+            
             if (left.Expression is MemberExpression parent)
             {
-                return GetFieldName(prefix, parent) + "_" + left.Member.Name;
+                return GetFieldName(prefix, parent, conventions) + "_" + memberName;
             }
 
             if (prefix != null)
-                return prefix + "_" + left.Member.Name;
+                return prefix + "_" + memberName;
 
-            return left.Member.Name;
+            return memberName;
         }
 
         private static object ParseSubExpression(BinaryExpression operation)

--- a/src/Raven.Client/Documents/Queries/Spatial/DynamicSpatialFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Spatial/DynamicSpatialFieldFactory.cs
@@ -1,28 +1,31 @@
 ﻿using System;
 using System.Linq.Expressions;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Queries.Spatial
 {
     public class DynamicSpatialFieldFactory<TEntity>
     {
-        public static readonly DynamicSpatialFieldFactory<TEntity> Instance = new DynamicSpatialFieldFactory<TEntity>();
+        private readonly DocumentConventions _conventions;
+        public static readonly DynamicSpatialFieldFactory<TEntity> Instance = new(DocumentConventions.Default);
 
-        private DynamicSpatialFieldFactory()
+        internal DynamicSpatialFieldFactory(DocumentConventions conventions)
         {
+            _conventions = conventions;
         }
 
         public PointField Point(Expression<Func<TEntity, object>> latitudePath, Expression<Func<TEntity, object>> longitudePath)
         {
-            var latitude = latitudePath.ToPropertyPath();
-            var longitude = longitudePath.ToPropertyPath();
+            var latitude = latitudePath.ToPropertyPath(_conventions);
+            var longitude = longitudePath.ToPropertyPath(_conventions);
 
             return new PointField(latitude, longitude);
         }
 
         public WktField Wkt(Expression<Func<TEntity, object>> wktPath)
         {
-            var wkt = wktPath.ToPropertyPath();
+            var wkt = wktPath.ToPropertyPath(_conventions);
 
             return new WktField(wkt);
         }

--- a/src/Raven.Client/Documents/Queries/Suggestions/AsyncSuggestionDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Suggestions/AsyncSuggestionDocumentQuery.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Documents.Queries.Suggestions
 
         public IAsyncSuggestionDocumentQuery<T> AndSuggestUsing(Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(_source.Conventions);
             builder.Invoke(f);
 
             _source.SuggestUsing(f.Suggestion);

--- a/src/Raven.Client/Documents/Queries/Suggestions/SuggestionDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Suggestions/SuggestionDocumentQuery.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Documents.Queries.Suggestions
 
         public ISuggestionDocumentQuery<T> AndSuggestUsing(Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(_source.Conventions);
             builder.Invoke(f);
 
             _source.SuggestUsing(f.Suggestion);

--- a/src/Raven.Client/Documents/Queries/Suggestions/SuggestionFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Suggestions/SuggestionFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Queries.Suggestions
@@ -24,8 +25,14 @@ namespace Raven.Client.Documents.Queries.Suggestions
 
     internal class SuggestionBuilder<T> : ISuggestionBuilder<T>, ISuggestionOperations<T>
     {
+        private readonly DocumentConventions _conventions;
         private SuggestionWithTerm _term;
         private SuggestionWithTerms _terms;
+
+        public SuggestionBuilder(DocumentConventions conventions)
+        {
+            _conventions = conventions;
+        }
 
         public ISuggestionOperations<T> WithDisplayName(string displayName)
         {
@@ -68,12 +75,12 @@ namespace Raven.Client.Documents.Queries.Suggestions
 
         public ISuggestionOperations<T> ByField(Expression<Func<T, object>> path, string term)
         {
-            return ByField(path.ToPropertyPath(), term);
+            return ByField(path.ToPropertyPath(_conventions), term);
         }
 
         public ISuggestionOperations<T> ByField(Expression<Func<T, object>> path, string[] terms)
         {
-            return ByField(path.ToPropertyPath(), terms);
+            return ByField(path.ToPropertyPath(_conventions), terms);
         }
 
         public ISuggestionOperations<T> WithOptions(SuggestionOptions options)

--- a/src/Raven.Client/Documents/Queries/Suggestions/SuggestionQuery.cs
+++ b/src/Raven.Client/Documents/Queries/Suggestions/SuggestionQuery.cs
@@ -84,7 +84,7 @@ namespace Raven.Client.Documents.Queries.Suggestions
 
         public ISuggestionQuery<T> AndSuggestUsing(Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(((IRavenQueryProvider)_source.Provider).QueryGenerator.Conventions);
             builder?.Invoke(f);
 
             return AndSuggestUsing(f.Suggestion);

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Facets.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Facets.cs
@@ -16,7 +16,7 @@ namespace Raven.Client.Documents.Session
                 throw new InvalidOperationException($"Aggregation query can select only facets while it got {token.GetType().Name} token");
             }
 
-            SelectTokens.AddLast(FacetToken.Create(facet, AddQueryParameter));
+            SelectTokens.AddLast(FacetToken.Create(facet, AddQueryParameter, _conventions));
         }
 
         public void AggregateUsing(string facetSetupDocumentId)

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Documents.Session
         /// <param name = "path">The path.</param>
         public void Include(Expression<Func<T, object>> path)
         {
-            Include(path.ToPropertyPath());
+            Include(path.ToPropertyPath(_conventions));
         }
 
         public void Include(IncludeBuilder includes)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Facets.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Facets.cs
@@ -10,7 +10,7 @@ namespace Raven.Client.Documents.Session
     {
         public IAsyncAggregationDocumentQuery<T> AggregateBy(Action<IFacetBuilder<T>> builder)
         {
-            var ff = new FacetBuilder<T>();
+            var ff = new FacetBuilder<T>(Conventions);
             builder.Invoke(ff);
 
             return AggregateBy(ff.Facet);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Highlightings.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Highlightings.cs
@@ -21,13 +21,13 @@ namespace Raven.Client.Documents.Session
 
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, out Highlightings highlightings)
         {
-            Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, null, out highlightings);
+            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, null, out highlightings);
             return this;
         }
 
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, HighlightingOptions options, out Highlightings highlightings)
         {
-            Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, options, out highlightings);
+            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, options, out highlightings);
             return this;
         }
     }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Spatial.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Spatial.cs
@@ -12,7 +12,7 @@ namespace Raven.Client.Documents.Session
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Spatial(Expression<Func<T, object>> path, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
             var criteria = clause(SpatialCriteriaFactory.Instance);
-            Spatial(path.ToPropertyPath(), criteria);
+            Spatial(path.ToPropertyPath(Conventions), criteria);
             return this;
         }
 
@@ -36,7 +36,7 @@ namespace Raven.Client.Documents.Session
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.Spatial(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
             var criteria = clause(SpatialCriteriaFactory.Instance);
-            var dynamicField = field(DynamicSpatialFieldFactory<T>.Instance);
+            var dynamicField = field(new DynamicSpatialFieldFactory<T>(Conventions));
             Spatial(dynamicField, criteria);
             return this;
         }
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.WithinRadiusOf<TValue>(Expression<Func<T, TValue>> propertySelector, double radius, double latitude, double longitude, SpatialUnits? radiusUnits, double distanceErrorPct)
         {
-            WithinRadiusOf(propertySelector.ToPropertyPath(), radius, latitude, longitude, radiusUnits, distanceErrorPct);
+            WithinRadiusOf(propertySelector.ToPropertyPath(Conventions), radius, latitude, longitude, radiusUnits, distanceErrorPct);
             return this;
         }
 
@@ -58,14 +58,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.RelatesToShape<TValue>(Expression<Func<T, TValue>> propertySelector, string shapeWkt, SpatialRelation relation, double distanceErrorPct)
         {
-            Spatial(propertySelector.ToPropertyPath(), shapeWkt, relation, null, distanceErrorPct);
+            Spatial(propertySelector.ToPropertyPath(Conventions), shapeWkt, relation, null, distanceErrorPct);
             return this;
         }
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.RelatesToShape<TValue>(Expression<Func<T, TValue>> propertySelector, string shapeWkt, SpatialRelation relation, SpatialUnits units, double distanceErrorPct)
         {
-            Spatial(propertySelector.ToPropertyPath(), shapeWkt, relation, units, distanceErrorPct);
+            Spatial(propertySelector.ToPropertyPath(Conventions), shapeWkt, relation, units, distanceErrorPct);
             return this;
         }
 
@@ -93,7 +93,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            OrderByDistance(field(new DynamicSpatialFieldFactory<T>(Conventions)), latitude, longitude);
             return this;
         }
 
@@ -107,14 +107,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            OrderByDistance(field(new DynamicSpatialFieldFactory<T>(Conventions)), shapeWkt);
             return this;
         }
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, double latitude, double longitude)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), latitude, longitude);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), latitude, longitude);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, string shapeWkt)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), shapeWkt);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), shapeWkt);
             return this;
         }
 
@@ -149,7 +149,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(Conventions)), latitude, longitude);
             return this;
         }
 
@@ -163,14 +163,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(Conventions)), shapeWkt);
             return this;
         }
 
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, double latitude, double longitude)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), latitude, longitude);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), latitude, longitude);
             return this;
         }
 
@@ -184,7 +184,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, string shapeWkt)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), shapeWkt);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), shapeWkt);
             return this;
         }
 
@@ -198,7 +198,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, double latitude, double longitude, double roundFactor)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), latitude, longitude, roundFactor);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), latitude, longitude, roundFactor);
             return this;
         }
 
@@ -212,7 +212,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, string shapeWkt, double roundFactor)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), shapeWkt, roundFactor);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), shapeWkt, roundFactor);
             return this;
         }
 
@@ -226,7 +226,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, double latitude, double longitude, double roundFactor)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), latitude, longitude, roundFactor);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), latitude, longitude, roundFactor);
             return this;
         }
 
@@ -240,7 +240,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IAsyncDocumentQuery<T> IDocumentQueryBase<T, IAsyncDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, string shapeWkt, double roundFactor)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), shapeWkt, roundFactor);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), shapeWkt, roundFactor);
             return this;
         }
 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Suggestions.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.Suggestions.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Session
 
         IAsyncSuggestionDocumentQuery<T> IAsyncDocumentQuery<T>.SuggestUsing(Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(Conventions);
             builder.Invoke(f);
 
             SuggestUsing(f.Suggestion);

--- a/src/Raven.Client/Documents/Session/DocumentQuery.Facets.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.Facets.cs
@@ -8,7 +8,7 @@ namespace Raven.Client.Documents.Session
     {
         public IAggregationDocumentQuery<T> AggregateBy(Action<IFacetBuilder<T>> builder)
         {
-            var ff = new FacetBuilder<T>();
+            var ff = new FacetBuilder<T>(Conventions);
             builder.Invoke(ff);
 
             return AggregateBy(ff.Facet);

--- a/src/Raven.Client/Documents/Session/DocumentQuery.Highlightings.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.Highlightings.cs
@@ -21,13 +21,13 @@ namespace Raven.Client.Documents.Session
 
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, out Highlightings highlightings)
         {
-            Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, null, out highlightings);
+            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, null, out highlightings);
             return this;
         }
 
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, HighlightingOptions options, out Highlightings highlightings)
         {
-            Highlight(path.ToPropertyPath(), fragmentLength, fragmentCount, null, out highlightings);
+            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, null, out highlightings);
             return this;
         }
     }

--- a/src/Raven.Client/Documents/Session/DocumentQuery.Spatial.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.Spatial.cs
@@ -12,7 +12,7 @@ namespace Raven.Client.Documents.Session
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.Spatial(Expression<Func<T, object>> path, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
             var criteria = clause(SpatialCriteriaFactory.Instance);
-            Spatial(path.ToPropertyPath(), criteria);
+            Spatial(path.ToPropertyPath(Conventions), criteria);
             return this;
         }
 
@@ -36,7 +36,7 @@ namespace Raven.Client.Documents.Session
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.Spatial(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, Func<SpatialCriteriaFactory, SpatialCriteria> clause)
         {
             var criteria = clause(SpatialCriteriaFactory.Instance);
-            var dynamicField = field(DynamicSpatialFieldFactory<T>.Instance);
+            var dynamicField = field(new DynamicSpatialFieldFactory<T>(Conventions));
             Spatial(dynamicField, criteria);
             return this;
         }
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.WithinRadiusOf<TValue>(Expression<Func<T, TValue>> propertySelector, double radius, double latitude, double longitude, SpatialUnits? radiusUnits, double distanceErrorPct)
         {
-            WithinRadiusOf(propertySelector.ToPropertyPath(), radius, latitude, longitude, radiusUnits, distanceErrorPct);
+            WithinRadiusOf(propertySelector.ToPropertyPath(Conventions), radius, latitude, longitude, radiusUnits, distanceErrorPct);
             return this;
         }
 
@@ -58,14 +58,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.RelatesToShape<TValue>(Expression<Func<T, TValue>> propertySelector, string shapeWkt, SpatialRelation relation, double distanceErrorPct)
         {
-            Spatial(propertySelector.ToPropertyPath(), shapeWkt, relation, null, distanceErrorPct);
+            Spatial(propertySelector.ToPropertyPath(Conventions), shapeWkt, relation, null, distanceErrorPct);
             return this;
         }
 
         /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.RelatesToShape<TValue>(Expression<Func<T, TValue>> propertySelector, string shapeWkt, SpatialRelation relation, SpatialUnits units, double distanceErrorPct)
         {
-            Spatial(propertySelector.ToPropertyPath(), shapeWkt, relation, units, distanceErrorPct);
+            Spatial(propertySelector.ToPropertyPath(Conventions), shapeWkt, relation, units, distanceErrorPct);
             return this;
         }
 
@@ -93,7 +93,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            OrderByDistance(field(new DynamicSpatialFieldFactory<T>(Conventions)), latitude, longitude);
             return this;
         }
 
@@ -107,14 +107,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            OrderByDistance(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            OrderByDistance(field(new DynamicSpatialFieldFactory<T>(Conventions)), shapeWkt);
             return this;
         }
 
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, double latitude, double longitude)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), latitude, longitude);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), latitude, longitude);
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, string shapeWkt)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), shapeWkt);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), shapeWkt);
             return this;
         }
 
@@ -149,7 +149,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, double latitude, double longitude)
         {
-            OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), latitude, longitude);
+            OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(Conventions)), latitude, longitude);
             return this;
         }
 
@@ -163,14 +163,14 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Func<DynamicSpatialFieldFactory<T>, DynamicSpatialField> field, string shapeWkt)
         {
-            OrderByDistanceDescending(field(DynamicSpatialFieldFactory<T>.Instance), shapeWkt);
+            OrderByDistanceDescending(field(new DynamicSpatialFieldFactory<T>(Conventions)), shapeWkt);
             return this;
         }
 
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, double latitude, double longitude)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), latitude, longitude);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), latitude, longitude);
             return this;
         }
 
@@ -184,7 +184,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, string shapeWkt)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), shapeWkt);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), shapeWkt);
             return this;
         }
 
@@ -198,7 +198,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, double latitude, double longitude, double roundFactor)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), latitude, longitude, roundFactor);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), latitude, longitude, roundFactor);
             return this;
         }
 
@@ -212,7 +212,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistance(Expression<Func<T, object>> propertySelector, string shapeWkt, double roundFactor)
         {
-            OrderByDistance(propertySelector.ToPropertyPath(), shapeWkt, roundFactor);
+            OrderByDistance(propertySelector.ToPropertyPath(Conventions), shapeWkt, roundFactor);
             return this;
         }
 
@@ -226,7 +226,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, double latitude, double longitude, double roundFactor)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), latitude, longitude, roundFactor);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), latitude, longitude, roundFactor);
             return this;
         }
 
@@ -240,7 +240,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.OrderByDistanceDescending(Expression<Func<T, object>> propertySelector, string shapeWkt, double roundFactor)
         {
-            OrderByDistanceDescending(propertySelector.ToPropertyPath(), shapeWkt, roundFactor);
+            OrderByDistanceDescending(propertySelector.ToPropertyPath(Conventions), shapeWkt, roundFactor);
             return this;
         }
 

--- a/src/Raven.Client/Documents/Session/DocumentQuery.Suggestions.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.Suggestions.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Session
 
         ISuggestionDocumentQuery<T> IDocumentQuery<T>.SuggestUsing(Action<ISuggestionBuilder<T>> builder)
         {
-            var f = new SuggestionBuilder<T>();
+            var f = new SuggestionBuilder<T>(Conventions);
             builder.Invoke(f);
 
             SuggestUsing(f.Suggestion);

--- a/src/Raven.Client/Documents/Session/Loaders/AsyncMultiLoaderWithInclude.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/AsyncMultiLoaderWithInclude.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <returns></returns>
         public AsyncMultiLoaderWithInclude<T> Include(Expression<Func<T, string>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public AsyncMultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, string>> path)
         {
-            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _session.Conventions));
+            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_session.Conventions), _session.Conventions));
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <returns></returns>
         public AsyncMultiLoaderWithInclude<T> Include(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public AsyncMultiLoaderWithInclude<T> Include<TInclude>(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _session.Conventions));
+            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_session.Conventions), _session.Conventions));
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -222,25 +222,25 @@ namespace Raven.Client.Documents.Session.Loaders
 
         ISubscriptionIncludeBuilder<T> IDocumentIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         ISubscriptionIncludeBuilder<T> IDocumentIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         ISubscriptionIncludeBuilder<T> IDocumentIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
         ISubscriptionIncludeBuilder<T> IDocumentIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
@@ -252,25 +252,25 @@ namespace Raven.Client.Documents.Session.Loaders
 
         IQueryIncludeBuilder<T> IDocumentIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IQueryIncludeBuilder<T> IDocumentIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IQueryIncludeBuilder<T> IDocumentIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
         IQueryIncludeBuilder<T> IDocumentIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
@@ -306,25 +306,25 @@ namespace Raven.Client.Documents.Session.Loaders
 
         IIncludeBuilder<T> IDocumentIncludeBuilder<T, IIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IIncludeBuilder<T> IDocumentIncludeBuilder<T, IIncludeBuilder<T>>.IncludeDocuments(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(path.ToPropertyPath());
+            IncludeDocuments(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IIncludeBuilder<T> IDocumentIncludeBuilder<T, IIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, string>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
         IIncludeBuilder<T> IDocumentIncludeBuilder<T, IIncludeBuilder<T>>.IncludeDocuments<TInclude>(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _conventions));
+            IncludeDocuments(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_conventions), _conventions));
             return this;
         }
 
@@ -343,7 +343,7 @@ namespace Raven.Client.Documents.Session.Loaders
         IQueryIncludeBuilder<T> IQueryIncludeBuilder<T>.IncludeTimeSeries(Expression<Func<T, string>> path, string name, DateTime from, DateTime to)
         {
             WithAlias(path);
-            IncludeTimeSeriesFromTo(path.ToPropertyPath(), name, from, to);
+            IncludeTimeSeriesFromTo(path.ToPropertyPath(_conventions), name, from, to);
             return this;
         }
         IQueryIncludeBuilder<T> ICompareExchangeValueIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeCompareExchangeValue(string path)
@@ -354,13 +354,13 @@ namespace Raven.Client.Documents.Session.Loaders
 
         IQueryIncludeBuilder<T> ICompareExchangeValueIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeCompareExchangeValue(Expression<Func<T, string>> path)
         {
-            IncludeCompareExchangeValue(path.ToPropertyPath());
+            IncludeCompareExchangeValue(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IQueryIncludeBuilder<T> ICompareExchangeValueIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeCompareExchangeValue(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeCompareExchangeValue(path.ToPropertyPath());
+            IncludeCompareExchangeValue(path.ToPropertyPath(_conventions));
             return this;
         }
 
@@ -372,13 +372,13 @@ namespace Raven.Client.Documents.Session.Loaders
 
         IIncludeBuilder<T> ICompareExchangeValueIncludeBuilder<T, IIncludeBuilder<T>>.IncludeCompareExchangeValue(Expression<Func<T, string>> path)
         {
-            IncludeCompareExchangeValue(path.ToPropertyPath());
+            IncludeCompareExchangeValue(path.ToPropertyPath(_conventions));
             return this;
         }
 
         IIncludeBuilder<T> ICompareExchangeValueIncludeBuilder<T, IIncludeBuilder<T>>.IncludeCompareExchangeValue(Expression<Func<T, IEnumerable<string>>> path)
         {
-            IncludeCompareExchangeValue(path.ToPropertyPath());
+            IncludeCompareExchangeValue(path.ToPropertyPath(_conventions));
             return this;
         }
         
@@ -527,13 +527,13 @@ namespace Raven.Client.Documents.Session.Loaders
         private void IncludeCounterWithAlias(Expression<Func<T, string>> path, string name)
         {
             WithAlias(path);
-            IncludeCounter(path.ToPropertyPath(), name);
+            IncludeCounter(path.ToPropertyPath(_conventions), name);
         }
 
         private void IncludeCountersWithAlias(Expression<Func<T, string>> path, string[] names)
         {
             WithAlias(path);
-            IncludeCounters(path.ToPropertyPath(), names);
+            IncludeCounters(path.ToPropertyPath(_conventions), names);
         }
 
         private void IncludeRevisionsBefore(DateTime dateTime)
@@ -582,7 +582,7 @@ namespace Raven.Client.Documents.Session.Loaders
         private void IncludeAllCountersWithAlias(Expression<Func<T, string>> path)
         {
             WithAlias(path);
-            IncludeAllCounters(path.ToPropertyPath());
+            IncludeAllCounters(path.ToPropertyPath(_conventions));
         }
 
         private void IncludeAllCounters(string sourcePath)
@@ -768,21 +768,21 @@ namespace Raven.Client.Documents.Session.Loaders
         IQueryIncludeBuilder<T> IRevisionIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeRevisions(Expression<Func<T, string>> changeVectorPath)
         {
             WithAlias(changeVectorPath);
-            IncludeRevisionsByChangeVectors(changeVectorPath.ToPropertyPath());
+            IncludeRevisionsByChangeVectors(changeVectorPath.ToPropertyPath(_conventions));
             return this;
         }
 
         IIncludeBuilder<T> IRevisionIncludeBuilder<T, IIncludeBuilder<T>>.IncludeRevisions(Expression<Func<T, string>> changeVectorPath)
         {
             WithAlias(changeVectorPath);
-            IncludeRevisionsByChangeVectors(changeVectorPath.ToPropertyPath());
+            IncludeRevisionsByChangeVectors(changeVectorPath.ToPropertyPath(_conventions));
             return this;
         }
 
         IIncludeBuilder<T> IRevisionIncludeBuilder<T, IIncludeBuilder<T>>.IncludeRevisions(Expression<Func<T, IEnumerable<string>>> changeVectorPaths)
         {
             WithAlias(changeVectorPaths);
-            IncludeRevisionsByChangeVectors(changeVectorPaths.ToPropertyPath());
+            IncludeRevisionsByChangeVectors(changeVectorPaths.ToPropertyPath(_conventions));
             return this;
         }
         
@@ -802,7 +802,7 @@ namespace Raven.Client.Documents.Session.Loaders
         IQueryIncludeBuilder<T> IRevisionIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeRevisions(Expression<Func<T, IEnumerable<string>>> changeVectorPaths)
         {
             WithAlias(changeVectorPaths);
-            IncludeRevisionsByChangeVectors(changeVectorPaths.ToPropertyPath());
+            IncludeRevisionsByChangeVectors(changeVectorPaths.ToPropertyPath(_conventions));
             return this;
         }
     }

--- a/src/Raven.Client/Documents/Session/Loaders/LazyMultiLoaderWithInclude.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/LazyMultiLoaderWithInclude.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILazyLoaderWithInclude<T> Include(Expression<Func<T, string>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILazyLoaderWithInclude<T> Include(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public IAsyncLazyLoaderWithInclude<T> Include(Expression<Func<T, string>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
 
@@ -149,7 +149,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public IAsyncLazyLoaderWithInclude<T> Include(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/Loaders/MultiLoaderWithInclude.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/MultiLoaderWithInclude.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILoaderWithInclude<T> Include(Expression<Func<T, string>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILoaderWithInclude<T> Include<TInclude>(Expression<Func<T, string>> path)
         {
-            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _session.Conventions));
+            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_session.Conventions), _session.Conventions));
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILoaderWithInclude<T> Include(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(path.ToPropertyPath());
+            return Include(path.ToPropertyPath(_session.Conventions));
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="path">The path.</param>
         public ILoaderWithInclude<T> Include<TInclude>(Expression<Func<T, IEnumerable<string>>> path)
         {
-            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(), _session.Conventions));
+            return Include(IncludesUtil.GetPrefixedIncludePath<TInclude>(path.ToPropertyPath(_session.Conventions), _session.Conventions));
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/Tokens/FacetToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/FacetToken.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.Facets;
 
@@ -60,13 +61,13 @@ namespace Raven.Client.Documents.Session.Tokens
             return token;
         }
 
-        public static FacetToken Create<T>(RangeFacet<T> facet, Func<object, string> addQueryParameter)
+        public static FacetToken Create<T>(RangeFacet<T> facet, Func<object, string> addQueryParameter, DocumentConventions conventions)
         {
             var optionsParameterName = GetOptionsParameterName(facet, addQueryParameter);
 
             var ranges = new List<string>();
             foreach (var expression in facet.Ranges)
-                ranges.Add(RangeFacet<T>.Parse(null, expression, addQueryParameter));
+                ranges.Add(RangeFacet<T>.Parse(null, expression, addQueryParameter, conventions));
 
             var token = new FacetToken(null, QueryFieldUtil.EscapeIfNecessary(facet.DisplayFieldName), ranges, optionsParameterName);
 
@@ -75,10 +76,10 @@ namespace Raven.Client.Documents.Session.Tokens
             return token;
         }
 
-        public static FacetToken Create(FacetBase facet, Func<object, string> addQueryParameter)
+        public static FacetToken Create(FacetBase facet, Func<object, string> addQueryParameter, DocumentConventions conventions)
         {
             // this is just a dispatcher
-            return facet.ToFacetToken(addQueryParameter);
+            return facet.ToFacetToken(conventions, addQueryParameter);
         }
 
         public override void WriteTo(StringBuilder writer)

--- a/src/Raven.Client/Extensions/ExpressionExtensions.cs
+++ b/src/Raven.Client/Extensions/ExpressionExtensions.cs
@@ -114,7 +114,7 @@ namespace Raven.Client.Extensions
 
             protected override Expression VisitMember(MemberExpression node)
             {
-                string convertedName = _conventions.PropertyNameConverter(node.Member);
+                string convertedName = _conventions.GetConvertedPropertyNameFor(node.Member);
                 if (IsDictionaryProperty(node, out string propertyName))
                 {
                     if (string.IsNullOrEmpty(propertyName) == false)

--- a/src/Raven.Client/Extensions/ExpressionExtensions.cs
+++ b/src/Raven.Client/Extensions/ExpressionExtensions.cs
@@ -114,12 +114,13 @@ namespace Raven.Client.Extensions
 
             protected override Expression VisitMember(MemberExpression node)
             {
+                string convertedName = _conventions.PropertyNameConverter(node.Member);
                 if (IsDictionaryProperty(node, out string propertyName))
                 {
                     if (string.IsNullOrEmpty(propertyName) == false)
                     {
                         AddPropertySeparator();
-                        Results.Push("$" + node.Member.Name);
+                        Results.Push("$" + convertedName);
                     }
 
                     return base.VisitMember(node);
@@ -127,14 +128,14 @@ namespace Raven.Client.Extensions
 
                 if (_isFirst == false && node.Expression != null && node.Member.IsField())
                 {
-                    Results.Push(node.Member.Name);
+                    Results.Push(convertedName);
                     AddPropertySeparator();
                     Results.Push(node.Expression.ToString());
                     return base.VisitMember(node);
                 }
 
                 AddPropertySeparator();
-                Results.Push(node.Member.Name);
+                Results.Push(convertedName);
                 return base.VisitMember(node);
             }
 

--- a/src/Raven.Client/Extensions/PropertyNameConventionJavaScriptCompilationExtension.cs
+++ b/src/Raven.Client/Extensions/PropertyNameConventionJavaScriptCompilationExtension.cs
@@ -20,19 +20,10 @@ namespace Raven.Client.Extensions
 
         public override IJavascriptMemberMetadata GetMemberMetadata(MemberInfo memberInfo)
         {
-            string name = null;
-            if (_conventions.PropertyNameConverter != null)
+            return new MemberMetadata
             {
-                if (memberInfo.DeclaringType?.Namespace?.StartsWith("System") == false &&
-                    memberInfo.DeclaringType?.Namespace?.StartsWith("Microsoft") == false)
-                {
-                    name = _conventions.PropertyNameConverter(memberInfo);
-                }              
-            }
-
-            return string.IsNullOrWhiteSpace(name) ?
-                new MemberMetadata { MemberName = memberInfo.Name } :
-                new MemberMetadata { MemberName = name };
+                MemberName = _conventions.GetConvertedPropertyNameFor(memberInfo)
+            };
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3795,7 +3795,7 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var field in metadata.IndexFieldNames)
             {
-                AssertKnownField(field);
+                AssertKnownField(field, metadata);
             }
 
             if (metadata.OrderBy != null)
@@ -3815,24 +3815,24 @@ namespace Raven.Server.Documents.Indexes
                         continue;
 #endif
 
-                    AssertKnownField(f);
+                    AssertKnownField(f, metadata);
                 }
             }
         }
 
-        private void AssertKnownField(string f)
+        private void AssertKnownField(string f, QueryMetadata queryMetadata)
         {
             // the catch all field name means that we have dynamic fields names
 
             if (Definition.HasDynamicFields || IndexPersistence.ContainsField(f))
                 return;
 
-            ThrowInvalidField(f);
+            ThrowInvalidField(f, queryMetadata);
         }
 
-        private static void ThrowInvalidField(string f)
+        private static void ThrowInvalidField(string f, QueryMetadata queryMetadata)
         {
-            throw new ArgumentException($"The field '{f}' is not indexed, cannot query/sort on fields that are not indexed");
+            throw new ArgumentException($"The field '{f}' is not indexed, cannot query/sort on fields that are not indexed in query: " + queryMetadata.QueryText);
         }
 
         private void FillFacetedQueryResult(FacetedQueryResult result, bool isStale, long facetSetupEtag, QueryMetadata q,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -816,7 +816,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
                 // get the current Lucene docid for the given RavenDB doc ID
                 if (td.ScoreDocs.Length == 0)
-                    throw new InvalidOperationException("Given filtering expression did not yield any documents that could be used as a base of comparison");
+                    throw new InvalidOperationException($"Given filtering expression '{query.Query}' did not yield any documents that could be used as a base of comparison");
 
                 baseDocId = td.ScoreDocs[0].Doc;
             }

--- a/test/SlowTests/Issues/RavenDB-11089.cs
+++ b/test/SlowTests/Issues/RavenDB-11089.cs
@@ -326,13 +326,12 @@ namespace SlowTests.Issues
 
                     foreach (var exp in expressions)
                     {
-                        var facetResults = s.Query<Camera, CameraCostIndex>()
+                         var facetResults = s.Query<Camera, CameraCostIndex>()
                             .Where(exp)
                             .AggregateBy(facets)
                             .Execute();
 
                         var filteredData = cameras.Where(exp.Compile()).ToList();
-
                         CheckFacetResultsMatchInMemoryData(facetResults, filteredData);
                     }
                 }
@@ -434,10 +433,10 @@ namespace SlowTests.Issues
                     var queryAsString = query.ToString();
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(user) {
-	var first = user.name;
-	var last = user.lastName;
-	var format = function(){return first+"" ""+last;};
-	return { FullName : format() };
+    var first = user.name;
+    var last = user.lastName;
+    var format = function(){return first+"" ""+last;};
+    return { FullName : format() };
 }
 from 'Users' as user select output(user)", queryAsString);
 

--- a/test/SlowTests/Issues/RavenDB-19209.cs
+++ b/test/SlowTests/Issues/RavenDB-19209.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19209 : RavenTestBase
+{
+    public RavenDB_19209(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ShouldGetResultOnQuery()
+    {
+        using (var store = GetDocumentStore(new Options
+               {
+                   ModifyDocumentStore = documentStore =>
+                   {
+                       documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                       {
+                           CustomizeJsonSerializer = (serializer) =>
+                           {
+                               serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                           }
+                       };
+                       documentStore.Conventions.PropertyNameConverter = mi => $"{char.ToLower(mi.Name[0])}{mi.Name[1..]}";
+                   }
+               }))
+        {
+            using (var session = store.OpenSession())
+            {
+                var workspace1 = new Workspace { Domain = "Encom" };
+                session.Store(workspace1, "workspaces/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var q = session.Query<Workspace>().Where(ws => ws.Domain == "Encom");
+                Console.WriteLine(q.ToString());
+                Assert.NotNull(q.FirstOrDefault());
+            }
+        }
+    }
+
+
+    private class Workspace
+    {
+        public string Id { get; set; }
+
+        //[JsonProperty("domain")]
+        public string Domain { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19209.cs
+++ b/test/SlowTests/Issues/RavenDB-19209.cs
@@ -2,6 +2,9 @@
 using System.Linq;
 using FastTests;
 using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,6 +15,60 @@ public class RavenDB_19209 : RavenTestBase
 {
     public RavenDB_19209(ITestOutputHelper output) : base(output)
     {
+    }
+
+
+    [Fact]
+    public void CamelCaseInStaticIndexes()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = documentStore =>
+            {
+                documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                {
+                    CustomizeJsonSerializer = (serializer) =>
+                    {
+                        serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                    }
+                };
+                documentStore.Conventions.PropertyNameConverter = mi => $"{char.ToLower(mi.Name[0])}{mi.Name[1..]}";
+            }
+        });
+        using (var session = store.OpenSession())
+        {
+            var workspace1 = new Workspace {Domain = "Encom", CamelCase = "SuperSecretTest"};
+            session.Store(workspace1, "workspaces/1");
+            session.SaveChanges();
+        }
+        new CamelCaseIndex().Execute(store);
+
+        using (var session = store.OpenSession())
+        {
+            var q = session.Query<Workspace, CamelCaseIndex>().AggregateBy(builder => builder.ByField(i => i.CamelCase));
+            Assert.Equal("from index 'CamelCaseIndex' select facet(camelCase)", q.ToString());
+            var aggregations = q.Execute();
+            Assert.Equal(1, aggregations.Count);
+            Assert.Equal("camelCase", aggregations.First().Key);
+        }
+    }
+
+    private class CamelCaseIndex : AbstractIndexCreationTask<Workspace>
+    {
+        public CamelCaseIndex()
+        {
+            Map = workspaces => workspaces.Select(i => new { Domain = i.Domain, CamelCase = i.CamelCase });
+        }
+    }
+    
+    private class Workspace
+    {
+        public string Id { get; set; }
+
+        //[JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        public string CamelCase { get; set; }
     }
 
     [Fact]
@@ -46,14 +103,5 @@ public class RavenDB_19209 : RavenTestBase
                 Assert.NotNull(q.FirstOrDefault());
             }
         }
-    }
-
-
-    private class Workspace
-    {
-        public string Id { get; set; }
-
-        //[JsonProperty("domain")]
-        public string Domain { get; set; }
     }
 }


### PR DESCRIPTION
…et property name

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19209 

### Additional description

This merge some renaming behavior deep in the guts of the linq provider to enable user extensions.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

I merged behavior across duplicated `if` branches, we'll need to ensure that no test is broken, but I don't expect it to.

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works