### PR TITLE
RavenDB-19329 Cluster Dashboard: internal ips on cluster overview

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/ClusterOverviewNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/ClusterOverviewNotificationSender.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
             return new ClusterOverviewPayload
             {
                 NodeTag = nodeTag,
-                NodeUrl = _server.WebUrl,
+                NodeUrl = _server.ServerStore.GetNodeHttpServerUrl(),
                 NodeType = nodeType,
                 NodeState = _server.ServerStore.CurrentRachisState,
                 StartTime = testStartTime,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19329

### Additional description

Show external url on cluster dashboard

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No
