### PR TITLE
RavenDB-19310 Low level Voron tests might randomly fail because of CompressionAccelerationStats.LastAcceleration

### DIFF
--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -1415,5 +1415,20 @@ namespace Voron
                 }
             }
         }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            public int? WriteToJournalCompressionAcceleration = null;
+        }
     }
 }

--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -34,6 +34,7 @@ namespace FastTests.Voron
         {
             IOExtensions.DeleteDirectory(DataDir);
             Options = StorageEnvironmentOptions.CreateMemoryOnly();
+            ForceConstantCompressionAcceleration(Options);
 
             Configure(Options);
             _storageEnvironment = new Lazy<StorageEnvironment>(() => new StorageEnvironment(Options), LazyThreadSafetyMode.ExecutionAndPublication);
@@ -48,6 +49,7 @@ namespace FastTests.Voron
             if (isFileBasedEnv)
             {
                 Options = StorageEnvironmentOptions.ForPath(DataDir);
+                ForceConstantCompressionAcceleration(Options);
                 Configure(Options);
             }
 
@@ -63,6 +65,7 @@ namespace FastTests.Voron
 
             IOExtensions.DeleteDirectory(DataDir);
             Options = StorageEnvironmentOptions.ForPath(DataDir);
+            ForceConstantCompressionAcceleration(Options);
             Configure(Options);
         }
 
@@ -163,6 +166,9 @@ namespace FastTests.Voron
             return Tuple.Create(item1, item2);
         }
 
-
+        private void ForceConstantCompressionAcceleration(StorageEnvironmentOptions options)
+        {
+            options.ForTestingPurposesOnly().WriteToJournalCompressionAcceleration = 1;
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19310

### Additional description

Found it in the following way:

- running all tests from `RavenDB_13940` make that everything was green
- running single test `RavenDB_13940.ShouldFailBecauseFirstValidTransactionIsTheOneWhichIsNotSynced` was always throwing

The investigation and comparison of actual transaction sizes showed that starting from one transaction the sizes were different than in the passing runs. That was because of different `LastAcceleration` values. Mostly it's 1 but when the test was failing it was 3

https://github.com/ravendb/ravendb/blob/18e9d43a339fd5279d59c54d95cb28bd7c256a36/src/Voron/Impl/Journal/WriteAheadJournal.cs#L1804-L1811

That could be the root cause of occasionally failing tests like this one:
https://issues.hibernatingrhinos.com/issue/RavenDB-18992/SlowTestsIssuesRavenDB15930ShouldNotReuseRecycledJournalIfItExceedMaxLogFileSizeOnSmallTxSize



### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the change

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
