### PR TITLE
RavenDB-19163: Dispose CertificateHolder.Certificate on RavenServer dispose

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -23,7 +23,6 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
-using Org.BouncyCastle.Pkcs;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.Replication;
@@ -36,7 +35,6 @@ using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
-using Raven.Server.Commercial.LetsEncrypt;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
@@ -2646,6 +2644,7 @@ namespace Raven.Server
                 }
 
                 ea.Execute(() => ServerStore?.Dispose());
+                ea.Execute(() => Certificate?.Dispose());
                 ea.Execute(() =>
                 {
                     try

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1015,6 +1015,7 @@ namespace Raven.Server
                     if (Interlocked.CompareExchange(ref Certificate, newCertificate, currentCertificate) == currentCertificate)
                         _httpsConnectionMiddleware.SetCertificate(newCertificate.Certificate);
                     ServerCertificateChanged?.Invoke(this, EventArgs.Empty);
+                    //todo: dispose old certificate
                     return;
                 }
 
@@ -1721,7 +1722,7 @@ namespace Raven.Server
         public string WebUrl { get; private set; }
 
         internal CertificateUtils.CertificateHolder Certificate;
-        
+
         public class TcpListenerStatus
         {
             public readonly List<TcpListener> Listeners = new List<TcpListener>();
@@ -2286,6 +2287,7 @@ namespace Raven.Server
             {
                 _httpsConnectionMiddleware.SetCertificate(certificate);
                 ServerCertificateChanged?.Invoke(this, EventArgs.Empty);
+                //todo: dispose old certificate
             }
         }
 
@@ -2644,7 +2646,6 @@ namespace Raven.Server
                 }
 
                 ea.Execute(() => ServerStore?.Dispose());
-                ea.Execute(() => Certificate?.Dispose());
                 ea.Execute(() =>
                 {
                     try
@@ -2662,6 +2663,7 @@ namespace Raven.Server
                 ea.Execute(() => _clusterMaintenanceWorker?.Dispose());
                 ea.Execute(() => _cpuCreditsMonitoring?.Join(int.MaxValue));
                 ea.Execute(() => CpuUsageCalculator.Dispose());
+                ea.Execute(() => Certificate?.Dispose());
 
                 // this should be last
                 ea.Execute(() => AfterDisposal?.Invoke());

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1015,7 +1015,6 @@ namespace Raven.Server
                     if (Interlocked.CompareExchange(ref Certificate, newCertificate, currentCertificate) == currentCertificate)
                         _httpsConnectionMiddleware.SetCertificate(newCertificate.Certificate);
                     ServerCertificateChanged?.Invoke(this, EventArgs.Empty);
-                    //todo: dispose old certificate
                     return;
                 }
 
@@ -2287,7 +2286,6 @@ namespace Raven.Server
             {
                 _httpsConnectionMiddleware.SetCertificate(certificate);
                 ServerCertificateChanged?.Invoke(this, EventArgs.Empty);
-                //todo: dispose old certificate
             }
         }
 
@@ -2622,6 +2620,8 @@ namespace Raven.Server
 
         internal NamedPipeServerStream LogStreamPipe { get; set; }
 
+        internal static bool SkipCertificateDispose = false;
+
         public void Dispose()
         {
             if (Disposed)
@@ -2663,7 +2663,9 @@ namespace Raven.Server
                 ea.Execute(() => _clusterMaintenanceWorker?.Dispose());
                 ea.Execute(() => _cpuCreditsMonitoring?.Join(int.MaxValue));
                 ea.Execute(() => CpuUsageCalculator.Dispose());
-                ea.Execute(() => Certificate?.Dispose());
+
+                if (SkipCertificateDispose == false)
+                    ea.Execute(() => Certificate?.Dispose());
 
                 // this should be last
                 ea.Execute(() => AfterDisposal?.Invoke());

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -110,11 +110,16 @@ namespace Raven.Server.Utils
             return true;
         }
 
-        public class CertificateHolder
+        public class CertificateHolder : IDisposable
         {
             public string CertificateForClients;
             public X509Certificate2 Certificate;
             public AsymmetricKeyEntry PrivateKey;
+
+            public void Dispose()
+            {
+                Certificate?.Dispose();
+            }
         }
         public static byte[] CreateSelfSignedTestCertificate(string commonNameValue, string issuerName, StringBuilder log = null)
         {

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -254,7 +254,7 @@ namespace Tests.Infrastructure
                         features: new TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures
                         {
                             MultiTree = true
-                        }, () => tcpClient.Client.Disconnect(false));
+                        }, () => tcpClient.Client?.Disconnect(false));
 
                     rachis.AcceptNewConnection(remoteConnection, tcpClient.Client.RemoteEndPoint, hello =>
                     {

--- a/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
@@ -78,7 +78,7 @@ public partial class RavenTestBase
             return certificates;
         }
 
-        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = false, [CallerMemberName] string caller = null)
+        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = true, [CallerMemberName] string caller = null)
         {
             if (createNew)
                 return ReturnCertificatesHolder(Generate(caller, Interlocked.Increment(ref Counter)));

--- a/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
@@ -78,7 +78,7 @@ public partial class RavenTestBase
             return certificates;
         }
 
-        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = true, [CallerMemberName] string caller = null)
+        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = false, [CallerMemberName] string caller = null)
         {
             if (createNew)
                 return ReturnCertificatesHolder(Generate(caller, Interlocked.Increment(ref Counter)));

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -95,6 +95,7 @@ namespace FastTests
             IgnoreProcessorAffinityChanges(ignore: true);
             LicenseManager.AddLicenseStatusToLicenseLimitsException = true;
             RachisStateMachine.EnableDebugLongCommit = true;
+            RavenServer.SkipCertificateDispose = true;
 
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();
             Lucene.Net.Util.UnmanagedStringArray.Segment.AllocateMemory = NativeMemory.AllocateMemory;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19163/Dispose-CertificateHolderCertificate-on-RavenServer-dispose

### Additional description

`CertificateHolder.Certificate` should be disposed of on `RavenServer` disposing of.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed