### PR TITLE
RavenDB-19385 Request timeout not applied for lazy queries

### DIFF
--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -48,7 +48,7 @@ namespace Sparrow.Server.Compression
         public Encoder3Gram(TEncoderState state)
         {
             _state = state;
-            _entries = NumberOfEntries;
+            _entries = ReadNumberOfEntries(state);
         }
 
         public static int GetDictionarySize(in TEncoderState state)
@@ -438,9 +438,15 @@ namespace Sparrow.Server.Compression
 
         public int NumberOfEntries
         {
-            get { return MemoryMarshal.Read<int>(_state.EncodingTable); }
+            get { return ReadNumberOfEntries(_state); }
             set { MemoryMarshal.Write(_state.EncodingTable, ref value);}
-        } 
+        }
+
+        private static int ReadNumberOfEntries(in TEncoderState encoderState)
+        {
+            return MemoryMarshal.Read<int>(encoderState.EncodingTable);
+        }
+
         public int MemoryUse => NumberOfEntries * Unsafe.SizeOf<Interval3Gram>();
 
         public int MaxBitSequenceLength

--- a/test/SlowTests/Issues/RavenDB-19385.cs
+++ b/test/SlowTests/Issues/RavenDB-19385.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19385 : RavenTestBase
+{
+    public RavenDB_19385(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void TimeoutInLazyQueriesTest()
+    {
+        using (var store = GetDocumentStore())
+        {
+            new DocIndex().Execute(store);
+
+            const int amount = 1000; // tweak to take long enough time
+
+            using (var bulkInsert = store.BulkInsert())
+            {
+                foreach (var id in Enumerable.Range(1, amount))
+                {
+                    bulkInsert.Store(new Doc { Id = "doc-" + id });
+                }
+            }
+
+            Indexes.WaitForIndexing(store);
+            string queryString = @"
+declare function output(row) {
+    for (var i = 0; i < 5000; i++) {}
+    return(row);
+}
+
+from index 'DocIndex' as row select output(row)";
+
+            using (var session = store.OpenSession())
+            {
+                using (session.Advanced.DocumentStore.SetRequestTimeout(TimeSpan.FromMilliseconds(50)))
+                {
+                    var query = session.Advanced.RawQuery<Doc>(queryString);
+                    Assert.Throws<RavenException>(() =>
+                    {
+                        var results = query.ToList();
+                    });
+
+                    var lazyQuery = session.Advanced.RawQuery<Doc>(queryString).Lazily();
+                    var sw = Stopwatch.StartNew();
+                    Assert.Throws<RavenException>(() =>
+                    {
+                        var results = lazyQuery.Value.ToList();
+                        Assert.True(sw.ElapsedMilliseconds > 1000);
+                    });
+                }
+            }
+        }
+    }
+
+    class Doc
+    {
+        public string Id { get; set; }
+    }
+
+    class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs =>
+                from doc in docs
+                select new { doc.Id, };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19385 

### Additional description

In `MultiGetHandler`, we were flushing the stream to the client before we executed the first request. That means that the server response was immediate, and bypassed the actual query time.

Now we'll buffer the whole thing in memory before sending anything to the caller.
This match the expectation of lazy as a single operation. 


https://github.com/ravendb/ravendb/discussions/14988#

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
