### PR TITLE
RavenDB-17872 - Get and update compare exchange metadata in the session.

### DIFF
--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -99,7 +99,7 @@ namespace Raven.Client.Documents.Session
             {
                 _session.IncrementRequestCount();
 
-                var value = await _session.Operations.SendAsync(new GetCompareExchangeValueOperation<BlittableJsonReaderObject>(key, materializeMetadata: true), sessionInfo: _session._sessionInfo, token: token).ConfigureAwait(false);
+                var value = await _session.Operations.SendAsync(new GetCompareExchangeValueOperation<BlittableJsonReaderObject>(key, materializeMetadata: false), sessionInfo: _session._sessionInfo, token: token).ConfigureAwait(false);
                 if (value == null)
                 {
                     RegisterMissingCompareExchangeValue(key);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17872/Get-and-update-compare-exchange-metadata-in-the-session

### Additional description

Fix - compare-exchange metadata can't be updated in the session.
Continue this PR: https://github.com/ravendb/ravendb/pull/14774

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
