### PR TITLE
RavenDB-19417 Persist indexing mode inside Index.

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -49,7 +49,7 @@ namespace Corax
             private static readonly byte[] LongTreeSuffixBytes = new byte[]  { (byte)'-', (byte)'L' };
 
             
-            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice;
+            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice;
             public const int IntKnownFieldMask = unchecked((int)0x80000000);
             public const short ShortKnownFieldMask = unchecked((short)0x8000);
             public const byte ByteKnownFieldMask = unchecked((byte)0x80);
@@ -64,6 +64,7 @@ namespace Corax
                     Slice.From(ctx, "NumberOfEntries", ByteStringType.Immutable, out NumberOfEntriesSlice);
                     Slice.From(ctx, "SuggestionFields", ByteStringType.Immutable, out SuggestionsFieldsSlice);
                     Slice.From(ctx, "IndexVersion", ByteStringType.Immutable, out IndexVersionSlice);
+                    Slice.From(ctx, "DynamicFieldsAnalyzers", ByteStringType.Immutable, out DynamicFieldsAnalyzersSlice);
                 }
             }
         }

--- a/src/Corax/FieldIndexingMode.cs
+++ b/src/Corax/FieldIndexingMode.cs
@@ -14,10 +14,10 @@ public enum FieldIndexingMode : byte
     /// </summary>
     Exact = 1,
 
-    Search = 1 << 2,
+    Search = 2,
     
     /// <summary>
     /// Use the attached analyzer from IndexFieldBinding
     /// </summary>
-    Normal = 1 << 3
+    Normal = 3
 }

--- a/src/Corax/FieldIndexingMode.cs
+++ b/src/Corax/FieldIndexingMode.cs
@@ -1,22 +1,23 @@
 ﻿namespace Corax;
 
