### PR TITLE
RavenDB-19360 observer is set in the background task, so we need to wait for it before setting the value to avoid NRE

### DIFF
--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -574,8 +574,9 @@ namespace FastTests.Client.Subscriptions
             var store = GetDocumentStore();
             try
             {
-                Server.ServerStore.Observer.Suspended = true;
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                Cluster.SuspendObserver(Server);
+
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 subscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     Strategy = SubscriptionOpeningStrategy.OpenIfFree,
@@ -597,12 +598,9 @@ namespace FastTests.Client.Subscriptions
                 });
                 var subscriptionTask = throwingSubscriptionWorker.Run(x => { });
 
-                Assert.True(await Assert.ThrowsAsync<SubscriptionInUseException>(() =>
-                {
-                    return subscriptionTask;
-                }).WaitWithoutExceptionAsync(_reasonableWaitTime));
+                Assert.True(await Assert.ThrowsAsync<SubscriptionInUseException>(() => subscriptionTask).WaitWithoutExceptionAsync(_reasonableWaitTime));
 
-                store.Subscriptions.DropConnection(id);
+                await store.Subscriptions.DropConnectionAsync(id);
 
                 notThrowingSubscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
@@ -725,8 +723,9 @@ namespace FastTests.Client.Subscriptions
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                Server.ServerStore.Observer.Suspended = true;
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                Cluster.SuspendObserver(Server);
+
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
@@ -746,7 +745,7 @@ namespace FastTests.Client.Subscriptions
 
                     Assert.True(docs.TryTake(out _, _reasonableWaitTime));
                     Assert.True(docs.TryTake(out _, _reasonableWaitTime));
-                    store.Subscriptions.DropConnection(id);
+                    await store.Subscriptions.DropConnectionAsync(id);
 
                     try
                     {

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -1180,7 +1180,9 @@ namespace RachisTests.DatabaseCluster
                     }
 
                     await Task.Delay(3000); // wait for cleanup
-                    cluster.Leader.ServerStore.Observer.Suspended = true;
+
+                    Cluster.SuspendObserver(cluster.Leader);
+
                     await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
 
                     using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8831.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8831.cs
@@ -27,7 +27,8 @@ namespace SlowTests.Client.Subscriptions
             DoNotReuseServer();
             using (var documentStore = GetDocumentStore())
             {
-                Server.ServerStore.Observer.Suspended = true;
+                Cluster.SuspendObserver(Server);
+
                 var originalDoc = new Doc
                 {
                     Id = "doc/1",
@@ -79,7 +80,8 @@ namespace SlowTests.Client.Subscriptions
             DoNotReuseServer();
             using (var documentStore = GetDocumentStore())
             {
-                Server.ServerStore.Observer.Suspended = true;
+                Cluster.SuspendObserver(Server);
+
                 var originalDoc = new Doc
                 {
                     Id = "doc/1",

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
@@ -63,7 +63,8 @@ namespace SlowTests.Client.Subscriptions
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                Server.ServerStore.Observer.Suspended = true;
+                Cluster.SuspendObserver(Server);
+
                 var id = store.Subscriptions.Create<User>();
 
                 const int numberOfClients = 2;

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -340,7 +340,8 @@ namespace SlowTests.Client.Subscriptions
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                Server.ServerStore.Observer.Suspended = true;
+                Cluster.SuspendObserver(Server);
+
                 var lastId = string.Empty;
                 var docsAmount = 50;
                 using (var biPeople = store.BulkInsert())

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -366,7 +366,7 @@ namespace SlowTests.Cluster
             var members = new List<string> {"A", "B", "C"};
             members.Remove(removedTag);
 
-            leader.ServerStore.Observer.Suspended = true;
+            Cluster.SuspendObserver(leader);
 
             using (var store = GetDocumentStore(new Options {Server = leader, ModifyDatabaseRecord = r => r.Topology = new DatabaseTopology {Members = members}}))
             {

--- a/test/SlowTests/Issues/RavenDB-18554.cs
+++ b/test/SlowTests/Issues/RavenDB-18554.cs
@@ -222,7 +222,7 @@ namespace SlowTests.Issues
         public async Task QueriesShouldFailoverIfIndexIsCompactingCluster()
         {
             var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true); // Prevent updating the db topology after getting it.
-            leader.ServerStore.Observer.Suspended = true;
+            Cluster.SuspendObserver(leader);
             Assert.Equal(nodes.Count, 2);
             var storeOptions = new Options
             {

--- a/test/SlowTests/Server/Replication/ReplicationWriteAssurance.cs
+++ b/test/SlowTests/Server/Replication/ReplicationWriteAssurance.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Replication
         public async Task ServerSideWriteAssurance()
         {
             var (_, leader) = await CreateRaftCluster(3);
-            leader.ServerStore.Observer.Suspended = true;
+            Cluster.SuspendObserver(leader);
             using (var store = GetDocumentStore(new Options
             {
                 Server = leader,

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -200,5 +200,13 @@ public partial class RavenTestBase
             }
             return string.Join(Environment.NewLine, states.OrderBy(x => x.transition.When).Select(x => $"State for {x.tag}-term{x.Item2.CurrentTerm}:{Environment.NewLine}{x.Item2.From}=>{x.Item2.To} at {x.Item2.When:o} {Environment.NewLine}because {x.Item2.Reason}"));
         }
+
+        public void SuspendObserver(RavenServer server)
+        {
+            // observer is set in the background task, hence we are waiting for it to not be null
+            WaitForValue(() => server.ServerStore.Observer != null, true);
+
+            server.ServerStore.Observer.Suspended = true;
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19360

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
