### PR TITLE
RavenDB-19279 - Unexpected behavior when saving attachment for entiti…

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
@@ -9,7 +9,11 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     public class PutAttachmentCommandData : ICommandData
     {
-        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector)
+        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector) : this(documentId, name, stream, contentType, changeVector, false)
+        {
+        }
+
+        internal PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector, bool fromEtl)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentNullException(nameof(documentId));
@@ -21,13 +25,9 @@ namespace Raven.Client.Documents.Commands.Batches
             Stream = stream;
             ContentType = contentType;
             ChangeVector = changeVector;
+            FromEtl = fromEtl;
 
             PutAttachmentCommandHelper.ValidateStream(stream);
-        }
-
-        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector, bool fromEtl) : this(documentId, name, stream, contentType, changeVector)
-        {
-            FromEtl = fromEtl;
         }
 
 

--- a/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
@@ -9,7 +9,7 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     public class PutAttachmentCommandData : ICommandData
     {
-        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector)
+        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector, bool fromEtl = false)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentNullException(nameof(documentId));
@@ -21,6 +21,7 @@ namespace Raven.Client.Documents.Commands.Batches
             Stream = stream;
             ContentType = contentType;
             ChangeVector = changeVector;
+            FromEtl = fromEtl;
 
             PutAttachmentCommandHelper.ValidateStream(stream);
         }
@@ -31,6 +32,7 @@ namespace Raven.Client.Documents.Commands.Batches
         public string ChangeVector {get; }
         public string ContentType { get; }
         public CommandType Type { get; } = CommandType.AttachmentPUT;
+        public bool FromEtl { get; }
 
         public DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
@@ -40,7 +42,8 @@ namespace Raven.Client.Documents.Commands.Batches
                 [nameof(Name)] = Name,
                 [nameof(ContentType)] = ContentType,
                 [nameof(ChangeVector)] = ChangeVector,
-                [nameof(Type)] = Type.ToString()
+                [nameof(Type)] = Type.ToString(),
+                [nameof(FromEtl)] = FromEtl
             };
         }
 

--- a/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
@@ -9,7 +9,7 @@ namespace Raven.Client.Documents.Commands.Batches
 {
     public class PutAttachmentCommandData : ICommandData
     {
-        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector, bool fromEtl = false)
+        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentNullException(nameof(documentId));
@@ -21,10 +21,15 @@ namespace Raven.Client.Documents.Commands.Batches
             Stream = stream;
             ContentType = contentType;
             ChangeVector = changeVector;
-            FromEtl = fromEtl;
 
             PutAttachmentCommandHelper.ValidateStream(stream);
         }
+
+        public PutAttachmentCommandData(string documentId, string name, Stream stream, string contentType, string changeVector, bool fromEtl) : this(documentId, name, stream, contentType, changeVector)
+        {
+            FromEtl = fromEtl;
+        }
+
 
         public string Id { get; }
         public string Name { get; }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -164,12 +164,6 @@ namespace Raven.Server.Documents
                 Debug.Assert(false);// never hit
             }
 
-            var existingDocument = _documentsStorage.Get(context, documentId);
-            if (existingDocument == null)
-            {
-                throw new DocumentDoesNotExistException($"Document {documentId} does not exist. Cannot store attachment to a missing document.");
-            }
-
             // Attachment etag should be generated before updating the document
             var attachmentEtag = _documentsStorage.GenerateNextEtag();
 

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -164,6 +164,12 @@ namespace Raven.Server.Documents
                 Debug.Assert(false);// never hit
             }
 
+            var existingDocument = _documentsStorage.Get(context, documentId);
+            if (existingDocument == null)
+            {
+                throw new DocumentDoesNotExistException($"Document {documentId} does not exist. Cannot store attachment to a missing document.");
+            }
+
             // Attachment etag should be generated before updating the document
             var attachmentEtag = _documentsStorage.GenerateNextEtag();
 

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents
                 // This will validate that we cannot put an attachment on a conflicted document
                 var hasDoc = TryGetDocumentTableValueReaderForAttachment(context, documentId, name, lowerDocumentId, out TableValueReader tvr);
                 if (hasDoc == false)
