### PR TITLE
RavenDB-19359 Add note that * is a glob pattern

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
@@ -54,7 +54,7 @@ class replicationAccessBaseModel {
             validation: [
                 {
                     validator: () => !this.filteringPathsRequired() || this.hubToSinkPrefixes().length,
-                    message: "Please add at least one filtering prefix path."
+                    message: "Please add at least one filtering path"
                 }
             ]
         })
@@ -63,10 +63,18 @@ class replicationAccessBaseModel {
             validation: [
                 {
                     validator: () => !this.filteringPathsRequired() || this.samePrefixesForBothDirections() || this.sinkToHubPrefixes().length,
-                    message: "Please add at least one filtering prefix path, or use the Hub to Sink prefixes."
+                    message: "Please add at least one filtering path, or use the Hub to Sink paths"
                 }
             ]
         })
+    }
+    
+    private hasSingleDocumentPattern(paths: prefixPathModel[]): KnockoutComputed<boolean> {
+        return ko.pureComputed(() => paths.length && !!paths.find(x => !x.path().endsWith("*")));
+    }
+    
+    getSingleDocumentPatternWarning() {
+        return "Path patterns that do Not end with * (asterisk) will match only a single document";
     }
 
     addHubToSinkInputPrefixWithBlink() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
@@ -389,8 +389,9 @@ class editReplicationHubTask extends viewModelBase {
             {
                 content:
                     "<ul class='no-margin padding'>" +
-                        "<li><small>These prefixes define what docments are allowed to be <strong>sent from the Hub.</strong></small></li>" +
-                        "<li><small>You can <strong>further restrict this list</strong> when defining a Sink task that receives data from this Hub.</small></li>" +
+                        "<li><small>These ID paths define <strong>what docments are allowed to be sent from the Hub.</strong></small></li>" +
+                        "<li><small>You can further restrict this list when defining a Sink task that receives data from this Hub.</small></li>" +
+                        "<li><small>To send all documents under some path use <code>&lt;path&gt;/*</code> or <code>&lt;path&gt;-*</code></small></li>" +
                     "</ul>"
             });
 
@@ -398,8 +399,9 @@ class editReplicationHubTask extends viewModelBase {
             {
                 content:
                     "<ul class='no-margin padding'>" +
-                        "<li><small>These prefixes define what docments are allowed to be <strong>sent to this Hub.</strong></small></li>" +
-                        "<li><small>You can <strong>further restrict this list</strong> when defining a Sink task that sends data to this Hub.</small></li>" +
+                        "<li><small>These ID paths define <strong>what docments are allowed to be sent to this Hub.</strong></small></li>" +
+                        "<li><small>You can further restrict this list when defining a Sink task that sends data to this Hub.</small></li>" +
+                        "<li><small>To send all documents under some path use <code>&lt;path&gt;/*</code> or <code>&lt;path&gt;-*</code></small></li>" +
                     "</ul>"
             });
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationSinkTask.ts
@@ -207,8 +207,9 @@ class editReplicationSinkTask extends viewModelBase {
             {
                 content:
                     "<ul class='no-margin padding'>" +
-                        "<li><small>These prefixes define what <strong>documents the Sink allows the Hub to send</strong>.</small></li>" +
-                        "<li><small>The documents will be sent from the Hub only if these paths are also allowed on the Hub task definition.</li>" +
+                        "<li><small>These ID paths define <strong>what documents the Sink allows the Hub to send</strong>.</small></li>" +
+                        "<li><small>The documents will be sent from the Hub only if these paths are also allowed on the Hub task definition.</small></li>" +
+                        "<li><small>To send all documents under some path use <code>&lt;path&gt;/*</code> or <code>&lt;path&gt;-*</code></small></li>" +
                     "</ul>"
             });
 
@@ -216,8 +217,9 @@ class editReplicationSinkTask extends viewModelBase {
             {
                 content:
                     "<ul class='no-margin padding'>" +
-                        "<li><small>These prefixes define what documents are <strong>allowed to be sent from this Sink to the Hub</strong>.</small></li>" +
-                        "<li><small>The documents will be sent to the Hub only if these paths are also allowed on the Hub task definition.</li>" +
+                        "<li><small>These ID paths define <strong>what documents are allowed to be sent from this Sink to the Hub</strong>.</small></li>" +
+                        "<li><small>The documents will be sent to the Hub only if these paths are also allowed on the Hub task definition.</small></li>" +
+                        "<li><small>To send all documents under some path use <code>&lt;path&gt;/*</code> or <code>&lt;path&gt;-*</code></small></li>" +
                     "</ul>"
             });
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
@@ -323,7 +323,7 @@
                         <div data-bind="visible: $parent.withFiltering" class="margin-bottom margin-bottom-lg">
                             <hr>
                             <div class="margin-bottom margin-bottom-lg">
