### PR TITLE
RavenDB-19286 Invalid query from the client side when using CompareTo…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19286.cs
+++ b/test/SlowTests/Issues/RavenDB-19286.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19286 : RavenTestBase
+{
+    public RavenDB_19286(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    class User
+    {
+        public string Name;
+    }
+
+    [Fact]
+    public async Task CanDoStringRangeQuery()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Zoof" });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") == 0)
+                .SingleAsync();
+
+            await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") == 0)
+                .SingleAsync();
+        }
+    }
+}


### PR DESCRIPTION
… on strings. Also handle string.Compare() == 0, also allow to run string.CompareOrginal as Exact(foo == bar) queries.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19286 


### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented?

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
