### PR TITLE
RavenDB-19399 added HttpPooledConnectionLifetime and HttpPooledConnectionIdleTimeout to DocumentConventions

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -150,6 +150,19 @@ namespace Raven.Client.Documents.Conventions
 
         static DocumentConventions()
         {
+#if NETCOREAPP3_1_OR_GREATER
+            var httpPooledConnectionLifetimeAsString = Environment.GetEnvironmentVariable("RAVEN_HTTP_POOLEDCONNECTIONLIFETIMEINSEC");
+            if (httpPooledConnectionLifetimeAsString != null)
+            {
+                if (int.TryParse(httpPooledConnectionLifetimeAsString, out var httpPooledConnectionLifetime) == false)
+                    throw new InvalidOperationException($"Could not parse 'RAVEN_HTTP_POOLEDCONNECTIONLIFETIMEINSEC' env variable with value '{httpPooledConnectionLifetimeAsString}'.");
+
+                DefaultForServer.HttpPooledConnectionLifetime = httpPooledConnectionLifetime < 0
+                    ? null
+                    : TimeSpan.FromSeconds(httpPooledConnectionLifetime);
+            }
+#endif
+
             Default.Freeze();
             DefaultForServer.Freeze();
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -24,7 +24,6 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Routing;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Extensions;
-using Raven.Client.Json.Serialization;
 using Raven.Client.Properties;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.Util;
@@ -51,8 +50,7 @@ namespace Raven.Client.Http
 
         internal static readonly TimeSpan GlobalHttpClientTimeout = TimeSpan.FromHours(12);
 
-        private static readonly ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GlobalHttpClientWithCompression = new ConcurrentDictionary<string, Lazy<HttpClientCacheItem>>();
-        private static readonly ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GlobalHttpClientWithoutCompression = new ConcurrentDictionary<string, Lazy<HttpClientCacheItem>>();
+        private static readonly ConcurrentDictionary<HttpClientCacheKey, Lazy<HttpClientCacheItem>> GlobalHttpClientCache = new ConcurrentDictionary<HttpClientCacheKey, Lazy<HttpClientCacheItem>>();
 
         private static readonly GetStatisticsOperation BackwardCompatibilityFailureCheckOperation = new GetStatisticsOperation(debugTag: "failure=check");
         private static readonly DatabaseHealthCheckOperation FailureCheckOperation = new DatabaseHealthCheckOperation();
@@ -230,29 +228,25 @@ namespace Raven.Client.Http
 
         private HttpClient GetHttpClient()
         {
-            var httpClientCache = GetHttpClientCache();
+            var cacheKey = GetHttpClientCacheKey();
 
-            var name = GetHttpClientName();
-
-            return httpClientCache.GetOrAdd(name, new Lazy<HttpClientCacheItem>(() => new HttpClientCacheItem
-                {
-                    HttpClient = CreateClient(),
-                    CreatedAt = SystemTime.UtcNow
-                })).Value.HttpClient;
+            return GlobalHttpClientCache.GetOrAdd(cacheKey, new Lazy<HttpClientCacheItem>(() => new HttpClientCacheItem
+            {
+                HttpClient = CreateClient(),
+                CreatedAt = SystemTime.UtcNow
+            })).Value.HttpClient;
         }
 
         internal bool TryRemoveHttpClient(bool force = false)
         {
-            var httpClientCache = GetHttpClientCache();
+            var cacheKey = GetHttpClientCacheKey();
 
-            var name = GetHttpClientName();
-
-            if (httpClientCache.TryGetValue(name, out var client) &&
-                ((client.IsValueCreated && 
+            if (GlobalHttpClientCache.TryGetValue(cacheKey, out var client) &&
+                ((client.IsValueCreated &&
                 SystemTime.UtcNow - client.Value.CreatedAt > MinHttpClientLifetime) || force))
             {
-                httpClientCache.TryRemove(name, out _);
-                    
+                GlobalHttpClientCache.TryRemove(cacheKey, out _);
+
                 _httpClient = null;
 
                 return true;
@@ -261,15 +255,22 @@ namespace Raven.Client.Http
             return false;
         }
 
-        private string GetHttpClientName()
+        private HttpClientCacheKey GetHttpClientCacheKey()
         {
-            return Certificate?.Thumbprint ?? string.Empty;
+#if NETCOREAPP3_1_OR_GREATER
+            var httpPooledConnectionLifetime = Conventions.HttpPooledConnectionLifetime;
+            var httpPooledConnectionIdleTimeout = Conventions.HttpPooledConnectionIdleTimeout;
+#else
+            TimeSpan? httpPooledConnectionLifetime = null;
+            TimeSpan? httpPooledConnectionIdleTimeout = null;
+#endif
+
+            return new HttpClientCacheKey(Certificate?.Thumbprint ?? string.Empty, Conventions.UseCompression, httpPooledConnectionLifetime, httpPooledConnectionIdleTimeout);
         }
 
         internal static void ClearHttpClientsPool()
         {
-            GlobalHttpClientWithCompression.Clear();
-            GlobalHttpClientWithoutCompression.Clear();
+            GlobalHttpClientCache.Clear();
         }
 
         private static bool ShouldRemoveHttpClient(SocketException exception)
@@ -285,13 +286,6 @@ namespace Raven.Client.Http
                 default:
                     return false;
             }
-        }
-
-        private ConcurrentDictionary<string, Lazy<HttpClientCacheItem>> GetHttpClientCache()
-        {
-            return Conventions.UseCompression ?
-                GlobalHttpClientWithCompression :
-                GlobalHttpClientWithoutCompression;
         }
 
         private static readonly Exception ServerCertificateCustomValidationCallbackRegistrationException;
@@ -1868,7 +1862,7 @@ namespace Raven.Client.Http
             _disposeOnceRunner.Dispose();
         }
 
-        public static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false)
+        public static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
         {
             HttpClientHandler httpMessageHandler;
 
@@ -1883,6 +1877,8 @@ namespace Raven.Client.Http
             {
                 httpMessageHandler = new HttpClientHandler();
             }
+
+            HttpClientHandlerHelper.Configure(httpMessageHandler, pooledConnectionLifetime, pooledConnectionIdleTimeout);
 
             if (httpMessageHandler.SupportsAutomaticDecompression)
             {
@@ -1921,10 +1917,21 @@ namespace Raven.Client.Http
 
         public HttpClient CreateClient()
         {
+#if NETCOREAPP3_1_OR_GREATER
+            var httpPooledConnectionLifetime = Conventions.HttpPooledConnectionLifetime;
+            var httpPooledConnectionIdleTimeout = Conventions.HttpPooledConnectionIdleTimeout;
+#else
+            TimeSpan? httpPooledConnectionLifetime = null;
+            TimeSpan? httpPooledConnectionIdleTimeout = null;
+#endif
+
             var httpMessageHandler = CreateHttpMessageHandler(Certificate,
                 setSslProtocols: true,
                 useCompression: Conventions.UseCompression,
-                hasExplicitlySetCompressionUsage: Conventions.HasExplicitlySetCompressionUsage);
+                hasExplicitlySetCompressionUsage: Conventions.HasExplicitlySetCompressionUsage,
+                httpPooledConnectionLifetime,
+                httpPooledConnectionIdleTimeout
+            );
 
             return new HttpClient(httpMessageHandler)
             {
@@ -2265,6 +2272,37 @@ namespace Raven.Client.Http
             public HttpClient HttpClient { get; set; }
 
             public DateTime CreatedAt { get; set; }
+        }
+
+        private readonly struct HttpClientCacheKey
+        {
+            private readonly string _certificateThumbprint;
+            private readonly bool _useCompression;
+            private readonly TimeSpan? _pooledConnectionLifetime;
+            private readonly TimeSpan? _pooledConnectionIdleTimeout;
+
+            public HttpClientCacheKey(string certificateThumbprint, bool useCompression, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout)
+            {
+                _certificateThumbprint = certificateThumbprint;
+                _useCompression = useCompression;
+                _pooledConnectionLifetime = pooledConnectionLifetime;
+                _pooledConnectionIdleTimeout = pooledConnectionIdleTimeout;
+            }
+
+            private bool Equals(HttpClientCacheKey other)
+            {
+                return _certificateThumbprint == other._certificateThumbprint && _useCompression == other._useCompression && Nullable.Equals(_pooledConnectionLifetime, other._pooledConnectionLifetime) && Nullable.Equals(_pooledConnectionIdleTimeout, other._pooledConnectionIdleTimeout);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is HttpClientCacheKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(_certificateThumbprint, _useCompression, _pooledConnectionLifetime, _pooledConnectionIdleTimeout);
+            }
         }
     }
 }

--- a/src/Raven.Client/Util/HttpClientHandlerHelper.cs
+++ b/src/Raven.Client/Util/HttpClientHandlerHelper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Net.Http;
+using System.Reflection;
+
+namespace Raven.Client.Util;
+
+internal static class HttpClientHandlerHelper
+{
+#if NETCOREAPP3_1_OR_GREATER
+    private static readonly FieldInfo GetUnderlyingHandler;
+#endif
+
+    static HttpClientHandlerHelper()
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        GetUnderlyingHandler = typeof(HttpClientHandler).GetField("_underlyingHandler", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (GetUnderlyingHandler == null)
+            throw new InvalidOperationException("Could not get underlying handler field from HttpClientHandler.");
+#endif
+    }
+
+    public static void Configure(HttpClientHandler handler, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout)
+    {
+        if (handler == null)
+            throw new ArgumentNullException(nameof(handler));
+
+        if (pooledConnectionLifetime == null && pooledConnectionIdleTimeout == null)
+            return;
+
+#if NETCOREAPP3_1_OR_GREATER
+        if (GetUnderlyingHandler.GetValue(handler) is not SocketsHttpHandler underlyingHandler)
+            throw new InvalidOperationException("Underlying handler for HttpClientHandler is not SocketsHttpHandler");
+
+        if (pooledConnectionLifetime.HasValue)
+            underlyingHandler.PooledConnectionLifetime = pooledConnectionLifetime.Value;
+
+        if (pooledConnectionIdleTimeout.HasValue)
+            underlyingHandler.PooledConnectionIdleTimeout = pooledConnectionIdleTimeout.Value;
+#else
+        throw new InvalidOperationException("Cannot set 'PooledConnectionLifetime' and 'PooledConnectionIdleTimeout' in this framework. Should not happen!");
+#endif
+    }
+}

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Raven.Client;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
@@ -358,7 +359,7 @@ namespace Raven.Server.Commercial
 
         private async Task<Client.ServerWide.Commands.NodeInfo> GetNodeInfo(string nodeUrl, TransactionOperationContext ctx)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, _serverStore.Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var infoCmd = new GetNodeInfoCommand(TimeSpan.FromSeconds(15));
 

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Http;
@@ -307,7 +308,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             Client.ServerWide.Commands.NodeInfo nodeInfo;
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 requestExecutor.DefaultTimeout = ServerStore.Engine.OperationTimeout;
 
@@ -679,7 +680,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                         }
 
                         var cmd = new RemoveEntryFromRaftLogCommand(index);
