### PR TITLE
RavenDB-19327 spurious calls in collection tracker

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -174,7 +174,13 @@ class collectionsTracker {
     }
 
     private onCollectionChanged(item: collection, incomingData: Raven.Server.NotificationCenter.Notifications.DatabaseStatsChanged.ModifiedCollection) {
+        if (item.lastDocumentChangeVector() === incomingData.LastDocumentChangeVector && item.documentCount() === incomingData.Count) {
+            // no change 
+            return;
+        }
+        
         item.documentCount(incomingData.Count);
+        item.lastDocumentChangeVector(incomingData.LastDocumentChangeVector);
 
         this.events.changed.forEach(handler => handler(item, incomingData.LastDocumentChangeVector));
 

--- a/src/Raven.Studio/typescript/models/database/documents/collection.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/collection.ts
@@ -10,6 +10,7 @@ class collection {
     static readonly hiloCollectionName = "@hilo";
 
     documentCount: KnockoutObservable<number> = ko.observable(0);
+    lastDocumentChangeVector = ko.observable<string>();
     name: string;
     sizeClass: KnockoutComputed<string>;
     countPrefix: KnockoutComputed<string>;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19327 

### Additional description

fixed spurious and fake staleness 

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

