### PR TITLE
RavenDB-16003 do not reuse server when cluster observer is off

### DIFF
--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -570,6 +570,7 @@ namespace FastTests.Client.Subscriptions
             SubscriptionWorker<dynamic> throwingSubscriptionWorker = null;
             SubscriptionWorker<dynamic> notThrowingSubscriptionWorker = null;
 
+            DoNotReuseServer();
             var store = GetDocumentStore();
             try
             {
@@ -721,6 +722,7 @@ namespace FastTests.Client.Subscriptions
         [Fact]
         public async Task RavenDB_3452_ShouldStopPullingDocsIfReleased()
         {
+            DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
                 Server.ServerStore.Observer.Suspended = true;

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8831.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8831.cs
@@ -24,6 +24,7 @@ namespace SlowTests.Client.Subscriptions
         [Fact]
         public async Task ReadDocWithCompressedStringFromOneContextAndWriteToAnother()
         {
+            DoNotReuseServer();
             using (var documentStore = GetDocumentStore())
             {
                 Server.ServerStore.Observer.Suspended = true;
@@ -75,6 +76,7 @@ namespace SlowTests.Client.Subscriptions
         [Fact]
         public async Task SubscriptionShouldRespectDocumentsWithCompressedData()
         {
+            DoNotReuseServer();
             using (var documentStore = GetDocumentStore())
             {
                 Server.ServerStore.Observer.Suspended = true;

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
@@ -60,6 +60,7 @@ namespace SlowTests.Client.Subscriptions
         [Fact]
         public async Task ShouldReplaceActiveClientWhen_TakeOver_StrategyIsUsed()
         {
+            DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
                 Server.ServerStore.Observer.Suspended = true;

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -337,6 +337,7 @@ namespace SlowTests.Client.Subscriptions
         [Fact]
         public void ShouldIncrementFailingTests()
         {
+            DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
                 Server.ServerStore.Observer.Suspended = true;

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -642,6 +642,12 @@ namespace FastTests
             var testOutcomeAnalyzer = new TestOutcomeAnalyzer(Context);
             var shouldSaveDebugPackage = testOutcomeAnalyzer.ShouldSaveDebugPackage();
 
+            exceptionAggregator.Execute(() =>
+            {
+                if (_globalServer?.ServerStore.Observer?.Suspended == true)
+                    throw new InvalidOperationException("The observer is suspended for the global server!");
+            });
+            
             Dispose(exceptionAggregator);
 
             DownloadAndSaveDebugPackage(shouldSaveDebugPackage, _globalServer, exceptionAggregator, Context);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16003

### Additional description

If we suspend the observer of the global server if will affect other tests

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
