### PR TITLE
RavenDB-16926 - Fix SlowTests.Issues.RavenDB_15900.RemoveEntryFromRaftLogTest

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -218,17 +218,17 @@ namespace Raven.Server.ServerWide
         }
     }
 
-    public class UnknownClusterCommand : Exception
+    public class UnknownClusterCommandException : Exception
     {
-        public UnknownClusterCommand()
+        public UnknownClusterCommandException()
         {
         }
 
-        public UnknownClusterCommand(string message) : base(message)
+        public UnknownClusterCommandException(string message) : base(message)
         {
         }
 
-        public UnknownClusterCommand(string message, Exception innerException) : base(message, innerException)
+        public UnknownClusterCommandException(string message, Exception innerException) : base(message, innerException)
         {
         }
     }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -577,7 +577,7 @@ namespace Raven.Server.ServerWide
                     default:
                         var massage = $"The command '{type}' is unknown and cannot be executed on server with version '{ServerVersion.FullVersion}'.{Environment.NewLine}" +
                                       "Updating this node version to match the rest should resolve this issue.";
-                        throw new UnknownClusterCommand(massage);
+                        throw new UnknownClusterCommandException(massage);
                 }
 
                 _parent.LogHistory.UpdateHistoryLog(context, index, _parent.CurrentTerm, cmd, result, null);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16926/SlowTestsIssuesRavenDB15900RemoveEntryFromRaftLogTest

### Additional description

Fixing SlowTests.Issues.RavenDB_15900.RemoveEntryFromRaftLogTest test failure.
Tried to prevent some raise conditions that probably cause it to fail.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
