### PR TITLE
RavenDB-17951 : adjustments to flaky test

### DIFF
--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -308,10 +308,7 @@ namespace RachisTests.DatabaseCluster
 
                 cluster.Leader.ServerStore.ClusterMaintenanceSupervisor.ForTestingPurposesOnly().SetTriggerTimeoutAfterNoChangeAction("B");
 
-                await Task.Delay(2 * 1000); // twice the StabilizationTime
-
-                var members = await GetMembersCount(store);
-                Assert.Equal(3, members);
+                await WaitForValueAsync(async () => await GetMembersCount(store), expectedVal: 3, timeout: 15_000);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17951/RachisTestsDatabaseClusterClusterDatabaseMaintenanceDontMoveToRehabOnNoChangeAfterTimeout

### Type of change

- Bug fix
- Tests Stabilization
 
### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behaviour change of other features due to this change?

- No

### UI work

- No UI work is needed
