### PR TITLE
RavenDB-19314 Remove backslash validation from document id

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -94,7 +94,6 @@ class editDocument extends viewModelBase {
     propertiesPanelVisible = ko.observable(true);
 
     globalValidationGroup = ko.validatedObservable({
-        userDocumentId: this.userSpecifiedId,
         userDocumentText: this.documentText
     });
     
@@ -305,15 +304,6 @@ class editDocument extends viewModelBase {
     }
 
     private initValidation() {
-        const rg1 = /^[^\\]*$/; // forbidden character - backslash
-        this.userSpecifiedId.extend({
-            validation: [
-                {
-                    validator: (val: string) => rg1.test(val),
-                    message: "Can't use backslash in document name"
-                }]
-        });
-
         this.documentText.extend({
             required: {
                 onlyIf: () => !this.isHugeDocument() && this.ignoreHugeDocument()


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19314

### Additional description
Remove backslash validation when saving document

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed (already done in RDoc-2259)

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