-                        using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(node.Value, Server.Certificate.Certificate))
+                        using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(node.Value, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                         {
                             await requestExecutor.ExecuteAsync(cmd, context);
                             nodeList.AddRange(cmd.Result);

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
@@ -138,7 +139,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         private async Task WriteDebugInfoPackageForNodeAsync(JsonOperationContext context, ZipArchive archive, string tag, string url, OperationCancelToken clusterOperationToken, int timeoutInSecPerNode)
         {
             //note : theoretically GetDebugInfoFromNodeAsync() can throw, error handling is done at the level of WriteDebugInfoPackageForNodeAsync() calls
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nextOperationId = new GetNextServerOperationIdCommand();
                 await requestExecutor.ExecuteAsync(nextOperationId, context);

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Esprima;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions;
@@ -478,7 +479,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                 // check that the subscription exists on AppropriateNode
                                 var clusterTopology = server.GetClusterTopology(ctx);
                                 using (var requester = ClusterRequestExecutor.CreateForSingleNode(
-                                    clusterTopology.GetUrlFromTag(subscriptionDoesNotBelongException.AppropriateNode), server.Server.Certificate.Certificate))
+                                    clusterTopology.GetUrlFromTag(subscriptionDoesNotBelongException.AppropriateNode), server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                                 {
                                     await requester.ExecuteAsync(new WaitForRaftIndexCommand(subscriptionDoesNotBelongException.Index), ctx);
                                 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2988,7 +2988,7 @@ namespace Raven.Server.ServerWide
 
         private ClusterRequestExecutor CreateNewClusterRequestExecutor(string leaderUrl)
         {
-            var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderUrl, Server.Certificate.Certificate);
+            var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer);
             requestExecutor.DefaultTimeout = Engine.OperationTimeout;
 
             return requestExecutor;

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Security;
@@ -44,7 +45,7 @@ namespace Raven.Server.Smuggler.Migration
             _skipServerCertificateValidation = configuration.SkipServerCertificateValidation;
 
             //because of backward compatibility useCompression == false here
-            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression: false);
+            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression: false, hasExplicitlySetCompressionUsage: false, DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime, DocumentConventions.DefaultForServer.HttpPooledConnectionIdleTimeout);
             httpClientHandler.UseDefaultCredentials = false;
 
             if (configuration.SkipServerCertificateValidation)

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.Util;
@@ -30,7 +31,7 @@ namespace Raven.Server.Utils
 
         public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, string databaseName, string databaseId, long etag, string tag, X509Certificate2 certificate, CancellationToken token)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 var getTcpInfoCommand = databaseId == null ? new GetTcpInfoCommand(tag, databaseName) : new GetTcpInfoCommand(tag, databaseName, databaseId, etag);

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.WebUtilities;
 using Raven.Client;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Extensions;
