### PR TITLE
RavenDB-19266: Incorrect size computation on large compressed documents

### DIFF
--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -266,11 +266,14 @@ namespace Voron.Data.Tables
         {
             byte marker = buffer[4];
             int dicIdCode = marker & 3;
+            bool singleElement = ((marker >> 5) & 1) == 1;
             int sizeId = marker >> 6;
             if (dicIdCode > 3)
                 throw new ArgumentOutOfRangeException("DicId was: +" + dicIdCode, nameof(dicIdCode));
 
             var pos = (int)LookupTable[dicIdCode];
+            if (!singleElement)
+                pos++;
        
             ulong decompressedSize = sizeId switch
             {

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -272,7 +272,7 @@ namespace Voron.Data.Tables
                 throw new ArgumentOutOfRangeException("DicId was: +" + dicIdCode, nameof(dicIdCode));
 
             var pos = (int)LookupTable[dicIdCode];
-            if (!singleElement)
+            if (singleElement == false)
                 pos++;
        
             ulong decompressedSize = sizeId switch

--- a/test/FastTests/Issues/RavenDB_19266.cs
+++ b/test/FastTests/Issues/RavenDB_19266.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.DocumentsCompression;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,9 +33,8 @@ namespace FastTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
-                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
+                var documentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
+                store.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(documentsCompression));
                 
                 using (var session = store.OpenSession())
                 {

--- a/test/FastTests/Issues/RavenDB_19266.cs
+++ b/test/FastTests/Issues/RavenDB_19266.cs
@@ -24,8 +24,11 @@ namespace FastTests.Issues
             public List<string> Lines = new();
         }
 
-        [Fact]
-        public void CompressAndDecompressDocument3Mb()
+        [Theory]
+        [InlineData(3)]
+        [InlineData(6)]
+        [InlineData(10)]
+        public void CompressAndDecompressDocument(int size)
         {
             using (var store = GetDocumentStore())
             {
@@ -37,62 +40,12 @@ namespace FastTests.Issues
                 {
                     var doc = new Order();
 
-                    for (int i = 0; i < 3 * 1024; i++)
+                    for (int i = 0; i < size * 1024; i++)
                     {
                         string line = RandomString(new Random(123), 1024);
                         doc.Lines.Add(line);
                     }
                     
-                    session.Store(doc);
-                    session.SaveChanges();
-                }
-            }
-        }
-
-        [Fact]
-        public void CompressAndDecompressDocument6Mb()
-        {
-            using (var store = GetDocumentStore())
-            {
-                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
-                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
-
-                using (var session = store.OpenSession())
-                {
-                    var doc = new Order();
-
-                    for (int i = 0; i < 6 * 1024; i++)
-                    {
-                        string line = RandomString(new Random(123), 1024);
-                        doc.Lines.Add(line);
-                    }
-
-                    session.Store(doc);
-                    session.SaveChanges();
-                }
-            }
-        }
-
-        [Fact]
-        public void CompressAndDecompressDocument10Mb()
-        {
-            using (var store = GetDocumentStore())
-            {
-                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
-                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
-
-                using (var session = store.OpenSession())
-                {
-                    var doc = new Order();
-
-                    for (int i = 0; i < 10 * 1024; i++)
-                    {
-                        string line = RandomString(new Random(123), 1024);
-                        doc.Lines.Add(line);
-                    }
-
                     session.Store(doc);
                     session.SaveChanges();
                 }

--- a/test/FastTests/Issues/RavenDB_19266.cs
+++ b/test/FastTests/Issues/RavenDB_19266.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_19266 : RavenTestBase
+    {
+        public RavenDB_19266(ITestOutputHelper output) : base(output) { }
+
+        public static string RandomString(Random random, int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            return new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+
+        internal class Order
+        {
+            public List<string> Lines = new();
+        }
+
+        [Fact]
+        public void CompressAndDecompressDocument3Mb()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
+                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
+                
+                using (var session = store.OpenSession())
+                {
+                    var doc = new Order();
+
+                    for (int i = 0; i < 3 * 1024; i++)
+                    {
+                        string line = RandomString(new Random(123), 1024);
+                        doc.Lines.Add(line);
+                    }
+                    
+                    session.Store(doc);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [Fact]
+        public void CompressAndDecompressDocument6Mb()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
+                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = new Order();
+
+                    for (int i = 0; i < 6 * 1024; i++)
+                    {
+                        string line = RandomString(new Random(123), 1024);
+                        doc.Lines.Add(line);
+                    }
+
+                    session.Store(doc);
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [Fact]
+        public void CompressAndDecompressDocument10Mb()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                record.DocumentsCompression = new DocumentsCompressionConfiguration(true, true, "Orders");
+                store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = new Order();
+
+                    for (int i = 0; i < 10 * 1024; i++)
+                    {
+                        string line = RandomString(new Random(123), 1024);
+                        doc.Lines.Add(line);
+                    }
+
+                    session.Store(doc);
+                    session.SaveChanges();
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19266.cs
+++ b/test/SlowTests/Issues/RavenDB_19266.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using FastTests;
 using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.DocumentsCompression;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace FastTests.Issues
+namespace SlowTests.Issues
 {
     public class RavenDB_19266 : RavenTestBase
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19266/Incorrect-size-computation-on-large-compressed-documents

### Additional description

Fixing size computation on large compressed documents with covering by unit test to check correct size computation on large compressed documents after [RavenDB-19117 improvements](https://github.com/ravendb/ravendb/commit/e97b4e3c69a1279331bb3c6081239176c6bca00e)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Testing 

- It has been verified by unit testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
