### PR TITLE
RavenDB-19225 Limit the number of HttpClient instances recreation during error handling. Do not recreate more often that once per 5 seconds

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -43,14 +43,16 @@ namespace Raven.Client.Http
 
         private static readonly Guid GlobalApplicationIdentifier = Guid.NewGuid();
 
+        private static readonly TimeSpan MinHttpClientLifetime = TimeSpan.FromSeconds(5);
+
         private const int InitialTopologyEtag = -2;
 
         // https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
 
         internal static readonly TimeSpan GlobalHttpClientTimeout = TimeSpan.FromHours(12);
 
-        private static readonly ConcurrentDictionary<string, Lazy<HttpClient>> GlobalHttpClientWithCompression = new ConcurrentDictionary<string, Lazy<HttpClient>>();
-        private static readonly ConcurrentDictionary<string, Lazy<HttpClient>> GlobalHttpClientWithoutCompression = new ConcurrentDictionary<string, Lazy<HttpClient>>();
+        private static readonly ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GlobalHttpClientWithCompression = new ConcurrentDictionary<string, Lazy<HttpClientCacheItem>>();
+        private static readonly ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GlobalHttpClientWithoutCompression = new ConcurrentDictionary<string, Lazy<HttpClientCacheItem>>();
 
         private static readonly GetStatisticsOperation BackwardCompatibilityFailureCheckOperation = new GetStatisticsOperation(debugTag: "failure=check");
         private static readonly DatabaseHealthCheckOperation FailureCheckOperation = new DatabaseHealthCheckOperation();
@@ -232,18 +234,31 @@ namespace Raven.Client.Http
 
             var name = GetHttpClientName();
 
-            return httpClientCache.GetOrAdd(name, new Lazy<HttpClient>(CreateClient)).Value;
+            return httpClientCache.GetOrAdd(name, new Lazy<HttpClientCacheItem>(() => new HttpClientCacheItem
+                {
+                    HttpClient = CreateClient(),
+                    CreatedAt = SystemTime.UtcNow
+                })).Value.HttpClient;
         }
 
-        internal void RemoveHttpClient()
+        internal bool TryRemoveHttpClient(bool force = false)
         {
             var httpClientCache = GetHttpClientCache();
 
             var name = GetHttpClientName();
 
-            httpClientCache.TryRemove(name, out _);
+            if (httpClientCache.TryGetValue(name, out var client) &&
+                ((client.IsValueCreated && 
+                SystemTime.UtcNow - client.Value.CreatedAt > MinHttpClientLifetime) || force))
+            {
+                httpClientCache.TryRemove(name, out _);
+                    
+                _httpClient = null;
 
-            _httpClient = null;
+                return true;
+            }
+
+            return false;
         }
 
         private string GetHttpClientName()
@@ -266,7 +281,7 @@ namespace Raven.Client.Http
             }
         }
 
-        private ConcurrentDictionary<string, Lazy<HttpClient>> GetHttpClientCache()
+        private ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GetHttpClientCache()
         {
             return Conventions.UseCompression ?
                 GlobalHttpClientWithCompression :
@@ -1001,8 +1016,8 @@ namespace Raven.Client.Http
                     {
                         if (requestContext.HttpClientRemoved == false)
                         {
-                            RemoveHttpClient();
-                            requestContext.HttpClientRemoved = true;
+                            if (TryRemoveHttpClient())
+                                requestContext.HttpClientRemoved = true;
                         }
                         else
                         {
@@ -2237,6 +2252,13 @@ namespace Raven.Client.Http
             {
                 Node = node ?? throw new ArgumentNullException(nameof(node));
             }
+        }
+
+        private class HttpClientCacheItem
+        {
+            public HttpClient HttpClient { get; set; }
+
+            public DateTime CreatedAt { get; set; }
         }
     }
 }

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -344,7 +344,7 @@ namespace SlowTests.Issues
             }.Initialize())
             {
                 var requestExecutor = store.GetRequestExecutor(databaseName);
-                requestExecutor.RemoveHttpClient(); // reset to forget the previous connection
+                requestExecutor.TryRemoveHttpClient(force: true); // reset to forget the previous connection
 
                 var ex = await Assert.ThrowsAsync<AuthorizationException>(async () => await TrySavingDocument((DocumentStore)store));
                 Assert.Contains($"Could not authorize access to {databaseName} using provided client certificate", ex.Message);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19225/Consider-to-limit-the-number-of-HttpClient-instances-recreation-during-error-handling

### Additional description

There is a suspicion that in some scenarios the client spawns too many connections which results in high number of active TCP connections we see occasionally on the server (e.g. during restart of the cluster nodes).

### Type of change

- Error handling

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Not applicable

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- No UI work is needed
