### PR TITLE
RavenDB-19223 Admin endpoint allowing to clear the pool of HttpClient instances

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -251,6 +251,12 @@ namespace Raven.Client.Http
             return Certificate?.Thumbprint ?? string.Empty;
         }
 
+        internal static void ClearHttpClientsPool()
+        {
+            GlobalHttpClientWithCompression.Clear();
+            GlobalHttpClientWithoutCompression.Clear();
+        }
+
         private static bool ShouldRemoveHttpClient(SocketException exception)
         {
             switch (exception.SocketErrorCode)

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Security;
+using Raven.Client.Http;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
@@ -22,6 +24,14 @@ namespace Raven.Server.Documents.Handlers.Debugging
 {
     public class NodeDebugHandler : RequestHandler
     {
+        [RavenAction("/admin/debug/node/clear-http-clients-pool", "GET", AuthorizationStatus.ClusterAdmin)]
+        public Task ClearHttpClientsPool()
+        {
+            RequestExecutor.ClearHttpClientsPool();
+
+            return NoContent(HttpStatusCode.OK);
+        }
+
         [RavenAction("/admin/debug/node/remote-connections", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task ListRemoteConnections()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19223/Create-an-admin-endpoint-allowing-to-reset-HttpClient-pool

### Additional description

Helper endpoint that is supposed to help in investigation of cluster connectivity issues. The suspicion is that we cannot get results from `/info/tcp` endpoint before doing the actual TCP connection due to some invalid state of HttpClient we use under the covers. 

This helper is supposed to clear the cached instances.  

### Type of change

- Investigation helper

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not applicable

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
