### PR TITLE
RavenDB-19286 Invalid query from the client side when using CompareTo…

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -489,12 +489,12 @@ namespace Raven.Client.Documents.Linq
                     {
                         case nameof(string.Compare):
                         case nameof(string.CompareOrdinal):
-                            EnsureStringComparisonMethodComparedWithZero(methodCallExpression);
+                            EnsureStringComparisonMethodComparedWithZero(expression, methodCallExpression);
                             expressionMemberInfo = GetMember(methodCallExpression.Arguments[0]);
                             argument = methodCallExpression.Arguments[1];
                             break;
                         case nameof(string.CompareTo):
-                            EnsureStringComparisonMethodComparedWithZero(methodCallExpression);
+                            EnsureStringComparisonMethodComparedWithZero(expression, methodCallExpression);
                             expressionMemberInfo = GetMember(methodCallExpression.Object);
                             argument = methodCallExpression.Arguments[0];
                             break;
@@ -536,17 +536,6 @@ namespace Raven.Client.Documents.Linq
                 IsNestedPath = memberInfo.IsNestedPath,
                 Exact = _insideExact
             });
-
-            void EnsureStringComparisonMethodComparedWithZero(MethodCallExpression mce)
-            {
-                bool comparedToConstantZero = expression.Right.NodeType == ExpressionType.Constant &&
-                                              Equals(((ConstantExpression)expression.Right).Value, 0);
-                if (comparedToConstantZero == false)
-                {
-                    throw new NotSupportedException("Usage of " + mce.Method + ", requires a comparison to a constant 0 only (use: string.Compare(x.Value, Arg) == 0 ), but was: " + expression);
-                }
-                
-            }
         }
 
         private bool IsMemberAccessForQuerySource(Expression node)
@@ -576,23 +565,60 @@ namespace Raven.Client.Documents.Linq
 
         private void VisitNotEquals(BinaryExpression expression)
         {
-            var methodCallExpression = expression.Left as MethodCallExpression;
             // checking for VB.NET string equality
-            if (methodCallExpression != null && methodCallExpression.Method.Name == "CompareString" &&
-                expression.Right.NodeType == ExpressionType.Constant &&
-                Equals(((ConstantExpression)expression.Right).Value, 0))
+            if (expression.Left is MethodCallExpression methodCallExpression) 
             {
-                var expressionMemberInfo = GetMember(methodCallExpression.Arguments[0]);
-                DocumentQuery.WhereNotEquals(new WhereParams
-                {
-                    FieldName = expressionMemberInfo.Path,
-                    Value = GetValueFromExpression(methodCallExpression.Arguments[0], GetMemberType(expressionMemberInfo)),
-                    AllowWildcards = false,
-                    Exact = _insideExact
-                });
-                return;
-            }
 
+                if (methodCallExpression.Method.Name == "CompareString" &&
+                    expression.Right.NodeType == ExpressionType.Constant &&
+                    Equals(((ConstantExpression)expression.Right).Value, 0))
+                {
+                    var expressionMemberInfo = GetMember(methodCallExpression.Arguments[0]);
+                    DocumentQuery.WhereNotEquals(new WhereParams
+                    {
+                        FieldName = expressionMemberInfo.Path,
+                        Value = GetValueFromExpression(methodCallExpression.Arguments[0], GetMemberType(expressionMemberInfo)),
+                        AllowWildcards = false,
+                        Exact = _insideExact
+                    });
+                    return;
+                }
+
+                if (methodCallExpression.Method.DeclaringType == typeof(string))
+                {
+                    ExpressionInfo expressionMemberInfo = null;
+                    Expression argument = null;
+                    var exact = _insideExact | methodCallExpression.Method.Name == nameof(string.CompareOrdinal);
+                    switch (methodCallExpression.Method.Name)
+                    {
+                        case nameof(string.Compare):
+                        case nameof(string.CompareOrdinal):
+                            EnsureStringComparisonMethodComparedWithZero(expression, methodCallExpression);
+                            expressionMemberInfo = GetMember(methodCallExpression.Arguments[0]);
+                            argument = methodCallExpression.Arguments[1];
+                            break;
+                        case nameof(string.CompareTo):
+                            EnsureStringComparisonMethodComparedWithZero(expression, methodCallExpression);
+                            expressionMemberInfo = GetMember(methodCallExpression.Object);
+                            argument = methodCallExpression.Arguments[0];
+                            break;
+                    }
+
+                    if (expressionMemberInfo != null)
+                    {
+                        DocumentQuery.WhereNotEquals(
+                            new WhereParams
+                            {
+                                FieldName = expressionMemberInfo.Path,
+                                Value = GetValueFromExpression(argument, GetMemberType(expressionMemberInfo)),
+                                AllowWildcards = false,
+                                Exact = exact
+                            });
+                        return;
+                    }
+                }
+            }
+            
             if (IsMemberAccessForQuerySource(expression.Left) == false && IsMemberAccessForQuerySource(expression.Right))
             {
                 VisitNotEquals(Expression.NotEqual(expression.Right, expression.Left));
@@ -614,6 +640,16 @@ namespace Raven.Client.Documents.Linq
             });
         }
 