-public enum FieldIndexingMode
+
+public enum FieldIndexingMode : byte
 {
     /// <summary>
     /// Do not index the field value. This field can thus not be searched, but one can still access its contents provided it is stored.
     /// </summary>
-    No,
+    No = 0,
     
     /// <summary>
     /// Index the field's value without using an Analyzer, so it can be searched.  As no analyzer is used the 
     /// value will be stored as a single term. This is useful for unique Ids like product numbers.
     /// </summary>
-    Exact,
+    Exact = 1,
 
-    Search,
+    Search = 1 << 2,
     
     /// <summary>
     /// Use the attached analyzer from IndexFieldBinding
     /// </summary>
-    Normal
+    Normal = 1 << 3
 }

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -530,10 +530,12 @@ namespace Corax
             {
                 
                 indexedField = new IndexedField(Constants.IndexWriter.DynamicField, binding.FieldName, binding.FieldNameLong, binding.FieldNameDouble, binding.Analyzer, binding.FieldIndexingMode, binding.HasSuggestions);
-
-                if (persistedAnalyzer != null && binding.FieldIndexingMode != (FieldIndexingMode)persistedAnalyzer.Reader.ReadByte())
+                
+                if (persistedAnalyzer != null)
                 {
-                    throw new InvalidDataException("Your index is dynamically changing analyzer in dynamic field. We do not support it.");
+                    var originalIndexingMode = (FieldIndexingMode)persistedAnalyzer.Reader.ReadByte();
+                    if (binding.FieldIndexingMode != originalIndexingMode)
+                        throw new InvalidDataException($"Inconsistent dynamic field creation options were detected. Field '{binding.FieldName}' was created with '{originalIndexingMode}' analyzer but now '{binding.FieldIndexingMode}' analyzer was specified. This is not supported");
                 }
                 
                 if (binding.FieldIndexingMode != FieldIndexingMode.Normal && persistedAnalyzer == null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Corax;
 using NetTopologySuite.Utilities;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Exceptions;
@@ -134,9 +135,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         {
             foreach (var (fieldName, fieldIndexing) in _indexingScope.DynamicFields)
             {
-                if (_dynamicFields.TryGetByFieldName(fieldName, out var binding))
+                if (_dynamicFields.TryGetByFieldName(fieldName, out _))
                 {
-                    Debug.Assert(binding.FieldIndexingMode == FieldIndexingIntoFieldIndexingMode(fieldIndexing));
                     continue;
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -439,7 +439,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 scope.CreatedFieldsCount++;
             else if (fieldAlreadyExists && scope.DynamicFields[name] != field.Indexing)
             {
-                throw new NotSupportedInCoraxException("Your index is dynamically changing analyzer in dynamic field. We do not support it.");
+                throw new InvalidDataException($"Inconsistent dynamic field creation options were detected. Field '{name}' was created with '{scope.DynamicFields[name]}' analyzer but now '{field.Indexing}' analyzer was specified. This is not supported");
             }
             scope.DynamicFields[name] = field.Indexing;
 

--- a/src/Voron/Data/CompactTrees/PersistentDictionary.cs
+++ b/src/Voron/Data/CompactTrees/PersistentDictionary.cs
@@ -49,7 +49,6 @@ namespace Voron.Data.CompactTrees
         public long PageNumber => _page.PageNumber;
         
         private readonly HopeEncoder<Encoder3Gram<NativeMemoryEncoderState>> _encoder;
-        private byte[] _tempBuffer;
 
         public static long CreateDefault(LowLevelTransaction llt)
         {

--- a/test/FastTests/Corax/DynamicFieldsIntegration.cs
+++ b/test/FastTests/Corax/DynamicFieldsIntegration.cs
@@ -155,7 +155,7 @@ public class DynamicFieldsIntegration : RavenTestBase
         Indexes.WaitForIndexing(store, allowErrors: true);
         var errors = Indexes.WaitForIndexingErrors(store, new[] {index.IndexName}, errorsShouldExists: true);
         Assert.Equal(1, errors.Length);
-        Assert.True(errors[0].Errors[0].Error.Contains("Exception: Raven.Client.Exceptions.Corax.NotSupportedInCoraxException: Your index is dynamically changing analyzer in dynamic field. We do not support it."));
+        Assert.True(errors[0].Errors[0].Error.Contains($"Inconsistent dynamic field creation options were detected. Field 'Name' was created with 'Search' analyzer but now 'Exact' analyzer was specified. This is not supported"));
     }
     
     private class Item

--- a/test/FastTests/Corax/DynamicFieldsIntegration.cs
+++ b/test/FastTests/Corax/DynamicFieldsIntegration.cs
@@ -93,7 +93,7 @@ public class DynamicFieldsIntegration : RavenTestBase
         
         {
             using var session = store.OpenAsyncSession();
-            var result = await session.Query<TestClassResult<float?[]>, IndexFloatList>().Where(i => i.Dynamic.Contains(50)).SingleOrDefaultAsync();
+            var result = await session.Query<TestClassResult<float?[]>, IndexFloatList>().Where(i => i.Dynamic!.Contains(50)).SingleOrDefaultAsync();
             AssertResult(result);
         }
     }
@@ -160,17 +160,17 @@ public class DynamicFieldsIntegration : RavenTestBase
     
     private class Item
     {
-        public string Id { get; set; }
-        public string Name { get; set; }
+        public string? Id { get; set; }
+        public string? Name { get; set; }
         
-        public bool Analyzed { get; set; }
+        public bool? Analyzed { get; set; }
     }
 
     private class SearchDynamicIndex : AbstractIndexCreationTask<Item>
     {
         public SearchDynamicIndex()
         {
-            Map = items => items.Select(i => new {Id = i.Id, _ = CreateField("Name", i.Name, false, i.Analyzed)});
+            Map = items => items.Select(i => new {Id = i.Id, _ = CreateField("Name", i.Name, false, i.Analyzed ?? false)});
         }
     }
     

--- a/test/SlowTests/Issues/RavenDB_14784.cs
+++ b/test/SlowTests/Issues/RavenDB_14784.cs
@@ -699,8 +699,7 @@ return attachments.map(attachment => ({
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19417")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void Can_Index_Multiple_Attachments_JavaScript(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19417

### Additional description

We've to persist which analyzer we used during indexing to be able to delete them when necessary (because it requires analyzing raw entries into indexed terms).

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
