### PR TITLE
RavenDB-17347 - Database group node state doesn't take into account replication of compare exchanges

### DIFF
--- a/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/GetCompareExchangeValueOperation.cs
@@ -14,9 +14,17 @@ namespace Raven.Client.Documents.Operations.CompareExchange
 
         private readonly bool _materializeMetadata;
 
+        private readonly string _nodeTag;
+
         public GetCompareExchangeValueOperation(string key)
             : this(key, materializeMetadata: true)
         {
+        }
+
+        internal GetCompareExchangeValueOperation(string key, string nodeTag)
+            : this(key, materializeMetadata: true)
+        {
+            _nodeTag = nodeTag;
         }
 
         internal GetCompareExchangeValueOperation(string key, bool materializeMetadata)
@@ -29,7 +37,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
 
         public RavenCommand<CompareExchangeValue<T>> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new GetCompareExchangeValueCommand(_key, _materializeMetadata, conventions);
+            return new GetCompareExchangeValueCommand(_key, _materializeMetadata, conventions, _nodeTag);
         }
 
         private class GetCompareExchangeValueCommand : RavenCommand<CompareExchangeValue<T>>
@@ -37,6 +45,12 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             private readonly string _key;
             private readonly bool _materializeMetadata;
             private readonly DocumentConventions _conventions;
+
+            internal GetCompareExchangeValueCommand(string key, bool materializeMetadata, DocumentConventions conventions, string selectedNodeTag)
+                : this(key, materializeMetadata, conventions)
+            {
+                SelectedNodeTag = selectedNodeTag;
+            }
 
             public GetCompareExchangeValueCommand(string key, bool materializeMetadata, DocumentConventions conventions)
             {

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -22,7 +22,8 @@ namespace Raven.Client.ServerWide
         Ok,
         OutOfCpuCredits,
         EarlyOutOfMemory,
-        HighDirtyMemory
+        HighDirtyMemory,
+        RaftIndexNotUpToDate
     }
 
     public interface IDatabaseTask

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Rachis
 
             if (ForTestingPurposes!=null && ForTestingPurposes.NodeTagsToDisconnect.Contains(tag))
             {
-                throw new InvalidOperationException("");
+                throw new InvalidOperationException($"Exception was thrown for disconnecting  node {tag} - For testing purposes.");
             }
 
             return StateMachine.ConnectToPeer(url, tag, certificate, _serverStore.ServerShutdown);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -108,6 +108,11 @@ namespace Raven.Server.Rachis
             if (_serverStore.Initialized == false)
                 throw new InvalidOperationException("Server store isn't initialized.");
 
+            if (ForTestingPurposes!=null && ForTestingPurposes.NodeTagsToDisconnect.Contains(tag))
+            {
+                throw new InvalidOperationException("");
+            }
+
             return StateMachine.ConnectToPeer(url, tag, certificate, _serverStore.ServerShutdown);
         }
 
@@ -754,6 +759,8 @@ namespace Raven.Server.Rachis
             internal LeaderLockDebug LeaderLock;
 
             internal ManualResetEventSlim Mre = new ManualResetEventSlim(false);
+
+            internal List<string> NodeTagsToDisconnect { get; set; } = new List<string>();
 
             public void OnLeaderElect()
             {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -228,6 +228,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 var dbInstance = dbTask.Result;
                 var currentHash = dbInstance.GetEnvironmentsHash();
                 report.EnvironmentsHash = currentHash;
+                report.LastExecutedRaftIndex = dbInstance.LastDatabaseRecordChangeIndex;
 
                 var documentsStorage = dbInstance.DocumentsStorage;
                 var indexStorage = dbInstance.IndexStore;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -228,7 +228,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 var dbInstance = dbTask.Result;
                 var currentHash = dbInstance.GetEnvironmentsHash();
                 report.EnvironmentsHash = currentHash;
-                report.LastExecutedRaftIndex = dbInstance.LastDatabaseRecordChangeIndex;
+                report.LastCompareExchangeIndex = _server.Cluster.GetLastCompareExchangeIndexForDatabase(ctx, dbName);
 
                 var documentsStorage = dbInstance.DocumentsStorage;
                 var indexStorage = dbInstance.IndexStore;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -61,6 +61,8 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
         public Dictionary<string, long> LastSentEtag = new Dictionary<string, long>();
 
+        public long LastExecutedRaftIndex { get; set; }
+
         public class ObservedIndexStatus
         {
             public bool IsSideBySide;
@@ -101,7 +103,8 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastCompletedClusterTransaction)] = LastCompletedClusterTransaction,
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
                 [nameof(Error)] = Error,
