### PR TITLE
RavenDB-13122 - Revert revision per collection

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/RevertResult.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevertResult.cs
@@ -44,12 +44,19 @@ namespace Raven.Client.Documents.Operations.Revisions
     public class RevertResult : OperationResult
     {
         public int RevertedDocuments { get; set; }
+        private int _failedCollections { get; set; }
 
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(RevertedDocuments)] = RevertedDocuments;
             return json;
+        }
+
+        public void WarnAboutFailedCollection(string message)
+        {
+            var id = $"Revert Collection Fail No.{++_failedCollections}";
+            Warn(id, message);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -189,7 +189,7 @@ namespace Raven.Server.Documents.Handlers
                 configuration = JsonDeserializationServer.RevertRevisions(json);
             }
             
-            HashSet<string> collections = configuration.ApplyToSpecifiedCollectionsOnly ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
+            HashSet<string> collections = configuration.Collections?.Length > 0 ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
 
             var token = CreateTimeLimitedOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -198,7 +198,7 @@ namespace Raven.Server.Documents.Handlers
                 Database,
                 $"Revert database '{Database.Name}' to {configuration.Time} UTC.",
                 Operations.Operations.OperationType.DatabaseRevert,
-                onProgress => Database.DocumentsStorage.RevisionsStorage.RevertRevisions(configuration.Time, TimeSpan.FromSeconds(configuration.WindowInSec), onProgress, token, collections),
+                onProgress => Database.DocumentsStorage.RevisionsStorage.RevertRevisions(configuration.Time, TimeSpan.FromSeconds(configuration.WindowInSec), onProgress, collections, token),
                 operationId,
                 token: token);
 

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -188,8 +188,8 @@ namespace Raven.Server.Documents.Handlers
 
                 configuration = JsonDeserializationServer.RevertRevisions(json);
             }
-
-            List<string> collections = configuration.PerCollections ? configuration.Collections : null;
+            
+            HashSet<string> collections = configuration.ApplyToSpecifiedCollectionsOnly ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
 
             var token = CreateTimeLimitedOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -214,7 +214,7 @@ namespace Raven.Server.Documents.Handlers
                 Database,
                 $"Revert database '{Database.Name}' to {configuration.Time} UTC.",
                 Operations.Operations.OperationType.DatabaseRevert,
-                onProgress => Database.DocumentsStorage.RevisionsStorage.RevertRevisions(configuration.Time, TimeSpan.FromSeconds(configuration.WindowInSec), onProgress, token, collection),
+                onProgress => Database.DocumentsStorage.RevisionsStorage.RevertRevisions(configuration.Time, TimeSpan.FromSeconds(configuration.WindowInSec), onProgress, token, new List<string>(){ collection } ),
                 operationId,
                 token: token);
 

--- a/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
@@ -6,7 +6,6 @@ namespace Raven.Server.Documents.Revisions
     {
         public DateTime Time { get; set; }
         public long WindowInSec { get; set; }
-        public bool ApplyToSpecifiedCollectionsOnly { get; set; } = false;
-        public string[] Collections { get; set; } = null;
+        public string[] Collections { get; set; } = null; 
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Amqp.Types;
 
 namespace Raven.Server.Documents.Revisions
 {
@@ -6,5 +8,7 @@ namespace Raven.Server.Documents.Revisions
     {
         public DateTime Time { get; set; }
         public long WindowInSec { get; set; }
+        public bool PerCollections { get; set; } = false;
+        public List<string> Collections { get; set; } = null;
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Amqp.Types;
 
 namespace Raven.Server.Documents.Revisions
 {

--- a/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/RevertRevisionsRequest.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.Revisions
     {
         public DateTime Time { get; set; }
         public long WindowInSec { get; set; }
-        public bool PerCollections { get; set; } = false;
-        public List<string> Collections { get; set; } = null;
+        public bool ApplyToSpecifiedCollectionsOnly { get; set; } = false;
+        public string[] Collections { get; set; } = null;
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1496,7 +1496,7 @@ namespace Raven.Server.Documents.Revisions
             list.Clear();
         }
 
-        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, HashSet<string> collections = null)
+        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, HashSet<string> collections)
         {
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
             using (readCtx.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions.Documents;
 using Raven.Client.ServerWide;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
@@ -1453,7 +1454,7 @@ namespace Raven.Server.Documents.Revisions
             public Action<IOperationProgress> OnProgress;
         }
 
-        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token)
+        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token, string collection = null)
         {
             var list = new List<Document>();
             var result = new RevertResult();
@@ -1477,7 +1478,7 @@ namespace Raven.Server.Documents.Revisions
 
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
                 {
-                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token);
+                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collection);
                     await WriteRevertedRevisions(list, token);
                 }
             }
