### PR TITLE
RavenDB-13930: Don't allow to create a server-wide-backup with an existing name

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/PutServerWideBackupConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutServerWideBackupConfigurationCommand.cs
@@ -45,7 +45,12 @@ namespace Raven.Server.ServerWide.Commands
             {
                 previousValue.Modifications ??= new DynamicJsonValue();
 
-                if (previousValue.TryGet(Value.Name, out object _) == false)
+                if (previousValue.TryGet(Value.Name, out BlittableJsonReaderObject previousTask))
+                {
+                    if (previousTask.TryGet(nameof(ServerWideBackupConfiguration.TaskId), out long existingTaskId) && existingTaskId != prevTaskId)
+                        throw new RachisApplyException($"Can't use task name '{Value.Name}', there is already a Server-Wide Backup task with that name");
+                }
+                else
                 {
                     if (prevTaskId != 0)
                     {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -761,7 +761,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var e = await Assert.ThrowsAsync<RavenException>(() => store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration2)));
-                var expectedError = $"Can't use task name '{backupName}', there is already a Periodic ServerWide Backup task with that name";
+                var expectedError = $"Can't use task name '{backupName}', there is already a Server-Wide Backup task with that name";
                 Assert.Contains(expectedError, e.Message);
 
                 serverWideBackups = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationsOperation());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13930/Dont-allow-to-create-a-server-wide-backup-with-an-existing-name

### Additional description

- Added protection of creation of a server-wide-backup with an existing name;
- Implemented unit test confirming this protection;
- Previously existing tests are aligned with new protection.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed