### PR TITLE
RavenDB-19344: handle timeout, network exceptions when they are wrapped by RavenException

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -849,7 +850,14 @@ namespace Raven.Client.Documents.Subscriptions
                 case AuthorizationException _:
                 case AllTopologyNodesDownException _:
                 case SubscriberErrorException _:
-                case RavenException _:
+                    _processingCts.Cancel();
+                    return false;
+                case RavenException re:
+                    if (re.InnerException is HttpRequestException or TimeoutException)
+                    {
+                        goto default;
+                    }
+
                     _processingCts.Cancel();
                     return false;
 

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1322,6 +1322,51 @@ namespace SlowTests.Client.Subscriptions
             }, true, timeout: 60000, interval: 1000), $"WaitForValue=>LastRecentlyUsed");
         }
 
+        [Fact]
+        public async Task ShouldContinueSubscriptionOnClientException()
+        {
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options { Server = server });
+
+            var subscriptionDocuments = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+
+            Assert.Equal(0, subscriptionDocuments.Count);
+
+            await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
+
+            subscriptionDocuments = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+
+            Assert.Equal(1, subscriptionDocuments.Count);
+            Assert.Equal("from 'Users' as doc", subscriptionDocuments[0].Query);
+
+            using var subscription = store.Subscriptions.GetSubscriptionWorker(
+                new SubscriptionWorkerOptions(subscriptionDocuments[0].SubscriptionName) { TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1) });
+
+            server.Dispose();
+            var unexpected = new AsyncManualResetEvent();
+            var retry = new AsyncManualResetEvent();
+            Exception onUnexpectedSubscriptionError = null;
+            Exception onSubscriptionConnectionRetry = null;
+            subscription.OnUnexpectedSubscriptionError += exception =>
+            {
+                onUnexpectedSubscriptionError = exception;
+                unexpected.Set();
+            };
+            subscription.OnSubscriptionConnectionRetry += exception =>
+            {
+                onSubscriptionConnectionRetry = exception;
+                retry.Set();
+            };
+            var t =  subscription.Run(x => { });
+            Assert.True(await unexpected.WaitAsync(_reasonableWaitTime));
+            Assert.True(await retry.WaitAsync(_reasonableWaitTime));
+            Assert.False(t.IsFaulted);
+            Assert.Equal(onSubscriptionConnectionRetry.GetType().FullName, onUnexpectedSubscriptionError.GetType().FullName);
+            Assert.NotNull(onSubscriptionConnectionRetry.InnerException);
+            Assert.NotNull(onUnexpectedSubscriptionError.InnerException);
+            Assert.Equal(onSubscriptionConnectionRetry.InnerException.GetType().FullName, onUnexpectedSubscriptionError.InnerException.GetType().FullName);
+        }
+
         private class IdleDatabaseStatistics
         {
             public string MaxIdleTime { get; set; }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19344

### Additional description

In some cases `RequestExecutor` wraps client side exceptions inside `RavenException`, which makes the subscription worker stop processing.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Ensured. 
client side exceptions are still being wrapped by RavenException.

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
