### PR TITLE
Revert "RavenDB-19040 CalculateMemoryInfoExtended should be done as a backgro…"

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/CpuUsageNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/CpuUsageNotificationSender.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using Raven.Server.Commercial;
 using Raven.Server.NotificationCenter;
 using Raven.Server.Utils;
-using Raven.Server.Utils.Cpu;
 
 namespace Raven.Server.Dashboard.Cluster.Notifications
 {
@@ -51,7 +50,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
 
         protected override AbstractClusterDashboardNotification CreateNotification()
         {
-            var cpuInfo = _server.MetricCacher.GetValue<CpuUsageStats>(
+            var cpuInfo = _server.MetricCacher.GetValue<(double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)>(
                 MetricCacher.Keys.Server.CpuUsage);
 
             TryFillNodeLicenseLimits();

--- a/src/Raven.Server/Documents/DatabaseMetricCacher.cs
+++ b/src/Raven.Server/Documents/DatabaseMetricCacher.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents
             Register(MetricCacher.Keys.Database.DiskSpaceInfo, TimeSpan.FromSeconds(30), CalculateDiskSpaceInfo);
         }
 
-        private object CalculateDiskSpaceInfo()
+        private DiskSpaceResult CalculateDiskSpaceInfo()
         {
             return DiskUtils.GetDiskSpaceInfo(_database.Configuration.Core.DataDirectory.FullPath);
         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -549,8 +549,7 @@ namespace Raven.Server
             {
                 try
                 {
-                    var cpuUsage = MetricCacher.GetValue(Raven.Server.Utils.MetricCacher.Keys.Server.CpuUsage, CpuUsageCalculator.Calculate);
-                    var overallMachineCpuUsage = cpuUsage.MachineCpuUsage;
+                    var (overallMachineCpuUsage, _, _) = MetricCacher.GetValue(Raven.Server.Utils.MetricCacher.Keys.Server.CpuUsage, CpuUsageCalculator.Calculate);
                     var utilizationOverAllCores = (overallMachineCpuUsage / 100) * Environment.ProcessorCount;
                     CpuCreditsBalance.CurrentConsumption = utilizationOverAllCores;
                     CpuCreditsBalance.MachineCpuUsage = overallMachineCpuUsage;

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.ServerWide
             return MemoryInformation.GetMemoryInfo(_smapsReader, extended: true);
         }
 
-        private object CalculateDiskSpaceInfo()
+        private DiskSpaceResult CalculateDiskSpaceInfo()
         {
             return DiskUtils.GetDiskSpaceInfo(_server.ServerStore.Configuration.Core.DataDirectory.FullPath);
         }
@@ -56,7 +56,7 @@ namespace Raven.Server.ServerWide
         {
             return GC.GetGCMemoryInfo(gcKind);
         }
-        private static object CalculateMemInfo()
+        private static MemInfo CalculateMemInfo()
         {
             if (PlatformDetails.RunningOnPosix == false)
                 return MemInfo.Invalid;

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.ServerWide
         }
         private static object CalculateMemInfo()
         {
-            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
+            if (PlatformDetails.RunningOnPosix == false)
                 return MemInfo.Invalid;
 
             return MemInfoReader.Read();

--- a/src/Raven.Server/Utils/MetricCacher.cs
+++ b/src/Raven.Server/Utils/MetricCacher.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Util;
-using Sparrow.Logging;
 
 namespace Raven.Server.Utils
 {
@@ -60,7 +59,7 @@ namespace Raven.Server.Utils
 
         public void Register(string key, TimeSpan refreshRate, Func<object> factory)
         {
-            if (_metrics.TryAdd(key, new MetricValue(refreshRate, key, factory)) == false)
+            if (_metrics.TryAdd(key, new MetricValue(refreshRate, factory)) == false)
                 throw new InvalidOperationException($"Cannot cache '{key}' metric, because it already exists.");
         }
 
@@ -79,11 +78,9 @@ namespace Raven.Server.Utils
             private Task<DateTime> _task;
             private object _value;
             private long _observedFailureTicks;
-            private readonly Logger _logger;
 
-            public MetricValue(TimeSpan refreshRate, string key, Func<object> factory)
+            public MetricValue(TimeSpan refreshRate, Func<object> factory)
             {
-                _logger = LoggingSource.Instance.GetLogger<MetricValue>(key);
                 _refreshRate = refreshRate;
                 _factory = factory;
                 _value = factory();
@@ -106,8 +103,8 @@ namespace Raven.Server.Utils
                         Interlocked.Exchange(ref _observedFailureTicks, SystemTime.UtcNow.Ticks);
                         TryStartingRefreshTask();
                     }
-
-                    return _value; // return cached value in case of an error, better than throwing.
+                    // the error must be reported 
+                    throw new InvalidOperationException("Failed to get value", currentTask.Exception);
                 }
 
                 var nextRefreshForTask = currentTask.Result;
@@ -125,28 +122,9 @@ namespace Raven.Server.Utils
                 {
                     var task = new Task<DateTime>(() =>
                     {
-                        object result;
-                        try
-                        {
-                            result = _factory();
-                        }
-                        catch (Exception e)
-                        {
-                            if (_logger.IsOperationsEnabled)
-                            {
-                                _logger.Operations("Got an error while refreshing value", e);
-                            }
-                            throw;
-                        }
+                        var result = _factory();
                         var nextRefresh = SystemTime.UtcNow + _refreshRate;
                         Interlocked.Exchange(ref _value, result);
-                        if (currentTask.IsFaulted)
-                        {
-                            if (_logger.IsOperationsEnabled)
-                            {
-                                _logger.Operations("Recovered from error in refreshing value.");
-                            }
-                        }
                         return nextRefresh;
                     });
                     // try to update the task

--- a/src/Raven.Server/Utils/MetricCacher.cs
+++ b/src/Raven.Server/Utils/MetricCacher.cs
@@ -69,10 +69,7 @@ namespace Raven.Server.Utils
             if (_metrics.TryGetValue(key, out var value) == false)
                 throw new InvalidOperationException($"Metric '{key}' was not found.");
 
-            var result = value.GetRefreshedValue();
-            if (result == null)
-                return default;
-            return (T)result;
+            return (T)value.GetRefreshedValue();
         }
 
         private class MetricValue
@@ -89,19 +86,8 @@ namespace Raven.Server.Utils
                 _logger = LoggingSource.Instance.GetLogger<MetricValue>(key);
                 _refreshRate = refreshRate;
                 _factory = factory;
+                _value = factory();
                 _task = Task.FromResult(SystemTime.UtcNow + _refreshRate);
-                try
-                {
-                    _value = factory();
-                }
-                catch (Exception e)
-                {
-                    _value = default;
-                    if (_logger.IsOperationsEnabled)
-                    {
-                        _logger.Operations("Got an error while refreshing value", e);
-                    }
-                }
             }
 
             public object GetRefreshedValue()

--- a/test/SlowTests/Issues/RavenDB-14342.cs
+++ b/test/SlowTests/Issues/RavenDB-14342.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
         }
 
         [LicenseRequiredFact]
-        public async Task ServerMonitoringTest()
+        public void ServerMonitoringTest()
         {
             DoNotReuseServer();
         
@@ -43,19 +43,9 @@ namespace SlowTests.Issues
             
                 using (var commands = store.Commands())
                 {
-                    ServerMetrics metrics = null;
-
-                    // since RavenDB-19040 we're calculating the metrics as the background task
-                    // we need to wait for non default (empty) values
-
-                    await WaitForGreaterThanAsync(async () =>
-                    {
-                        var command = new ServerMonitoringCommand();
-                        await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
-                        metrics = command.Result;
-
-                        return metrics.Cpu.ProcessUsage;
-                    }, double.Epsilon);
+                    var command = new ServerMonitoringCommand();
+                    commands.RequestExecutor.Execute(command, commands.Context);
+                    var metrics = command.Result;
                     
                     Assert.Equal(string.Join(";", Server.Configuration.Core.ServerUrls), string.Join(";", metrics.Config.ServerUrls));
                     Assert.Equal(ServerVersion.Version, metrics.ServerVersion);

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -28,8 +28,8 @@ namespace Tests.Infrastructure.TestMetrics
         private object CalculateMemoryInfoExtended()
             => MemoryInformation.GetMemoryInfo(_smapsReader, extended: true);
 
-        public CpuUsageStats GetCpuUsage()
-            => GetValue<CpuUsageStats>(Keys.Server.CpuUsage);
+        public (double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait) GetCpuUsage()
+            => GetValue<(double MachineCpuUsage, double ProcessCpuUsage, double? MachineIoWait)>(Keys.Server.CpuUsage);
 
         public MemoryInfoResult GetMemoryInfoExtended()
             => GetValue<MemoryInfoResult>(Keys.Server.MemoryInfoExtended.RefreshRate15Seconds);


### PR DESCRIPTION
Reverts ravendb/ravendb#14677

Reverting this changes temporarily to check if this solves problems with some metric issues we see in internal monitoring