### PR TITLE
RavenDB-19016 - Skipped document during indexing of references

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -16,7 +16,6 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
@@ -234,6 +233,8 @@ namespace Raven.Server.Documents.Indexes
         private readonly ConcurrentDictionary<string, SpatialField> _spatialFields = new ConcurrentDictionary<string, SpatialField>(StringComparer.OrdinalIgnoreCase);
 
         internal readonly QueryBuilderFactories _queryBuilderFactories;
+
+        internal int _numberOfDocumentsToCheckForCanContinueBatch = 128;
 
         private string IndexingThreadName => "Indexing of " + Name + " of " + _indexStorage.DocumentDatabase.Name;
 
@@ -4277,7 +4278,7 @@ namespace Raven.Server.Documents.Indexes
                 return CanContinueBatchResult.False;
             }
 
-            if (parameters.Count % 128 != 0)
+            if (parameters.Count % _numberOfDocumentsToCheckForCanContinueBatch != 0)
             {
                 // do the actual check only every N ops
                 return CanContinueBatchResult.True;
@@ -5077,7 +5078,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         internal TestingStuff ForTestingPurposesOnly()
         {
@@ -5092,6 +5093,8 @@ namespace Raven.Server.Documents.Indexes
             internal Action ActionToCallInFinallyOfExecuteIndexing;
 
             internal bool ShouldRenewTransaction;
+
+            internal Action BeforeClosingDocumentsReadTransactionForHandleReferences;
 
             internal IDisposable CallDuringFinallyOfExecuteIndexing(Action action)
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -234,8 +234,6 @@ namespace Raven.Server.Documents.Indexes
 
         internal readonly QueryBuilderFactories _queryBuilderFactories;
 
-        internal int _numberOfDocumentsToCheckForCanContinueBatch = 128;
-
         private string IndexingThreadName => "Indexing of " + Name + " of " + _indexStorage.DocumentDatabase.Name;
 
         private readonly WarnIndexOutputsPerDocument.WarningDetails _indexOutputsPerDocumentWarning = new WarnIndexOutputsPerDocument.WarningDetails
@@ -4278,7 +4276,7 @@ namespace Raven.Server.Documents.Indexes
                 return CanContinueBatchResult.False;
             }
 
-            if (parameters.Count % _numberOfDocumentsToCheckForCanContinueBatch != 0)
+            if (parameters.Count % 128 != 0)
             {
                 // do the actual check only every N ops
                 return CanContinueBatchResult.True;

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
-using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
 using Raven.Server.Config;

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
 using Raven.Server.Config;
@@ -649,20 +650,31 @@ namespace Raven.Server.Documents.Indexes
 
                 foreach (var collections in referencesByCollection)
                 {
-                    var collectionTree = tx.InnerTransaction.CreateTree(_referenceCollectionPrefix + collections.Key); // #collection
-
-                    foreach (var keys in collections.Value)
-                    {
-                        var key = keys.Key;
-                        foreach (var referenceKey in keys.Value)
-                        {
-                            collectionTree.MultiAdd(referenceKey, key);
-                            referencesTree.MultiAdd(key, referenceKey);
-                        }
-
-                        RemoveReferences(key, collections.Key, keys.Value, tx);
-                    }
+                    WriteReferencesForSingleCollectionInternal(referencesTree, collections.Key, collections.Value, tx);
                 }
+            }
+
+            private void WriteReferencesForSingleCollectionInternal(Tree referencesTree, string collection, Dictionary<Slice, HashSet<Slice>> references, RavenTransaction tx)
+            {
+                var collectionTree = tx.InnerTransaction.CreateTree(_referenceCollectionPrefix + collection); // #collection
+
+                foreach (var keys in references)
+                {
+                    var key = keys.Key;
+                    foreach (var referenceKey in keys.Value)
+                    {
+                        collectionTree.MultiAdd(referenceKey, key);
+                        referencesTree.MultiAdd(key, referenceKey);
+                    }
+
+                    RemoveReferences(key, collection, keys.Value, tx);
+                }
+            }
+
+            public void WriteReferencesForSingleCollection(string collection, Dictionary<Slice, HashSet<Slice>> references, RavenTransaction tx)
+            {
+                var referencesTree = tx.InnerTransaction.ReadTree(_referenceTreeName);
+                WriteReferencesForSingleCollectionInternal(referencesTree, collection, references, tx);
             }
 
             internal (long ReferenceTableCount, long CollectionTableCount) GetReferenceTablesCount(string collection, RavenTransaction tx)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2565,7 +2565,7 @@ namespace Raven.Server.Documents.Indexes
 
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
-            internal Action AfterReferencedDocumentWasIndexed;
+
             public TestingStuff(IndexStore parent)
             {
                 _parent = parent;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2565,6 +2565,7 @@ namespace Raven.Server.Documents.Indexes
 
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
+            internal Action AfterReferencedDocumentWasIndexed;
             public TestingStuff(IndexStore parent)
             {
                 _parent = parent;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -374,12 +374,14 @@ namespace Raven.Server.Documents.Indexes.Workers
                 CurrentIndexingScope.Current.ReferencesByCollection.TryGetValue(collection, out var values))
             {
                 _indexStorage.ReferencesForDocuments.WriteReferencesForSingleCollection(collection, values, indexContext.Transaction);
+                values.Clear();
             }
 
             if (CurrentIndexingScope.Current.ReferencesByCollectionForCompareExchange != null &&
                 CurrentIndexingScope.Current.ReferencesByCollectionForCompareExchange.TryGetValue(collection, out values))
             {
                 _indexStorage.ReferencesForCompareExchange.WriteReferencesForSingleCollection(collection, values, indexContext.Transaction);
+                values.Clear();
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-19016.cs
+++ b/test/SlowTests/Issues/RavenDB-19016.cs
@@ -1,0 +1,147 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19016 : RavenTestBase
+{
+    public RavenDB_19016(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Can_Index_Nested_Document_Change()
+    {
+        using (var server = GetNewServer())
+        using (var store = GetDocumentStore(new Options { Server = server }))
+        {
+            const string orderId = "OrdErs/1";
+            const string companyId = "CompaNies/1";
+            const string userName = "Grisha";
+            const string companyName = "Hibernating Rhinos";
+            const int orderCount = 10;
+
+            await new UsersIndex().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Name = userName,
+                    CompanyId = companyId
+                }, "UseRs/1");
+
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                await session.SaveChangesAsync();
+            }
+
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var indexStore = database.IndexStore;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var runOnce = false;
+
+                indexStore.ForTestingPurposesOnly().AfterReferencedDocumentWasIndexed = () =>
+                {
+                    if (runOnce)
+                        return;
+
+                    runOnce = true;
+                    using (var session2 = store.OpenSession())
+                    {
+                        session2.Store(new Order
+                        {
+                            Count = orderCount
+                        }, orderId);
+                        session2.SaveChanges();
+                    }
+                };
+
+                await session.StoreAsync(new Company
+                {
+                    Name = companyName,
+                    OrderId = orderId
+                }, companyId);
+
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var results = await session
+                    .Query<UsersIndex.Result, UsersIndex>()
+                    .ProjectInto<UsersIndex.Result>()
+                    .ToListAsync();
+
+                Assert.Equal(1, results.Count);
+                Assert.Equal(userName, results[0].UserName);
+                Assert.Equal(orderId, results[0].OrderId);
+                Assert.Equal(companyId, results[0].CompanyId);
+                Assert.Equal(companyName, results[0].CompanyName);
+                Assert.Equal(orderCount, results[0].OrderCount);
+            }
+        }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string CompanyId { get; set; }
+    }
+
+    private class Order
+    {
+        public string Id { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    private class Company
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string OrderId { get; set; }
+    }
+
+    private class UsersIndex : AbstractIndexCreationTask<User>
+    {
+        public class Result
+        {
+            public string UserName { get; set; }
+            public string OrderId { get; set; }
+            public string CompanyId { get; set; }
+            public string CompanyName { get; set; }
+            public int OrderCount { get; set; }
+        }
+
+        public UsersIndex()
+        {
+            Map = users =>
+                from user in users
+                let company = LoadDocument<Company>(user.CompanyId)
+                let order = LoadDocument<Order>(company.OrderId)
+                select new Result
+                {
+                    UserName = user.Name,
+                    OrderId = company.OrderId,
+                    CompanyId = user.CompanyId,
+                    CompanyName = company.Name,
+                    OrderCount = order.Count
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19016/Skipped-document-during-indexing-of-references

### Additional description

Fixing a rare race condition between handling a referenced document and saving that referenced document.
When references are found during handling references, we save them in memory.
After the indexing batch was completed, they are stored in the storage.
BUT, as long as were are handling references, they are processed only from the storage.
In order to avoid skipping handling the found references, we must save them in storage.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
