### PR TITLE
RavenDB-19274 Add avg response size to Traffic Watch stats

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -14,6 +14,7 @@ import recentQueriesStorage = require("common/storage/savedQueriesStorage");
 import queryCriteria = require("models/database/query/queryCriteria");
 import databasesManager = require("common/shell/databasesManager");
 import accessManager = require("common/shell/accessManager");
+import TrafficWatchHttpChange = Raven.Client.Documents.Changes.TrafficWatchHttpChange;
 
 type trafficChangeType = Raven.Client.Documents.Changes.TrafficWatchChangeType | Raven.Client.ServerWide.Tcp.TcpConnectionHeaderMessage.OperationTypes; 
 
@@ -65,6 +66,24 @@ type certificateInfo = {
     clearance: Raven.Client.ServerWide.Operations.Certificates.SecurityClearance;
 }
 
+interface statistics {
+    min: string;
+    avg: string;
+    max: string;
+    percentile_90: string;
+    percentile_99: string;
+    percentile_99_9: string;
+}
+
+const notAvailableStats: statistics = {
+    min: "N/A",
+    avg: "N/A",
+    percentile_90: "N/A",
+    percentile_99: "N/A",
+    percentile_99_9: "N/A",
+    max: "N/A"
+}
+
 class trafficWatch extends viewModelBase {
     
     static readonly isSecureServer = accessManager.default.secureServer();
@@ -104,12 +123,8 @@ class trafficWatch extends viewModelBase {
         sourceIpsCount: ko.observable<string>(),
         httpRequestCount: ko.observable<string>(),
         tcpOperationCount: ko.observable<string>(),
-        min: ko.observable<string>(),
-        avg: ko.observable<string>(),
-        max: ko.observable<string>(),
-        percentile_90: ko.observable<string>(),
-        percentile_99: ko.observable<string>(),
-        percentile_99_9: ko.observable<string>()
+        requestDuration: ko.observable<statistics>(notAvailableStats),
+        responseSize: ko.observable<statistics>(notAvailableStats)
     };
     
     filter = ko.observable<string>();
@@ -274,75 +289,56 @@ class trafficWatch extends viewModelBase {
         this.stats.httpRequestCount(this.filteredDataHttp.length.toLocaleString());
         this.stats.tcpOperationCount(this.filteredDataTcp.length.toLocaleString());
 
-        if (!this.filteredDataHttp.length) {
-            this.httpStatsNotAvailable();
-        } else {
-            const filteredDataHttpNoWebSockets = this.filteredDataHttp.filter(x => x.ResponseStatusCode !== 101);
-            
-            if (filteredDataHttpNoWebSockets.length === 0) {
-                this.httpStatsNotAvailable();
-            } else {
-                this.updateDurationStats(filteredDataHttpNoWebSockets);
-                this.updatePercentiles(filteredDataHttpNoWebSockets);
-            }
-        }
+        const filteredDataHttpNoWebSockets = this.filteredTypeDataHttp.length ? this.filteredDataHttp.filter(x => x.ResponseStatusCode !== 101) : [];
+
+        this.stats.requestDuration(trafficWatch.computeStats(filteredDataHttpNoWebSockets, x => x.ElapsedMilliseconds, x => generalUtils.formatTimeSpan(x, false)));
+        this.stats.responseSize(trafficWatch.computeStats(filteredDataHttpNoWebSockets, x => x.ResponseSizeInBytes, x => generalUtils.formatBytesToSize(x, 1)));
     }
-                
-    private httpStatsNotAvailable(): void {
-        this.stats.avg("N/A");
-        this.stats.min("N/A");
-        this.stats.max("N/A");
-
-        this.stats.percentile_90("N/A");
-        this.stats.percentile_99("N/A");
-        this.stats.percentile_99_9("N/A");
-                }
-
-    private updateDurationStats(data: Raven.Client.Documents.Changes.TrafficWatchHttpChange[]): void {
-        const firstItem = data[0];
-
-        let sum = 0;
-        let min = firstItem.ElapsedMilliseconds;
-        let max = firstItem.ElapsedMilliseconds;
-
-        for (let i = 0; i < data.length; i++) {
-            const item = data[i];
-
-                if (item.ElapsedMilliseconds < min) {
-                    min = item.ElapsedMilliseconds;
-                }
-
-                if (item.ElapsedMilliseconds > max) {
-                    max = item.ElapsedMilliseconds;
-                }
-
-                sum += item.ElapsedMilliseconds;
-            }
-
-            this.stats.min(generalUtils.formatTimeSpan(min, false));
-            this.stats.max(generalUtils.formatTimeSpan(max, false));
-        this.stats.avg(generalUtils.formatTimeSpan(sum / data.length));
-            }
     
-    private updatePercentiles(data: Raven.Client.Documents.Changes.TrafficWatchHttpChange[]): void {
-        const timings: number[] = [];
+    private static computeStats(data: TrafficWatchHttpChange[],
+                                accessor: (item: TrafficWatchHttpChange) => number,
+                                formatter: (value: number) => string): statistics {
+        if (data.length === 0) {
+            return notAvailableStats;
+        }
+
+        const scalars: number[] = [];
+        let min = accessor(data[0]);
+        let max = accessor(data[0]);
+        let sum = 0;
 
         for (let i = data.length - 1; i >= 0; i--) {
             const item = data[i];
+            const value = accessor(item);
 
-            if (timings.length === 2048) {
+            if (scalars.length === 2048) {
                 // compute using max 2048 latest values
                 break;
             }
+            
+            if (value < min) {
+                min = value;
+            }
+            
+            if (value > max) {
+                max = value;
+            }
+            
+            sum += value;
 
-            timings.push(item.ElapsedMilliseconds);
+            scalars.push(value);
         }
 
-        timings.sort((a, b) => a - b);
+        scalars.sort((a, b) => a - b);
         
-        this.stats.percentile_90(generalUtils.formatTimeSpan(timings[Math.ceil(90 / 100 * timings.length) - 1]));
-        this.stats.percentile_99(generalUtils.formatTimeSpan(timings[Math.ceil(99 / 100 * timings.length) - 1]));
-        this.stats.percentile_99_9(generalUtils.formatTimeSpan(timings[Math.ceil(99.9 / 100 * timings.length) - 1]));
+        return {
+            min: formatter(min),
+            avg: formatter(sum / scalars.length),
+            percentile_90: formatter(scalars[Math.ceil(90 / 100 * scalars.length) - 1]),
+            percentile_99: formatter(scalars[Math.ceil(99 / 100 * scalars.length) - 1]),
+            percentile_99_9: formatter(scalars[Math.ceil(99.9 / 100 * scalars.length) - 1]),
+            max: formatter(max)
+        }
     }
 
     private formatSource(item: Raven.Client.Documents.Changes.TrafficWatchChangeBase, asHtml: boolean): string {

--- a/src/Raven.Studio/wwwroot/App/views/manage/trafficWatch.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/trafficWatch.html
@@ -98,39 +98,65 @@
                 </div>
             </div>
             <div class="row margin-top">
-                <div class="properties-container stats-container flex-horizontal padding padding-sm" data-label="Duration (HTTP)"
-                     data-toggle="tooltip" title="Requests duration info <br> (excluding web sockets)" data-placement="top">
-                    <div class="property">
-                        <h5><i class="icon-arrow-filled-down"></i><span>Minimum duration</span></h5>
-                        <strong data-bind="text: stats.min" class="stats-property"></strong>
+                <div class="properties-container stats-container flex-horizontal padding padding-sm" data-label="Request Duration (HTTP)"
+                     data-toggle="tooltip" title="Requests duration percentiles <br> (excluding web sockets - calculated based on last 2048 items)" data-placement="top">
+                    <div class="property right-border">
+                        <h5><i class="icon-average"></i><span>Average</span></h5>
+                        <strong data-bind="text: stats.requestDuration().avg" class="stats-property"></strong>
                     </div>
                     <div class="property">
-                        <h5><i class="icon-average"></i><span>Average duration</span></h5>
-                        <strong data-bind="text: stats.avg" class="stats-property"></strong>
+                        <h5><i class="icon-arrow-filled-down"></i><span>Minimum</span></h5>
+                        <strong data-bind="text: stats.requestDuration().min" class="stats-property"></strong>
                     </div>
-                    <div class="property">
-                        <h5><i class="icon-arrow-filled-up"></i><span>Maximum duration</span></h5>
-                        <strong data-bind="text: stats.max" class="stats-property"></strong>
-                    </div>
-                </div>
-            </div>
-            <div class="row margin-top">
-                <div class="properties-container stats-container padding padding-sm" data-label="Percentiles (HTTP)"
-                     data-toggle="tooltip" title="Percentiles info <br> (excluding web sockets)" data-placement="top">
                     <div class="property">
                         <h5>90%</h5>
-                        <strong data-bind="text: stats.percentile_90"></strong>
+                        <strong data-bind="text: stats.requestDuration().percentile_90"></strong>
                     </div>
                     <div class="property">
                         <h5>99%</h5>
-                        <strong data-bind="text: stats.percentile_99"></strong>
+                        <strong data-bind="text: stats.requestDuration().percentile_99"></strong>
                     </div>
                     <div class="property">
                         <h5>99.9%</h5>
-                        <strong data-bind="text: stats.percentile_99_9"></strong>
+                        <strong data-bind="text: stats.requestDuration().percentile_99_9"></strong>
+                    </div>
+                    <div class="property">
+                        <h5><i class="icon-arrow-filled-up"></i><span>Maximum</span></h5>
+                        <strong data-bind="text: stats.requestDuration().max" class="stats-property"></strong>
                     </div>
                 </div>
             </div>
+
+            <div class="row margin-top">
+                <div class="properties-container stats-container flex-horizontal padding padding-sm" data-label="Response size (HTTP)"
+                     data-toggle="tooltip" title="Response size percentiles <br> (excluding web sockets - calculated based on last 2048 items)" data-placement="top">
+                    <div class="property right-border">
+                        <h5><i class="icon-average"></i><span>Average</span></h5>
+                        <strong data-bind="text: stats.responseSize().avg" class="stats-property"></strong>
+                    </div>
+                    <div class="property">
+                        <h5><i class="icon-arrow-filled-down"></i><span>Minimum</span></h5>
+                        <strong data-bind="text: stats.responseSize().min" class="stats-property"></strong>
+                    </div>
+                    <div class="property">
+                        <h5>90%</h5>
+                        <strong data-bind="text: stats.responseSize().percentile_90"></strong>
+                    </div>
+                    <div class="property">
+                        <h5>99%</h5>
+                        <strong data-bind="text: stats.responseSize().percentile_99"></strong>
+                    </div>
+                    <div class="property">
+                        <h5>99.9%</h5>
+                        <strong data-bind="text: stats.responseSize().percentile_99_9"></strong>
+                    </div>
+                    <div class="property">
+                        <h5><i class="icon-arrow-filled-up"></i><span>Maximum</span></h5>
+                        <strong data-bind="text: stats.responseSize().max"></strong>
+                    </div>
+                </div>
+            </div>
+            
             <div class="row" data-bind="visible: isDataFiltered">
                 <div class="properties-container pull-right">
                     <small class="text-warning bg-warning padding padding-xs">

--- a/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
@@ -13,19 +13,25 @@
             text-transform: uppercase;
             content: attr(data-label);
         }
+        
+        .right-border {
+            border-right: solid 1px @gray-dark;
+        }
     }
 
     #trafficFilter {
         width: 220px;
     }
     
+    
+    
     .dropdown {
         .dropdown-menu.stats-menu {
             width: max-content;
         }
         
-        .stats-property {
-            margin-left: 3px;
+        .property {
+            min-width: 90px;
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19274

### Additional description

Added stats for response size to traffic watch

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