@@ -163,7 +164,7 @@ namespace Raven.Server.Web
         {
             await ServerStore.Cluster.WaitForIndexNotification(index); // first let see if we commit this in the leader
 
-            using (var requester = ClusterRequestExecutor.CreateForSingleNode(clusterTopology.GetUrlFromTag(node), ServerStore.Server.Certificate.Certificate))
+            using (var requester = ClusterRequestExecutor.CreateForSingleNode(clusterTopology.GetUrlFromTag(node), ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 await requester.ExecuteAsync(new WaitForRaftIndexCommand(index), context);
             }
@@ -189,7 +190,7 @@ namespace Raven.Server.Web
                     foreach (var member in members)
                     {
                         var url = clusterTopology.GetUrlFromTag(member);
-                        var executor = ClusterRequestExecutor.CreateForSingleNode(url, ServerStore.Server.Certificate.Certificate);
+                        var executor = ClusterRequestExecutor.CreateForSingleNode(url, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer);
                         executors.Add(executor);
                         waitingTasks.Add(ExecuteTask(executor, member, cts.Token));
                     }

--- a/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
+++ b/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
@@ -190,7 +191,7 @@ namespace Raven.Server.Web.Studio
             {
                 try
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(serverUrl, _serverStore.Server.Certificate.Certificate))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(serverUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                     using (_serverStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
                         var dataDirectoryInfo = new GetDataDirectoryInfoCommand(_path, _name, _isBackup);

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
@@ -39,7 +40,7 @@ namespace Raven.Server.Web.System
                 // test the connection from the remote node to this one
                 if (bidirectional == true && result.Success)
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, ServerStore.Server.Certificate.Certificate))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                     {
                         result = await ServerStore.TestConnectionFromRemote(requestExecutor, context, url);
                     }

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
@@ -50,7 +51,7 @@ namespace InterversionTests
 
             var chosenOne = processes[0];
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(chosenOne.Url, certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(chosenOne.Url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 foreach (var processNode in processes)
@@ -97,7 +98,7 @@ namespace InterversionTests
             };
 
             using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderServer.WebUrl, certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderServer.WebUrl, certificate, DocumentConventions.DefaultForServer))
             {
                 var local = new List<RavenServer>();
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -59,7 +59,7 @@ namespace RachisTests
 
             await ActionWithLeader((l) => l.ServerStore.RemoveFromClusterAsync(watcher.ServerStore.NodeTag));
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(watcher.WebUrl, watcher.ServerStore.NodeTag), ctx);
@@ -217,7 +217,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -247,7 +247,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -278,7 +278,7 @@ namespace RachisTests
 
             // here we pusblish a wrong PublicServerUrl, but connect to the ServerUrl, so the HTTP connection should be okay, but will when trying to the TCP connection.
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -308,7 +308,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -715,7 +715,7 @@ namespace RachisTests
             var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
             Servers.Add(server2);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 var ex = await Assert.ThrowsAsync<RavenException>(async () =>
@@ -753,7 +753,7 @@ namespace RachisTests
                 var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
                 Servers.Add(server2);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);
@@ -779,7 +779,7 @@ namespace RachisTests
             var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
             Servers.Add(server2);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);

