### PR TITLE
RavenDB-13953 Allow to define document id postfix in RavenDB ETL

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
@@ -16,5 +16,6 @@ namespace Raven.Client.Documents.Operations.ETL
         ConfigurationName = 1 << 8,
         MentorNode = 1 << 9,
         ConfigurationDisabled = 1 << 10,
+        TransformationDocumentIdPostfix = 1 << 11
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -248,6 +248,8 @@ namespace Raven.Client.Documents.Operations.ETL
         internal bool IsAddingAttachments { get; private set; }
 
         internal bool IsLoadingAttachments { get; private set; }
+        
+        public string DocumentIdPostfix { get; set; }
 
         public Transformation()
         {

--- a/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Transformation.cs
@@ -429,6 +429,7 @@ namespace Raven.Client.Documents.Operations.ETL
                 [nameof(Script)] = Script,
                 [nameof(Collections)] = new DynamicJsonArray(Collections),
                 [nameof(ApplyToAllDocuments)] = ApplyToAllDocuments,
+                [nameof(DocumentIdPostfix)] = DocumentIdPostfix,
                 [nameof(Disabled)] = Disabled
             };
         }
@@ -462,6 +463,9 @@ namespace Raven.Client.Documents.Operations.ETL
             if (transformation.ApplyToAllDocuments != ApplyToAllDocuments)
                 differences |= EtlConfigurationCompareDifferences.TransformationApplyToAllDocuments;
 
+            if (transformation.DocumentIdPostfix != DocumentIdPostfix)
+                differences |= EtlConfigurationCompareDifferences.TransformationDocumentIdPostfix;
+            
             if (transformation.Disabled != Disabled)
                 differences |= EtlConfigurationCompareDifferences.TransformationDisabled;
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -238,7 +238,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
         public override void Transform(RavenEtlItem item, EtlStatsScope stats, EtlProcessState state)
         {
             Current = item;
-            _currentRun ??= new RavenEtlScriptRun(stats);
+            _currentRun ??= new RavenEtlScriptRun(stats, _transformation);
 
             if (item.IsDelete == false)
             {
@@ -321,7 +321,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         {
                             if (item.IsAttachmentTombstone == false)
                             {
-                                _currentRun.Delete(new DeleteCommandData(item.DocumentId, null, null));
+                                _currentRun.Delete(item.DocumentId);
                             }
                             else
                             {
@@ -808,12 +808,12 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         && _transformation.TimeSeries.IsAddingTimeSeries == false
                         && _currentRun.IsDocumentLoadedToSameCollection(item.DocumentId))
                         continue;
-                    _currentRun.Delete(new DeleteCommandData(item.DocumentId, null, null));
+                    _currentRun.Delete(item.DocumentId);
                     isLoadedToDefaultCollectionDeleted = true;
                 }
                 else
                 {
-                    _currentRun.Delete(new DeletePrefixedCommandData(GetPrefixedId(item.DocumentId, collection)));
+                    _currentRun.DeleteByPrefix(GetPrefixedId(item.DocumentId, collection));
                 }
             }
         }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
@@ -17,6 +17,8 @@ class ongoingTaskElasticSearchTransformationModel {
     canAddCollection: KnockoutComputed<boolean>;
     applyScriptForAllCollections = ko.observable<boolean>(false);
 
+    documentIdPostfix = ko.observable<string>();
+    
     validationGroup: KnockoutValidationGroup;
 
     dirtyFlag: () => DirtyFlag;
@@ -43,7 +45,8 @@ class ongoingTaskElasticSearchTransformationModel {
             this.script,
             this.resetScript,
             this.applyScriptForAllCollections,
-            this.transformScriptCollections
+            this.transformScriptCollections,
+            this.documentIdPostfix
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -54,7 +57,8 @@ class ongoingTaskElasticSearchTransformationModel {
                 Collections: [],
                 Disabled: false,
                 Name: name || "",
-                Script: ""
+                Script: "",
+                DocumentIdPostfix: ""
             }, true, false);
     }
 
@@ -64,7 +68,8 @@ class ongoingTaskElasticSearchTransformationModel {
             Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
-            Script: this.script()
+            Script: this.script(),
+            DocumentIdPostfix: this.documentIdPostfix()
         }
     }
 
