### PR TITLE
RavenDB-19313 - fix the error message, the Value is already disposed at this point

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -863,7 +863,7 @@ namespace Raven.Server.Smuggler.Documents
                     catch (Exception e)
                     {
                         result.CompareExchange.ErroredCount++;
-                        result.AddError($"Could not write compare exchange '{kvp.Key.Key}->{kvp.Value}': {e.Message}");
+                        result.AddError($"Could not write compare exchange with key: '{kvp.Key.Key}': {e.Message}");
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19312/Failure-to-restore-because-of-cluster-OperationTimeout

### Additional description

Remove the `Value` from the error message since it's already disposed at this point

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing
