### PR TITLE
RavenDB-18647 - Inconsistent result of a conflict between doc & attachment with the same name

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.ServerWide;
+using Raven.Server.Documents.Replication;
 using Sparrow.Server;
 using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;
@@ -238,6 +239,7 @@ namespace Raven.Server.Documents
                         }
                         
                         flags |= DocumentFlags.HasRevisions;
+                        Console.WriteLine($"{_documentDatabase.Name} Putting revision in storage {document} {changeVector}");
                         _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks, configuration, collectionName);
                     }
                 }
@@ -266,6 +268,8 @@ namespace Raven.Server.Documents
                     }
                 }
 
+                Console.WriteLine($"{_documentDatabase.Name} Putting document {lowerId} with cv {changeVector} tx: {context.GetTransactionMarker()}");
+
                 if (collectionName.IsHiLo == false)
                 {
                     _documentsStorage.ExpirationStorage.Put(context, lowerId, document);
@@ -284,7 +288,7 @@ namespace Raven.Server.Documents
 
                 ValidateDocumentHash(id, document, documentDebugHash);
                 ValidateDocument(id, document, ref documentDebugHash);
-
+                
                 return new PutOperationResults
                 {
                     Etag = newEtag,
@@ -498,6 +502,7 @@ namespace Raven.Server.Documents
 #endif
                 }
             }
+            Console.WriteLine($"{_documentDatabase.Name} Doc recreated to {document}");
         }
 
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -498,8 +498,8 @@ namespace Raven.Server.Documents
 
         public string CreateNextDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
         {
-            var databaseChangeVector = context.LastDatabaseChangeVector ?? GetDatabaseChangeVector(context);
-            context.SkipChangeVectorValidation = TryRemoveUnusedIds(ref databaseChangeVector);
+            var databaseChangeVector = GetNewChangeVector(context).ChangeVector;//context.LastDatabaseChangeVector ?? GetDatabaseChangeVector(context);
+           // context.SkipChangeVectorValidation = TryRemoveUnusedIds(ref databaseChangeVector);
             changeVector = ChangeVectorUtils.MergeVectors(databaseChangeVector, changeVector);
             return ChangeVectorUtils.TryUpdateChangeVector(DocumentDatabase, changeVector).ChangeVector;
         }

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Handlers;
@@ -260,6 +261,7 @@ namespace Raven.Server.Documents.Replication
                     nonPersistentFlags |= NonPersistentDocumentFlags.ResolveTimeSeriesConflict;
 
                 _database.DocumentsStorage.Put(context, id, null, incomingDoc, lastModifiedTicks, mergedChangeVector, nonPersistentFlags: nonPersistentFlags);
+                Console.WriteLine($"{_database.Name} Incoming doc resolved identical. original cv: {incomingChangeVector}. merged cv: {mergedChangeVector} \n{incomingDoc}");
                 return true;
             }
 

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -88,9 +88,8 @@ namespace Raven.Server.Documents.Replication
                             conflicts.Add(local);
 
                         var resolved = _conflictResolver.ResolveToLatest(conflicts);
-                        _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: true, conflictedDoc);
-
-                        return;
+                        if(_conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: true, conflictedDoc))
+                            return;
                     }
                 }
 
@@ -178,8 +177,7 @@ namespace Raven.Server.Documents.Replication
                 conflictedDocs,
                 documentsContext.GetLazyString(collection), out var resolved))
             {
-                _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, conflict);
-                return true;
+                return  _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, conflict);
             }
 
             return false;

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1187,9 +1187,9 @@ namespace Raven.Server.Documents.Replication
                                 var tombstone = AttachmentsStorage.GetAttachmentTombstoneByKey(context, attachmentTombstone.Key);
                                 if (tombstone != null && ChangeVectorUtils.GetConflictStatus(item.ChangeVector, tombstone.ChangeVector) == ConflictStatus.AlreadyMerged)
                                     continue;
-                                
-                                var hashSlice = database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, attachmentTombstone.Key, false, "$fromReplication", null,
-                                    rcvdChangeVector, attachmentTombstone.LastModifiedTicks, deleteAttachmentStream: false);
+
+                                var hashSlice = database.DocumentsStorage.AttachmentsStorage.DeleteAttachmentDirect(context, attachmentTombstone.Key, isPartialKey: false,
+                                    "$fromReplication", expectedChangeVector: null, rcvdChangeVector, attachmentTombstone.LastModifiedTicks, deleteAttachmentStream: false);
                                 
                                 if(hashSlice.HasValue)
                                     _replicationInfo.AttachmentStreamsToDeleteAtTheEndOfBatch.Add(hashSlice);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -945,6 +945,8 @@ namespace Raven.Server.Documents.Replication
         {
             _lastSentDocumentEtag = replicationBatchReply.LastEtagAccepted;
 
+            if(LastAcceptedChangeVector != replicationBatchReply.DatabaseChangeVector)
+                Console.WriteLine($"{this.FromToString} \n         UpdateDestinationChangeVectorHeartbeat from {LastAcceptedChangeVector} to {replicationBatchReply.DatabaseChangeVector}");
             LastAcceptedChangeVector = replicationBatchReply.DatabaseChangeVector;
             if (ReplicationType != ReplicationLatestEtagRequest.ReplicationType.External)
             {

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -425,6 +425,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     if (Interlocked.CompareExchange(ref next, nextReplication, state.CurrentNext) == state.CurrentNext)
                     {
+                        Console.WriteLine($"ReplicationDocumentSender: {_parent.FromToString} state.Delay.Ticks > 0");
                         return false;
                     }
                 }
@@ -443,6 +444,8 @@ namespace Raven.Server.Documents.Replication
             if (state.MaxSizeToSend.HasValue && totalSize >= state.MaxSizeToSend.Value.GetValue(SizeUnit.Bytes) ||
                 state.BatchSize.HasValue && state.NumberOfItemsSent >= state.BatchSize.Value)
             {
+                Console.WriteLine($"ReplicationDocumentSender: {_parent.FromToString} state.MaxSizeToSend.HasValue");
+
                 return false;
             }
 
@@ -451,6 +454,8 @@ namespace Raven.Server.Documents.Replication
                 // ReSharper disable once PossibleLossOfFraction
                 if ((_parent._parent.MinimalHeartbeatInterval / 2) < _stats.Storage.Duration.TotalMilliseconds)
                 {
+                    Console.WriteLine($"ReplicationDocumentSender: {_parent.FromToString} (_stats.Storage.CurrentStats.InputCount");
+
                     return false;
                 }
             }
