### PR TITLE
RavenDB-19218 Taking into account that we sometimes we mix regular en…

### DIFF
--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1261,10 +1261,20 @@ namespace Voron.Data.BTrees
 
                             using (p.GetNodeKey(_llt, i, out Slice fixedSizeTreeName))
                             {
-                                var fixedSizeTree = new FixedSizeTree(_llt, this, fixedSizeTreeName, valueSize);
+                                FixedSizeTree fixedSizeTree;
 
-                                var pages = fixedSizeTree.AllPages();
-                                results.AddRange(pages);
+                                try
+                                {
+                                    fixedSizeTree = new FixedSizeTree(_llt, this, fixedSizeTreeName, valueSize);
+
+                                    var pages = fixedSizeTree.AllPages();
+                                    results.AddRange(pages);
+                                }
+                                catch (InvalidFixedSizeTree)
+                                {
+                                    // ignored - we sometimes have trees with mixed types of values - regular values reside next to fixed size tree headers
+                                    continue;
+                                }
 
                                 if ((State.Flags & TreeFlags.Streams) == TreeFlags.Streams)
                                 {


### PR DESCRIPTION
…tries with headers of fixed size trees in b-trees. That is the case for map-reduce related threes. We have there entries like `__raven/map-reduce/#next-map-result-id` or `__raven/map-reduce/#nested-section-...`

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19218

### Additional description

Ignoring the failures of opening an entry of B+Tree as FixedSizeTree while it's just a regular record so we won't fail to get storage report.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
