### PR TITLE
RavenDB-18370 - TimeSeriesStats.GetStats start and end timestamps are…

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -68,6 +68,7 @@ namespace Raven.Server.Documents.Handlers
                         first = false;
 
                         var stats = Database.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(context, documentId, tsName);
+                        Debug.Assert(stats.Start.Kind == DateTimeKind.Utc);
 
                         writer.WriteStartObject();
 
@@ -192,6 +193,8 @@ namespace Raven.Server.Documents.Handlers
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                     return;
                 }
+
+                Debug.Assert(stats.Start.Kind == DateTimeKind.Utc);
 
                 var includesCommand = includeDoc || includeTags
                     ? new IncludeDocumentsDuringTimeSeriesLoadingCommand(context, documentId, includeDoc, includeTags)
@@ -446,6 +449,7 @@ namespace Raven.Server.Documents.Handlers
                 {
                     Debug.Assert(context != null);
                     stats = context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(context, documentId, name);
+                    Debug.Assert(stats == default || stats.Start.Kind == DateTimeKind.Utc);
                 }
 
                 for (var i = 0; i < ranges.Count; i++)
@@ -499,6 +503,7 @@ namespace Raven.Server.Documents.Handlers
                 {
                     Debug.Assert(context != null);
                     stats = context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(context, documentId, name);
+                    Debug.Assert(stats == default || stats.Start.Kind == DateTimeKind.Utc);
                 }
 
                 for (var i = 0; i < ranges.Count; i++)

--- a/src/Raven.Server/Documents/Includes/IncludeTimeSeriesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeTimeSeriesCommand.cs
@@ -158,6 +158,7 @@ namespace Raven.Server.Documents.Includes
                 if (timeSeriesStats.TryGetValue(timeSeries, out var stats) == false)
                     timeSeriesStats[timeSeries] = stats = _context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(_context, documentId, timeSeries);
 
+                Debug.Assert(stats == default || stats.Start.Kind == DateTimeKind.Utc);
                 return stats;
             }
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -413,6 +413,7 @@ namespace Raven.Server.Documents.Patch
 
                 string timeSeries = GetStringArg(name, _timeSeriesSignature, "name");
                 var stats = _database.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(_docsCtx, id, timeSeries);
+                Debug.Assert(stats == default || stats.Start.Kind == DateTimeKind.Utc);
 
                 var tsStats = new ObjectInstance(ScriptEngine);
                 tsStats.Set(nameof(stats.Start), ScriptEngine.Date.Construct(stats.Start));

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -780,6 +781,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
         private (long Count, DateTime Start, DateTime End) GetStatsAndRemoveQuotesIfNeeded(string documentId)
         {
             var stats = _context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.Stats.GetStats(_context, documentId, _source);
+            Debug.Assert(stats == default || stats.Start.Kind == DateTimeKind.Utc);
             if (stats.Count > 0 || _quoted == false) 
                 return stats;
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -510,6 +510,7 @@ namespace Raven.Server.Documents.Revisions
                 {
                     var name = timeSeriesNames[i].ToString();
                     var (count, start, end) = _documentsStorage.TimeSeriesStorage.Stats.GetStats(context, id, name);
+                    Debug.Assert(start == default || start.Kind == DateTimeKind.Utc);
 
                     dvj[name] = new DynamicJsonValue
                     {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -326,7 +326,7 @@ namespace Raven.Server.Documents.TimeSeries
         public (long Count, DateTime Start, DateTime End) GetStats(ref TableValueReader tvr)
         {
             var count = DocumentsStorage.TableValueToLong((int)StatsColumns.Count, ref tvr);
-            var start = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref tvr)));
+            var start = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref tvr)), DateTimeKind.Utc);
             var end = DocumentsStorage.TableValueToDateTime((int)StatsColumns.End, ref tvr);
 
             return (count, start, end);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -11,7 +11,6 @@ using System.Text;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.TimeSeries;
-using Raven.Client.Exceptions.Documents;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
@@ -360,6 +359,7 @@ namespace Raven.Server.Documents.TimeSeries
                 if (stats.End < from)
                     return null; // nothing to delete here
 
+                Debug.Assert(stats.Start.Kind == DateTimeKind.Utc);
                 slicer.SetBaselineToKey(stats.Start > from ? stats.Start : from);
 
                 // first try to find the previous segment containing from value
@@ -2246,7 +2246,7 @@ namespace Raven.Server.Documents.TimeSeries
             var first = reader.First().Timestamp;
             var last = reader.Last().Timestamp;
 
-            Debug.Assert(first == stats.Start, $"Failed start check: {first} == {stats.Start}");
+            Debug.Assert(first == stats.Start && stats.Start.Kind == DateTimeKind.Utc, $"Failed start check: {first} == {stats.Start}");
             Debug.Assert(last == stats.End, $"Failed end check: {last} == {stats.End}");
 
             if (segment.NumberOfLiveEntries > 0)


### PR DESCRIPTION
… in different timezones

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18370/TimeSeriesStatsGetStats-start-and-end-timestamps-are-in-different-timezones

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