@@ -585,6 +590,8 @@ namespace Raven.Server.Documents.Replication
             if (ShouldSkip(item, stats, skippedReplicationItemsInfo))
                 return false;
 
+            Console.WriteLine($"ReplicationDocumentSender: {_parent.FromToString} Adding {item.Type} with change vector {item.ChangeVector} tx: {item.TransactionMarker} ({_parent.LastAcceptedChangeVector})");
+
             if (skippedReplicationItemsInfo.SkippedItems > 0)
             {
                 if (_log.IsInfoEnabled)
@@ -659,6 +666,7 @@ namespace Raven.Server.Documents.Replication
             // destination already has it
             if (_parent._database.DocumentsStorage.GetConflictStatus(item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
             {
+                Console.WriteLine($"ReplicationDocumentSender: {_parent.FromToString} Skipping {item.Type} with change vector {item.ChangeVector} tx: {item.TransactionMarker} ({_parent.LastAcceptedChangeVector})");
                 stats.RecordChangeVectorSkip();
                 skippedReplicationItemsInfo.Update(item);
                 return true;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -307,14 +307,14 @@ namespace Raven.Server.Documents.Revisions
                     return false;
             }
 
-            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
-                return true;
-
             if (Configuration == null)
                 return false;
 
             if (configuration.Disabled)
                 return false;
+
+            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
+                return true;
 
             if (configuration.MinimumRevisionsToKeep == 0)
             {
@@ -434,7 +434,7 @@ namespace Raven.Server.Documents.Revisions
                 if (flags.Contain(DocumentFlags.HasAttachments) &&
                     flags.Contain(DocumentFlags.Revision) == false)
                 {
-                    _documentsStorage.AttachmentsStorage.RevisionAttachments(context, lowerId, changeVectorSlice);
+                    _documentsStorage.AttachmentsStorage.RevisionAttachments(context, document, lowerId, changeVectorSlice);
                 }
 
                 document = AddCounterAndTimeSeriesSnapshotsIfNeeded(context, id, document);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -307,14 +307,14 @@ namespace Raven.Server.Documents.Revisions
                     return false;
             }
 
+            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
+                return true;
+
             if (Configuration == null)
                 return false;
 
             if (configuration.Disabled)
                 return false;
-
-            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
-                return true;
 
             if (configuration.MinimumRevisionsToKeep == 0)
             {

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Utils;
@@ -21,6 +22,10 @@ namespace Raven.Server.ServerWide.Context
 
                 if (DbIdsToIgnore == null || DbIdsToIgnore.Count == 0 || string.IsNullOrEmpty(value))
                 {
+                    if(_lastDatabaseChangeVector != value)
+                        Console.WriteLine($"{_documentDatabase.Name} {_lastDatabaseChangeVector} -> {value}");
+                  //  Console.WriteLine($"{_documentDatabase.Name} {_lastDatabaseChangeVector} -> {value} \n{System.Environment.StackTrace}");
+
                     _lastDatabaseChangeVector = value;
                     return;
                 }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -101,6 +101,7 @@ namespace FastTests
                             [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = runInMemory.ToString(),
                             [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "true",
                             [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString(),
+                            [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString(),
                         }
                     };
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using FastTests.Blittable;
 using FastTests.Client;
+using FastTests.Client.Subscriptions;
 using RachisTests;
+using SlowTests.Client.Attachments;
 using SlowTests.Client.TimeSeries.Replication;
+using SlowTests.Cluster;
 using SlowTests.Issues;
 using SlowTests.MailingList;
 using SlowTests.Rolling;
@@ -24,15 +28,16 @@ namespace Tryouts
         public static async Task Main(string[] args)
         {
             Console.WriteLine(Process.GetCurrentProcess().Id);
+
             for (int i = 0; i < 10_000; i++)
             {
                  Console.WriteLine($"Starting to run {i}");
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new ElectionTests(testOutputHelper))
+                    using (var test = new AttachmentsReplication(testOutputHelper))
                     {
-                         await test.CanElectOnDivergence4();
+                         await test.ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder_RevisionsDisabled();
                     }
                 }
                 catch (Exception e)
@@ -40,6 +45,7 @@ namespace Tryouts
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.WriteLine(e);
                     Console.ForegroundColor = ConsoleColor.White;
+                    return;
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18647

### Additional description

Problem summary:

A document with a conflict against a document with a replaced attachment caused uneven results in both stores. One of them had no attachments at all in the resolved doc.
The document with the replaced attachment sent a tombstone for the old attachment via replication which caused it to be immediately deleted in the other store.
However, the document with the old attachment won the conflict (last modified) but its attachment no longer existed there.

Solution:

When resolving attachment conflicts, we now put new attachment metadata in storage according to the resolved doc (if the md doesn't exist).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 
### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
