### PR TITLE
RavenDB-19364 [Corax test] Assert on filtered buffer.

### DIFF
--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -560,10 +560,14 @@ namespace FastTests.Corax
                 // Because there is no guarantee that multiple Fill operations would return sequential non redundant document ids,
                 // we need to sort and remove duplicates before actually testing the final condition. 
                 var sortedActual = actual.ToArray();
-                Sorting.SortAndRemoveDuplicates(sortedActual.AsSpan());
-                for (int i = 0; i < count; i++)
+                var uniqueIdsCount = Sorting.SortAndRemoveDuplicates(sortedActual.AsSpan());
+                var uniqueIds = sortedActual.AsSpan().Slice(0, uniqueIdsCount);
+                
+                Assert.Equal(matchesId.Count, uniqueIdsCount);
+                
+                for (int i = 0; i < uniqueIdsCount; i++)
                 {
-                    Assert.Equal(matchesId[i], sortedActual[i]);
+                    Assert.Equal(matchesId[i], uniqueIds[i]);
                 }
 
                 Assert.Equal((setSize / 3) * 2, count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19364

### Additional description

```
Because there is no guarantee that multiple Fill operations would return sequential non-redundant document ids
, we need to sort and remove duplicates before actually testing the final condition. 
```
We removed duplicates from the buffer in the test but did assertions on unfiltered data.

### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
