### PR TITLE
RavenDB-18257 Handling of Not Modified status code when dealing with sharded queries.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
@@ -32,6 +32,9 @@ public partial class LuceneIndexReadOperation
                 case OrderByFieldType.Double:
                     documentWithOrderByFields.AddDoubleOrderByField(_searcher.IndexReader.GetDoubleValueFor(field.OrderByName, FieldCache_Fields.NUMERIC_UTILS_DOUBLE_PARSER, doc, _state));
                     break;
+                case OrderByFieldType.Random:
+                    // we order by random when merging results from shards
+                    break;
                 default:
                     documentWithOrderByFields.AddStringOrderByField(_searcher.IndexReader.GetStringValueFor(field.OrderByName, doc, _state));
                     break;

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Diagnostics;
+using System.Net.Http;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
@@ -14,7 +15,7 @@ public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObjec
     private readonly BlittableJsonReaderObject _query;
     private readonly string _indexName;
 
-    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName) : base(indexQuery, false, metadataOnly, indexEntriesOnly)
+    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName) : base(indexQuery, true, metadataOnly, indexEntriesOnly)
     {
         _query = query;
         _indexName = indexName;
@@ -44,6 +45,9 @@ public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObjec
             // is null only when index doesn't exist
             throw new IndexDoesNotExistException($"Index `{_indexName}` was not found");
         }
+
+        if (fromCache) 
+            response = HandleCachedResponse(context, response);
 
         Result = JsonDeserializationClient.QueryResult(response);
     }

--- a/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
+++ b/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
@@ -17,7 +17,7 @@ namespace FastTests.Server.Documents.Queries
         }
         
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task Returns_correct_results_from_cache_if_server_response_was_not_modified(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Sharding/Queries/RavenDB_18257.cs
+++ b/test/SlowTests/Sharding/Queries/RavenDB_18257.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Queries;
+
+public class RavenDB_18257 : RavenTestBase
+{
+    public RavenDB_18257(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ShouldReturnNotModified(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i % 2 == 0 ? "Arek" : "Joe" }, $"users/{i}");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenSession())
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                var query = new IndexQuery
+                {
+                    Query = "FROM Users WHERE Name = 'Arek'",
+                    WaitForNonStaleResultsTimeout = TimeSpan.FromMinutes(1)
+                };
+
+                var command = new QueryCommand((InMemoryDocumentSessionOperations)session, query);
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command, context);
+
+                var users = command.Result;
+
+                Assert.Equal(50, users.Results.Length);
+
+                var command2 = new QueryCommand((InMemoryDocumentSessionOperations)session, query);
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command2, context);
+
+                Assert.Equal(HttpStatusCode.NotModified, command2.StatusCode);
+                Assert.Equal(-1, command2.Result.DurationInMs); // taken from cache
+
+                // let's modify a single document to ensure we won't get stale results and NotModified
+                var user = session.Load<User>("users/0");
+
+                user.Name = "Foo";
+
+                session.SaveChanges();
+
+                var command3 = new QueryCommand((InMemoryDocumentSessionOperations)session, query);
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command3, context);
+
+                Assert.NotEqual(HttpStatusCode.NotModified, command3.StatusCode);
+
+                users = command3.Result;
+
+                Assert.Equal(49, users.Results.Length);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ShouldNotReturnNotModifiedIfOrderByRandomApplied(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i % 2 == 0 ? "Arek" : "Joe" }, $"users/{i}");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenSession())
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                var query = new IndexQuery
+                {
+                    Query = "FROM Users WHERE Name = 'Arek' order by random()",
+                    WaitForNonStaleResultsTimeout = TimeSpan.FromMinutes(1)
+                };
+
+                var command = new QueryCommand((InMemoryDocumentSessionOperations)session, query);
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command, context);
+
+                var users = command.Result;
+
+                Assert.Equal(50, users.Results.Length);
+
+                var command2 = new QueryCommand((InMemoryDocumentSessionOperations)session, query);
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command2, context);
+
+                Assert.NotEqual	(HttpStatusCode.NotModified, command2.StatusCode);
+
+                users = command2.Result;
+                Assert.Equal(50, users.Results.Length);
+
+            }
+        }
+    }
+}


### PR DESCRIPTION

-  An orchestrator has its own HTTP cache per shard so we can benefit from that when sending queries to shards. If all shards return NotModified then we can return NotModified to the client as well. If there was any modification then we need to get the updated results from a given shard and combine the results but we still benefit from per shard cache if others were not modified.
- Fixed handling of `order by random()` - NRE was thrown under the covers inside Lucene because we don't pass a field name then

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18257/Sharding-Queries-Return-Not-Modified


### Type of change

- Bug fix
- Regression bug fix
- New feature

### How risky is the change?

- Sharding implementation of existing feature

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
