### PR TITLE
RavenDB-19278 Fixing Voron recovery error handling and missing header update on partial recovery scenario

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1608,9 +1608,14 @@ namespace Raven.Server.Documents
 
         internal void HandleNonDurableFileSystemError(object sender, NonDurabilitySupportEventArgs e)
         {
+            string title = $"Non Durable File System - {Name ?? "Unknown Database"}";
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"{title}. {e.Message}", e.Exception);
+
             _serverStore?.NotificationCenter.Add(AlertRaised.Create(
                 Name,
-                $"Non Durable File System - {Name ?? "Unknown Database"}",
+                title,
                 e.Message,
                 AlertType.NonDurableFileSystem,
                 NotificationSeverity.Warning,
@@ -1658,12 +1663,17 @@ namespace Raven.Server.Documents
                     throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
             }
 
+            string message = $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}";
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"{title}. {message}", e.Exception);
+
             nc?.Add(AlertRaised.Create(Name,
                 title,
-                $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}",
+                message,
                 AlertType.RecoveryError,
                 NotificationSeverity.Error,
-                key: resourceName));
+                key: $"{resourceName}/{SystemTime.UtcNow.Ticks % 5}")); // if this was called multiple times let's try to not overwrite previous alerts
         }
 
         internal void HandleOnDatabaseIntegrityErrorOfAlreadySyncedData(object sender, DataIntegrityErrorEventArgs e)
@@ -1706,18 +1716,26 @@ namespace Raven.Server.Documents
                     throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
             }
 
