### PR TITLE
RavenDB-19298 Helm: Install via artifacthub.io

### DIFF
--- a/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
+++ b/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
@@ -14,6 +14,7 @@ public class CreateSetupPackageParameters
     public string Mode;
     public string CertificatePath;
     public string CertPassword;
+    public string HelmValuesOutputPath;
     public SetupProgressAndResult Progress;
     public CancellationToken CancellationToken;
 }

--- a/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
+++ b/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
@@ -16,5 +16,6 @@ public class CreateSetupPackageParameters
     public string CertPassword;
     public string HelmValuesOutputPath;
     public SetupProgressAndResult Progress;
+    public bool RegisterTcpDnsRecords;
     public CancellationToken CancellationToken;
 }

--- a/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
@@ -39,6 +39,18 @@ public class RavenDnsRecordHelper
                             : new List<string> {node.Value.ExternalIpAddress}
                     };
 
+                    if (parameters.RegisterTcpDnsRecords)
+                    {
+                        var regNodeTcpInfo = new RegistrationNodeInfo
+                        {
+                            SubDomain = (node.Key + "-tcp." + parameters.SetupInfo.Domain).ToLower(),
+                            Ips = node.Value.ExternalIpAddress == null
+                                ? node.Value.Addresses
+                                : new List<string> {node.Value.ExternalIpAddress}
+                        };
+                        registrationInfo.SubDomains.Add(regNodeTcpInfo);
+                    }
+
                     registrationInfo.SubDomains.Add(regNodeInfo);
                 }
                 

--- a/src/Raven.Server/Commercial/LetsEncrypt/UpdateDnsRecordParameters.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/UpdateDnsRecordParameters.cs
@@ -10,5 +10,6 @@ public class UpdateDnsRecordParameters
     public SetupProgressAndResult Progress;
     public string Challenge;
     public SetupInfo SetupInfo;
+    public bool RegisterTcpDnsRecords;
     public CancellationToken Token;
 }

--- a/src/Raven.Server/Commercial/SetupInfo.cs
+++ b/src/Raven.Server/Commercial/SetupInfo.cs
@@ -138,7 +138,7 @@ namespace Raven.Server.Commercial
             }
             case  "lets-encrypt":
             {
-                return await LetsEncryptSetupUtils.Setup(parameters.SetupInfo, parameters.Progress, parameters.CancellationToken);
+                return await LetsEncryptSetupUtils.Setup(parameters.SetupInfo, parameters.Progress, parameters.RegisterTcpDnsRecords, parameters.CancellationToken);
             }
             default: throw new InvalidOperationException("Invalid mode provided.");
         }

--- a/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Raven.Server.Commercial;
 using Raven.Server.Commercial.LetsEncrypt;
 using Raven.Server.Utils;
 
@@ -13,7 +14,7 @@ public static class LetsEncryptSetupUtils
 {
         private const string AcmeClientUrl = "https://acme-v02.api.letsencrypt.org/directory";
 
-        public static async Task<byte[]> Setup(SetupInfo setupInfo,  SetupProgressAndResult progress, CancellationToken token)
+        public static async Task<byte[]> Setup(SetupInfo setupInfo,  SetupProgressAndResult progress, bool registerTcpDnsRecords, CancellationToken token)
         {
             progress.Processed++;
             progress?.AddInfo("Setting up RavenDB in Let's Encrypt security mode.");
@@ -64,13 +65,13 @@ public static class LetsEncryptSetupUtils
                 {
                     throw new InvalidOperationException($"Failed to claim the given domain: {registrationInfo.Domain}", e);
                 }
-           
                 await RavenDnsRecordHelper.UpdateDnsRecordsTask(new UpdateDnsRecordParameters
                 {
                     Challenge = challengeResult.Challenge,
                     SetupInfo = setupInfo,
                     Progress = progress,
-                    Token = CancellationToken.None
+                    Token = CancellationToken.None,
+                    RegisterTcpDnsRecords = registerTcpDnsRecords
                 });
                 progress?.AddInfo($"Updating DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}.");
             }

--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -356,6 +356,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             Processed = 0,
             Total = 4
         },
