### PR TITLE
RavenDB-19169 - SlowTests.Issues.RavenDB_18554.QueriesShouldFailoverIfIndexIsCompactingCluster fails.

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -45,14 +45,15 @@ public partial class RavenTestBase
             await _parent.Server.ServerStore.Cluster.WaitForIndexNotification(updateIndex, TimeSpan.FromSeconds(10));
         }
 
-        public async Task CreateIndexInClusterAsync(IDocumentStore store, AbstractIndexCreationTask index)
+        public async Task CreateIndexInClusterAsync(IDocumentStore store, AbstractIndexCreationTask index, List<RavenServer> nodes = null)
         {
             var results = (await store.Maintenance.ForDatabase(store.Database)
                                         .SendAsync(new PutIndexesOperation(index.CreateIndexDefinition())))
                                         .Single(r => r.Index == index.IndexName);
 
             // wait for index creation on cluster
-            await WaitForRaftIndexToBeAppliedInClusterAsync(results.RaftCommandIndex);
+            nodes ??= _parent.Servers;
+            await WaitForRaftIndexToBeAppliedOnClusterNodesAsync(results.RaftCommandIndex, nodes);
         }
 
         public long LastRaftIndexForCommand(RavenServer server, string commandType)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19169

### Additional description

-Fix SlowTests.Issues.RavenDB_18554.QueriesShouldFailoverIfIndexIsCompactingCluster failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
