### PR TITLE
RavenDB-19076 Different results when using the `Filter` keyword

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -1046,10 +1046,11 @@ class query extends viewModelBase {
                         }
 
                         const totalFromQuery = queryResults.totalResultCount || 0;
+                        const filterByQuery = !!queryResults.additionalResultInfo.ScannedResults;
                         
                         itemsSoFar += queryResults.items.length;
                         
-                        if (totalFromQuery != -1) {
+                        if (totalFromQuery !== -1) {
                             if (itemsSoFar > totalFromQuery) {
                                 itemsSoFar = totalFromQuery;
                             }
@@ -1072,7 +1073,7 @@ class query extends viewModelBase {
                             this.totalResultsForUi(this.hasMoreUnboundedResults() ? itemsSoFar - 1 : itemsSoFar);
                         }
                         
-                        if (queryResults.additionalResultInfo.SkippedResults) {
+                        if (queryResults.additionalResultInfo.SkippedResults || filterByQuery) {
                             // apply skipped results (if any)
                             totalSkippedResults += queryResults.additionalResultInfo.SkippedResults;
                             
@@ -1084,7 +1085,7 @@ class query extends viewModelBase {
                             }
                         }
                         
-                        if (totalSkippedResults) {
+                        if (totalSkippedResults || filterByQuery) {
                             queryResults.totalResultCount = skip + queryResults.items.length;
                             if (queryResults.items.length === take + 1) {
                                 queryResults.totalResultCount += 30;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19076 

### Additional description

Show 100+ when dealing with filter query w/o skipped results. 


### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change
