### PR TITLE
RavenDB-19294 we need to use separate server, because in this case we can fail any test that is being executed at the same time

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19109.cs
+++ b/test/SlowTests/Issues/RavenDB-19109.cs
@@ -29,6 +29,8 @@ public class RavenDB_19109 : RavenTestBase
     [Fact]
     public void DatabaseThrowsOnOpenWhenDisableMarkerIsInDirectory()
     {
+        DoNotReuseServer();
+
         using var store = GetDocumentStore(out var databasePath);
 
         DoCommand(store, true, out var exception);
@@ -62,6 +64,8 @@ public class RavenDB_19109 : RavenTestBase
     [Fact]
     public void IndexThrowsOnOpenWhenDisableMarkerIsInDirectory()
     {
+        DoNotReuseServer();
+
         using var store = GetDocumentStore(out var databasePath);
         var index = new IndexToDisable();
         index.Execute(store);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19294

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