@@ -122,6 +127,7 @@ class ongoingTaskElasticSearchTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean): void {
         this.name(dto.Name);
         this.script(dto.Script);
+        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlTransformationModel.ts
@@ -19,6 +19,8 @@ class ongoingTaskOlapEtlTransformationModel {
 
     isNew = ko.observable<boolean>(true);
     resetScript = ko.observable<boolean>(false);
+
+    documentIdPostfix = ko.observable<string>();
     
     validationGroup: KnockoutValidationGroup;
     dirtyFlag: () => DirtyFlag;
@@ -45,7 +47,8 @@ class ongoingTaskOlapEtlTransformationModel {
             this.script,
             this.resetScript,
             this.applyScriptForAllCollections,
-            this.transformScriptCollections
+            this.transformScriptCollections,
+            this.documentIdPostfix
        ], false, jsonUtil.newLineNormalizingHashFunction);
     }
    
@@ -56,7 +59,8 @@ class ongoingTaskOlapEtlTransformationModel {
                 Collections: [],
                 Disabled: false,
                 Name: name || "",
-                Script: ""
+                Script: "",
+                DocumentIdPostfix: ""
             }, true, false);
     }
 
@@ -66,7 +70,8 @@ class ongoingTaskOlapEtlTransformationModel {
             Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
-            Script: this.script()
+            Script: this.script(),
+            DocumentIdPostfix: this.documentIdPostfix()
         }
     }
 
@@ -144,6 +149,7 @@ class ongoingTaskOlapEtlTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
         this.name(dto.Name);
         this.script(dto.Script);
+        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
@@ -16,6 +16,8 @@ class ongoingTaskQueueEtlTransformationModel {
     inputCollection = ko.observable<string>();
     canAddCollection: KnockoutComputed<boolean>;
 
+    documentIdPostfix = ko.observable<string>();
+
     validationGroup: KnockoutValidationGroup; 
     
     dirtyFlag: () => DirtyFlag;
@@ -30,7 +32,9 @@ class ongoingTaskQueueEtlTransformationModel {
             this.script,
             this.resetScript,
             this.applyScriptForAllCollections,
-            this.transformScriptCollections], 
+            this.transformScriptCollections,
+            this.documentIdPostfix
+            ], 
         false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -49,7 +53,8 @@ class ongoingTaskQueueEtlTransformationModel {
                 Collections: [],
                 Disabled: false,
                 Name: name || "",
-                Script: ""
+                Script: "",
+                DocumentIdPostfix: ""
             }, true, false);
     }
 
@@ -59,7 +64,8 @@ class ongoingTaskQueueEtlTransformationModel {
             Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
-            Script: this.script()
+            Script: this.script(),
+            DocumentIdPostfix: this.documentIdPostfix()
         }
     }
 
@@ -124,6 +130,7 @@ class ongoingTaskQueueEtlTransformationModel {
     private update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
         this.name(dto.Name);
         this.script(dto.Script);
+        this.documentIdPostfix(dto.DocumentIdPostfix);
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);
         

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlTransformationModel.ts
@@ -16,6 +16,8 @@ class ongoingTaskRavenEtlTransformationModel {
     inputCollection = ko.observable<string>();
     canAddCollection: KnockoutComputed<boolean>;
 
+    documentIdPostfix = ko.observable<string>();
+
     validationGroup: KnockoutValidationGroup; 
     
     dirtyFlag: () => DirtyFlag;
@@ -30,7 +32,9 @@ class ongoingTaskRavenEtlTransformationModel {
             this.script,
             this.resetScript,
             this.applyScriptForAllCollections,
-            this.transformScriptCollections], 
+            this.transformScriptCollections,
+            this.documentIdPostfix
+            ], 
         false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -49,7 +53,8 @@ class ongoingTaskRavenEtlTransformationModel {
                 Collections: [],
                 Disabled: false,
                 Name: name || "",
-                Script: ""
+                Script: "",
+                DocumentIdPostfix: ""
             }, true, false);
     }
 
@@ -59,7 +64,8 @@ class ongoingTaskRavenEtlTransformationModel {
             Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
-            Script: this.script()
+            Script: this.script(),
+            DocumentIdPostfix: this.documentIdPostfix()
         }
     }
 
