### PR TITLE
RavenDB-19287 Rename 'Document Preview' to 'Index Entry Preview'

### DIFF
--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
@@ -193,7 +193,7 @@ class documentBasedColumnsProvider {
         const docDto = doc.toDto(true);
         
         const text = JSON.stringify(docDto, null, 4);
-        const title = doc.getId() ? "Document: " + doc.getId() : "Document preview";
+        const title = doc.getId() ? "Document: " + doc.getId() : "Index Entry preview";
         app.showBootstrapDialog(new showDataDialog(title, text, "javascript"));
     }
 

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
@@ -51,7 +51,7 @@ class documentBasedColumnsProvider {
     private readonly detectTimeSeries: boolean;
     private readonly showSelectAllCheckbox: boolean;
     private readonly columnOptions: columnOptionsDto;
-    private readonly customInlinePreview: (doc: document) => void;
+    private readonly customInlinePreview: (doc: document, title?: string) => void;
     private readonly collectionTracker: collectionsTracker;
     private readonly customColumnProvider: () => virtualColumn[];
     private readonly timeSeriesActionHandler: (type: timeSeriesColumnEventType, documentId: string, name: string, value: timeSeriesQueryResultDto, event: JQueryEventObject) => void;
@@ -109,7 +109,8 @@ class documentBasedColumnsProvider {
         }
 
         if (this.enableInlinePreview) {
-            const previewColumn = new actionColumn<document>(this.gridController, this.customInlinePreview, "Preview", `<i class="icon-preview"></i>`, "75px",
+            const previewColumn = new actionColumn<document>(this.gridController,
+                    doc => this.customInlinePreview(doc, doc.getId() ? null : "Index Entry Preview"), "Preview", `<i class="icon-preview"></i>`, "75px",
             {
                 title: () => 'Show item preview'
             });
@@ -189,12 +190,12 @@ class documentBasedColumnsProvider {
         }
     }
     
-    static showPreview(doc: document) {
+    static showPreview(doc: document, title?: string) {
         const docDto = doc.toDto(true);
         
         const text = JSON.stringify(docDto, null, 4);
-        const title = doc.getId() ? "Document: " + doc.getId() : "Index Entry preview";
-        app.showBootstrapDialog(new showDataDialog(title, text, "javascript"));
+        const titleToUse = title ?? doc.getId() ? "Document: " + doc.getId() : "Document Preview";
+        app.showBootstrapDialog(new showDataDialog(titleToUse, text, "javascript"));
     }
 
     static extractUniquePropertyNames(results: pagedResult<document>) {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19287

### Additional description
Rename dialog title to 'Index entry preview' when viewing an 'index entry'

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
