### PR TITLE
RavenDB-19258 Making sure that an error in reading index error count won't mark a whole database as errored

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2458,7 +2458,17 @@ namespace Raven.Server.Documents.Indexes
                 if (Type == IndexType.Faulty)
                     return 1;
 
-                return _indexStorage.ReadErrorsCount();
+                try
+                {
+                    return _indexStorage.ReadErrorsCount();
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations("Failed to get index error count", e);
+
+                    return 1;
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19258

### Additional description

`GetErrorCount()` is called in multiple places. It's used in endpoints returning statistics - endpoints for the studio, SNMP, websockets for server and cluster dashboards. In particular it's called by `DatabasesHandler.WriteDatabaseInfo()` which on error marks the database as errored on UI which was not true - the database was accessible just the index was in a bad state.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