+            string message = $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}";
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"{title}. {message}", e.Exception);
+
             nc?.Add(AlertRaised.Create(Name,
                 title,
-                $"{e.Message}{Environment.NewLine}{Environment.NewLine}Environment: {environment}",
+                message,
                 AlertType.IntegrityErrorOfAlreadySyncedData,
                 NotificationSeverity.Warning,
-                key: resourceName));
+                key: $"{resourceName}/{SystemTime.UtcNow.Ticks % 5}")); // if this was called multiple times let's try to not overwrite previous alerts
         }
 
         internal void HandleRecoverableFailure(object sender, RecoverableFailureEventArgs e)
         {
             var title = $"Recoverable Voron error in '{Name}' database";
             var message = $"Failure {e.FailureMessage} in the following environment: {e.EnvironmentPath}";
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"{title}. {message}", e.Exception);
 
             try
             {
@@ -1734,9 +1752,6 @@ namespace Raven.Server.Documents
             {
                 // exception in raising an alert can't prevent us from unloading a database
             }
-
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"{title}. {message}", e.Exception);
         }
 
         public long GetEnvironmentsHash()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -618,9 +618,14 @@ namespace Raven.Server.ServerWide
 
             options.OnNonDurableFileSystemError += (obj, e) =>
             {
+                var title = "Non Durable File System - System Storage";
+
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"{title}. {e.Message}", e.Exception);
+
                 var alert = AlertRaised.Create(
                     null,
-                    "Non Durable File System - System Storage",
+                    title,
                     e.Message,
                     AlertType.NonDurableFileSystem,
                     NotificationSeverity.Warning,
@@ -638,13 +643,18 @@ namespace Raven.Server.ServerWide
 
             options.OnRecoveryError += (obj, e) =>
             {
+                string title = "Recovery Error - System Storage";
+
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"{title}. {e.Message}", e.Exception);
+
                 var alert = AlertRaised.Create(
                     null,
-                    "Recovery Error - System Storage",
+                    title,
                     e.Message,
                     AlertType.RecoveryError,
                     NotificationSeverity.Error,
-                    "Recovery Error System");
+                    key: $"Recovery Error System/{SystemTime.UtcNow.Ticks % 5}"); // if this was called multiple times let's try to not overwrite previous alerts
 
                 if (NotificationCenter.IsInitialized)
                 {
@@ -658,13 +668,18 @@ namespace Raven.Server.ServerWide
 
             options.OnIntegrityErrorOfAlreadySyncedData += (obj, e) =>
             {
+                string title = "Integrity error of already synced data - System Storage";
+
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"{title}. {e.Message}", e.Exception);
+
                 var alert = AlertRaised.Create(
                     null,
-                    "Integrity error of already synced data - System Storage",
+                    title,
                     e.Message,
                     AlertType.IntegrityErrorOfAlreadySyncedData,
                     NotificationSeverity.Warning,
-                    "Integrity Error of Synced Data - System");
+                    key: $"Integrity Error of Synced Data - System/{SystemTime.UtcNow.Ticks % 5}"); // if this was called multiple times let's try to not overwrite previous alerts
 
                 if (NotificationCenter.IsInitialized)
                 {

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -654,7 +654,7 @@ namespace Voron.Impl.Journal
 
         private bool IsOldTransactionFromRecycledJournal(TransactionHeader* currentTx)
         {
-            // when reusing journal we might encounter a transaction with valid Id but it comes from already deleted (and reused journal - recyclable one)
+            // when reusing journal we might encounter a transaction with valid Id but it comes from already deleted (and reused) journal - recyclable one
 
             if (_firstValidTransactionHeader != null && currentTx->TransactionId < _firstValidTransactionHeader->TransactionId)
                 return true;

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -32,6 +32,7 @@ namespace Voron.Impl.Journal
 
         private long? _firstSkippedTx = null;
         private long? _lastSkippedTx = null;
+        private bool _skippedLastTx;
 
         public bool RequireHeaderUpdate { get; private set; }
 
@@ -62,36 +63,19 @@ namespace Voron.Impl.Journal
             if (_readAt4Kb >= _journalPagerNumberOfAllocated4Kb)
                 return false;
 
-            if (TryReadAndValidateHeader(options, out TransactionHeader* current) == false)
+            if (TryReadAndValidateHeader(options, ReadExpectation.ValidTransaction, out TransactionHeader* current) == false)
             {
-                var lastValid4Kb = _readAt4Kb;
-                _readAt4Kb++;
-
-                while (_readAt4Kb < _journalPagerNumberOfAllocated4Kb)
-                {
-                    if (TryReadAndValidateHeader(options, out current))
-                    {
-                        if (CanIgnoreDataIntegrityErrorBecauseTxWasSynced(current, options))
-                        {
-                            SkipCurrentTransaction(current);
-                            return true;
-                        }
-
-                        RequireHeaderUpdate = true;
-                        break;
-                    }
-                    _readAt4Kb++;
-                }
-
-                _readAt4Kb = lastValid4Kb;
                 return false;
             }
 
             if (IsAlreadySyncTransaction(current))
             {
                 SkipCurrentTransaction(current);
+                _skippedLastTx = true;
                 return true;
             }
+
+            _skippedLastTx = false;
 
             var performDecompression = current->CompressedSize != -1;
 
@@ -351,12 +335,22 @@ namespace Voron.Impl.Journal
                 throw new InvalidOperationException($"Unable to decrypt transaction {num}, rc={rc}");
         }
 
-        private bool TryReadAndValidateHeader(StorageEnvironmentOptions options, out TransactionHeader* current)
+        private enum ReadExpectation
+        {
+            ValidTransaction,
+
+            // We don't expect any valid transactions but continue to read to verify that.
+            // We ignore zeros and garbage that we might read due to the reuse of journal files
+            // Reading in this mode suppresses recovery / integrity errors handlers and RequireHeaderUpdate calls
+            ZerosOrGarbage
+        }
+
+        private bool TryReadAndValidateHeader(StorageEnvironmentOptions options, ReadExpectation readExpectation, out TransactionHeader* current)
         {
             if (_readAt4Kb > _journalPagerNumberOfAllocated4Kb)
             {
                 current = null;
-                return false; // end of jouranl
+                return false; // end of journal
             }
 
             const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
@@ -365,32 +359,118 @@ namespace Voron.Impl.Journal
 
             current = (TransactionHeader*)
                 (_journalPager.AcquirePagePointer(this, pageNumber) + positionInsidePage);
-
-            // due to the reuse of journals we no longer can assume we have zeros in the end of the journal
-            // we might have there random garbage or old transactions we can ignore, so we have the following scenarios:
-            // * TxId <= current Id      ::  we can ignore old transaction of the reused journal and continue
-            // * TxId == current Id + 1  ::  valid, but if hash is invalid. Transaction hasn't been committed
-            // * TxId >  current Id + 1  ::  if hash is invalid we can ignore reused/random, but if hash valid then we might missed TXs 
-
+            
             if (current->HeaderMarker != Constants.TransactionHeaderMarker)
-            {  
-                // not a transaction page, 
+            {
+                // If the header marker is zero or garbage, we are probably in the area at the end of the log file.
+                // So we don't expect to have any additional transaction log records to read from it.
+                // This can happen if the next transaction was too big to fit in the current log file.
 
-                // if the header marker is zero or garbage, we are probably in the area at the end of the log file, and have no additional log records
-                // to read from it. This can happen if the next transaction was too big to fit in the current log file. We stop reading
-                // this log file and move to the next one, or it might have happened because of reuse of journal file 
+                // We're about to stop reading this journal file and move to the next one but first we need to verify there is no valid later tx in the journal file.
+                // This would mean we have true corruption rather than random garbage being a result of the reuse of journals.
 
-                // note : we might encounter a "valid" TransactionHeaderMarker which is still garbage, so we will test that later on
+                // note : we might encounter a "valid" TransactionHeaderMarker which is still garbage, so we will test that later when reading in ReadExpectation.ZerosOrGarbage mode
 
-                RequireHeaderUpdate = false;
-                return false;
+                switch (readExpectation)
+                {
+                    case ReadExpectation.ValidTransaction:
+                        // due to the reuse of journals we no longer can assume we have zeros in the end of the journal
+                        // we might have there random garbage or old transactions we can ignore, so we have the following scenarios:
+
+                        // * TxId < current Id      ::  we can ignore old transaction of the reused journal and continue
+                        // * TxId == current Id + 1  ::  valid, but if hash is invalid. Transaction hasn't been committed
+                        // * TxId >  current Id + 1  ::  if hash is invalid we can ignore reused/random, but if hash valid then we might missed TXs 
+
+                        var lastRead4Kb = _readAt4Kb;
+                        var lastReadTransactionHeader = LastTransactionHeader;
+
+                        _readAt4Kb++;
+
+                        TransactionHeader* unexpectedValidHeader = null;
+                        var encounteredUnexpectedValidHeader = false;
+
+                        using (options.DisableOnRecoveryErrorHandler()) // disable error handlers so we'll get InvalidDataException instead of raising false positive alerts 
+                        using (options.DisableOnIntegrityErrorOfAlreadySyncedDataHandler()) // in this mode we expect to get garbage
+                        {
+                            while (_readAt4Kb < _journalPagerNumberOfAllocated4Kb)
+                            {
+                                try
+                                {
+                                    if (TryReadAndValidateHeader(options, ReadExpectation.ZerosOrGarbage, out unexpectedValidHeader))
+                                    {
+                                        // found a valid transaction header - that isn't expected since we already got garbage
+
+                                        if (_skippedLastTx && options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions)
+                                        {
+                                            // BUT the last read transaction was skipped and we're running in "ignore already synced but corrupted transactions" mode
+                                            // so this transaction can be either:
+                                            // - first not synced (but valid) after reading the garbage but ignoring it
+                                            // - synced - so we'll ignore it anyway
+                                            // in both cases we can stop reading in ReadExpectation.ZerosOrGarbage and continue the recovery
+
+                                            current = unexpectedValidHeader;
+                                            return true;
+                                        }
+                                        
+                                        encounteredUnexpectedValidHeader = true;
+                                        break;
+                                    }
+                                }
+                                catch (InvalidDataException)
+                                {
+                                    // ignored - data errors are expected
+                                }
+                                //catch (InvalidJournalException)
+                                //{
+                                // found that the journal is invalid
+                                // we must not ignore even when reading in ReadExpectation.ZerosOrGarbage mode
+                                //}
+
+                                _readAt4Kb++;
+                            }
+                        }
+
+                        if (encounteredUnexpectedValidHeader)
+                        {
+                            RequireHeaderUpdate = true;
+
+                            var message =
+                                $"Got header marker set to {(current->HeaderMarker == 0 ? "zero" : "garbage")} value at position {lastRead4Kb * 4 * Constants.Size.Kilobyte} when reading journal {_journalPager}. ";
+
+                            if (lastReadTransactionHeader != null)
+                                message += $"Last read transaction was:{Environment.NewLine}{lastReadTransactionHeader->ToString()}.{Environment.NewLine}";
+
+                            message += $"Although further reading found a valid transaction at position {_readAt4Kb * 4 * Constants.Size.Kilobyte}:{Environment.NewLine}{unexpectedValidHeader->ToString()}.{Environment.NewLine}" +
+                                       "Journal file is likely to be corrupted.";
+
+                            throw new InvalidJournalException(message, _journalInfo);
+                        }
+
+                        // we didn't find any valid transaction when reading the rest of the journal in ReadExpectation.ZerosOrGarbage mode
+                        // it means we can continue the recovery process
+
+                        _readAt4Kb = lastRead4Kb;
+                        LastTransactionHeader = lastReadTransactionHeader;
+
+                        RequireHeaderUpdate = false;
+                        return false;
+
+                    case ReadExpectation.ZerosOrGarbage:
+                        return false;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(readExpectation), readExpectation, "Unsupported enum value");
+                }
             }
 
-            if (current->TransactionId < 0)
-                return false;
 
-            if (IsOldTransactionFromRecycledJournal(current))
-                return false;
+            if (readExpectation == ReadExpectation.ZerosOrGarbage)
+            {
+                if (current->TransactionId < 0)
+                    return false;
+
+                if (IsOldTransactionFromRecycledJournal(current))
+                    return false;
+            }
 
             current = EnsureTransactionMapped(current, pageNumber, positionInsidePage);
             bool hashIsValid;
@@ -431,6 +511,7 @@ namespace Voron.Impl.Journal
 
                     RequireHeaderUpdate = true;
                     options.InvokeRecoveryError(this, "Transaction " + current->TransactionId + " was not committed", ex);
+
                     return false;
                 }
             }
