### PR TITLE
RavenDB-19181 support `string.Empty` & Throw for TimeSeriesCopy, AttachmentMOVE, AttachmentCOPY

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -179,7 +179,7 @@ public class MergedBatchCommand : TransactionMergedCommand
                         // attachment sent by Raven ETL, only prefix is defined
 
                         if (lastPutResult == null)
-                            ThrowUnexpectedOrderOfRavenEtlCommands();
+                            ThrowUnexpectedOrderOfRavenEtlCommands("Bulk Docs");
 
                         Debug.Assert(lastPutResult.Value.Id.StartsWith(docId));
 
@@ -460,7 +460,7 @@ public class MergedBatchCommand : TransactionMergedCommand
         // counter/time-series sent by Raven ETL, only prefix is defined
 
         if (lastPutResult == null)
-            ThrowUnexpectedOrderOfRavenEtlCommands();
+            ThrowUnexpectedOrderOfRavenEtlCommands("Raven ETL");
 
         Debug.Assert(lastPutResult.HasValue && lastPutResult.Value.Id.StartsWith(docId));
         return lastPutResult.Value.Id;
@@ -491,8 +491,8 @@ public class MergedBatchCommand : TransactionMergedCommand
         public Stream Stream;
     }
 
-    private void ThrowUnexpectedOrderOfRavenEtlCommands()
+    private void ThrowUnexpectedOrderOfRavenEtlCommands(string source)
     {
-        throw new InvalidOperationException($"Unexpected order of commands sent by Raven ETL. {CommandType.AttachmentPUT} needs to be preceded by {CommandType.PUT}");
+        throw new InvalidOperationException($"Unexpected order of commands sent by {source}. {CommandType.AttachmentPUT} needs to be preceded by {CommandType.PUT}");
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeries.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeries.cs
@@ -45,6 +45,9 @@ namespace Raven.Server.Documents.Handlers.Processors.TimeSeries
             {
                 rangeResult = await GetTimeSeriesAndWriteAsync(context, documentId, name, from, to, start, pageSize, includeDoc, includeTags, fullResults);
 
+                if (rangeResult == null)
+                    return; // not-modified or not-found
+
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
                     WriteRange(writer, rangeResult, rangeResult?.TotalResults);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
@@ -112,7 +112,8 @@ public class ShardedBatchCommand : IBatchCommand, IEnumerable<SingleShardedComma
     {
         if (isServerSideIdentity)
         {
-            return _databaseContext.GetShardNumber(_context, cmd.Id.AsSpan(0, cmd.Id.Length - 2));   // here we are cheating by cutting '$/' from the end to detect shard number based on BASE26 part
+            var bucket = ShardHelper.GetBucketOfIdentity(_context, cmd.Id, _databaseContext.IdentityPartsSeparator);
+            return _databaseContext.GetShardNumber(bucket);
         }
 
         if (cmd.Type == CommandType.Counters)

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -105,14 +105,6 @@ namespace Raven.Server.Documents.Sharding
             return ShardHelper.GetShardNumber(_record.Sharding.BucketRanges, bucket);
         }
 
-        public int GetShardNumber(TransactionOperationContext context, ReadOnlySpan<char> id)
-        {
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Pawel, DevelopmentHelper.Severity.Normal, "RavenDB-19086 Optimize this");
-            var bucket = ShardHelper.GetBucket(context, id.ToString());
-
-            return ShardHelper.GetShardNumber(_record.Sharding.BucketRanges, bucket);
-        }
-
         public bool HasTopologyChanged(long etag)
         {
             // TODO fix this

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -13,6 +13,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server;
 using Sparrow.Threading;
+using Sparrow.Utils;
 using Voron;
 
 namespace Raven.Server.Utils
@@ -355,6 +356,18 @@ namespace Raven.Server.Utils
                 .Append(identityPartsSeparator);
 
             return builder.ToString();
+        }
+
+        public static int GetBucketOfIdentity(TransactionOperationContext context, string id, char identityPartsSeparator)
+        {
+            // the expected id format here is users/$BASE26$/
+            // so we cut the '$/' from the end to detect shard number based on BASE26 part
+            Debug.Assert(id[^1] == identityPartsSeparator, $"id[^1] != {identityPartsSeparator} for {id}");
+            Debug.Assert(id[^2] == '$', $"id[^2] != $ for {id}");
+            var actualId = id.AsSpan(0, id.Length - 2);
+
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Pawel, DevelopmentHelper.Severity.Normal, "RavenDB-19086 Optimize this");
+            return GetBucket(context, actualId.ToString());
         }
 
         public static unsafe void ExtractStickyId(ref char* buffer, ref int size)

--- a/test/FastTests/Sharding/BasicSharding.cs
+++ b/test/FastTests/Sharding/BasicSharding.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -70,10 +69,8 @@ namespace FastTests.Sharding
                 {
                     var u = new User();
                     s.Store(u, "users/1");
-                    /*s.CountersFor(u).Increment("Likes", 555);
+                    s.CountersFor(u).Increment("Likes", 555);
                     s.CountersFor(u).Increment("Views", 100);
-                    s.TimeSeriesFor(u, "BPM").Append(DateTime.UtcNow, 120);
-                    s.TimeSeriesFor(u, "Price").Append(DateTime.UtcNow, 1000);*/
                     s.SaveChanges();
                 }
 
@@ -88,7 +85,7 @@ namespace FastTests.Sharding
                             {
                                 new CounterOperation
                                 {
-                                    Type = CounterOperationType.Put,
+                                    Type = CounterOperationType.Increment,
                                     CounterName = "likes",
                                     Delta = 10
                                 }
@@ -96,6 +93,13 @@ namespace FastTests.Sharding
                         }
                     }
                 }));
+
+                using (var s = store.OpenSession())
+                {
+                    var u = s.Load<User>("users/1");
+                    Assert.Equal(565,s.CountersFor(u).Get("Likes"));
+                    Assert.Equal(100,s.CountersFor(u).Get("Views"));
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19181

### Additional description

- Support passing `string.Empty` as and ID
- Throw `NotSupportedInShardingException` for TimeSeriesCopy, AttachmentMOVE, AttachmentCOPY commands
Because this might require us to send the attachment/TS to a different shard, which might be complex. 
- Handle `PUT` command without any change vector (we get such thing from studio and probably from non-C# clients)

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Breaking change since we will throw for TimeSeriesCopy, AttachmentMOVE, AttachmentCOPY commands

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
Yes, cloning for a document with attachment/TimeSeries is not going to work for the sharded database
