### PR TITLE
RavenDB-19399 increase default HttpPooledConnectionLifetime for Server conventions to 19min

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Conventions
             SendApplicationIdentifier = false,
             MaxContextSizeToKeep = new Size(PlatformDetails.Is32Bits == false ? 8 : 2, SizeUnit.Megabytes),
 #if NETCOREAPP3_1_OR_GREATER
-            HttpPooledConnectionLifetime = TimeSpan.FromMinutes(3)
+            HttpPooledConnectionLifetime = TimeSpan.FromMinutes(19)
 #endif
         };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19399

### Additional description

HttpPooledConnectionLifetime should only be used as a last resort, with SocketError.TryAgain handled we can increase this to a higher value.

### Type of change

- Bug fix
- Regression bug fix
- New feature
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