+        private static void EnsureStringComparisonMethodComparedWithZero(BinaryExpression expression, MethodCallExpression mce)
+        {
+            bool comparedToConstantZero = expression.Right.NodeType == ExpressionType.Constant &&
+                                          Equals(((ConstantExpression)expression.Right).Value, 0);
+            if (comparedToConstantZero == false)
+            {
+                throw new NotSupportedException("Usage of " + mce.Method + ", requires a comparison to a constant 0 only (use: string.Compare(x.Value, Arg) == 0 ), but was: " + expression);
+            }
+        }
+        
         private static Type GetMemberType(ExpressionInfo info)
         {
             return info.Type;

--- a/test/SlowTests/Issues/RavenDB-19286.cs
+++ b/test/SlowTests/Issues/RavenDB-19286.cs
@@ -25,18 +25,76 @@ public class RavenDB_19286 : RavenTestBase
         using (var session = store.OpenAsyncSession())
         {
             await session.StoreAsync(new User { Name = "Zoof" });
+            await session.StoreAsync(new User { Name = "Aoof" });
             await session.SaveChangesAsync();
         }
 
         using (var session = store.OpenAsyncSession())
         {
-            await session.Query<User>()
+            var equalByCompareTo = await session.Query<User>()
                 .Where(x => x.Name.CompareTo( "Zoof") == 0)
-                .SingleAsync();
-
-            await session.Query<User>()
+                .ToListAsync();
+            Assert.Equal(1, equalByCompareTo.Count);
+            
+            
+            var equalByStringCompare = await session.Query<User>()
                 .Where(x => string.Compare(x.Name, "Zoof") == 0)
-                .SingleAsync();
+                .ToListAsync();
+            Assert.Equal(1, equalByStringCompare.Count);
+            
+            
+            var lessThanByCompareTo = await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") < 0)
+                .ToListAsync();
+            Assert.Equal(1, lessThanByCompareTo.Count);
+            
+            var lessThanByStringCompare = await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") < 0)
+                .ToListAsync();
+            Assert.Equal(1, lessThanByStringCompare.Count);
+            
+            
+            var lessOrEqualsThanByCompareTo = await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") <= 0)
+                .ToListAsync();
+            Assert.Equal(2, lessOrEqualsThanByCompareTo.Count);
+            
+            var lessOrEqualsThanByStringCompare = await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") <= 0)
+                .ToListAsync();
+            Assert.Equal(2, lessOrEqualsThanByStringCompare.Count);
+            
+            
+            var greaterThanByCompareTo = await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") > 0)
+                .ToListAsync();
+            Assert.Equal(0, greaterThanByCompareTo.Count);
+            
+            var greaterThanByStringCompare = await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") > 0)
+                .ToListAsync();
+            Assert.Equal(0, greaterThanByStringCompare.Count);
+            
+            
+            var greaterOrEqualsThanByCompareTo = await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") >= 0)
+                .ToListAsync();
+            Assert.Equal(1, greaterOrEqualsThanByCompareTo.Count);
+            
+            var greaterOrEqualsThanByStringCompare = await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") >= 0)
+                .ToListAsync();
+            Assert.Equal(1, greaterOrEqualsThanByStringCompare.Count);
+            
+            var notEqualsThanByCompareTo = await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") != 0)
+                .ToListAsync();
+            Assert.Equal(1, notEqualsThanByCompareTo.Count);
+            
+            var notEqualsThanByStringCompare = await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") != 0)
+                .ToListAsync();
+            Assert.Equal(1, notEqualsThanByStringCompare.Count);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-19286.cs
+++ b/test/SlowTests/Issues/RavenDB-19286.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19286 : RavenTestBase
+{
+    public RavenDB_19286(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    class User
+    {
+        public string Name;
+    }
+
+    [Fact]
+    public async Task CanDoStringRangeQuery()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Zoof" });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.Query<User>()
+                .Where(x => x.Name.CompareTo( "Zoof") == 0)
+                .SingleAsync();
+
+            await session.Query<User>()
+                .Where(x => string.Compare(x.Name, "Zoof") == 0)
+                .SingleAsync();
+        }
+    }
+}


### PR DESCRIPTION
… on strings. Also handle string.Compare() == 0, also allow to run string.CompareOrginal as Exact(foo == bar) queries.


### Issue link
https://github.com/ravendb/ravendb/pull/14864
https://issues.hibernatingrhinos.com/issue/RavenDB-19286


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