@@ -1495,14 +1496,30 @@ namespace Raven.Server.Documents.Revisions
             list.Clear();
         }
 
-        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token)
+        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, string collection = null)
         {
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
             using (readCtx.OpenReadTransaction())
             {
-                var revisions = new Table(RevisionsSchema, readCtx.Transaction.InnerTransaction);
-                foreach (var tvr in revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice],
-                    parameters.LastScannedEtag))
+                IEnumerable<Table.TableValueHolder> tvrs = null;
+                if (collection != null)
+                {
+                    var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
+                    if (collectionName == null)
+                    {
+                        throw new InvalidOperationException($"There's no such collection as '{collection}'");
+                    }
+                    var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
+                    var revisions = readCtx.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
+                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag);
+                }
+                else
+                {
+                    var revisions = new Table(RevisionsSchema, readCtx.Transaction.InnerTransaction);
+                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], parameters.LastScannedEtag);
+                }
+                
+                foreach (var tvr in tvrs)
                 {
                     token.ThrowIfCancellationRequested();
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1504,6 +1504,10 @@ namespace Raven.Server.Documents.Revisions
                 IEnumerable<Table.TableValueHolder> tvrs = null;
                 if (collections != null)
                 {
+                    if (collections.Comparer != null && collections.Comparer != StringComparer.OrdinalIgnoreCase)
+                    {
+                        throw new InvalidOperationException("'collections' hashset must have an 'OrdinalIgnoreCase' comparer");
+                    }
                     tvrs = Enumerable.Empty<Table.TableValueHolder>();
                     foreach (var collection in collections)
                     {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1506,6 +1506,10 @@ namespace Raven.Server.Documents.Revisions
                 {
                     foreach(var collection in collections)
                     {
+                        if (collection == null)
+                        {
+                            throw new InvalidOperationException($"Collection name couldn't be null");
+                        }
                         var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
                         if (collectionName == null)
                         {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1471,6 +1471,16 @@ namespace Raven.Server.Documents.Revisions
             // send initial progress
             parameters.OnProgress?.Invoke(result);
 
+            HashSet<string> collectionsHashSet = null;
+            if (collections != null)
+            {
+                collectionsHashSet = new HashSet<string>();
+                foreach (var col in collections)
+                {
+                    collectionsHashSet.Add(col.ToLower());
+                }
+            }
+
             var hasMore = true;
             while (hasMore)
             {
@@ -1478,7 +1488,7 @@ namespace Raven.Server.Documents.Revisions
 
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
                 {
-                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collections);
+                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collectionsHashSet);
                     await WriteRevertedRevisions(list, token);
                 }
             }
@@ -1496,7 +1506,7 @@ namespace Raven.Server.Documents.Revisions
             list.Clear();
         }
 
-        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, List<string> collections = null)
+        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, HashSet<string> collections = null)
         {
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
             using (readCtx.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1518,12 +1518,16 @@ namespace Raven.Server.Documents.Revisions
                     {
                         if (collection == null)
                         {
-                            throw new InvalidOperationException($"Collection name couldn't be null");
+                            if(_logger.IsInfoEnabled)
+                                _logger.Info($"Tried to revert revisions in collection that is null");
+                            continue;
                         }
                         var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
                         if (collectionName == null)
                         {
-                            throw new InvalidOperationException($"There's no such collection as '{collection}'");
+                            if (_logger.IsInfoEnabled)
+                                _logger.Info($"Tried to revert revisions in the collection '{collection}' which does not exist");
+                            continue;
                         }
                         var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                         var revisions = readCtx.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1454,7 +1454,12 @@ namespace Raven.Server.Documents.Revisions
             public Action<IOperationProgress> OnProgress;
         }
 
-        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token, HashSet<string> collections = null)
+        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token)
+        {
+            return await RevertRevisions(before, window, onProgress, collections: null, token);
+        }
+
+        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, HashSet<string> collections, OperationCancelToken token)
         {
             var list = new List<Document>();
             var result = new RevertResult();
@@ -1478,7 +1483,7 @@ namespace Raven.Server.Documents.Revisions
 
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
                 {
-                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collections);
+                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, collections, token);
                     await WriteRevertedRevisions(list, token);
                 }
             }
@@ -1496,7 +1501,7 @@ namespace Raven.Server.Documents.Revisions
             list.Clear();
         }
 