@@ -123,6 +129,8 @@ class ongoingTaskRavenEtlTransformationModel {
     private update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
         this.name(dto.Name);
         this.script(dto.Script);
+        this.documentIdPostfix(dto.DocumentIdPostfix);
+        
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);
         

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlTransformationModel.ts
@@ -16,6 +16,8 @@ class ongoingTaskSqlEtlTransformationModel {
 
     canAddCollection: KnockoutComputed<boolean>;
     applyScriptForAllCollections = ko.observable<boolean>(false);
+
+    documentIdPostfix = ko.observable<string>();
     
     validationGroup: KnockoutValidationGroup; 
   
@@ -43,7 +45,8 @@ class ongoingTaskSqlEtlTransformationModel {
             this.script,
             this.resetScript,
             this.applyScriptForAllCollections,
-            this.transformScriptCollections
+            this.transformScriptCollections,
+            this.documentIdPostfix
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
    
@@ -54,7 +57,8 @@ class ongoingTaskSqlEtlTransformationModel {
                 Collections: [],
                 Disabled: false,
                 Name: name || "",
-                Script: ""
+                Script: "",
+                DocumentIdPostfix: ""
             }, true, false);
     }
 
@@ -64,7 +68,8 @@ class ongoingTaskSqlEtlTransformationModel {
             Collections: this.applyScriptForAllCollections() ? null : this.transformScriptCollections(),
             Disabled: false,
             Name: this.name(),
-            Script: this.script()
+            Script: this.script(),
+            DocumentIdPostfix: this.documentIdPostfix()
         }
     }
 
@@ -122,6 +127,7 @@ class ongoingTaskSqlEtlTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean): void {
         this.name(dto.Name);
         this.script(dto.Script);
+        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -243,6 +243,13 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
+                    <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                        <label class="control-label"><strong>Document ID postfix:</strong></label>
+                        <div class="flex-grow margin-left">
+                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                        </div>
+                    </div>
                     <div class="margin-bottom margin-top margin-top-lg">
                         <div class="flex-horizontal margin-bottom">
                             <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -230,6 +230,13 @@
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
                         </div>
+                        <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                            <label class="control-label"><strong>Document ID postfix:</strong></label>
+                            <div class="flex-grow margin-left">
+                                <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                            </div>
+                        </div>
                         <div class="margin-bottom margin-top margin-top-lg">
                             <div class="flex-horizontal">
                                 <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -260,6 +260,13 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
+                    <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                        <label class="control-label"><strong>Document ID postfix:</strong></label>
+                        <div class="flex-grow margin-left">
+                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                        </div>
+                    </div>
                     <div class="margin-bottom margin-top margin-top-lg">
                         <div class="flex-horizontal margin-bottom">
                             <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -232,6 +232,13 @@
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
                         </div>
+                        <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                            <label class="control-label"><strong>Document ID postfix:</strong></label>
+                            <div class="flex-grow margin-left">
+                                <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                            </div>
+                        </div>
                         <div class="margin-bottom margin-top margin-top-lg">
                             <div class="flex-horizontal">
                                 <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -250,6 +250,13 @@
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
                         </div>
+                        <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                            <label class="control-label"><strong>Document ID postfix:</strong></label>
+                            <div class="flex-grow margin-left">
+                                <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                            </div>
+                        </div>
                         <div class="margin-bottom margin-top margin-top-lg">
                             <div class="flex-horizontal">
                                 <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -304,6 +304,13 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
+                    <div class="flex-horizontal margin-bottom margin-top" data-bind="validationElement: documentIdPostfix">
+                        <label class="control-label"><strong>Document ID postfix:</strong></label>
+                        <div class="flex-grow margin-left">
+                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
+                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                        </div>
+                    </div>
                     <div class="margin-bottom margin-top margin-top-lg">
                         <div class="flex-horizontal margin-bottom">
                             <div class="flex-grow">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13953 

### Additional description

We can now define a `DocumentIdPostfix` in the ETL process.
That would ensure that you can send remotes from two ETLs on different machines who share the same id space without conflicts.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