--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -154,7 +154,7 @@ namespace SlowTests.Cluster
                 await AddCompareExchangesWithExpire(count, compareExchanges, store, expiry);
                 await AssertCompareExchanges(compareExchanges, store, expiry);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(follower.WebUrl, watcher: true), ctx);
@@ -216,7 +216,7 @@ namespace SlowTests.Cluster
                     var follower = GetNewServer();
                     ServersForDisposal.Add(follower);
 
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                     using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                     {
                         await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(follower.WebUrl, watcher: true), ctx);
@@ -446,7 +446,7 @@ namespace SlowTests.Cluster
                 var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
                 Servers.Add(server2);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);

--- a/test/SlowTests/Issues/RavenDB-16958.cs
+++ b/test/SlowTests/Issues/RavenDB-16958.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
@@ -220,7 +221,7 @@ namespace SlowTests.Issues
             var cluster = await CreateRaftClusterWithSsl(1, watcherCluster: true);
             var serverB = CreateSecuredServer(cluster.Leader.ServerStore.GetNodeTcpServerUrl(), uniqueCerts: false);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(cluster.Leader.WebUrl, cluster.Leader.Certificate.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(cluster.Leader.WebUrl, cluster.Leader.Certificate.Certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 string database = GetDatabaseName();

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -1002,7 +1002,7 @@ namespace Tests.Infrastructure
         private static async Task<string[]> GetClusterNodeUrlsAsync(string leadersUrl, IDocumentStore store)
         {
             string[] urls;
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leadersUrl, store.Certificate))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leadersUrl, store.Certificate, DocumentConventions.DefaultForServer))
             {
                 try
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19399

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
