### PR TITLE
RavenDB-19352 Removing unnecessary allocation in CoraxIndexWriteOperation

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -27,13 +27,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private readonly IndexWriter _indexWriter;
         private readonly CoraxDocumentConverterBase _converter;
         private readonly IndexFieldsMapping _knownFields;
-        private readonly IDisposable _bufferScope;
-        private readonly ByteString _buffer;
         private long _entriesCount = 0;
 
         public CoraxIndexWriteOperation(Index index, Transaction writeTransaction, CoraxDocumentConverterBase converter, Logger logger) : base(index, logger)
         {
-            _bufferScope = writeTransaction.Allocator.Allocate(DocumentBufferSize, out _buffer);
             _converter = converter;
             _knownFields = _converter.GetKnownFieldsForWriter();
             try
@@ -173,7 +170,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         
         public override void Dispose()
         {
-            _bufferScope?.Dispose();
             _indexWriter?.Dispose();
             if (_converter.StringsListForEnumerableScope?.Capacity > MaximumPersistedCapacityOfCoraxWriter)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19352 
https://issues.hibernatingrhinos.com/issue/RavenDB-19354
https://issues.hibernatingrhinos.com/issue/RavenDB-19356
https://issues.hibernatingrhinos.com/issue/RavenDB-19355
https://issues.hibernatingrhinos.com/issue/RavenDB-19353
### Additional description

Removing unnecessary allocation in `CoraxIndexWriteOperation`. This was not in use since the new `IndexEntryWriter`.

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
