### PR TITLE
RavenDB-19401 Recreate HttpClient on SocketError.TryAgain socket erro…

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -280,6 +280,7 @@ namespace Raven.Client.Http
                 case SocketError.HostNotFound:
                 case SocketError.HostUnreachable:
                 case SocketError.ConnectionRefused:
+                case SocketError.TryAgain:
                     return true;
 
                 default:


### PR DESCRIPTION
…r so we won't get stuck with HttpClient instance in a faulty state which prevents from sending next requests (requests were timing out)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19401/Recreate-HttpClient-on-SocketErrorTryAgain-socket-error

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- No UI work is needed
