### PR TITLE
RDBC-631 TimeOnly DateOnly support for single projections

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -493,24 +493,35 @@ namespace Sparrow.Json
                             ThrowFormatException(result, result.GetType().FullName, "char");
                         obj = (T)(object)@char;
                     }
-                    #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
                     else if (type == typeof(DateOnly))
                     {
                         if (ChangeTypeToString(result, out string dateOnlyString) == false)
                             ThrowFormatException(result, result.GetType().FullName, "string");
-                        if (DateOnly.TryParse(dateOnlyString, out DateOnly dateOnly) == false)
-                            ThrowFormatException(result, result.GetType().FullName, "DateOnly");
+
+                        DateOnly dateOnly;
+                        fixed (char* dateOnlyStringPtr = dateOnlyString.AsSpan())
+                        {
+                            if (LazyStringParser.TryParseDateOnly(dateOnlyStringPtr, dateOnlyString.Length, out dateOnly) == false)
+                                ThrowFormatException(result, result.GetType().FullName, "DateOnly");
+                        }
                         obj = (T)(object)dateOnly;
                     }
                     else if (type == typeof(TimeOnly))
                     {
                         if (ChangeTypeToString(result, out string timeOnlyString) == false)
                             ThrowFormatException(result, result.GetType().FullName, "string");
-                        if (TimeOnly.TryParse(timeOnlyString, out TimeOnly timeOnly) == false)
-                            ThrowFormatException(result, result.GetType().FullName, "TimeOnly");
+                        
+                        TimeOnly timeOnly;
+
+                        fixed (char* timeOnlyStringPtr = timeOnlyString.AsSpan())
+                        {
+                            if (LazyStringParser.TryParseTimeOnly(timeOnlyStringPtr, timeOnlyString.Length, out timeOnly) == false)
+                                ThrowFormatException(result, result.GetType().FullName, "TimeOnly");
+                        }
                         obj = (T)(object)timeOnly;
                     }
-                    #endif
+#endif
                     else
                     {
                         switch (result)

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -493,6 +493,24 @@ namespace Sparrow.Json
                             ThrowFormatException(result, result.GetType().FullName, "char");
                         obj = (T)(object)@char;
                     }
+                    #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                    else if (type == typeof(DateOnly))
+                    {
+                        if (ChangeTypeToString(result, out string dateOnlyString) == false)
+                            ThrowFormatException(result, result.GetType().FullName, "string");
+                        if (DateOnly.TryParse(dateOnlyString, out DateOnly dateOnly) == false)
+                            ThrowFormatException(result, result.GetType().FullName, "DateOnly");
+                        obj = (T)(object)dateOnly;
+                    }
+                    else if (type == typeof(TimeOnly))
+                    {
+                        if (ChangeTypeToString(result, out string timeOnlyString) == false)
+                            ThrowFormatException(result, result.GetType().FullName, "string");
+                        if (TimeOnly.TryParse(timeOnlyString, out TimeOnly timeOnly) == false)
+                            ThrowFormatException(result, result.GetType().FullName, "TimeOnly");
+                        obj = (T)(object)timeOnly;
+                    }
+                    #endif
                     else
                     {
                         switch (result)

--- a/test/SlowTests/Issues/RDBC-631.cs
+++ b/test/SlowTests/Issues/RDBC-631.cs
@@ -51,7 +51,7 @@ public class RDBC_631 : RavenTestBase
             using var bulkInsert = store.BulkInsert();
             foreach (var i in Enumerable.Range(0, 100))
             {
-                var date = new TimeOnly(i);
+                var date = new TimeOnly(i * TimeSpan.TicksPerMinute);
                 bulkInsert.Store(new Mock<TimeOnly>() {Date = date});
                 datesOnly.Add(date);
             }

--- a/test/SlowTests/Issues/RDBC-631.cs
+++ b/test/SlowTests/Issues/RDBC-631.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Microsoft.Azure.Documents.SystemFunctions;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+using TimeOnly = System.TimeOnly;
+
+namespace SlowTests.Issues;
+
+public class RDBC_631 : RavenTestBase
+{
+    public RDBC_631(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanProjectOnlyDateOnly()
+    {
+        var datesOnly = new List<DateOnly>();
+        using var store = GetDocumentStore();
+        {
+            using var bulkInsert = store.BulkInsert();
+            foreach (var i in Enumerable.Range(0, 100))
+            {
+                var date = new DateOnly(2022, (i / 28) + 1, (i % 28) + 1);
+                bulkInsert.Store(new Mock<DateOnly>() {Date = date});
+                datesOnly.Add(date);
+            }
+        }
+        new DateOnlyIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var session = store.OpenSession();
+            var datesFromRaven = session.Query<Mock<DateOnly>, DateOnlyIndex>().Select(i => i.Date).ToList();
+            datesOnly.Sort();
+            datesFromRaven.Sort();
+            Assert.True(datesFromRaven.SequenceEqual(datesOnly));
+        }
+    }
+    
+    [Fact]
+    public void CanProjectOnlyTimeOnly()
+    {
+        var datesOnly = new List<TimeOnly>();
+        using var store = GetDocumentStore();
+        {
+            using var bulkInsert = store.BulkInsert();
+            foreach (var i in Enumerable.Range(0, 100))
+            {
+                var date = new TimeOnly(i);
+                bulkInsert.Store(new Mock<TimeOnly>() {Date = date});
+                datesOnly.Add(date);
+            }
+        }
+        new TimeOnlyIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var session = store.OpenSession();
+            var datesFromRaven = session.Query<Mock<TimeOnly>, TimeOnlyIndex>().Select(i => i.Date).ToList();
+            datesOnly.Sort();
+            datesFromRaven.Sort();
+            Assert.True(datesFromRaven.SequenceEqual(datesOnly));
+        }
+    }
+    
+    private class Mock<T>
+    {
+        public string Id { get; set; }
+        public T Date { get; set; }
+    }
+
+    private class TimeOnlyIndex : AbstractIndexCreationTask<Mock<TimeOnly>>
+    {
+        public TimeOnlyIndex()
+        {
+            Map = mocks => mocks.Select(i => new Mock<TimeOnly>() {Id = i.Id, Date = i.Date});
+        }
+    }
+    
+    private class DateOnlyIndex : AbstractIndexCreationTask<Mock<DateOnly>>
+    {
+        public DateOnlyIndex()
+        {
+            Map = mocks => mocks.Select(i => new Mock<DateOnly>() {Id = i.Id, Date = i.Date});
+        }
+    }
+
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-631

### Additional description

Support conversion from string to `DateOnly` and `TimeOnly` in single item projections.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
