### PR TITLE
RavenDB-19389 / RavenDB-18257 When we send a query without an etag th…

### DIFF
--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -62,6 +62,7 @@ namespace Raven.Client.Http
         public virtual TimeSpan? Timeout { get; protected internal set; }
         public virtual bool CanCache { get; protected internal set; }
         public virtual bool CanCacheAggressively { get; protected internal set; }
+        internal virtual bool CanReadFromCache { get; set; } = true;
         public virtual string SelectedNodeTag { get; protected internal set; }
         internal virtual int? SelectedShardNumber { get; set; }
         public int NumberOfAttempts { get; internal set; }
@@ -81,6 +82,7 @@ namespace Raven.Client.Http
             CancellationToken = copy.CancellationToken;
             Timeout = copy.Timeout;
             CanCache = copy.CanCache;
+            CanReadFromCache = copy.CanReadFromCache;
             CanCacheAggressively = copy.CanCacheAggressively;
             SelectedNodeTag = copy.SelectedNodeTag;
             SelectedShardNumber = copy.SelectedShardNumber;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1305,7 +1305,7 @@ namespace Raven.Client.Http
 
         private HttpCache.ReleaseCacheItem GetFromCache<TResult>(JsonOperationContext context, RavenCommand<TResult> command, bool useCache, string url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue)
         {
-            if (useCache && command.CanCache && command.IsReadRequest && command.ResponseType == RavenCommandResponseType.Object)
+            if (useCache && command.CanCache && command.CanReadFromCache && command.IsReadRequest && command.ResponseType == RavenCommandResponseType.Object)
             {
                 return Cache.Get(context, url, out cachedChangeVector, out cachedValue);
             }

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
@@ -15,10 +15,11 @@ public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObjec
     private readonly BlittableJsonReaderObject _query;
     private readonly string _indexName;
 
-    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName) : base(indexQuery, true, metadataOnly, indexEntriesOnly)
+    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName, bool canReadFromCache) : base(indexQuery, true, metadataOnly, indexEntriesOnly)
     {
         _query = query;
         _indexName = indexName;
+        CanReadFromCache = canReadFromCache;
     }
 
     protected override ulong GetQueryHash(JsonOperationContext ctx)

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -62,7 +62,7 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
 
     protected override ShardedQueryCommand CreateCommand(BlittableJsonReaderObject query)
     {
-        return new ShardedQueryCommand(_context.ReadObject(query, "query"), _query, _metadataOnly, _indexEntriesOnly, _query.Metadata.IndexName);
+        return new ShardedQueryCommand(_context.ReadObject(query, "query"), _query, _metadataOnly, _indexEntriesOnly, _query.Metadata.IndexName, canReadFromCache: _existingResultEtag != null);
     }
 
     public override async Task<ShardedQueryResult> ExecuteShardedOperations()

--- a/src/Raven.Server/Web/Http/ProxyCommand.cs
+++ b/src/Raven.Server/Web/Http/ProxyCommand.cs
@@ -66,6 +66,16 @@ public class ProxyCommand<T> : RavenCommand
         }
     }
 
+    internal override bool CanReadFromCache
+    {
+        get => _command?.CanReadFromCache ?? false;
+        set
+        {
+            if (_command != null)
+                _command.CanReadFromCache = value;
+        }
+    }
+
     public override RavenCommandResponseType ResponseType
     {
         get => _command?.ResponseType ?? RavenCommandResponseType.Empty;


### PR DESCRIPTION
…en prevent from reading a response from the cache (but still can put the result into the cache). The problem was that on client side NoCache() was used. This is client side only option - we don't propagate that to the orchestrator. We could do it for 6.0 clients but then older clients wouldn't work. So the solution is to avoid reading from cache if a query request doesn't have etag specified.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19389

### Additional description

The test started to fail after https://github.com/ravendb/ravendb/pull/14931

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Ensured. Please explain how has it been implemented? - older clients will also work since we don't send anything additional

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the fix

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
