### PR TITLE
RavenDB-18636 Ensure that index thread exists (test fix)

### DIFF
--- a/test/SlowTests/Issues/RavenDB-15890.cs
+++ b/test/SlowTests/Issues/RavenDB-15890.cs
@@ -127,6 +127,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -172,6 +177,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -379,6 +389,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal, 3000);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -396,6 +411,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Disabled, 3000);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Disabled);
                     Assert.Equal(IndexState.Disabled, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Disabled, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -413,6 +433,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal, 3000);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -446,6 +471,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal, 3000);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }
@@ -474,6 +504,11 @@ namespace SlowTests.Issues
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                         return documentDatabase.IndexStore.GetIndex(indexName).State;
                     }, IndexState.Normal);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(indexName).Status;
+                    }, IndexRunningStatus.Running);
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                     Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(indexName).Status);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18636

### Additional description

Same fix we already did in the past - https://github.com/ravendb/ravendb/pull/14594. Also backporting that fix from 5.3

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
