### PR TITLE
RavenDB-17721 - Fix CanPreformSeveralClusterTransactions test failure

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -278,11 +278,14 @@ namespace SlowTests.Cluster
                                 }
 
                                 if (numberOfNodes > 1)
-                                    await ActionWithLeader(l =>
+                                    await ActionWithLeader(async l =>
                                     {
+                                        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                                        var waitForLeaderChangeTask = l.ServerStore.Engine.WaitForLeaderChange(cts.Token);
                                         l.ServerStore.Engine.CurrentLeader?.StepDown();
-                                        return Task.CompletedTask;
+                                        await waitForLeaderChangeTask;
                                     });
+
                                 using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(numberOfNodes)))
                                 {
                                     await session.SaveChangesAsync(cts.Token);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -334,7 +334,8 @@ namespace Tests.Infrastructure
             {
                 try
                 {
-                    var leader = servers == null ? Servers.FirstOrDefault(s => s.ServerStore.IsLeader()) : servers.FirstOrDefault(s => s.ServerStore.IsLeader());
+                    servers ??= Servers;
+                    var leader = servers.FirstOrDefault(s => s.ServerStore.IsLeader());
                     if (leader != null)
                     {
                         await act(leader);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17721/SlowTestsClusterClusterTransactionTestsCanPreformSeveralClusterTransactionsnumberOfNodes-5

### Additional description

Fix CanPreformSeveralClusterTransactions test failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
