### PR TITLE
RavenDB-18879 - Sharding - Replication - Handlers

### DIFF
--- a/src/Raven.Server/Documents/Commands/Replication/GetIncomingReplicationRejectionInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetIncomingReplicationRejectionInfoCommand.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
 using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Json;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Commands.Replication
 {
-    internal class GetIncomingReplicationRejectionInfoCommand : RavenCommand<object>
+    internal class GetIncomingReplicationRejectionInfoCommand : RavenCommand<ReplicationIncomingRejectionInfoPreview>
     {
         public GetIncomingReplicationRejectionInfoCommand()
         {
@@ -32,7 +34,7 @@ namespace Raven.Server.Documents.Commands.Replication
             if (response == null)
                 ThrowInvalidResponse();
 
-            Result = response;
+            Result = JsonDeserializationServer.ReplicationIncomingRejectionInfoPreview(response);
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Server/Documents/Commands/Replication/GetIncomingReplicationRejectionInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetIncomingReplicationRejectionInfoCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Replication
+{
+    internal class GetIncomingReplicationRejectionInfoCommand : RavenCommand<object>
+    {
+        public GetIncomingReplicationRejectionInfoCommand()
+        {
+        }
+
+        public GetIncomingReplicationRejectionInfoCommand(string nodeTag)
+        {
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/replication/debug/incoming-rejection-info";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationActiveConnectionsInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationActiveConnectionsInfoCommand.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Replication;
-using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.Json;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Commands.Replication
@@ -35,27 +34,7 @@ namespace Raven.Server.Documents.Commands.Replication
             if (response == null)
                 ThrowInvalidResponse();
 
-            var incomingConnectionsInfo = new List<IncomingConnectionInfo>();
-            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.IncomingConnections), out BlittableJsonReaderArray bjra))
-            {
-                foreach (BlittableJsonReaderObject bjro in bjra)
-                {
-                    var incomingConnectionInfo = IncomingConnectionInfo.FromJson(bjro);
-                    incomingConnectionsInfo.Add(incomingConnectionInfo);
-                }
-            }
-
-            var outgoingConnectionsInfo = new List<ReplicationActiveConnectionsPreview.OutgoingConnectionInfo>();
-            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.OutgoingConnections), out bjra))
-            {
-                foreach (BlittableJsonReaderObject bjro in bjra)
-                {
-                    var outgoingConnectionInfo = ReplicationActiveConnectionsPreview.OutgoingConnectionInfo.FromJson(bjro);
-                    outgoingConnectionsInfo.Add(outgoingConnectionInfo);
-                }
-            }
-
-            Result = new ReplicationActiveConnectionsPreview { IncomingConnections = incomingConnectionsInfo, OutgoingConnections = outgoingConnectionsInfo };
+            Result = JsonDeserializationServer.ReplicationActiveConnectionsPreview(response);
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationActiveConnectionsInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationActiveConnectionsInfoCommand.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Documents.Replication.Stats;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Replication
+{
+    internal class GetReplicationActiveConnectionsInfoCommand : RavenCommand<ReplicationActiveConnectionsPreview>
+    {
+        public GetReplicationActiveConnectionsInfoCommand()
+        {
+        }
+
+        public GetReplicationActiveConnectionsInfoCommand(string nodeTag)
+        {
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/replication/active-connections";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            var incomingConnectionsInfo = new List<IncomingConnectionInfo>();
+            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.IncomingConnections), out BlittableJsonReaderArray bjra))
+            {
+                foreach (BlittableJsonReaderObject bjro in bjra)
+                {
+                    var incomingConnectionInfo = IncomingConnectionInfo.FromJson(bjro);
+                    incomingConnectionsInfo.Add(incomingConnectionInfo);
+                }
+            }
+
+            var outgoingConnectionsInfo = new List<ReplicationActiveConnectionsPreview.OutgoingConnectionInfo>();
+            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.OutgoingConnections), out bjra))
+            {
+                foreach (BlittableJsonReaderObject bjro in bjra)
+                {
+                    var outgoingConnectionInfo = ReplicationActiveConnectionsPreview.OutgoingConnectionInfo.FromJson(bjro);
+                    outgoingConnectionsInfo.Add(outgoingConnectionInfo);
+                }
+            }
+
+            Result = new ReplicationActiveConnectionsPreview { IncomingConnections = incomingConnectionsInfo, OutgoingConnections = outgoingConnectionsInfo };
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationIncomingActivityTimesInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationIncomingActivityTimesInfoCommand.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
 using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Json;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Commands.Replication
 {
-    internal class GetReplicationIncomingActivityTimesInfoCommand : RavenCommand<object>
+    internal class GetReplicationIncomingActivityTimesInfoCommand : RavenCommand<ReplicationIncomingLastActivityTimePreview>
     {
         public GetReplicationIncomingActivityTimesInfoCommand()
         {
@@ -32,7 +34,7 @@ namespace Raven.Server.Documents.Commands.Replication
             if (response == null)
                 ThrowInvalidResponse();
 
-            Result = response;
+            Result = JsonDeserializationServer.ReplicationIncomingLastActivityTimePreview(response);
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationIncomingActivityTimesInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationIncomingActivityTimesInfoCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Replication
+{
+    internal class GetReplicationIncomingActivityTimesInfoCommand : RavenCommand<object>
+    {
+        public GetReplicationIncomingActivityTimesInfoCommand()
+        {
+        }
+
+        public GetReplicationIncomingActivityTimesInfoCommand(string nodeTag)
+        {
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/replication/debug/incoming-last-activity-time";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingReconnectionQueueCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingReconnectionQueueCommand.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
 using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Json;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Commands.Replication
 {
-    internal class GetReplicationOutgoingReconnectionQueueCommand : RavenCommand<object>
+    internal class GetReplicationOutgoingReconnectionQueueCommand : RavenCommand<ReplicationOutgoingReconnectionQueuePreview>
     {
         public GetReplicationOutgoingReconnectionQueueCommand()
         {
@@ -32,7 +34,7 @@ namespace Raven.Server.Documents.Commands.Replication
             if (response == null)
                 ThrowInvalidResponse();
 
-            Result = response;
+            Result = JsonDeserializationServer.ReplicationOutgoingReconnectionQueuePreview(response);
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingReconnectionQueueCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingReconnectionQueueCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Replication
+{
+    internal class GetReplicationOutgoingReconnectionQueueCommand : RavenCommand<object>
+    {
+        public GetReplicationOutgoingReconnectionQueueCommand()
+        {
+        }
+
+        public GetReplicationOutgoingReconnectionQueueCommand(string nodeTag)
+        {
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/replication/debug/outgoing-reconnect-queue";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
 using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Json;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Commands.Replication
 {
-    internal class GetReplicationOutgoingsFailureInfoCommand : RavenCommand<object>
+    internal class GetReplicationOutgoingsFailureInfoCommand : RavenCommand<ReplicationOutgoingsFailurePreview>
     {
         public GetReplicationOutgoingsFailureInfoCommand()
         {
@@ -32,7 +34,7 @@ namespace Raven.Server.Documents.Commands.Replication
             if (response == null)
                 ThrowInvalidResponse();
 
-            Result = response;
+            Result = JsonDeserializationServer.ReplicationOutgoingsFailurePreview(response);
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Replication
+{
+    internal class GetReplicationOutgoingsFailureInfoCommand : RavenCommand<object>
+    {
+        public GetReplicationOutgoingsFailureInfoCommand()
+        {
+        }
+
+        public GetReplicationOutgoingsFailureInfoCommand(string nodeTag)
+        {
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/replication/debug/outgoing-failures";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -17,7 +17,6 @@ using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Revisions;
-using Raven.Server.Documents.Sharding.Handlers.Processors.Replication;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Storage.Layout;
@@ -1142,8 +1141,6 @@ namespace Raven.Server.Documents
                 var tombstone = TableValueToTombstone(context, ref result.Reader);
                 tombstones.Add(tombstone);
             }
-
-            tombstones.Sort(ShardedReplicationHandlerProcessorForGetTombstones.TombstonesPreviewComparer.Instance);
 
             return new GetTombstonesPreviewResult
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Net.Http;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using static Raven.Server.Documents.Handlers.Processors.Replication.ReplicationActiveConnectionsPreview;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
@@ -21,60 +20,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         }
 
         protected override RavenCommand<ReplicationActiveConnectionsPreview> CreateCommandForNode(string nodeTag) => new GetReplicationActiveConnectionsInfoCommand(nodeTag);
-    }
-
-    internal class GetReplicationActiveConnectionsInfoCommand : RavenCommand<ReplicationActiveConnectionsPreview>
-    {
-        public GetReplicationActiveConnectionsInfoCommand()
-        {
-        }
-
-        public GetReplicationActiveConnectionsInfoCommand(string nodeTag)
-        {
-            SelectedNodeTag = nodeTag;
-        }
-
-        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-        {
-            url = $"{node.Url}/databases/{node.Database}/replication/active-connections";
-
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get
-            };
-
-            return request;
-        }
-
-        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-        {
-            if (response == null)
-                ThrowInvalidResponse();
-
-            var incomingConnectionsInfo = new List<IncomingConnectionInfo>();
-            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.IncomingConnections), out BlittableJsonReaderArray bjra))
-            {
-                foreach (BlittableJsonReaderObject bjro in bjra)
-                {
-                    var incomingConnectionInfo = IncomingConnectionInfo.FromJson(bjro);
-                    incomingConnectionsInfo.Add(incomingConnectionInfo);
-                }
-            }
-
-            var outgoingConnectionsInfo = new List<OutgoingConnectionInfo>();
-            if (response.TryGet(nameof(ReplicationActiveConnectionsPreview.OutgoingConnections), out bjra))
-            {
-                foreach (BlittableJsonReaderObject bjro in bjra)
-                {
-                    var outgoingConnectionInfo = OutgoingConnectionInfo.FromJson(bjro);
-                    outgoingConnectionsInfo.Add(outgoingConnectionInfo);
-                }
-            }
-           
-            Result = new ReplicationActiveConnectionsPreview { IncomingConnections = incomingConnectionsInfo, OutgoingConnections = outgoingConnectionsInfo };
-        }
-
-        public override bool IsReadRequest => true;
     }
 
     public class ReplicationActiveConnectionsPreview

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Replication.Stats;
-using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -26,33 +26,15 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
     {
         public List<IncomingConnectionInfo> IncomingConnections;
 
-        public List<OutgoingConnectionInfo> OutgoingConnections;
+        public List<ReplicationNode> OutgoingConnections;
 
-        public class OutgoingConnectionInfo
+        public DynamicJsonValue ToJson()
         {
-            public string Url;
-
-            public string Database;
-
-            public bool Disabled;
-
-            public static DynamicJsonValue ToJson(ReplicationNode replicationNode)
+            return new DynamicJsonValue
             {
-                return new DynamicJsonValue
-                {
-                    [nameof(Url)] = replicationNode.Url,
-                    [nameof(Database)] = replicationNode.Database,
-                    [nameof(Disabled)] = replicationNode.Disabled
-                };
-            }
-
-            public static OutgoingConnectionInfo FromJson(BlittableJsonReaderObject json)
-            {
-                if (json == null)
-                    return null;
-
-                return JsonDeserializationServer.ReplicationOutgoingConnectionInfo(json);
-            }
+                [nameof(IncomingConnections)] = new DynamicJsonArray(IncomingConnections.Select(i => i.ToJson())),
+                [nameof(OutgoingConnections)] = new DynamicJsonArray(OutgoingConnections.Select(o => o.ToJson()))
+            };
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -1,11 +1,16 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
+using Raven.Server.Documents.Replication.Stats;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
-    internal abstract class AbstractReplicationHandlerProcessorForGetIncomingActivityTimes<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+    internal abstract class AbstractReplicationHandlerProcessorForGetIncomingActivityTimes<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<ReplicationIncomingLastActivityTimePreview, TRequestHandler, TOperationContext>
         where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
     {
@@ -14,9 +19,31 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
         }
 
-        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        protected override RavenCommand<ReplicationIncomingLastActivityTimePreview> CreateCommandForNode(string nodeTag)
         {
             return new GetReplicationIncomingActivityTimesInfoCommand(nodeTag);
+        }
+    }
+
+    public class ReplicationIncomingLastActivityTimePreview
+    {
+        public IDictionary<IncomingConnectionInfo, DateTime> IncomingActivityTimes;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                ["Stats"] = new DynamicJsonArray(IncomingActivityTimes.Select(IncomingActivityTimeToJson))
+            };
+        }
+
+        private DynamicJsonValue IncomingActivityTimeToJson(KeyValuePair<IncomingConnectionInfo, DateTime> kvp)
+        {
+            return new DynamicJsonValue
+            {
+                ["Key"] = kvp.Key.ToJson(),
+                ["Value"] = kvp.Value
+            };
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal abstract class AbstractReplicationHandlerProcessorForGetIncomingActivityTimes<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractReplicationHandlerProcessorForGetIncomingActivityTimes([NotNull] TRequestHandler requestHandler)
+            : base(requestHandler)
+        {
+        }
+
+        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        {
+            return new GetReplicationIncomingActivityTimesInfoCommand(nodeTag);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -27,13 +27,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
     public class ReplicationIncomingLastActivityTimePreview
     {
-        public IDictionary<IncomingConnectionInfo, DateTime> IncomingActivityTimes;
+        public IDictionary<IncomingConnectionInfo, DateTime> Stats;
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                ["Stats"] = new DynamicJsonArray(IncomingActivityTimes.Select(IncomingActivityTimeToJson))
+                [nameof(Stats)] = new DynamicJsonArray(Stats.Select(IncomingActivityTimeToJson))
             };
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal abstract class AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo([NotNull] TRequestHandler requestHandler)
+            : base(requestHandler)
+        {
+        }
+
+        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        {
+            return new GetIncomingReplicationRejectionInfoCommand(nodeTag);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -28,13 +28,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
     public class ReplicationIncomingRejectionInfoPreview
     {
-        public IDictionary<IncomingConnectionInfo, ConcurrentQueue<ReplicationLoader.IncomingConnectionRejectionInfo>> IncomingRejectionStats;
+        public IDictionary<IncomingConnectionInfo, ConcurrentQueue<ReplicationLoader.IncomingConnectionRejectionInfo>> Stats;
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                ["Stats"] = new DynamicJsonArray(IncomingRejectionStats.Select(IncomingRejectionInfoToJson))
+                [nameof(Stats)] = new DynamicJsonArray(Stats.Select(IncomingRejectionInfoToJson))
             };
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -27,13 +27,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
     public class ReplicationOutgoingsFailurePreview
     {
-        public IDictionary<ReplicationNode, ConnectionShutdownInfo> OutgoingsFailureInfo;
+        public IDictionary<ReplicationNode, ConnectionShutdownInfo> Stats;
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                ["Stats"] = new DynamicJsonArray(OutgoingsFailureInfo.Select(OutgoingFailureInfoToJson))
+                [nameof(Stats)] = new DynamicJsonArray(Stats.Select(OutgoingFailureInfoToJson))
             };
         }
 
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         private DynamicJsonValue ReplicationNodeToJson(ReplicationNode replicationNode)
         {
             var json = replicationNode.ToJson();
-            json[nameof(ReplicationNode)] = replicationNode.GetType().ToString();
+            json["Type"] = replicationNode.GetType().ToString();
             return json;
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingFailureStats<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractReplicationHandlerProcessorForGetOutgoingFailureStats([NotNull] TRequestHandler requestHandler)
+            : base(requestHandler)
+        {
+        }
+
+        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        {
+            return new GetReplicationOutgoingsFailureInfoCommand(nodeTag);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -1,11 +1,16 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
+using Raven.Server.Documents.Replication;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
-    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingFailureStats<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingFailureStats<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<ReplicationOutgoingsFailurePreview, TRequestHandler, TOperationContext>
         where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
     {
@@ -14,9 +19,38 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
         }
 
-        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        protected override RavenCommand<ReplicationOutgoingsFailurePreview> CreateCommandForNode(string nodeTag)
         {
             return new GetReplicationOutgoingsFailureInfoCommand(nodeTag);
+        }
+    }
+
+    public class ReplicationOutgoingsFailurePreview
+    {
+        public IDictionary<ReplicationNode, ConnectionShutdownInfo> OutgoingsFailureInfo;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                ["Stats"] = new DynamicJsonArray(OutgoingsFailureInfo.Select(OutgoingFailureInfoToJson))
+            };
+        }
+
+        private DynamicJsonValue OutgoingFailureInfoToJson(KeyValuePair<ReplicationNode, ConnectionShutdownInfo> kvp)
+        {
+            return new DynamicJsonValue
+            {
+                ["Key"] = ReplicationNodeToJson(kvp.Key),
+                ["Value"] = kvp.Value
+            };
+        }
+    
+        private DynamicJsonValue ReplicationNodeToJson(ReplicationNode replicationNode)
+        {
+            var json = replicationNode.ToJson();
+            json[nameof(ReplicationNode)] = replicationNode.GetType().ToString();
+            return json;
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
@@ -1,11 +1,15 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
-    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<ReplicationOutgoingReconnectionQueuePreview, TRequestHandler, TOperationContext>
         where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
     {
@@ -14,9 +18,22 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
         }
 
-        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        protected override RavenCommand<ReplicationOutgoingReconnectionQueuePreview> CreateCommandForNode(string nodeTag)
         {
             return new GetReplicationOutgoingReconnectionQueueCommand(nodeTag);
+        }
+    }
+
+    public class ReplicationOutgoingReconnectionQueuePreview
+    {
+        public List<ReplicationNode> QueueInfo;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                ["Queue-Info"] = new DynamicJsonArray(QueueInfo.Select(o => o.ToJson()))
+            };
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal abstract class AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<object, TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue([NotNull] TRequestHandler requestHandler)
+            : base(requestHandler)
+        {
+        }
+
+        protected override RavenCommand<object> CreateCommandForNode(string nodeTag)
+        {
+            return new GetReplicationOutgoingReconnectionQueueCommand(nodeTag);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             {
                 var stats = new ReplicationIncomingLastActivityTimePreview
                 {
-                    IncomingActivityTimes = new Dictionary<IncomingConnectionInfo, DateTime>(RequestHandler.Database.ReplicationLoader.IncomingLastActivityTime)
+                    Stats = new Dictionary<IncomingConnectionInfo, DateTime>(RequestHandler.Database.ReplicationLoader.IncomingLastActivityTime)
                 };
 
                 context.Write(writer, stats.ToJson());

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal class ReplicationHandlerProcessorForGetIncomingActivityTimes : AbstractReplicationHandlerProcessorForGetIncomingActivityTimes<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public ReplicationHandlerProcessorForGetIncomingActivityTimes([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                var data = new DynamicJsonArray();
+                foreach (var item in RequestHandler.Database.ReplicationLoader.IncomingLastActivityTime)
+                {
+                    data.Add(new DynamicJsonValue
+                    {
+                        ["Key"] = item.Key.ToJson(),
+                        ["Value"] = item.Value
+                    });
+                }
+
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Stats"] = data
+                });
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -1,10 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.Http;
-using Sparrow.Json.Parsing;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
@@ -18,26 +21,18 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
         protected override async ValueTask HandleCurrentNodeAsync()
         {
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
             {
-                var data = new DynamicJsonArray();
-                foreach (var item in RequestHandler.Database.ReplicationLoader.IncomingLastActivityTime)
+                var stats = new ReplicationIncomingLastActivityTimePreview
                 {
-                    data.Add(new DynamicJsonValue
-                    {
-                        ["Key"] = item.Key.ToJson(),
-                        ["Value"] = item.Value
-                    });
-                }
+                    IncomingActivityTimes = new Dictionary<IncomingConnectionInfo, DateTime>(RequestHandler.Database.ReplicationLoader.IncomingLastActivityTime)
+                };
 
-                context.Write(writer, new DynamicJsonValue
-                {
-                    ["Stats"] = data
-                });
+                context.Write(writer, stats.ToJson());
             }
         }
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationIncomingLastActivityTimePreview> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             {
                 var stats = new ReplicationIncomingRejectionInfoPreview
                 {
-                    IncomingRejectionStats = new Dictionary<IncomingConnectionInfo, ConcurrentQueue<ReplicationLoader.IncomingConnectionRejectionInfo>>(RequestHandler.Database.ReplicationLoader.IncomingRejectionStats)
+                    Stats = new Dictionary<IncomingConnectionInfo, ConcurrentQueue<ReplicationLoader.IncomingConnectionRejectionInfo>>(RequestHandler.Database.ReplicationLoader.IncomingRejectionStats)
                 };
               
                 context.Write(writer, stats.ToJson());

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -1,11 +1,14 @@
-﻿using System.Linq;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.Http;
-using Sparrow.Json.Parsing;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
@@ -19,30 +22,18 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
         protected override async ValueTask HandleCurrentNodeAsync()
         {
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
             {
-                var stats = new DynamicJsonArray();
-                foreach (var statItem in RequestHandler.Database.ReplicationLoader.IncomingRejectionStats)
+                var stats = new ReplicationIncomingRejectionInfoPreview
                 {
-                    stats.Add(new DynamicJsonValue
-                    {
-                        ["Key"] = statItem.Key.ToJson(),
-                        ["Value"] = new DynamicJsonArray(statItem.Value.Select(x => new DynamicJsonValue
-                        {
-                            ["Reason"] = x.Reason,
-                            ["When"] = x.When
-                        }))
-                    });
-                }
-
-                context.Write(writer, new DynamicJsonValue
-                {
-                    ["Stats"] = stats
-                });
+                    IncomingRejectionStats = new Dictionary<IncomingConnectionInfo, ConcurrentQueue<ReplicationLoader.IncomingConnectionRejectionInfo>>(RequestHandler.Database.ReplicationLoader.IncomingRejectionStats)
+                };
+              
+                context.Write(writer, stats.ToJson());
             }
         }
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationIncomingRejectionInfoPreview> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal class ReplicationHandlerProcessorForGetIncomingRejectionInfo : AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public ReplicationHandlerProcessorForGetIncomingRejectionInfo([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                var stats = new DynamicJsonArray();
+                foreach (var statItem in RequestHandler.Database.ReplicationLoader.IncomingRejectionStats)
+                {
+                    stats.Add(new DynamicJsonValue
+                    {
+                        ["Key"] = statItem.Key.ToJson(),
+                        ["Value"] = new DynamicJsonArray(statItem.Value.Select(x => new DynamicJsonValue
+                        {
+                            ["Reason"] = x.Reason,
+                            ["When"] = x.When
+                        }))
+                    });
+                }
+
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Stats"] = stats
+                });
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal class ReplicationHandlerProcessorForGetOutgoingFailureStats : AbstractReplicationHandlerProcessorForGetOutgoingFailureStats<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public ReplicationHandlerProcessorForGetOutgoingFailureStats([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                var data = new DynamicJsonArray();
+                foreach (var item in RequestHandler.Database.ReplicationLoader.OutgoingFailureInfo)
+                {
+                    data.Add(new DynamicJsonValue
+                    {
+                        ["Key"] = new DynamicJsonValue
+                        {
+                            [nameof(item.Key)] = item.Key.GetType().ToString(),
+                            [nameof(item.Key.Url)] = item.Key.Url,
+                            [nameof(item.Key.Database)] = item.Key.Database,
+                            [nameof(item.Key.Disabled)] = item.Key.Disabled
+                        },
+                        ["Value"] = new DynamicJsonValue
+                        {
+                            ["ErrorsCount"] = item.Value.Errors.Count,
+                            [nameof(item.Value.Errors)] = new DynamicJsonArray(item.Value.Errors.Select(e => e.ToString())),
+                            [nameof(item.Value.NextTimeout)] = item.Value.NextTimeout,
+                            [nameof(item.Value.RetryOn)] = item.Value.RetryOn,
+                            [nameof(item.Value.DestinationDbId)] = item.Value.DestinationDbId,
+                            [nameof(item.Value.LastHeartbeatTicks)] = item.Value.LastHeartbeatTicks,
+                        }
+                    });
+                }
+
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Stats"] = data
+                });
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -1,11 +1,13 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Replication;
+using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.Http;
-using Sparrow.Json.Parsing;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
@@ -19,40 +21,18 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
         protected override async ValueTask HandleCurrentNodeAsync()
         {
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
             {
-                var data = new DynamicJsonArray();
-                foreach (var item in RequestHandler.Database.ReplicationLoader.OutgoingFailureInfo)
+                var stats = new ReplicationOutgoingsFailurePreview
                 {
-                    data.Add(new DynamicJsonValue
-                    {
-                        ["Key"] = new DynamicJsonValue
-                        {
-                            [nameof(item.Key)] = item.Key.GetType().ToString(),
-                            [nameof(item.Key.Url)] = item.Key.Url,
-                            [nameof(item.Key.Database)] = item.Key.Database,
-                            [nameof(item.Key.Disabled)] = item.Key.Disabled
-                        },
-                        ["Value"] = new DynamicJsonValue
-                        {
-                            ["ErrorsCount"] = item.Value.Errors.Count,
-                            [nameof(item.Value.Errors)] = new DynamicJsonArray(item.Value.Errors.Select(e => e.ToString())),
-                            [nameof(item.Value.NextTimeout)] = item.Value.NextTimeout,
-                            [nameof(item.Value.RetryOn)] = item.Value.RetryOn,
-                            [nameof(item.Value.DestinationDbId)] = item.Value.DestinationDbId,
-                            [nameof(item.Value.LastHeartbeatTicks)] = item.Value.LastHeartbeatTicks,
-                        }
-                    });
-                }
-
-                context.Write(writer, new DynamicJsonValue
-                {
-                    ["Stats"] = data
-                });
+                    OutgoingsFailureInfo = new Dictionary<ReplicationNode, ConnectionShutdownInfo>(RequestHandler.Database.ReplicationLoader.OutgoingFailureInfo)
+                };
+       
+                context.Write(writer, stats.ToJson());
             }
         }
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationOutgoingsFailurePreview> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             {
                 var stats = new ReplicationOutgoingsFailurePreview
                 {
-                    OutgoingsFailureInfo = new Dictionary<ReplicationNode, ConnectionShutdownInfo>(RequestHandler.Database.ReplicationLoader.OutgoingFailureInfo)
+                    Stats = new Dictionary<ReplicationNode, ConnectionShutdownInfo>(RequestHandler.Database.ReplicationLoader.OutgoingFailureInfo)
                 };
        
                 context.Write(writer, stats.ToJson());

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Replication
+{
+    internal class ReplicationHandlerProcessorForGetOutgoingReconnectionQueue : AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public ReplicationHandlerProcessorForGetOutgoingReconnectionQueue([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                var data = new DynamicJsonArray();
+                foreach (var queueItem in RequestHandler.Database.ReplicationLoader.ReconnectQueue)
+                {
+                    data.Add(ReplicationActiveConnectionsPreview.OutgoingConnectionInfo.ToJson(queueItem));
+                }
+
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Queue-Info"] = data
+                });
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -62,30 +62,8 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/replication/debug/incoming-last-activity-time", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetReplicationIncomingActivityTimes()
         {
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
-            {
-                var data = new DynamicJsonArray();
-                foreach (var item in Database.ReplicationLoader.IncomingLastActivityTime)
-                {
-                    data.Add(new DynamicJsonValue
-                    {
-                        ["Key"] = new DynamicJsonValue
-                        {
-                            ["SourceDatabaseId"] = item.Key.SourceDatabaseId,
-                            ["SourceDatabaseName"] = item.Key.SourceDatabaseName,
-                            ["SourceMachineName"] = item.Key.SourceMachineName,
-                            ["SourceUrl"] = item.Key.SourceUrl
-                        },
-                        ["Value"] = item.Value
-                    });
-                }
-
-                context.Write(writer, new DynamicJsonValue
-                {
-                    ["Stats"] = data
-                });
-            }
+            using (var processor = new ReplicationHandlerProcessorForGetIncomingActivityTimes(this))
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/replication/debug/incoming-rejection-info", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -76,25 +76,8 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/replication/debug/outgoing-reconnect-queue", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetReplicationReconnectionQueue()
         {
-            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
-            {
-                var data = new DynamicJsonArray();
-                foreach (var queueItem in Database.ReplicationLoader.ReconnectQueue)
-                {
-                    data.Add(new DynamicJsonValue
-                    {
-                        ["Url"] = queueItem.Url,
-                        ["Database"] = queueItem.Database,
-                        ["Disabled"] = queueItem.Disabled
-                    });
-                }
-
-                context.Write(writer, new DynamicJsonValue
-                {
-                    ["Queue-Info"] = data
-                });
-            }
+            using (var processor = new ReplicationHandlerProcessorForGetOutgoingReconnectionQueue(this))
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/replication/conflicts/solver", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]

--- a/src/Raven.Server/Documents/Replication/ConnectionShutdownInfo.cs
+++ b/src/Raven.Server/Documents/Replication/ConnectionShutdownInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Raven.Client.Documents.Replication;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Replication
 {
@@ -48,6 +50,19 @@ namespace Raven.Server.Documents.Replication
             NextTimeout *= 2;
             NextTimeout = TimeSpan.FromMilliseconds(Math.Min(NextTimeout.TotalMilliseconds, MaxConnectionTimeout));
             RetryOn = DateTime.UtcNow + NextTimeout;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                ["ErrorsCount"] = Errors.Count,
+                [nameof(Errors)] = new DynamicJsonArray(Errors.Select(e => e.ToString())),
+                [nameof(NextTimeout)] = NextTimeout,
+                [nameof(RetryOn)] = RetryOn,
+                [nameof(DestinationDbId)] = DestinationDbId,
+                [nameof(LastHeartbeatTicks)] = LastHeartbeatTicks
+            };
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 
         protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationIncomingLastActivityTimePreview> command, OperationCancelToken token)
         {
             var shardNumber = GetShardNumber();
             return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingActivityTimes.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingActivityTimes.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
+{
+    internal class ShardedReplicationHandlerProcessorForGetIncomingActivityTimes : AbstractReplicationHandlerProcessorForGetIncomingActivityTimes<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedReplicationHandlerProcessorForGetIncomingActivityTimes([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+
+        protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 
         protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationIncomingRejectionInfoPreview> command, OperationCancelToken token)
         {
             var shardNumber = GetShardNumber();
             return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
+{
+    internal class ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo : AbstractReplicationHandlerProcessorForGetIncomingRejectionInfo<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+
+        protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
+{
+    internal class ShardedReplicationHandlerProcessorForGetOutgoingFailureStats : AbstractReplicationHandlerProcessorForGetOutgoingFailureStats<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedReplicationHandlerProcessorForGetOutgoingFailureStats([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+
+        protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingFailureStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingFailureStats.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 
         protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationOutgoingsFailurePreview> command, OperationCancelToken token)
         {
             var shardNumber = GetShardNumber();
             return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 
         protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
 
-        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<ReplicationOutgoingReconnectionQueuePreview> command, OperationCancelToken token)
         {
             var shardNumber = GetShardNumber();
             return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
+{
+    internal class ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue : AbstractReplicationHandlerProcessorForGetOutgoingReconnectionQueue<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+
+        protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
@@ -51,11 +51,6 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
             {
                 var final = new GetTombstonesPreviewResult();
 
-                foreach (var result in results.Span)
-                {
-                    result.Tombstones.Sort(TombstonesPreviewComparer.Instance);
-                }
-
                 final.Tombstones = _handler.DatabaseContext.Streaming.PagedShardedItem(
                     results,
                     selector: r => r.Tombstones,

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
@@ -51,6 +51,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
             {
                 var final = new GetTombstonesPreviewResult();
 
+                foreach (var result in results.Span)
+                {
+                    result.Tombstones.Sort(TombstonesPreviewComparer.Instance);
+                }
+
                 final.Tombstones = _handler.DatabaseContext.Streaming.PagedShardedItem(
                     results,
                     selector: r => r.Tombstones,

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
@@ -54,4 +54,11 @@ public class ShardedReplicationHandler : ShardedDatabaseRequestHandler
         using (var processor = new ShardedReplicationHandlerProcessorForGetPulsesLive(this))
             await processor.ExecuteAsync();
     }
+
+    [RavenShardedAction("/databases/*/replication/debug/outgoing-failures", "GET")]
+    public async Task GetReplicationOutgoingFailureStats()
+    {
+        using (var processor = new ShardedReplicationHandlerProcessorForGetOutgoingFailureStats(this))
+            await processor.ExecuteAsync();
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
@@ -75,4 +75,11 @@ public class ShardedReplicationHandler : ShardedDatabaseRequestHandler
         using (var processor = new ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo(this))
             await processor.ExecuteAsync();
     }
+
+    [RavenShardedAction("/databases/*/replication/debug/outgoing-reconnect-queue", "GET")]
+    public async Task GetReplicationReconnectionQueue()
+    {
+        using (var processor = new ShardedReplicationHandlerProcessorForGetOutgoingReconnectionQueue(this))
+            await processor.ExecuteAsync();
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
@@ -68,4 +68,11 @@ public class ShardedReplicationHandler : ShardedDatabaseRequestHandler
         using (var processor = new ShardedReplicationHandlerProcessorForGetIncomingActivityTimes(this))
             await processor.ExecuteAsync();
     }
+
+    [RavenShardedAction("/databases/*/replication/debug/incoming-rejection-info", "GET")]
+    public async Task GetReplicationIncomingRejectionInfo()
+    {
+        using (var processor = new ShardedReplicationHandlerProcessorForGetIncomingRejectionInfo(this))
+            await processor.ExecuteAsync();
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedReplicationHandler.cs
@@ -61,4 +61,11 @@ public class ShardedReplicationHandler : ShardedDatabaseRequestHandler
         using (var processor = new ShardedReplicationHandlerProcessorForGetOutgoingFailureStats(this))
             await processor.ExecuteAsync();
     }
+
+    [RavenShardedAction("/databases/*/replication/debug/incoming-last-activity-time", "GET")]
+    public async Task GetReplicationIncomingActivityTimes()
+    {
+        using (var processor = new ShardedReplicationHandlerProcessorForGetIncomingActivityTimes(this))
+            await processor.ExecuteAsync();
+    }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -36,6 +36,7 @@ using Raven.Server.Documents.ETL.Providers.Raven.Test;
 using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Handlers.Debugging;
+using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup.Restore;
@@ -58,7 +59,6 @@ using Raven.Server.Utils;
 using Raven.Server.Web.Studio;
 using Raven.Server.Web.System;
 using Sparrow.Json;
-using static Raven.Server.Documents.Handlers.Processors.Replication.ReplicationActiveConnectionsPreview;
 using FacetSetup = Raven.Client.Documents.Queries.Facets.FacetSetup;
 
 namespace Raven.Server.Json
@@ -83,9 +83,17 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, ReplicationInitialRequest> ReplicationInitialRequest = GenerateJsonDeserializationRoutine<ReplicationInitialRequest>();
 
-        public static readonly Func<BlittableJsonReaderObject, IncomingConnectionInfo> ReplicationIncomingConnectionInfo = GenerateJsonDeserializationRoutine<IncomingConnectionInfo>();
+        public static readonly Func<BlittableJsonReaderObject, ReplicationActiveConnectionsPreview> ReplicationActiveConnectionsPreview = GenerateJsonDeserializationRoutine<ReplicationActiveConnectionsPreview>();
 
-        public static readonly Func<BlittableJsonReaderObject, OutgoingConnectionInfo> ReplicationOutgoingConnectionInfo = GenerateJsonDeserializationRoutine<OutgoingConnectionInfo>();
+        public static readonly Func<BlittableJsonReaderObject, ReplicationOutgoingReconnectionQueuePreview> ReplicationOutgoingReconnectionQueuePreview = GenerateJsonDeserializationRoutine<ReplicationOutgoingReconnectionQueuePreview>();
+
+        public static readonly Func<BlittableJsonReaderObject, ReplicationOutgoingsFailurePreview> ReplicationOutgoingsFailurePreview = GenerateJsonDeserializationRoutine<ReplicationOutgoingsFailurePreview>();
+
+        public static readonly Func<BlittableJsonReaderObject, ReplicationIncomingLastActivityTimePreview> ReplicationIncomingLastActivityTimePreview = GenerateJsonDeserializationRoutine<ReplicationIncomingLastActivityTimePreview>();
+
+        public static readonly Func<BlittableJsonReaderObject, ReplicationIncomingRejectionInfoPreview> ReplicationIncomingRejectionInfoPreview = GenerateJsonDeserializationRoutine<ReplicationIncomingRejectionInfoPreview>();
+
+        public static readonly Func<BlittableJsonReaderObject, IncomingConnectionInfo> ReplicationIncomingConnectionInfo = GenerateJsonDeserializationRoutine<IncomingConnectionInfo>();
 
         public static readonly Func<BlittableJsonReaderObject, SubscriptionConnectionClientMessage> SubscriptionConnectionClientMessage = GenerateJsonDeserializationRoutine<SubscriptionConnectionClientMessage>();
 

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Utils;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18879/Sharding-Replication-Handlers

### Additional description

Implemented EPs:

1. GET /databases/*/replication/debug/outgoing-failures
2. GET /databases/*/replication/debug/incoming-last-activity-time
3. GET /databases/*/replication/debug/incoming-rejection-info
4. GET /databases/*/replication/debug/outgoing-reconnect-queue

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