-                    throw new InvalidOperationException($"Cannot put attachment {name} on a non existent document '{documentId}'.");
+                    throw new DocumentDoesNotExistException($"Cannot put attachment {name} on a non existent document '{documentId}'.");
                 var flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
                 if (flags.HasFlag(DocumentFlags.Artificial))
                     throw new InvalidOperationException($"Cannot put attachment {name} on artificial document '{documentId}'.");

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             {
                 foreach (var attachment in attachments)
                 {
-                    commands.Add(new PutAttachmentCommandData(id, attachment.Name, attachment.Stream, attachment.ContentType, null));
+                    commands.Add(new PutAttachmentCommandData(id, attachment.Name, attachment.Stream, attachment.ContentType, null, fromEtl: true));
 
                     _stats.IncrementBatchSize(attachment.Stream.Length);
                 }
@@ -291,7 +291,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                         foreach (var addAttachment in putAttachments)
                         {
                             commands.Add(new PutAttachmentCommandData(put.Value.Id, addAttachment.Name, addAttachment.Attachment.Stream, addAttachment.Attachment.ContentType,
-                                null));
+                                null, fromEtl: true));
                         }
                     }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -918,7 +918,7 @@ namespace Raven.Server.Documents.Handlers
 
                             var docId = cmd.Id;
 
-                            if (docId[docId.Length - 1] == Database.IdentityPartsSeparator)
+                            if (docId[docId.Length - 1] == Database.IdentityPartsSeparator && cmd.FromEtl)
                             {
                                 // attachment sent by Raven ETL, only prefix is defined
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -918,17 +918,7 @@ namespace Raven.Server.Documents.Handlers
 
                             var docId = cmd.Id;
 
-                            if (docId[docId.Length - 1] == Database.IdentityPartsSeparator && cmd.FromEtl)
-                            {
-                                // attachment sent by Raven ETL, only prefix is defined
-
-                                if (lastPutResult == null)
-                                    ThrowUnexpectedOrderOfRavenEtlCommands();
-
-                                Debug.Assert(lastPutResult.Value.Id.StartsWith(docId));
-
-                                docId = lastPutResult.Value.Id;
-                            }
+                            EtlGetDocIdFromPrefixIfNeeded(ref docId, cmd, lastPutResult);
 
                             var attachmentPutResult = Database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, docId, cmd.Name,
                                 cmd.ContentType, attachmentStream.Hash, cmd.ChangeVector, stream, updateDocument: false);