-                [nameof(UpTime)] = UpTime
+                [nameof(UpTime)] = UpTime,
+                [nameof(LastExecutedRaftIndex)] = LastExecutedRaftIndex
             };
             var indexStats = new DynamicJsonValue();
             foreach (var stat in LastIndexStats)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
         public Dictionary<string, long> LastSentEtag = new Dictionary<string, long>();
 
-        public long LastExecutedRaftIndex { get; set; }
+        public long LastCompareExchangeIndex { get; set; }
 
         public class ObservedIndexStatus
         {
@@ -104,7 +104,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime,
-                [nameof(LastExecutedRaftIndex)] = LastExecutedRaftIndex
+                [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex
             };
             var indexStats = new DynamicJsonValue();
             foreach (var stat in LastIndexStats)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1376,30 +1376,49 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
-            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
-            {
-                var leaderLastCompareExchangeIndex = _server.Cluster.GetLastCompareExchangeIndexForDatabase(context, dbName);
-                var promotableLastCompareExchangeIndex = promotableDbStats.LastCompareExchangeIndex;
+            
+            var promotableLastCompareExchangeIndex = promotableDbStats.LastCompareExchangeIndex;
 
-                if (leaderLastCompareExchangeIndex > promotableLastCompareExchangeIndex)
+            long leaderLastCompareExchangeIndex = -1;
+            var leaderNodeTag = _server.NodeTag;
+            if (current.TryGetValue(leaderNodeTag, out var leaderCurrClusterStats) &&
+                leaderCurrClusterStats.Report.TryGetValue(dbName, out var leaderCurrDbStats))
+            {
+                leaderLastCompareExchangeIndex = leaderCurrDbStats.LastCompareExchangeIndex;
+            }
+            else // leader isn't in db
+            {
+                using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
                 {
-                    var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the leader hasn't sent all of the compare exchanges yet." + Environment.NewLine +
+                    leaderLastCompareExchangeIndex = _server.Cluster.GetLastCompareExchangeIndexForDatabase(context, dbName);
+                }
+            }
+
+            if (leaderLastCompareExchangeIndex == -1)
+            {
+                LogMessage($"Can't find last compare exchange raft index of leader {leaderNodeTag} for {promotable}", database: dbName);
+                return (false, null);
+            }
+
+            if (leaderLastCompareExchangeIndex > promotableLastCompareExchangeIndex)
+            {
+                var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because not all of the compare exchanges have been sent yet." + Environment.NewLine +
                               $"Last Compare Exchange Raft Index: {promotableLastCompareExchangeIndex}" + Environment.NewLine +
                               $"Leader's Compare Exchange Raft Index: {leaderLastCompareExchangeIndex}";
 
-                    LogMessage($"Node {promotable} hasn't been promoted because it's raft index isn't updated yet", database: dbName);
+                LogMessage($"Node {promotable} hasn't been promoted because it's raft index isn't updated yet", database: dbName);
 
-                    if (topology.DemotionReasons.TryGetValue(promotable, out var demotionReason) == false ||
-                        msg.Equals(demotionReason) == false)
-                    {
-                        topology.DemotionReasons[promotable] = msg;
-                        topology.PromotablesStatus[promotable] = DatabasePromotionStatus.RaftIndexNotUpToDate;
-                        return (false, msg);
-                    }
-                    return (false, null);
-                }
+                if (topology.DemotionReasons.TryGetValue(promotable, out var demotionReason) == false ||
+                    msg.Equals(demotionReason) == false)
+                {
+                    topology.DemotionReasons[promotable] = msg;
+                    topology.PromotablesStatus[promotable] = DatabasePromotionStatus.RaftIndexNotUpToDate;
+                    return (false, msg);
+                } 
+                return (false, null);
             }
+            
 
             var indexesCaughtUp = CheckIndexProgress(
                 promotablePrevDbStats.LastEtag,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1376,14 +1376,14 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
-            var mentorsLastRaftIndex = mentorPrevDbStats.LastExecutedRaftIndex;
-            var promotableRaftIndex = promotableDbStats.LastExecutedRaftIndex;
+            var mentorsLastCompareExchangeIndex = mentorCurrDbStats.LastCompareExchangeIndex;
+            var promotableLastCompareExchangeIndex = promotableDbStats.LastCompareExchangeIndex;
 
-            if (mentorsLastRaftIndex > promotableRaftIndex)
+            if (mentorsLastCompareExchangeIndex > promotableLastCompareExchangeIndex)
             {
                 var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the mentor hasn't sent all commands yet." + Environment.NewLine +
-                          $"Last Raft Index: {promotableRaftIndex}" + Environment.NewLine +
-                          $"Mentor's Raft Index: {mentorsLastRaftIndex}";
+                          $"Last Raft Index: {promotableLastCompareExchangeIndex}" + Environment.NewLine +
+                          $"Mentor's Raft Index: {mentorsLastCompareExchangeIndex}";
 
                 LogMessage($"Node {promotable} hasn't been promoted because it's raft index isn't updated yet", database: dbName);
 

--- a/test/SlowTests/Issues/RavenDB-17347.cs
+++ b/test/SlowTests/Issues/RavenDB-17347.cs
@@ -131,7 +131,7 @@ namespace SlowTests.Issues
             Assert.True(await WaitUntilDatabaseHasState(store, timeout: TimeSpan.FromSeconds(15), predicate: record =>
             {
                 var members = record?.Topology?.Members;
-                return members != null && members.Count == expectedMembers.Count && ContainsAll(members, expectedMembers);
+                return members != null && ContainsAll(members, expectedMembers);
             }), "Members are not as expected");
         }
 

--- a/test/SlowTests/Issues/RavenDB-17347.cs
+++ b/test/SlowTests/Issues/RavenDB-17347.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Esprima.Ast;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17347 : ClusterTestBase
+    {
+        public RavenDB_17347(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Database_Group_Node_State_Doesnt_Take_Into_Account_Replication_Of_ACompareExchanges()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            (var nodes, var leader) = await CreateRaftCluster(3, shouldRunInMemory: false, watcherCluster: true);
+
+            leader.ServerStore.Engine.ForTestingPurposes = new RachisConsensus.TestingStuff()
+            {
+                Mre = null
+            };
+
+            using var store = GetDocumentStore(new Options { RunInMemory = false, Server = leader, ReplicationFactor = 2 });
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var topologyNodeTag = record.Topology.AllNodes.ToList();
+
+            var node2inDb = nodes.First(n => n.ServerStore.IsLeader() == false && topologyNodeTag.Contains(n.ServerStore.NodeTag) );
+            var node1inDb = nodes.First(n => topologyNodeTag.Contains(n.ServerStore.NodeTag) && n.ServerStore.NodeTag!= node2inDb.ServerStore.NodeTag);
+
+            DisconnectNode(new List<RavenServer>(){ leader }, node2inDb.ServerStore.NodeTag);
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(node2inDb); // for not saving on this node
+
+            var objForCmpexch = new TestObj()
+            {
+                Id = "testObjs/0",
+                Prop = "testObjs0_prop"
+            };
+
+            var objForDocument = new TestObj()
+            {
+                Id = "testObjs/1",
+                Prop = "testObjs1_prop"
+            };
+
+
+            // wait for node2inDb to be rehab
+            await WaitAndAssertRehabs(store, new List<string>() { node2inDb.ServerStore.NodeTag });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(objForDocument);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(objForCmpexch.Id, objForCmpexch);
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var entity = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<TestObj>(objForCmpexch.Id);
+                Assert.Equal(objForCmpexch.Prop, entity.Value.Prop);
+            }
+            
+            // restart
+            GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+            });
+
+            await WaitAndAssertRehabs(store, new List<string>() { node2inDb.ServerStore.NodeTag });
+
+            ReconnectNode(new List<RavenServer>() { leader }, node2inDb.ServerStore.NodeTag);
+
+            // wait for all to be members
+            await WaitAndAssertMembers(store, new List<string>() { node1inDb.ServerStore.NodeTag, node2inDb.ServerStore.NodeTag });
+
+            var entity1 = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<TestObj>(objForCmpexch.Id, node1inDb.ServerStore.NodeTag));
+            var entity2 = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<TestObj>(objForCmpexch.Id, node2inDb.ServerStore.NodeTag));
+
+            Assert.NotNull(entity1);
+            Assert.NotNull(entity1.Value);
+            Assert.NotNull(entity2);
+            Assert.NotNull(entity2.Value);
+            Assert.Equal(objForCmpexch.Prop, entity1.Value.Prop);
+            Assert.Equal(entity1.Value.Prop, entity2.Value.Prop);
+        }
+
+        private async Task WaitAndAssertRehabs(DocumentStore store, List<string> expectedRehabs)
+        {
+            Assert.True(await WaitUntilDatabaseHasState(store, timeout: TimeSpan.FromSeconds(15), predicate: record =>
+            {
+                var rehabs = record?.Topology?.Rehabs;
+                return rehabs != null && rehabs.Count == expectedRehabs.Count && ContainsAll(rehabs, expectedRehabs);
+            }), "Rehabs are not as expected");
+        }
+
+        private async Task WaitAndAssertMembers(DocumentStore store, List<string> expectedMembers)
+        {
+            Assert.True(await WaitUntilDatabaseHasState(store, timeout: TimeSpan.FromSeconds(15), predicate: record =>
+            {
+                var members = record?.Topology?.Members;
+                return members != null && members.Count == expectedMembers.Count && ContainsAll(members, expectedMembers);
+            }), "Members are not as expected");
+        }
+
+        private static void DisconnectNode(List<RavenServer> nodes, string nodeTag)
+        {
+            foreach (var node in nodes)
+            {
+                node.ServerStore.Engine.ForTestingPurposes.NodeTagsToDisconnect.Add(nodeTag);
+            }
+        }
+
+        private static void ReconnectNode(List<RavenServer> nodes, string nodeTag)
+        {
+            foreach (var node in nodes)
+            {
+                if (node.ServerStore.Engine.ForTestingPurposes.NodeTagsToDisconnect.Remove(nodeTag) == false)
+                {
+                    throw new InvalidOperationException($"Node '{nodeTag}' was already connected to node '{node.ServerStore.NodeTag}");
+                }
+            }
+        }
+
+        private bool ContainsAll<T>(IEnumerable<T> a, IEnumerable<T> b)
+        {
+            foreach (var v in b)
+            {
+                if (a.Contains(v) == false)
+                    return false;
+            }
+            return true;
+        }
+
+        private class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17347.cs
+++ b/test/SlowTests/Issues/RavenDB-17347.cs
@@ -128,11 +128,18 @@ namespace SlowTests.Issues
 
         private async Task WaitAndAssertMembers(DocumentStore store, List<string> expectedMembers)
         {
+            List<string> members = new List<string>();
             Assert.True(await WaitUntilDatabaseHasState(store, timeout: TimeSpan.FromSeconds(15), predicate: record =>
             {
-                var members = record?.Topology?.Members;
-                return members != null && ContainsAll(members, expectedMembers);
-            }), "Members are not as expected");
+                var actualMembers = record?.Topology?.Members;
+                members.Clear();
+                foreach (var v in actualMembers)
+                {
+                    members.Add(v);
+                }
+                
+                return actualMembers != null && ContainsAll(actualMembers, expectedMembers);
+            }), $"Members are not as expected. Expected: {String.Join(" ", expectedMembers)}, Actual: {String.Join(" ", members)}");
         }
 
         private static void DisconnectNode(List<RavenServer> nodes, string nodeTag)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17347/Database-group-node-state-doesnt-take-into-account-replication-of-compare-exchanges

### Additional description

Fixing Database group node state doesn't take into account replication of compare exchanges.
The problem is that the DB nodes which are in rehab state will be promoted even if some compare exchanges haven't been replicated to their DB instance yet.
The solution is to ensure all compare exchanges have been replicated to the rehab nodes before the leader promotes them.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
