### PR TITLE
Add jsonl streaming support

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -315,6 +315,11 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 ThrowUnsupportedException("Using json output format with custom fields is not supported.");
             }
 
+            if (string.IsNullOrEmpty(format) == false && string.Equals(format, "jsonl", StringComparison.OrdinalIgnoreCase))
+            {
+                return new StreamJsonlDocumentQueryResultWriter(responseBodyStream, context);
+            }
+
             return new StreamJsonDocumentQueryResultWriter(responseBodyStream, context);
         }
 

--- a/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Json;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Queries
+{
+    public class StreamJsonlDocumentQueryResultWriter : IStreamQueryResultWriter<Document>
+    {
+        private readonly AsyncBlittableJsonTextWriter _writer;
+        private readonly JsonOperationContext _context;
+
+        public StreamJsonlDocumentQueryResultWriter(Stream stream, JsonOperationContext context)
+        {
+            _context = context;
+            _writer = new AsyncBlittableJsonTextWriter(context, stream);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return _writer.DisposeAsync();
+        }
+
+        public void StartResponse()
+        {
+        }
+
+        public void StartResults()
+        {
+        }
+
+        public void EndResults()
+        {
+        }
+
+        public async ValueTask AddResultAsync(Document res, CancellationToken token)
+        {
+            _writer.WriteDocument(_context, res, metadataOnly: false);
+            _writer.WriteNewLine();
+            await _writer.MaybeFlushAsync(token);
+        }
+
+        public void EndResponse()
+        {
+        }
+
+        public ValueTask WriteErrorAsync(Exception e)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask WriteErrorAsync(string error)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool SupportError => false;
+        public bool SupportStatistics => false;
+    }
+}

--- a/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Queries
         {
         }
 
-        public ValueTask WriteErrorAsync(Exception e)
+        public async ValueTask WriteErrorAsync(Exception e)
         {
             _writer.WriteStartObject();
             _writer.WritePropertyName("Error");
@@ -61,10 +61,10 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            return default;
+            await _writer.FlushAsync();
         }
 
-        public ValueTask WriteErrorAsync(string error)
+        public async ValueTask WriteErrorAsync(string error)
         {
             _writer.WriteStartObject();
             _writer.WritePropertyName("Error");
@@ -73,7 +73,7 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            return default;
+            await _writer.FlushAsync();
         }
 
         public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-622

### Additional description

Support for JSON streaming, more specifically [line-delimited JSON](https://jsonlines.org/), for query streaming. The intent is to reduce the amount of work done by the clients when parsing JSON stream. So far while testing locally, it is at least 2x faster to process a JSONL response vs a JSON response in a stream.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Opt-in functionality.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed, or at least i didn't see any documentation for stream response formatting

### Testing 

- It has been verified by manual testing
- Would implement unit test but need help to set one up due to the dependencies `AsyncBlittableJsonTextWriter` needs.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