@@ -1197,9 +1187,9 @@ namespace Raven.Server.Documents.Handlers
 
             private void EtlGetDocIdFromPrefixIfNeeded(ref string docId, BatchRequestParser.CommandData cmd, DocumentsStorage.PutOperationResults? lastPutResult)
             {
-                if (!cmd.FromEtl || docId[^1] != Database.IdentityPartsSeparator)
+                if (cmd.FromEtl==false || docId[^1] != Database.IdentityPartsSeparator)
                     return;
-                // counter/time-series sent by Raven ETL, only prefix is defined
+                // counter/time-series/attachments sent by Raven ETL, only prefix is defined
 
                 if (lastPutResult == null)
                     ThrowUnexpectedOrderOfRavenEtlCommands();

--- a/test/SlowTests/Issues/RavenDB-19279.cs
+++ b/test/SlowTests/Issues/RavenDB-19279.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Exceptions.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19279 : RavenTestBase
+    {
+        public RavenDB_19279(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Saving_Attachment_In_Wrong_Document_When_Store_Docs_And_Attachment_In_SameRequest()
+        {
+
+            using var store = GetDocumentStore();
+            
+            using (var session = store.OpenAsyncSession())
+            using (var ms = new MemoryStream(new byte[] { 1, 2, 3 }))
+            using (var ms2 = new MemoryStream(new byte[] { 1, 2, 3, 4 }))
+            {
+                var user = new User { Name = "User 1" };
+                var user2 = new User { Name = "User 2" };
+                var user3 = new User { Name = "User 3" };
+
+                await session.StoreAsync(user, "users/");
+                await session.StoreAsync(user2, "users/");
+                await session.StoreAsync(user3, "users/");
+
+                session.Advanced.Attachments.Store(user, "foo", ms);
+                session.Advanced.Attachments.Store(user2, "foo2", ms2);
+                await Assert.ThrowsAsync<DocumentDoesNotExistException>(async () =>
+                {
+                    await session.SaveChangesAsync();
+                });
+
+            }
+        }
+
+
+        [Fact]
+        public async Task Saving_Counters_In_Wrong_Document_When_Store_Docs_And_Attachment_In_SameRequest()
+        {
+
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User { Name = "User 1" };
+                var user2 = new User { Name = "User 2" };
+                var user3 = new User { Name = "User 3" };
+
+                await session.StoreAsync(user, "users/");
+                await session.StoreAsync(user2, "users/");
+                await session.StoreAsync(user3, "users/");
+
+                session.CountersFor(user).Increment("HeartRate", 1);
+                session.CountersFor(user2).Increment("HeartRate", 1);
+
+                await Assert.ThrowsAsync<DocumentDoesNotExistException>(async () =>
+                {
+                    await session.SaveChangesAsync();
+                });
+            }
+        }
+
+        private class User
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19279.cs
+++ b/test/SlowTests/Issues/RavenDB-19279.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Xunit;
 using Xunit.Abstractions;
@@ -37,11 +38,21 @@ namespace SlowTests.Issues
 
                 session.Advanced.Attachments.Store(user, "foo", ms);
                 session.Advanced.Attachments.Store(user2, "foo2", ms2);
-                await Assert.ThrowsAsync<DocumentDoesNotExistException>(async () =>
+
+                Exception exception = null;
+                try
                 {
                     await session.SaveChangesAsync();
-                });
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                }
 
+                Assert.NotNull(exception);
+                Assert.IsType<RavenException>(exception);
+                var ravenException = (RavenException)exception;
+                Assert.IsType<InvalidOperationException>(ravenException.InnerException);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-19279.cs
+++ b/test/SlowTests/Issues/RavenDB-19279.cs
@@ -39,20 +39,10 @@ namespace SlowTests.Issues
                 session.Advanced.Attachments.Store(user, "foo", ms);
                 session.Advanced.Attachments.Store(user2, "foo2", ms2);
 
-                Exception exception = null;
-                try
+                await Assert.ThrowsAsync<DocumentDoesNotExistException>(async () =>
                 {
                     await session.SaveChangesAsync();
-                }
-                catch (Exception e)
-                {
-                    exception = e;
-                }
-
-                Assert.NotNull(exception);
-                Assert.IsType<RavenException>(exception);
-                var ravenException = (RavenException)exception;
-                Assert.IsType<InvalidOperationException>(ravenException.InnerException);
+                });
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/EtlCountersTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlCountersTests.cs
@@ -52,7 +52,7 @@ for (var i = 0; i < counters.length; i++) {
             {
                 using var session = dest.OpenAsyncSession();
                 var all = (await session.CountersFor(entity.Id).GetAllAsync()).Keys.ToArray();
-                return all.Except(counters).Any() == false;
+                return all.Length == count && all.Except(counters).Any() == false;
             }, interval:_waitInterval);
 
             using (var session = src.OpenAsyncSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19279

### Additional description

Fixing unexpected behavior when saving attachments for entities with server-side id generation.
The attachment was saved on the last saved document (in the "Users" collection) instead of in the right documents we wanted.
It seems this should be used only for commands that come from ETL, so storing attachments with "only prefix" document id is now limited only for ETL use, otherwise it throws an exception that says this document does not exist.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
