### PR TITLE
RavenDB-12023: Using the WebSocket to getting the real-time ThreadInfo

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Background;
+using Raven.Server.NotificationCenter;
+using Raven.Server.Utils;
+using Sparrow.Collections;
+
+namespace Raven.Server.Dashboard;
+
+public class ThreadsInfoNotificationSender : BackgroundWorkBase
+{
+    private readonly ConcurrentSet<ConnectedWatcher> _watchers;
+    private readonly TimeSpan _notificationsThrottle;
+    private readonly ThreadsUsage _threadsUsage;
+    private DateTime _lastSentNotification = DateTime.MinValue;
+
+    public ThreadsInfoNotificationSender(string resourceName,
+        ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
+        : base(resourceName, shutdown)
+    {
+        _watchers = watchers;
+        _notificationsThrottle = notificationsThrottle;
+        _threadsUsage = new ThreadsUsage();
+    }
+
+    protected override async Task DoWork()
+    {
+        var now = DateTime.UtcNow;
+        var timeSpan = now - _lastSentNotification;
+        if (timeSpan < _notificationsThrottle)
+        {
+            await WaitOrThrowOperationCanceled(_notificationsThrottle - timeSpan);
+        }
+
+        try
+        {
+            if (CancellationToken.IsCancellationRequested)
+                return;
+
+            if (_watchers.Count == 0)
+                return;
+
+            var threadsInfo = _threadsUsage.Calculate();
+            foreach (var watcher in _watchers)
+            {
+                // serialize to avoid race conditions
+                // please notice we call ToJson inside a loop since DynamicJsonValue is not thread-safe
+                watcher.NotificationsQueue.Enqueue(threadsInfo.ToJson());
+            }
+        }
+        finally
+        {
+            _lastSentNotification = DateTime.UtcNow;
+        }
+    }
+}

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading;
+using Raven.Server.NotificationCenter;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Dashboard;
+
+public class ThreadsInfoNotifications : NotificationsBase
+{
+    public ThreadsInfoNotifications(CancellationToken shutdown)
+    {
+        var options = new ThreadsInfoOptions();
+
+        var threadsInfoNotificationSender = new ThreadsInfoNotificationSender(nameof(ServerStore), Watchers, options.ThreadsInfoThrottle, shutdown);
+        BackgroundWorkers.Add(threadsInfoNotificationSender);
+    }
+}

--- a/src/Raven.Server/Dashboard/ThreadsInfoOptions.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoOptions.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Raven.Server.Dashboard;
+
+public class ThreadsInfoOptions
+{
+    public TimeSpan ThreadsInfoThrottle { get; set; } = TimeSpan.FromSeconds(5);
+}

--- a/src/Raven.Server/Dashboard/ThreadsInfoOptions.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoOptions.cs
@@ -4,5 +4,5 @@ namespace Raven.Server.Dashboard;
 
 public class ThreadsInfoOptions
 {
-    public TimeSpan ThreadsInfoThrottle { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan ThreadsInfoThrottle { get; set; } = TimeSpan.FromSeconds(1);
 }

--- a/src/Raven.Server/NotificationCenter/Handlers/ThreadsInfoHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ThreadsInfoHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.Dashboard;
+using Raven.Server.Routing;
+using Raven.Server.Utils;
+
+namespace Raven.Server.NotificationCenter.Handlers
+{
+    public class ThreadsInfoHandler : ServerNotificationCenterHandler
+    {
+        [RavenAction("/threads-info/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
+        public async Task GetThreadsInfo()
+        {
+            using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
+            using (var writer  = new NotificationCenterWebSocketWriter(webSocket, ServerStore.ThreadsInfoNotifications, ServerStore.ContextPool, ServerStore.ServerShutdown))
+            {
+                await writer.WriteNotifications(null);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -121,6 +121,7 @@ namespace Raven.Server.ServerWide
         public readonly DatabasesLandlord DatabasesLandlord;
         public readonly NotificationCenter.NotificationCenter NotificationCenter;
         public readonly ServerDashboardNotifications ServerDashboardNotifications;
+        public readonly ThreadsInfoNotifications ThreadsInfoNotifications;
         public readonly LicenseManager LicenseManager;
         public readonly FeedbackSender FeedbackSender;
         public readonly StorageSpaceMonitor StorageSpaceMonitor;
@@ -159,6 +160,8 @@ namespace Raven.Server.ServerWide
             NotificationCenter = new NotificationCenter.NotificationCenter(_notificationsStorage, null, ServerShutdown, configuration);
 
             ServerDashboardNotifications = new ServerDashboardNotifications(this, ServerShutdown);
+
+            ThreadsInfoNotifications = new ThreadsInfoNotifications(ServerShutdown);
 
             _operationsStorage = new OperationsStorage();
 

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -25,7 +25,22 @@ namespace Raven.Server.Utils
                 {
                     using (thread)
                     {
-                        _threadTimesInfo[thread.Id] = thread.TotalProcessorTime.Ticks;
+                        try
+                        {
+                            _threadTimesInfo[thread.Id] = thread.TotalProcessorTime.Ticks;
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // thread has exited
+                        }
+                        catch (Win32Exception e) when (e.HResult == 0x5)
+                        {
+                            // thread has exited
+                        }
+                        catch (NotSupportedException)
+                        {
+                            // nothing to do
+                        }
                     }
                 }
 

--- a/src/Raven.Studio/typescript/common/threadsInfoWebSocketClient.ts
+++ b/src/Raven.Studio/typescript/common/threadsInfoWebSocketClient.ts
@@ -1,0 +1,32 @@
+/// <reference path="../../typings/tsd.d.ts" />
+import abstractWebSocketClient = require("common/abstractWebSocketClient");
+import endpoints = require("endpoints");
+
+class threadsInfoWebSocketClient extends abstractWebSocketClient<Raven.Server.Dashboard.ThreadsInfo> {
+
+    private readonly onData: (data: Raven.Server.Dashboard.ThreadsInfo) => void;
+
+    constructor(onData: (data: Raven.Server.Dashboard.ThreadsInfo) => void) {
+        super(null);
+        this.onData = onData;
+    }
+
+    get connectionDescription() {
+        return "Threads Info";
+    }
+
+    protected webSocketUrlFactory() {
+        return endpoints.global.threadsInfo.threadsInfoWatch;
+    }
+
+    get autoReconnect() {
+        return true;
+    }
+
+    protected onMessage(e: Raven.Server.Dashboard.ThreadsInfo) {
+        this.onData(e);
+    }
+}
+
+export = threadsInfoWebSocketClient;
+

--- a/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
@@ -4,15 +4,32 @@
             <div class="flex-header flex-horizontal flex-noshrink margin-bottom">
                 <div>
                     <div class="btn-group">
-                        <button type="button" class="btn btn-primary"
-                                data-bind="click: refresh, enable: !spinners.refresh(), css: { 'btn-spinner': spinners.refresh() }">
-                            <i class="icon-refresh"></i>
-                            <span>Refresh</span>
+                        <button class="btn btn-primary" data-bind="click: pause, visible: liveClient">
+                            <i class="icon-pause"></i> <span>Pause</span>
+                        </button>
+                        <button class="btn btn-primary" data-bind="click: resume, visible: !liveClient()">
+                            <i class="icon-play"></i> <span>Resume</span>
                         </button>
                     </div>
                 </div>
                 <div>
                     <input class="form-control" placeholder="Filter (Name, Thread Id)" data-bind="textInput: filter" />
+                </div>
+                <div>
+                    <div class="text-muted info-block">
+                        <div class="text-center"><small>RavenDB CPU Usage:</small></div>
+                        <div class="text-center">
+                            <small><strong data-bind="text: serverCpuUsage().toFixed(0) + ' %'"></strong></small>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <div class="text-muted info-block">
+                        <div class="text-center"><small>Machine CPU Usage:</small></div>
+                        <div class="text-center">
+                            <small><strong data-bind="text: machineCpuUsage().toFixed(0) + ' %'"></strong></small>
+                        </div>
+                    </div>
                 </div>
                 <div>
                     <div class="text-muted info-block">
@@ -33,7 +50,13 @@
             </div>
         </div>
     </div>
-    <div class="flex-window-scroll">
+    <div class="flex-grow">
+        <div class="results-error" data-bind="visible: !isConnectedToWebSocket()">
+            <div class="help-block bg-warning text-warning">
+                <span data-bind="visible: isPause"><i class="icon-warning"></i><span>Live Update is paused</span></span>
+                <span data-bind="visible: !isPause()"><i class="btn-spinner"></i><span class="margin-left">Trying to Connect</span></span>
+            </div>
+        </div>
         <div class="scroll-stretch">
             <div class="panel-body">
                 <virtual-grid class="resizable documents-grid" params="controller: gridController, emptyTemplate: 'empty-threads-info-template'"></virtual-grid>

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -133,6 +133,7 @@ namespace TypingsGenerator
                 .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(ConcurrentQueue<>))
                 .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(IReadOnlyList<>))
                 .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(IReadOnlyCollection<>))
+                .WithTypeMapping(new TsInterface(new TsName("Array")), typeof(SortedSet<>))
                 .WithTypeMapping(new TsInterface(new TsName("dictionary<Raven.Client.Documents.Queries.Timings.QueryTimings>")),
                     typeof(IDictionary<string, QueryTimings>))
                 .WithTypeMapping(new TsInterface(new TsName("dictionary<Raven.Server.NotificationCenter.Notifications.Details.HugeDocumentInfo>")),


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-12023/Add-threads-CPU-usage

### Additional description

We want to use the WebSocket, which is already ready on the server-side, and get the real-time stats instead of manually clicking "Refresh" button on the `admin/settings/debug/advanced/threadsRuntime` page.
Added new endpoint to get WebSocket.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- Yes

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No need