### PR TITLE
RavenDB-18788 Reducing timeout for MREs used in the test. If we fail to dispose the database from the test then let's print that to the console

### DIFF
--- a/test/RachisTests/RavenDB_18013.cs
+++ b/test/RachisTests/RavenDB_18013.cs
@@ -16,7 +16,7 @@ public class RavenDB_18013 : ClusterTestBase
     public RavenDB_18013(ITestOutputHelper output) : base(output)
     {
     }
-    private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);
+    private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(40);
     [Fact]
     public async Task ShouldHandleDatabaseDeleteWhileItsBeingDeleted()
     {
@@ -100,7 +100,15 @@ public class RavenDB_18013 : ClusterTestBase
             removeNodeFromDatabaseCommandMre.Set();
 
             // finish delete
-            await t;
+            try
+            {
+                await t;
+            }
+            catch (Exception e)
+            {
+                Output.WriteLine($"Failed to delete database from test {nameof(ShouldHandleDatabaseDeleteWhileItsBeingDeleted)}:{e}");
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18788

### Additional description

Trying to narrow down an issue.