@@ -500,7 +581,6 @@ namespace Voron.Impl.Journal
                         {
                             // when running in ignore data integrity errors mode then we could skip corrupted but already sync data
                             // so it's expected in this case that txIdDiff > 1, let it continue to work then
-
                             options.InvokeIntegrityErrorOfAlreadySyncedData(this,
                                 $"Encountered integrity error of transaction data which has been already synced (tx id: {current->TransactionId}, last synced tx: {_journalInfo.LastSyncedTransactionId}, journal: {_journalInfo.CurrentJournal}). Tx diff is: {txIdDiff}. " +
                                 $"Safely continuing the startup recovery process. Debug details - file header {_currentFileHeader}", null);
@@ -512,12 +592,12 @@ namespace Voron.Impl.Journal
                         {
                             throw new InvalidJournalException(
                                 $"Transaction has valid(!) hash with invalid transaction id {current->TransactionId}, the last valid transaction id is {LastTransactionHeader->TransactionId}. Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}." +
-                                $" Journal file {_journalPager.FileName} might be corrupted. Debug details - file header {_currentFileHeader}", _journalInfo);
+                                $" Journal file {_journalPager.FileName} might be corrupted or some journals are missing. Debug details - file header {_currentFileHeader}", _journalInfo);
                         }
 
                         throw new InvalidJournalException(
-                            $"The last synced transaction id was {_journalInfo.LastSyncedTransactionId} (in journal: {_journalInfo.LastSyncedJournal}) but the first transaction being read in the recovery process is {current->TransactionId} (transaction has valid hash). Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}. " +
-                            $"Some journals might be missing. Current journal file {_journalPager.FileName}. Debug details - file header {_currentFileHeader}", _journalInfo);
+                            $"The last synced transaction id was {_journalInfo.LastSyncedTransactionId} (in journal: {_journalInfo.LastSyncedJournal}) but the first transaction being read in the recovery process is {current->TransactionId} in journal {_journalPager} (transaction has valid hash). Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}. " +
+                            $"Some journals might be missing. Debug details - file header {_currentFileHeader}", _journalInfo);
                     }
                 }
 
