### PR TITLE
RavenDB-19282 Enable the following experimental features is displayed…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/wizard/security.html
+++ b/src/Raven.Studio/wwwroot/App/views/wizard/security.html
@@ -110,7 +110,6 @@
             <label for="features">Enable the following experimental features:</label>
         </div>
         <ul class="margin-left">
-            <li>Graph API</li>
             <li>PostgreSQL Integration</li>
             <li>Corax Search Engine</li>
         </ul>


### PR DESCRIPTION
… twice

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19282

### Additional description

Removed Graph API from 6.0 features (it was deprecated) 