-        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, OperationCancelToken token, HashSet<string> collections)
+        private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, HashSet<string> collections, OperationCancelToken token)
         {
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
             using (readCtx.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1454,7 +1454,7 @@ namespace Raven.Server.Documents.Revisions
             public Action<IOperationProgress> OnProgress;
         }
 
-        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token, List<string> collections = null)
+        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token, HashSet<string> collections = null)
         {
             var list = new List<Document>();
             var result = new RevertResult();
@@ -1471,16 +1471,6 @@ namespace Raven.Server.Documents.Revisions
             // send initial progress
             parameters.OnProgress?.Invoke(result);
 
-            HashSet<string> collectionsHashSet = null;
-            if (collections != null)
-            {
-                collectionsHashSet = new HashSet<string>();
-                foreach (var col in collections)
-                {
-                    collectionsHashSet.Add(col.ToLower());
-                }
-            }
-
             var hasMore = true;
             while (hasMore)
             {
@@ -1488,7 +1478,7 @@ namespace Raven.Server.Documents.Revisions
 
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
                 {
-                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collectionsHashSet);
+                    hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, token, collections);
                     await WriteRevertedRevisions(list, token);
                 }
             }
@@ -1514,27 +1504,29 @@ namespace Raven.Server.Documents.Revisions
                 IEnumerable<Table.TableValueHolder> tvrs = null;
                 if (collections != null)
                 {
-                    foreach(var collection in collections)
+                    tvrs = Enumerable.Empty<Table.TableValueHolder>();
+                    foreach (var collection in collections)
                     {
                         if (collection == null)
                         {
-                            if(_logger.IsInfoEnabled)
-                                _logger.Info($"Tried to revert revisions in collection that is null");
+                            var msg = "Tried to revert revisions in collection that is null";
+                            if (_logger.IsInfoEnabled)
+                                _logger.Info(msg);
+                            result.WarnAboutFailedCollection(msg);
                             continue;
                         }
                         var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
                         if (collectionName == null)
                         {
+                            var msg = $"Tried to revert revisions in the collection '{collection}' which does not exist";
                             if (_logger.IsInfoEnabled)
-                                _logger.Info($"Tried to revert revisions in the collection '{collection}' which does not exist");
+                                _logger.Info(msg);
+                            result.WarnAboutFailedCollection(msg);
                             continue;
                         }
                         var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                         var revisions = readCtx.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
-                        if (tvrs == null)
-                            tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag);
-                        else
-                            tvrs = tvrs.Concat(revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag));
+                        tvrs = tvrs.Concat(revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag));
                     }
                 }
                 else

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -531,18 +531,6 @@ namespace Raven.Server.Web
             return values[0];
         }
 
-        protected string GetQueryOptionalStringValue(string name)
-        {
-            var values = HttpContext.Request.Query[name];
-            if (values.Count == 0)
-                return null;
-            if (string.IsNullOrWhiteSpace(values[0]))
-                InvalidEmptyValue(name);
-            if (values.Count > 1)
-                InvalidCountOfValues(name);
-            return values[0];
-        }
-
         private static void InvalidEmptyValue(string name)
         {
             throw new ArgumentException($"Query string value '{name}' must have a non empty value");

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -531,6 +531,18 @@ namespace Raven.Server.Web
             return values[0];
         }
 
+        protected string GetQueryOptionalStringValue(string name)
+        {
+            var values = HttpContext.Request.Query[name];
+            if (values.Count == 0)
+                return null;
+            if (string.IsNullOrWhiteSpace(values[0]))
+                InvalidEmptyValue(name);
+            if (values.Count > 1)
+                InvalidCountOfValues(name);
+            return values[0];
+        }
+
         private static void InvalidEmptyValue(string name)
         {
             throw new ArgumentException($"Query string value '{name}' must have a non empty value");

--- a/src/Raven.Studio/typescript/models/database/documents/revertRevisionsRequest.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/revertRevisionsRequest.ts
@@ -58,7 +58,9 @@ class revertRevisionsRequest {
         
         return {
             Time: date,
-            WindowInSec: window
+            WindowInSec: window,
+            ApplyToSpecifiedCollectionsOnly: false,
+            Collections: null
         }
     }
 }

--- a/src/Raven.Studio/typescript/models/database/documents/revertRevisionsRequest.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/revertRevisionsRequest.ts
@@ -59,7 +59,6 @@ class revertRevisionsRequest {
         return {
             Time: date,
             WindowInSec: window,
-            ApplyToSpecifiedCollectionsOnly: false,
             Collections: null
         }
     }

--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -26,6 +26,25 @@ namespace FastTests.Utils
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
         }
 
