### PR TITLE
RavenDB-19295 fixing test

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17980.cs
+++ b/test/SlowTests/Issues/RavenDB-17980.cs
@@ -1,15 +1,16 @@
 ﻿using System.IO;
 using EmbeddedTests.TestDriver;
 using Raven.Client.Documents;
+using Raven.Server.Utils;
 using Raven.TestDriver;
 using SlowTests.Core.Utils.Entities;
 using Xunit;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_17980 : RavenTestDriver
+    public abstract class Abstract_RavenDB_17980 : RavenTestDriver
     {
-        static RavenDB_17980()
+        static Abstract_RavenDB_17980()
         {
             ConfigureServer(new TestServerOptions
             {
@@ -19,66 +20,67 @@ namespace SlowTests.Issues
 
         protected override void PreInitialize(IDocumentStore documentStore)
         {
-            var dir = documentStore.Conventions.TopologyCacheLocation + "TestDriverTopologyFiles_testDirectory\\";
+            var dir = Path.Combine(documentStore.Conventions.TopologyCacheLocation, "TopologyCache", documentStore.Database);
 
-            if (Directory.Exists(dir) == false)
-                Directory.CreateDirectory(dir);
+            IOExtensions.DeleteDirectory(dir);
+            Directory.CreateDirectory(dir);
 
             documentStore.Conventions.TopologyCacheLocation = dir;
         }
+    }
 
-        public class Test_Without_Overriding_PreInitialize : RavenDB_17980
+    public class Test_Without_Overriding_PreInitialize : Abstract_RavenDB_17980
+    {
+        [Fact]
+        public void Disable_Creating_Topology_Files_For_TestDrivers()
         {
-            [Fact]
-            public void disable_Creating_Topology_Files_For_TestDrivers()
+            using (var store = GetDocumentStore())
             {
-                using (var store = GetDocumentStore())
+                using (var session = store.OpenSession())
                 {
-                    using (var session = store.OpenSession())
-                    {
-                        session.Store(new User { Name = "Yonatan", });
-                        session.SaveChanges();
-                    }
-
-                    var numberOfDatabaseTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-database-topology").Length;
-                    Assert.True(numberOfDatabaseTopologyFiles == 0, $"number of files: {numberOfDatabaseTopologyFiles}");
-
-                    var numberOfClusterTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-cluster-topology").Length;
-                    Assert.True(numberOfClusterTopologyFiles == 0, $"number of files: {numberOfClusterTopologyFiles}");
-
-                    Directory.Delete(store.Conventions.TopologyCacheLocation, true);
+                    session.Store(new User { Name = "Yonatan", });
+                    session.SaveChanges();
                 }
+
+                var numberOfDatabaseTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-database-topology").Length;
+                Assert.True(numberOfDatabaseTopologyFiles == 0, $"number of files: {numberOfDatabaseTopologyFiles}");
+
+                var numberOfClusterTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-cluster-topology").Length;
+                Assert.True(numberOfClusterTopologyFiles == 0, $"number of files: {numberOfClusterTopologyFiles}");
+
+                IOExtensions.DeleteDirectory(store.Conventions.TopologyCacheLocation);
             }
         }
-        public class Test_With_PreInitialize_DisableTopologyCache_Equals_False : RavenDB_17980
+    }
+
+    public class Test_With_PreInitialize_DisableTopologyCache_Equals_False : Abstract_RavenDB_17980
+    {
+        protected override void PreInitialize(IDocumentStore documentStore)
         {
-            protected override void PreInitialize(IDocumentStore documentStore)
-            {
-                base.PreInitialize(documentStore);
-                documentStore.Conventions.DisableTopologyCache = false;
-            }
+            base.PreInitialize(documentStore);
+            documentStore.Conventions.DisableTopologyCache = false;
+        }
 
-            [Fact]
-            public void Creating_Topology_Files_For_TestDrivers()
+        [Fact]
+        public void Creating_Topology_Files_For_TestDrivers()
+        {
+            using (var store = GetDocumentStore())
             {
-                using (var store = GetDocumentStore())
+                Assert.False(store.Conventions.DisableTopologyCache);
+
+                using (var session = store.OpenSession())
                 {
-                    Assert.False(store.Conventions.DisableTopologyCache);
-
-                    using (var session = store.OpenSession())
+                    session.Store(new User
                     {
-                        session.Store(new User
-                        {
-                            Name = "Yonatan",
-                        });
-                        session.SaveChanges();
-                    }
-
-                    var numberOfDatabaseTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-database-topology").Length;
-                    Assert.False(numberOfDatabaseTopologyFiles == 0, $"number of files: {numberOfDatabaseTopologyFiles}");
-
-                    Directory.Delete(store.Conventions.TopologyCacheLocation, true);
+                        Name = "Yonatan",
+                    });
+                    session.SaveChanges();
                 }
+
+                var numberOfDatabaseTopologyFiles = Directory.GetFiles(store.Conventions.TopologyCacheLocation, "*.raven-database-topology").Length;
+                Assert.False(numberOfDatabaseTopologyFiles == 0, $"number of files: {numberOfDatabaseTopologyFiles}");
+
+                IOExtensions.DeleteDirectory(store.Conventions.TopologyCacheLocation);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19295

### Additional description

1. Using unique directories for topology cache per test
2. Make sure that those directories are empty
3. Use Path.Combine for path concatenation
4. Do not nest tests because it causes Jenkins issues

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