-                                <h3>Filter Replicated Documents by ID Prefixes</h3>
+                                <h3>Filter Replicated Documents by ID Paths</h3>
                             </div>
                             <div class="form-group" data-bind="validationElement: inputPrefixHubToSink().path">
                                 <label for="hubToSink" class="control-label">From Hub to Sink
@@ -332,11 +332,11 @@
                                 <div class="flex-grow" id="hubToSink" data-bind="validationElement: hubToSinkPrefixes">
                                     <div class="flex-horizontal">
                                         <div class="flex-grow">
-                                            <input type="text" class="form-control" placeholder="Enter documents prefix" data-bind="textInput: inputPrefixHubToSink().path" />
+                                            <input type="text" class="form-control" placeholder="Enter documents ID path. Use <path>/* for all child paths." data-bind="textInput: inputPrefixHubToSink().path" />
                                         </div>
                                         <button class="btn btn-info"
                                                 data-bind="click: addHubToSinkInputPrefixWithBlink, enable: inputPrefixHubToSink && inputPrefixHubToSink().path() && inputPrefixHubToSink().path.isValid()">
-                                            <i class="icon-plus"></i><span>Add Prefix</span>
+                                            <i class="icon-plus"></i><span>Add Path</span>
                                         </button>
                                     </div>
                                     <div data-bind="visible: hubToSinkPrefixes().length" class="margin-top">
@@ -348,13 +348,16 @@
                                         </ul>
                                     </div>
                                     <span class="help-block" data-bind="validationMessage: hubToSinkPrefixes"></span>
+                                    <div class="padding padding-xs text-warning bg-warning" data-bind="visible: hasSingleDocumentPattern(hubToSinkPrefixes())">
+                                        <small><i class="icon-warning"></i><span data-bind="text: getSingleDocumentPatternWarning()"></span></small>
+                                    </div>
                                 </div>
                             </div>
                             <div class="form-group margin-top margin-top-lg">
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle">
                                     <input id="useStuff" type="checkbox" data-bind="checked: samePrefixesForBothDirections" />
-                                    <label for="useStuff">Use above prefixes (<i>Hub to Sink</i>) for both directions</label>
+                                    <label for="useStuff">Use above paths (<i>Hub to Sink</i>) for both directions</label>
                                 </div>
                             </div>
                             <div class="form-group" data-bind="validationElement: inputPrefixSinkToHub().path">
@@ -364,11 +367,11 @@
                                 <div class="flex-grow" id="sinkToHub" data-bind="collapse: !samePrefixesForBothDirections(), validationElement: sinkToHubPrefixes">
                                     <div class="flex-horizontal">
                                         <div class="flex-grow">
-                                            <input type="text" class="form-control" placeholder="Enter documents prefix" data-bind="textInput: inputPrefixSinkToHub().path" />
+                                            <input type="text" class="form-control" placeholder="Enter documents ID path. Use <path>/* for all child paths." data-bind="textInput: inputPrefixSinkToHub().path" />
                                         </div>
                                         <button class="btn btn-info"
                                                 data-bind="click: addSinkToHubInputPrefixWithBlink, enable: inputPrefixSinkToHub && inputPrefixSinkToHub().path() && inputPrefixSinkToHub().path.isValid()">
-                                                <i class="icon-plus"></i><span>Add Prefix</span>
+                                                <i class="icon-plus"></i><span>Add Path</span>
                                         </button>
                                     </div>
                                     <div data-bind="visible: sinkToHubPrefixes().length" class="margin-top">
@@ -380,6 +383,9 @@
                                         </ul>
                                     </div>
                                     <span class="help-block" data-bind="validationMessage: sinkToHubPrefixes"></span>
+                                    <div class="padding padding-xs text-warning bg-warning" data-bind="visible: hasSingleDocumentPattern(sinkToHubPrefixes())">
+                                        <small><i class="icon-warning"></i><span data-bind="text: getSingleDocumentPatternWarning()"></span></small>
+                                    </div>
                                 </div>
                                 <div data-bind="visible: samePrefixesForBothDirections">
                                     <div class="form-control-static">Same as <i>Hub to Sink</i></div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