+        public static async Task<long> SetupRevisions(IDocumentStore documentStore, Raven.Server.ServerWide.ServerStore serverStore)
+        {
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false
+                }
+            };
+
+            var database = documentStore.Database;
+            var index = await SetupRevisions(serverStore, database, configuration);
+
+            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(index, serverStore.Engine.OperationTimeout);
+
+            return index;
+        }
+
         public static async Task<long> SetupRevisions(Raven.Server.ServerWide.ServerStore serverStore, string database, Action<RevisionsConfiguration> modifyConfiguration = null, int minRevisionToKeep = 5)
         {
             var configuration = new RevisionsConfiguration

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByCollection()
         {
-            var collections = new HashSet<string>() { "companies" };
+            var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "companies" };
             var company = new Company { Name = "Company Name" };
             var user = new User { Name = "User Name" };
             using (var store = GetDocumentStore())
@@ -92,7 +92,7 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByMultipleCollections()
         {
-            var collections = new HashSet<string>() { "companies", "users" };
+            var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "companies", "users" };
             var company = new Company { Name = "Company Name" };
             var user = new User { Name = "User Name" };
             var contact = new Contact { FirstName = "User Name" };
@@ -162,7 +162,7 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByMultipleExistingAndDeletedCollections()
         {
-            var collections = new HashSet<string>() { "companies", "users" };
+            var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "companies", "users" };
             var company = new Company { Name = "Company Name" };
             var user = new User { Name = "User Name" };
             var contact = new Contact { FirstName = "User Name" };
@@ -239,7 +239,7 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByWrongCollection()
         {
-            var collections = new HashSet<string>()
+            var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "companies", 
                 "notExistingCollection" // not existing collection

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -678,8 +678,8 @@ namespace SlowTests.Server.Documents.Revisions
 
             public RevertRevisionsOperation(DateTime time, long window, string[] collections) : this(time, window)
             {
-                Debug.Assert(collections != null);
-                _request.ApplyToSpecifiedCollectionsOnly = true;
+                if(collections == null || collections.Length == 0)
+                    throw new InvalidOperationException("Collections array cant be null or empty.");
                 _request.Collections = collections;
             }
 

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -193,10 +193,6 @@ namespace SlowTests.Server.Documents.Revisions
 
                 WaitForUserToContinueTheTest(store);
 
-                // Assert.Equal(2, result.ScannedRevisions);
-                // Assert.Equal(1, result.ScannedDocuments);
-                // Assert.Equal(1, result.RevertedDocuments);
-
                 using (var session = store.OpenAsyncSession())
                 {
                     var companiesRevisions = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
@@ -255,10 +251,6 @@ namespace SlowTests.Server.Documents.Revisions
                     result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
                         collections, token);
                 }
-
-                // Assert.Equal(4, result.ScannedRevisions);
-                // Assert.Equal(2, result.ScannedDocuments);
-                // Assert.Equal(2, result.RevertedDocuments);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -331,10 +323,6 @@ namespace SlowTests.Server.Documents.Revisions
                     result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
                         collections, token);
                 }
