### PR TITLE
Revert "RavenDB-19211 When calculating CPU let's force the metric to wait until the task refreshing the value is done. This prevents strange CPU spikes returned by SNMP."

### DIFF
--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.ServerWide
 
         public void Initialize()
         {
-            Register(MetricCacher.Keys.Server.CpuUsage, TimeSpan.FromMilliseconds(DefaultCpuRefreshRateInMs), _server.CpuUsageCalculator.Calculate, asyncRefresh: false);
+            Register(MetricCacher.Keys.Server.CpuUsage, TimeSpan.FromMilliseconds(DefaultCpuRefreshRateInMs), _server.CpuUsageCalculator.Calculate);
             Register(MetricCacher.Keys.Server.MemoryInfo, TimeSpan.FromSeconds(1), CalculateMemoryInfo);
             Register(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate15Seconds, TimeSpan.FromSeconds(15), CalculateMemoryInfoExtended);
             Register(MetricCacher.Keys.Server.MemoryInfoExtended.RefreshRate5Seconds, TimeSpan.FromSeconds(5), CalculateMemoryInfoExtended);


### PR DESCRIPTION
Reverts ravendb/ravendb#14795

This is first revert PR that we need to revert changes made in https://github.com/ravendb/ravendb/pull/14677 