### PR TITLE
RavenDB-19316 & RavenDB-19332

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -401,7 +401,7 @@ namespace Raven.Server.Documents.Indexes
                 };
             }
 
-            var entriesCount = statsTree.Read(IndexSchema.EntriesCount)?.Reader.ReadLittleEndianInt32();
+            var entriesCount = statsTree.Read(IndexSchema.EntriesCount)?.Reader.ReadLittleEndianInt64();
 
             if (entriesCount != null)
                 stats.EntriesCount = entriesCount.Value;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     return;
                 }
                 
-                _indexWriter.Update(keyFieldName, key.AsSpan(), lowerId, data.ToSpan());
+                _indexWriter.Update(keyFieldName, key.AsSpan(), lowerId, data.ToSpan(), ref _entriesCount);
             }
         }
 

--- a/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
+++ b/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
@@ -33,7 +33,8 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
 
             using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
             var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
-            oldId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
+            long numberOfEntries =0;
+            oldId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan(), ref numberOfEntries);
             
             indexWriter.Commit();
         }
@@ -58,7 +59,8 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
 
             using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
             var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
-            newId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
+            long numberOfEntries =0;
+            newId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan(), ref numberOfEntries);
             
             indexWriter.Commit();
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19316 
https://issues.hibernatingrhinos.com/issue/RavenDB-19332

### Additional description

Fixing issues related to the number of entries in an index when using Corax.

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 

Changed the way we are *reading* the number of entries from int32 to int64 (was always _stored_ as int64).

### Backward compatibility

- Non breaking change

The API is already working with longs.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing
