### PR TITLE
RavenDB-17453 disable topology cache for embedded

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -149,6 +149,8 @@ namespace Raven.Embedded
                     Conventions = options.Conventions
                 };
 
+                store.Conventions.DisableTopologyCache = true;
+
                 store.AfterDispose += (sender, args) => _documentStores.TryRemove(databaseName, out _);
 
                 store.Initialize();
@@ -242,7 +244,7 @@ namespace Raven.Embedded
 
             var process = await RavenServerRunner.RunAsync(_serverOptions).ConfigureAwait(false);
             if (_logger.IsInfoEnabled)
-                _logger.Info($"Starting global server: { process.Id }");
+                _logger.Info($"Starting global server: {process.Id}");
 
             process.Exited += (sender, e) => ServerProcessExited?.Invoke(sender, new ServerProcessExitedEventArgs());
 

--- a/test/EmbeddedTests/BasicTests.cs
+++ b/test/EmbeddedTests/BasicTests.cs
@@ -37,6 +37,7 @@ namespace EmbeddedTests
                 {
                     Assert.True(store.Conventions.SaveEnumsAsIntegers);
                     Assert.True(store.GetRequestExecutor().Conventions.SaveEnumsAsIntegers);
+                    Assert.True(store.Conventions.DisableTopologyCache);
 
                     using (var session = store.OpenSession())
                     {
@@ -62,6 +63,7 @@ namespace EmbeddedTests
                 {
                     Assert.False(store.Conventions.SaveEnumsAsIntegers);
                     Assert.False(store.GetRequestExecutor().Conventions.SaveEnumsAsIntegers);
+                    Assert.True(store.Conventions.DisableTopologyCache);
 
                     using (var session = store.OpenSession())
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17453

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- 
### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