@@ -569,7 +649,7 @@ namespace Voron.Impl.Journal
             // then we can continue the recovery regardless encountered errors
 
             return options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions &&
-                   IsAlreadySyncTransaction(currentTx); 
+                   IsAlreadySyncTransaction(currentTx);
         }
 
         private bool IsOldTransactionFromRecycledJournal(TransactionHeader* currentTx)
@@ -581,8 +661,6 @@ namespace Voron.Impl.Journal
 
             if (LastTransactionHeader != null && currentTx->TransactionId < LastTransactionHeader->TransactionId)
                 return true;
-
-
 
             return false;
         }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -246,7 +246,7 @@ namespace Voron.Impl.Journal
 
                             lastProcessedJournal = journalNumber;
 
-                            if (journalReader.RequireHeaderUpdate) //this should prevent further loading of transactions
+                            if (journalReader.RequireHeaderUpdate) //this should prevent further load of transactions
                             {
                                 requireHeaderUpdate = true;
                                 break;
@@ -379,12 +379,6 @@ namespace Voron.Impl.Journal
 
             _journalIndex = lastProcessedJournal;
 
-            addToInitLog?.Invoke($"Cleanup Newer Invalid Journal Files (Last Flushed Journal={lastProcessedJournal})");
-            if (_env.Options.CopyOnWriteMode == false)
-            {
-                CleanupNewerInvalidJournalFiles(lastProcessedJournal);
-            }
-
             if (_files.Count > 0)
             {
                 var lastFile = _files.Last();
@@ -393,6 +387,55 @@ namespace Voron.Impl.Journal
                     CurrentFile = lastFile;
             }
             addToInitLog?.Invoke($"Info: Current File = '{CurrentFile?.Number}', Position (4KB)='{CurrentFile?.WritePosIn4KbPosition}'. Require Header Update = {requireHeaderUpdate}");
+
+            if (requireHeaderUpdate)
+            {
+                // we didn't process all journals due to encountered errors
+                // we must update the header and set current journal to the last processed one
+
+                _headerAccessor.Modify(
+                    header =>
+                    {
+                        header->Journal.CurrentJournal = lastProcessedJournal;
+                        header->IncrementalBackup.LastCreatedJournal = lastProcessedJournal;
+                    });
+
+                if (CurrentFile != null)
+                {
+                    // we're gonna have further writes to a partially recovered journal
+                    // there might be more transactions already there (even with valid hash) that we didn't apply
+                    // in order to avoid false positive recovery errors next time (if the journal will still exist)
+                    // let's erase not processed transactions that are gonna be overwritten anyway
+
+                    long fourKb = 4L * Constants.Size.Kilobyte;
+
+                    var ptr = Marshal.AllocHGlobal(new IntPtr(2 * fourKb));
+
+                    try
+                    {
+                        var emptyFourKbPtr = (byte*)(ptr.ToInt64() + (fourKb - (ptr.ToInt64() % fourKb))); // ensure 4KB pointer alignment
+
+                        Memory.Set(emptyFourKbPtr, 0, fourKb);
+
+                        for (long pos = CurrentFile.WritePosIn4KbPosition; pos < CurrentFile.JournalWriter.NumberOfAllocated4Kb; pos++)
+                        {
+                            CurrentFile.JournalWriter.Write(pos, emptyFourKbPtr, 1);
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal(ptr);
+                    }
+                }
+            }
+
+            if (_env.Options.CopyOnWriteMode == false)
+            {
+                addToInitLog?.Invoke($"Cleanup Newer Invalid Journal Files (Last Flushed Journal={lastProcessedJournal})");
+
+                CleanupNewerInvalidJournalFiles(lastProcessedJournal);
+            }
+
             return requireHeaderUpdate;
         }
 
@@ -414,7 +457,7 @@ namespace Voron.Impl.Journal
         private void RecoverCurrentJournalSize(AbstractPager pager, out bool isMoreThanMaxFileSize)
         {
             var journalSize = Bits.PowerOf2(pager.TotalAllocationSize);
-            if (journalSize >= _env.Options.MaxLogFileSize) // can't set for more than the max log file size{
+            if (journalSize >= _env.Options.MaxLogFileSize) // can't set for more than the max log file size
             {
                 isMoreThanMaxFileSize = true;
                 return;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -85,6 +85,14 @@ namespace Voron
 
         public bool EnablePrefetching = true;
 
+        internal DisposableAction DisableOnRecoveryErrorHandler()
+        {
+            var handler = OnRecoveryError;
+            OnRecoveryError = null;
+
+            return new DisposableAction(() => OnRecoveryError = handler);
+        }
+
         public void InvokeRecoveryError(object sender, string message, Exception e)
         {
             var handler = OnRecoveryError;
@@ -95,6 +103,14 @@ namespace Voron
             }
 
             handler(this, new RecoveryErrorEventArgs(message, e));
+        }
+
+        internal DisposableAction DisableOnIntegrityErrorOfAlreadySyncedDataHandler()
+        {
+            var handler = OnIntegrityErrorOfAlreadySyncedData;
+            OnIntegrityErrorOfAlreadySyncedData = null;
+
+            return new DisposableAction(() => OnIntegrityErrorOfAlreadySyncedData = handler);
         }
 
         public void InvokeIntegrityErrorOfAlreadySyncedData(object sender, string message, Exception e)

--- a/test/SlowTests/Voron/Issues/RavenDB_19278.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_19278.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using FastTests.Voron;
+using Sparrow.Utils;
+using Voron;
+using Voron.Global;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_19278 : StorageTest
+{
+    private List<string> _onRecoveryErrorMessages = new();
+
+    public RavenDB_19278(ITestOutputHelper output) : base(output)
+    {
+    }
+
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.InitialLogFileSize = 4 * Constants.Size.Megabyte;
+        options.MaxLogFileSize = 32 * Constants.Size.Megabyte;
+
+        options.OnRecoveryError += (sender, args) =>
+        {
+            _onRecoveryErrorMessages.Add(args.Message);
+        };
+        options.ManualSyncing = true;
+        options.ManualFlushing = true;
+        options.MaxScratchBufferSize = 1 * Constants.Size.Gigabyte;
+    }
+
+    [Fact]
+    public void StopRecoveryAndRaisePartiallyRecoveredAlertAfterGettingInvalidHashOfTransaction()
+    {
+        RequireFileBasedPager();
+
+        using (var tx = Env.WriteTransaction())
+        {
+            tx.CreateTree("tree");
+
+            tx.Commit();
+        }
+
+        const long corruptedTx = 9;
+
+        var random = new Random(3);
+
+        var itemsToReadAfterRecovery = new List<string>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var buffer = new byte[2 * Constants.Size.Megabyte];
+            random.NextBytes(buffer);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int j = 0; j < 10; j++)
+                {
+                    string key = "a" + i + j;
+                    tx.CreateTree("tree").Add(key, new MemoryStream(buffer));
+
+                    if (tx.LowLevelTransaction.Id < corruptedTx)
+                    {
+                        itemsToReadAfterRecovery.Add(key);
+                    }
+                }
+
+                tx.Commit();
+            }
+        }
+
+        var journalToCorrupt = Env.Journal.GetCurrentJournalInfo().CurrentJournal - 3;
+
+        StopDatabase(); 
+
+        CorruptJournal(journalToCorrupt, 10 * Constants.Size.Kilobyte * 4 - 1000); // it will corrupt tx 9
+
+        StartDatabase(); // it must not throw, it should partially recover the database
+
+        Assert.Equal(2, _onRecoveryErrorMessages.Count);
+
+        Assert.Contains($"Invalid hash signature for transaction: HeaderMarker: Valid, TransactionId: {corruptedTx}", _onRecoveryErrorMessages[0]);
+        Assert.Contains("Database recovered partially. Some data was lost.", _onRecoveryErrorMessages[1]);
+
+        using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            operation.SyncDataFile(); // force the sync so it will delete already synced journals
+        }
+
+        var journalPath = Env.Options.JournalPath.FullPath;
+
+        // older journals should be deleted, newer but not processed should be deleted too due to partial recovery 
+        Assert.True(SpinWait.SpinUntil(() => new DirectoryInfo(journalPath).GetFiles($"*.journal").Length == 1,
+            TimeSpan.FromSeconds(30)));
+
+        using (var tx = Env.ReadTransaction())
+        {
+            foreach (var key in itemsToReadAfterRecovery)
+            {
+                var readA = tx.ReadTree("tree").Read(key);
+
+                Assert.NotNull(readA);
+            }
+        }
+
+        using (var tx = Env.WriteTransaction())
+        {
+            Assert.Equal(corruptedTx, tx.LowLevelTransaction.Id);
+
+            var buffer = new byte[123];
+            random.NextBytes(buffer);
+
+            tx.CreateTree("tree").Add("new", new MemoryStream(buffer));
+            
+            tx.Commit();
+        }
+
+        StopDatabase();
+
+        Configure(Options); // when we stop db we always call _options.NullifyHandlers() so we need to hook them up again
+
+        StartDatabase(); // TODO arek - currently fails with InvalidJournalException: No such journal '0000000000000000008.journal' - that is true, we removed it in the process of (partial) recovery
+    }
+
+    private void CorruptJournal(long journal, long position, int numberOfCorruptedBytes = Constants.Size.Kilobyte * 4, byte value = 42, bool preserveValue = false)
+    {
+        Options.Dispose();
+        Options = StorageEnvironmentOptions.ForPath(DataDir);
+        Configure(Options);
+        using (var fileStream = SafeFileStream.Create(Options.GetJournalPath(journal).FullPath,
+                   FileMode.Open,
+                   FileAccess.ReadWrite,
+                   FileShare.ReadWrite | FileShare.Delete))
+        {
+            fileStream.Position = position;
+
+            var buffer = new byte[numberOfCorruptedBytes];
+
+            var remaining = buffer.Length;
+            var start = 0;
+            while (remaining > 0)
+            {
+                var read = fileStream.Read(buffer, start, remaining);
+                if (read == 0)
+                    break;
+                start += read;
+                remaining -= read;
+            }
+
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                if (buffer[i] != value || preserveValue)
+                    buffer[i] = value;
+                else
+                    buffer[i] = (byte)(value + 1); // we really want to change the original value here so it must not stay the same
+            }
+            fileStream.Position = position;
+            fileStream.Write(buffer, 0, buffer.Length);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19278/Faulty-recovery-error-handling-during-storage-environment-startup
https://issues.hibernatingrhinos.com/issue/RavenDB-19328/Missing-handling-of-RequireHeaderUpdate-when-doing-partial-recovery

### Additional description

In order to review this PR please go over each commit. The commit messages include full details about the problem that it fixes.

For reference - PRs related to changes made here:

1. Voron recovery error handling:

https://github.com/ravendb/ravendb/pull/1402 - introduction of journals reuse
https://github.com/ravendb/ravendb/pull/1415 - forcing to continue reading journals after not getting valid tx

2. Handling for `RequireHeaderUpdate`:

https://github.com/ravendb/ravendb/pull/8556 - here we removed it while we should keep it for partial recovery scenario

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- Existing tests will verify no breaking changes to current behavior. In particular the following tests:
    - `RavenDB_13940`, `RavenDB_13940_Encrypted`, `RecoveryMultipleJournals`, `RavenDB_12725*`

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
