### PR TITLE
RavenDB-19367 we cannot use the static instance of the LowMemoryNotification because it is not designed to be used concurrently (inactiveHandler is a List)

### DIFF
--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -190,7 +190,7 @@ namespace Sparrow.LowMemory
         private bool _enableHighTemporaryDirtyMemoryUse;
         private CancellationTokenRegistration _cancellationTokenRegistration;
 
-        private LowMemoryNotification()
+        internal LowMemoryNotification()
         {
             _logger = LoggingSource.Instance.GetLogger<LowMemoryNotification>("Server");
         }

--- a/test/FastTests/Issues/RavenDB_10732.cs
+++ b/test/FastTests/Issues/RavenDB_10732.cs
@@ -16,7 +16,8 @@ namespace FastTests.Issues
         {
             using (var monitor = new LowMemoryMonitor())
             {
-                LowMemoryNotification.Instance.CheckMemoryStatus(monitor);
+                var lowMemoryNotification = new LowMemoryNotification();
+                lowMemoryNotification.CheckMemoryStatus(monitor);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19367

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