@@ -267,7 +267,7 @@
                             <div class="margin-bottom margin-bottom-lg margin-top margin-top-lg">
                                 <hr>
                                 <div class="margin-bottom margin-bottom-lg">
-                                    <h3>Filter Replicated Documents by Id Prefixes</h3>
+                                    <h3>Filter Replicated Documents by ID Paths</h3>
                                 </div>
                                 <div class="form-group" data-bind="validationElement: inputPrefixHubToSink().path">
                                     <label for="hubToSink" class="control-label">From Hub to Sink
@@ -276,11 +276,11 @@
                                     <div class="flex-grow" id="hubToSink" data-bind="validationElement: hubToSinkPrefixes">
                                         <div class="flex-horizontal">
                                             <div class="flex-grow">
-                                                <input type="text" class="form-control" placeholder="Enter documents prefix" data-bind="textInput: inputPrefixHubToSink().path" />
+                                                <input type="text" class="form-control" placeholder="Enter documents ID path. Use <path>/* for all child paths." data-bind="textInput: inputPrefixHubToSink().path" />
                                             </div>
                                             <button class="btn btn-info"
                                                     data-bind="click: addHubToSinkInputPrefixWithBlink, enable: inputPrefixHubToSink && inputPrefixHubToSink().path() && inputPrefixHubToSink().path.isValid()">
-                                                <i class="icon-plus"></i><span>Add Prefix</span>
+                                                <i class="icon-plus"></i><span>Add Path</span>
                                             </button>
                                         </div>
                                         <div data-bind="visible: hubToSinkPrefixes().length" class="margin-top">
@@ -292,13 +292,16 @@
                                             </ul>
                                         </div>
                                         <span class="help-block" data-bind="validationMessage: hubToSinkPrefixes"></span>
+                                        <div class="padding padding-xs text-warning bg-warning" data-bind="visible: hasSingleDocumentPattern(hubToSinkPrefixes())">
+                                            <small><i class="icon-warning"></i><span data-bind="text: getSingleDocumentPatternWarning()"></span></small>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="form-group margin-top margin-top-lg">
                                     <label class="control-label">&nbsp;</label>
                                     <div class="toggle">
                                         <input id="useStuff" type="checkbox" data-bind="checked: samePrefixesForBothDirections" />
-                                        <label for="useStuff">Use above prefixes (<i>Hub to Sink</i>) for both directions</label>
+                                        <label for="useStuff">Use above paths (<i>Hub to Sink</i>) for both directions</label>
                                     </div>
                                 </div>
                                 <div class="form-group margin-bottom" data-bind="validationElement: inputPrefixSinkToHub().path">
@@ -308,11 +311,11 @@
                                     <div class="flex-grow" id="sinkToHub" data-bind="collapse: !samePrefixesForBothDirections(), validationElement: sinkToHubPrefixes">
                                         <div class="flex-horizontal">
                                             <div class="flex-grow">
-                                                <input type="text" class="form-control" placeholder="Enter documents prefix" data-bind="textInput: inputPrefixSinkToHub().path" />
+                                                <input type="text" class="form-control" placeholder="Enter documents ID path. Use <path>/* for all child paths." data-bind="textInput: inputPrefixSinkToHub().path" />
                                             </div>
                                             <button class="btn btn-info"
                                                     data-bind="click: addSinkToHubInputPrefixWithBlink, enable: inputPrefixSinkToHub && inputPrefixSinkToHub().path() && inputPrefixSinkToHub().path.isValid()">
-                                                <i class="icon-plus"></i><span>Add Prefix</span>
+                                                <i class="icon-plus"></i><span>Add Path</span>
                                             </button>
                                         </div>
                                         <div data-bind="visible: sinkToHubPrefixes().length" class="margin-top">
@@ -324,6 +327,9 @@
                                             </ul>
                                         </div>
                                         <span class="help-block" data-bind="validationMessage: sinkToHubPrefixes"></span>
+                                        <div class="padding padding-xs text-warning bg-warning" data-bind="visible: hasSingleDocumentPattern(sinkToHubPrefixes())">
+                                            <small><i class="icon-warning"></i><span data-bind="text: getSingleDocumentPatternWarning()"></span></small>
+                                        </div>
                                     </div>
                                     <div data-bind="visible: samePrefixesForBothDirections">
                                         <div class="form-control-static">Same as <i>Hub to Sink</i></div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19359

### Additional description
Add info about using prefix/* to send all docs from all child paths

### Type of change
- Bug fix

### How risky is the change?
- Low 
- 
### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
