### PR TITLE
RavenDB-19309: Reproduction of error

### DIFF
--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -667,7 +667,7 @@ public unsafe partial struct IndexEntryWriter : IDisposable
 
         // Since we are duplicating we need to ensure that the extension will fit.
         var newSize = _rawBuffer.Length * 2;
-        while (newSize - _rawBuffer.Length < extraRequiredSpace)
+        while (newSize <= extraRequiredSpace)
             newSize *= 2;
 
         var newBufferScope = _context.Allocate(newSize, out var newBuffer);

--- a/src/Corax/IndexWriter.Debug.cs
+++ b/src/Corax/IndexWriter.Debug.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Voron;
+using Voron.Data.BTrees;
+
+namespace Corax
+{
+    partial class IndexWriter
+    {
+        private struct IndexTermDumper : IDisposable
+        {
+#if ENABLE_TERMDUMPER
+            private readonly StreamWriter _writer;
+
+            public IndexTermDumper(Tree tree, int fieldId)
+            {
+                _writer = File.AppendText(tree.Name.ToString() + fieldId);
+            }
+#else
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public IndexTermDumper(Tree tree, int fieldId)
+            {}
+#endif
+
+            [Conditional("ENABLE_TERMDUMPER")]
+            public void WriteBatch()
+            {
+#if ENABLE_TERMDUMPER
+                _writer.WriteLine("###");
+#endif
+            }
+
+            [Conditional("ENABLE_TERMDUMPER")]
+            public void WriteAddition(Slice term, long termId)
+            {
+#if ENABLE_TERMDUMPER
+                _writer.WriteLine($"+ {term} {termId}");
+#endif
+            }
+
+            [Conditional("ENABLE_TERMDUMPER")]
+            public void WriteRemoval(Slice term, long termId)
+            {
+#if ENABLE_TERMDUMPER
+                _writer.WriteLine($"- {term} {termId}");
+#endif
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Dispose()
+            {
+#if ENABLE_TERMDUMPER
+                _writer?.Dispose();
+#endif
+            }
+        }
+    }
+}

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -407,7 +407,7 @@ namespace Voron.Data.CompactTrees
             if (shouldBeInCurrentPage)
             {
                 // we didn't find the key, but we found a _greater_ key in the page
-                // therefor, we don't have it (we know the previous key was in this page
+                // therefore, we don't have it (we know the previous key was in this page
                 // so if there is a greater key in this page, we didn't find it
                 value = default;
                 return false;

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -37,6 +37,8 @@
     <EmbeddedResource Include="Corax\Bugs\Terms-2.txt.gz" />
     <None Remove="Corax\Bugs\3-2015-10.txt.gz" />
     <EmbeddedResource Include="Corax\Bugs\3-2015-10.txt.gz" />
+    <None Remove="Corax\Bugs\repro-4.log.gz" />
+    <EmbeddedResource Include="Corax\Bugs\repro-4.log.gz" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Sparrow\BitVectors.cs" />


### PR DESCRIPTION
Includes the ability to toggle on and off (on compilation) the ability to dump the terms. 