-
-                // Assert.Equal(5, result.ScannedRevisions);
-                // Assert.Equal(2, result.ScannedDocuments);
-                // Assert.Equal(2, result.RevertedDocuments);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Server.Documents.Revisions
+{
+    public class RevertRevisionsByCollectionTests : ReplicationTestBase
+    {
+        public RevertRevisionsByCollectionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task RevertByCollection()
+        {
+            var collection = "companies";
+            var company = new Company { Name = "Company Name" };
+            var user = new User { Name = "User Name" };
+            using (var store = GetDocumentStore())
+            {
+                DateTime last = default;
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                    last = DateTime.UtcNow;
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = "Hibernating Rhinos";
+                    user.Name = "Shahar";
+                    await session.StoreAsync(company);
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                }
+
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                RevertResult result;
+                using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                {
+                    result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token, collection: collection);
+                }
+
+                Assert.Equal(2, result.ScannedRevisions);
+                Assert.Equal(1, result.ScannedDocuments);
+                Assert.Equal(1, result.RevertedDocuments);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var companiesRevisions = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
+                    Assert.Equal(3, companiesRevisions.Count);
+
+                    Assert.Equal("Company Name", companiesRevisions[0].Name);
+                    Assert.Equal("Hibernating Rhinos", companiesRevisions[1].Name);
+                    Assert.Equal("Company Name", companiesRevisions[2].Name);
+
+                    var usersRevisions = await session.Advanced.Revisions.GetForAsync<Company>(user.Id);
+                    Assert.Equal(2, usersRevisions.Count);
+
+                    Assert.Equal("Shahar", usersRevisions[0].Name);
+                    Assert.Equal("User Name", usersRevisions[1].Name);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RevertByWrongCollectionShouldThrow()
+        {
+            var collection = "companies1";
+            var company = new Company { Name = "Company Name" };
+            using (var store = GetDocumentStore())
+            {
+                DateTime last = default;
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.SaveChangesAsync();
+                    last = DateTime.UtcNow;
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = "Hibernating Rhinos";
+                    await session.StoreAsync(company);
+                    await session.SaveChangesAsync();
+                }
+
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None)) 
+                    { 
+                        var result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                            token: token, collection: collection);
+                    }
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var companiesRevisions = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
+                    Assert.Equal(2, companiesRevisions.Count);
+
+                    Assert.Equal("Hibernating Rhinos", companiesRevisions[0].Name);
+                    Assert.Equal("Company Name", companiesRevisions[1].Name);
+                }
+            }
+        }
+
+
+        [Fact]
+        public async Task RevertRevisionsEndPointCheck()
+        {
+            var collection = "companies";
+            var company = new Company { Name = "Company Name" };
+            var user = new User { Name = "User Name" };
+            using (var store = GetDocumentStore())
+            {
+                DateTime last = default;
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                    last = DateTime.UtcNow;
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = "Hibernating Rhinos";
+                    user.Name = "Shahar";
+                    await session.StoreAsync(company);
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                }
+
+                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collection));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var companiesRevisions = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
+                    Assert.Equal(3, companiesRevisions.Count);
+
+                    Assert.Equal("Company Name", companiesRevisions[0].Name);
+                    Assert.Equal("Hibernating Rhinos", companiesRevisions[1].Name);
+                    Assert.Equal("Company Name", companiesRevisions[2].Name);
+
+                    var usersRevisions = await session.Advanced.Revisions.GetForAsync<Company>(user.Id);
+                    Assert.Equal(2, usersRevisions.Count);
+
+                    Assert.Equal("Shahar", usersRevisions[0].Name);
+                    Assert.Equal("User Name", usersRevisions[1].Name);
+                }
+            }
+        }
+
+
+        [Fact]
+        public async Task RevertRevisionsEndPointCheckWrongCollection()
+        {
+            var collection = "companies1";
+            var company = new Company { Name = "Company Name" };
+            using (var store = GetDocumentStore())
+            {
+                DateTime last = default;
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.SaveChangesAsync();
+                    last = DateTime.UtcNow;
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = "Hibernating Rhinos";
+                    await session.StoreAsync(company);
+                    await session.SaveChangesAsync();
+                }
+
+                await Assert.ThrowsAsync<BadResponseException>(async () =>
+                {
+                    var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collection));
+                    var result = await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var companiesRevisions = await session.Advanced.Revisions.GetForAsync<Company>(company.Id);
+                    Assert.Equal(2, companiesRevisions.Count);
+
+                    Assert.Equal("Hibernating Rhinos", companiesRevisions[0].Name);
+                    Assert.Equal("Company Name", companiesRevisions[1].Name);
+                }
+            }
+        }
+
+        private class RevertRevisionsOperation : IMaintenanceOperation<OperationIdResult>
+        {
+            private readonly RevertRevisionsRequest _request;
+            private readonly string _collection;
+
+            public RevertRevisionsOperation(DateTime time, long window, string collection = null)
+            {
+                _request = new RevertRevisionsRequest() { Time = time, WindowInSec = window };
+                _collection = collection;
+            }
+
+            public RevertRevisionsOperation(RevertRevisionsRequest request)
+            {
+                _request = request ?? throw new ArgumentNullException(nameof(request));
+            }
+
+            public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new RevertRevisionsCommand(_request, _collection);
+            }
+
+            private class RevertRevisionsCommand : RavenCommand<OperationIdResult>
+            {
+                private readonly RevertRevisionsRequest _request;
+                private readonly string _collection;
+
+                public RevertRevisionsCommand(RevertRevisionsRequest request, string collection = null)
+                {
+                    _request = request;
+                    _collection = collection;
+                }
+
+                public override bool IsReadRequest => false;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/revisions/revert";
+                    if (_collection != null)
+                    {
+                        url += $"?collection={_collection}";
+                    }
+
+                    return new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Post,
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
+                    };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null)
+                        ThrowInvalidResponse();
+
+                    Result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<OperationIdResult>(response);
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13122/Revert-revision-per-collection

### Additional description

Revert revision per collection

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- UI work is needed
