### PR TITLE
RavenDB-17030 - SlowTests.Issues.RavenDB_15430.MarkPolicyAfterRollup

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2088,15 +2088,6 @@ namespace Raven.Server.ServerWide
             return SendToLeaderAsync(editRevisions);
         }
 
-        public Task<(long, object)> ModifyTimeSeriesConfiguration(JsonOperationContext context, string name, BlittableJsonReaderObject configurationJson, string raftRequestId)
-        {
-            var configuration = JsonDeserializationCluster.TimeSeriesConfiguration(configurationJson);
-            configuration?.InitializeRollupAndRetention();
-            LicenseManager.AssertCanAddTimeSeriesRollupsAndRetention(configuration);
-            var editTimeSeries = new EditTimeSeriesConfigurationCommand(configuration, name, raftRequestId);
-            return SendToLeaderAsync(editTimeSeries);
-        }
-
         public async Task<(long, object)> PutConnectionString(TransactionOperationContext context, string databaseName, BlittableJsonReaderObject connectionString, string raftRequestId)
         {
             if (connectionString.TryGet(nameof(ConnectionString.Type), out string type) == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17030/SlowTestsIssuesRavenDB15430MarkPolicyAfterRollup

### Additional description

Faulted scenario:

- The last node on topology (that will become the first in topology further in the test) receives a new TS ''**_**Heartrate@ByMinutes**_**" from replication right before `TimeSeriesPolicyRunner` is set. 

- In `AppendToNewSegment`, the new segment not marked for policy, thus a new Rollup entry not written to the `TimeSeriesRollupTable`. 

- Running `RunRollups` on the previous last in topology node (which now is first), does nothing because `TimeSeriesRollupTable` does not contain the relevant entry.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
