### PR TITLE
RavenDB-18257 Fixing typo

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedReadOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedReadOperation.cs
@@ -31,17 +31,17 @@ public interface IShardedReadOperation<TResult, TCombinedResult> : IShardedOpera
 
         if (ExpectedEtag == result.CombinedEtag)
         {
-            var allNodModified = true;
+            var allNotModified = true;
             foreach (var cmd in span)
             {
                 if (cmd.StatusCode == HttpStatusCode.NotModified) 
                     continue;
                 
-                allNodModified = false;
+                allNotModified = false;
                 break;
             }
 
-            if (allNodModified)
+            if (allNotModified)
             {
                 result.StatusCode = (int)HttpStatusCode.NotModified;
                 return result;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18257/Sharding-Queries-Return-Not-Modified

### Additional description

It fixes PR comment: https://github.com/ravendb/ravendb/pull/14931#discussion_r971776631

### Type of change

- Typo

### How risky is the change?

- Low 