+            false,
             CancellationToken.None);
 
         X509Certificate2 serverCert;
@@ -490,6 +491,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             Processed = 0,
             Total = 4
         },
+            false,
             CancellationToken.None);
 
         X509Certificate2 serverCert;

--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -655,7 +655,9 @@ namespace rvn
 
         private static CommandOption ConfigureGenerateValues(CommandLineApplication cmd)
         {
-            return cmd.Option("--generate-helm-values", "Path to values.yaml", CommandOptionType.SingleOrNoValue);
+            var opt = cmd.Option("--generate-helm-values", "Path to values.yaml", CommandOptionType.SingleOrNoValue);
+            opt.DefaultValue = "values.yaml";
+            return opt;
         }
 
         private static CommandOption ConfigureServiceNameOption(CommandLineApplication cmd)

--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -134,7 +134,7 @@ namespace rvn
                 cmd.Description = "This command creates a RavenDB setup ZIP file";
                 cmd.ExtendedHelpText = "Usage example:" +
                                        Environment.NewLine + 
-                                       "rvn create-setup-package -m=\"lets-encrypt\" -s=\"json-file-path\" -o=\"output-zip-file-name\" -g=\"values.yaml\"" +
+                                       "rvn create-setup-package -m=\"lets-encrypt\" -s=\"json-file-path\" -o=\"output-zip-file-name\" --generate-helm-values[=\"values.yaml\"]" +
                                        Environment.NewLine;
                 
                 cmd.HelpOption(HelpOptionString);
@@ -153,7 +153,7 @@ namespace rvn
                     var packageOutPathVal = packageOutPath.Value();
                     var certPathVal = certPath.Value();
                     var certPassTuple = certPass.Value() ?? Environment.GetEnvironmentVariable("RVN_CERT_PASS");
-                    var generateHelmValuesVal = generateHelmValues.Value();
+                    var generateHelmValuesVal = generateHelmValues.HasValue() && generateHelmValues.Value() is null ? "values.yaml" : generateHelmValues.Value(); 
 
                     return await CreateSetupPackage(new CreateSetupPackageParameters
                     {
@@ -654,7 +654,7 @@ namespace rvn
 
         private static CommandOption ConfigureGenerateValues(CommandLineApplication cmd)
         {
-            return cmd.Option("--generate-helm-values", "Path to values.yaml", CommandOptionType.SingleValue);
+            return cmd.Option("--generate-helm-values", "Path to values.yaml", CommandOptionType.SingleOrNoValue);
         }
 
         private static CommandOption ConfigureServiceNameOption(CommandLineApplication cmd)

--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -176,6 +176,7 @@ namespace rvn
                                 Console.Error.WriteLine(tuple.Exception.Message);
                             }
                         }),
+                        RegisterTcpDnsRecords = generateHelmValuesVal is not null,
                         CancellationToken = token
                     });
                 });

--- a/tools/rvn/HelmInfo.cs
+++ b/tools/rvn/HelmInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace rvn
+{
+    public class HelmInfo
+    {
+        public string StorageSize { get; set; } = "10Gi";
+        public string RavenImageTag { get; set; } = "latest";
+        public string ImagePullPolicy { get; set; } = "IfNotPresent";
+        public string IngressClassName { get; set; } = "nginx";
+
+        public List<string> NodeTags { get; set; }
+        public string Domain { get; set; }
+        public string Email { get; set; }
+        public string SetupMode { get; set; }
+        public string License { get; set; }
+    }
+}

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -14,8 +14,6 @@
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\src\Raven.Client\Extensions\MemberInfoExtensions.cs" Link="Client\Extensions\MemberInfoExtensions.cs" />
-    <Compile Include="..\..\src\Raven.Client\Extensions\StringExtensions.cs" Link="Client\Extensions\StringExtensions.cs" />
     <Compile Include="..\..\src\Raven.Server\Commercial\CompleteClusterConfigurationResult.cs" Link="Server\Commercial\CompleteClusterConfigurationResult.cs" />
     <Compile Include="..\..\src\Raven.Server\Commercial\GetSetupZipFileParameters.cs" Link="Server\Commercial\GetSetupZipFileParameters.cs" />
     <Compile Include="..\..\src\Raven.Server\Commercial\SetupMode.cs" Link="Server\Commercial\SetupMode.cs" />
@@ -67,19 +65,6 @@
     <Compile Include="..\..\src\Raven.Server\Commercial\ApiHttpClient.cs" Link="Server\Commercial\ApiHttpClient.cs" />
     <Compile Include="..\..\src\Raven.Server\Smuggler\Documents\Processors\BuildVersion.cs" Link="Server\Smuggler\Documents\Processors\BuildVersion.cs" />
     <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
-    <Compile Include="..\..\src\Raven.Client\Exceptions\UnsuccessfulFileAccessException.cs" Link="Client\Exceptions\UnsuccessfulFileAccessException.cs" />
-    <Compile Include="..\..\src\Raven.Client\Extensions\ExpressionExtensions.cs" Link="Client\Extensions\ExpressionExtensions.cs" />
-    <Compile Include="..\..\src\Raven.Client\Extensions\WhoIsLocking.cs" Link="Client\Extensions\WhoIsLocking.cs" />
-    <Compile Include="..\..\src\Raven.Client\Documents\Operations\Configuration\StudioConfiguration.cs" Link="Client\Documents\Operations\Configuration\StudioConfiguration.cs" />
-    <Compile Include="..\..\src\Raven.Client\Documents\Operations\OperationState.cs" Link="Client\Documents\Operations\OperationState.cs" />
-    <Compile Include="..\..\src\Raven.Client\Documents\Operations\IOperationProgress.cs" Link="Client\Documents\Operations\IOperationProgress.cs" />
-    <Compile Include="..\..\src\Raven.Client\Util\SystemTime.cs" Link="Client\Util\SystemTime.cs" />
-    <Compile Include="..\..\src\Raven.Client\Constants.cs" Link="Client\Constants.cs" />
-   <Compile Include="..\..\src\Raven.Client\Properties\VersionInfo.cs" Link="Client\Properties\VersionInfo.cs" />
-    <Compile Include="..\..\src\Raven.Client\Exceptions\Security\SecurityException.cs" Link="Client\Exceptions\Security\SecurityException.cs" />
-    <Compile Include="..\..\src\Raven.Client\Exceptions\RavenException.cs" Link="Client\Exceptions\RavenException.cs" />
-    <Compile Include="..\..\src\Raven.Client\ServerWide\Operations\Certificates\CertificateDefinition.cs" Link="Client\ServerWide\Operations\Certificates\CertificateDefinition.cs" />
-    <Compile Include="..\..\src\Raven.Client\Extensions\CharExtensions.cs" Link="Client\Extensions\CharExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows64)' == 'true'">
     <None Include="..\..\libs\libsodium\libsodium.win.x64.dll" Link="libsodium.win.x64.dll">
@@ -176,6 +161,7 @@
     <PackageReference Include="YamlDotNet" Version="12.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -173,6 +173,7 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
+    <PackageReference Include="YamlDotNet" Version="12.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19298/Helm-Install-via-artifacthubio

### Additional description

Initial patch of the `rvn create-setup-package` that allows using `--generate-helm-values|-g [path]` option

### Type of change

- New feature


### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes and no - it simplifies our Helm chart flow, I'll link a PR from helm chart repo here 
- https://github.com/ravendb/helm-charts/pull/18

