### PR TITLE
RavenDB-19317 Lowercase the term when performing TermMatch on FullTextSearch field.

### DIFF
--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -12,6 +12,7 @@ namespace Corax
     public unsafe class Analyzer : IDisposable
     {
         public static Analyzer DefaultAnalyzer = Create(default(KeywordTokenizer), default(ExactTransformer));
+        public static Analyzer DefaultLowercaseAnalyzer = Create(default(KeywordTokenizer), default(LowerCaseTransformer));
         public static readonly ArrayPool<byte> BufferPool = ArrayPool<byte>.Create();
         public static readonly ArrayPool<Token> TokensPool = ArrayPool<Token>.Create();
         public readonly int DefaultOutputSize;

--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -92,7 +92,7 @@ public unsafe partial class IndexSearcher
         return matches;
     }
 
-    public long TermAmount(string field, string term)
+    public long TermAmount(string field, string term, int fieldId)
     {
         var fields = _transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
         var terms = fields?.CompactTreeFor(field);
@@ -107,8 +107,8 @@ public unsafe partial class IndexSearcher
         if (term.Length == 0)
             return TermAmount(terms, Constants.EmptyStringSlice);
 
-        using var _ = Slice.From(Allocator, term, out Slice termAsSlice);
-        return TermAmount(terms, termAsSlice);
+        var encodedSlice = EncodeAndApplyAnalyzer(term, fieldId);
+        return TermAmount(terms, encodedSlice);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -128,7 +128,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     internal ByteStringContext<ByteStringMemoryCache>.InternalScope ApplyAnalyzer(string originalTerm, int fieldId, out Slice value)
     {
         if (_fieldMapping.TryGetByFieldId(fieldId, out var binding) == false
-            || binding.FieldIndexingMode is FieldIndexingMode.Exact or FieldIndexingMode.Search
+            || binding.FieldIndexingMode is FieldIndexingMode.Exact
             || binding.Analyzer is null)
         {
             var disposable = Slice.From(Allocator, originalTerm, ByteStringType.Immutable, out var originalTermSliced);
@@ -145,7 +145,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     internal ByteStringContext<ByteStringMemoryCache>.InternalScope ApplyAnalyzer(ReadOnlySpan<byte> originalTerm, int fieldId, out Slice value)
     {
         if (_fieldMapping.TryGetByFieldId(fieldId, out var binding) == false
-            || binding.FieldIndexingMode is FieldIndexingMode.Exact or FieldIndexingMode.Search
+            || binding.FieldIndexingMode is FieldIndexingMode.Exact
             || binding.Analyzer is null)
         {
             var disposable = Slice.From(Allocator, originalTerm, ByteStringType.Immutable, out var originalTermSliced);
@@ -160,7 +160,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     internal ByteStringContext<ByteStringMemoryCache>.InternalScope ApplyAnalyzer(Slice originalTerm, int fieldId, out Slice value)
     {
         if (_fieldMapping.TryGetByFieldId(fieldId, out var binding) == false
-            || binding.FieldIndexingMode is FieldIndexingMode.Exact or FieldIndexingMode.Search
+            || binding.FieldIndexingMode is FieldIndexingMode.Exact
             || binding.Analyzer is null)
         {
             value = originalTerm;
@@ -173,7 +173,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ByteStringContext<ByteStringMemoryCache>.InternalScope AnalyzeTerm(IndexFieldBinding binding, ReadOnlySpan<byte> originalTerm, int fieldId, out Slice value)
     {
-        var analyzer = binding.Analyzer!;
+        var analyzer = binding.FieldIndexingMode is FieldIndexingMode.Search 
+            ? Analyzer.DefaultLowercaseAnalyzer // lowercase only when search is used in non-full-text-search match 
+            : binding.Analyzer!;
         analyzer.GetOutputBuffersSize(originalTerm.Length, out int outputSize, out int tokenSize);
 
         Debug.Assert(outputSize < 1024 * 1024, "Term size is too big for analyzer.");

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
@@ -46,7 +46,7 @@ public readonly struct CoraxBooleanItem : IQueryMatch
         if (operation is UnaryMatchOperation.Equals or UnaryMatchOperation.NotEquals)
         {
             TermAsString = QueryBuilderHelper.CoraxGetValueAsString(term);
-            Count = searcher.TermAmount(name, TermAsString);
+            Count = searcher.TermAmount(name, TermAsString, fieldId);
         }
         else
         {

--- a/test/SlowTests/Issues/RavenDB-19317.cs
+++ b/test/SlowTests/Issues/RavenDB-19317.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19317 : RavenTestBase
+{
+    public RavenDB_19317(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CoraxLowercaseTheTermWhenFieldHasFullTextSearchConfiguration(RavenTestBase.Options options)
+    {
+        using var store = GetDocumentStore(options);
+        {
+            using var session = store.OpenSession();
+            session.Store(new Data() {DisplayName = "Jeff Matt"});
+            session.SaveChanges();
+        }
+        new TestIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+        {
+            using var session = store.OpenSession();
+            var firstQuery = session.Query<Data, TestIndex>().Count(i => i.DisplayName == "Jeff");
+            var secondQuery = session.Query<Data, TestIndex>().Count(i => i.DisplayName == "jeff");
+            Assert.Equal(1, firstQuery);
+            Assert.Equal(1, secondQuery);
+        }
+    }
+
+    private class Data
+    {
+        public string DisplayName { get; set; }
+    }
+
+    private class TestIndex : AbstractIndexCreationTask<Data, Data>
+    {
+        public TestIndex()
+        {
+            Map = docs => from doc in docs
+                select new {DisplayName = doc.DisplayName};
+            Index("DisplayName", FieldIndexing.Search);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19317

### Additional description

FullTextSearch analyzer can produce multiple terms from a single term. We want to get only one term. This behavior is taken from Lucene.

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
