### PR TITLE
RavenDB-17154 - Invoke the OnAfterConversionToEntity event after enti…

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -536,6 +536,7 @@ more responsive application.
                     IncludedDocumentsById.Remove(id);
                     DocumentsByEntity[docInfo.Entity] = docInfo;
                 }
+                OnAfterConversionToEntityInvoke(id, docInfo.Document, docInfo.Entity);
 
                 return docInfo.Entity;
             }
@@ -551,6 +552,7 @@ more responsive application.
                     DocumentsById.Add(docInfo);
                     DocumentsByEntity[docInfo.Entity] = docInfo;
                 }
+                OnAfterConversionToEntityInvoke(id, docInfo.Document, docInfo.Entity);
 
                 return docInfo.Entity;
             }
@@ -574,6 +576,7 @@ more responsive application.
                 DocumentsById.Add(newDocumentInfo);
                 DocumentsByEntity[entity] = newDocumentInfo;
             }
+            OnAfterConversionToEntityInvoke(id, document, entity);
 
             return entity;
         }
@@ -2252,6 +2255,7 @@ more responsive application.
             if (DocumentsById.TryGetValue(documentInfo.Id, out DocumentInfo documentInfoById))
                 documentInfoById.Entity = entity;
 
+            OnAfterConversionToEntityInvoke(documentInfo.Id, documentInfo.Document, documentInfo.Entity);
         }
 
         protected static T GetOperationResult<T>(object result)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2156,7 +2156,9 @@ more responsive application.
         private object DeserializeFromTransformer(Type entityType, string id, BlittableJsonReaderObject document, bool trackEntity)
         {
             HandleInternalMetadata(document);
-            return JsonConverter.FromBlittable(entityType, ref document, id, trackEntity);
+            var entity = JsonConverter.FromBlittable(entityType, ref document, id, trackEntity);
+            OnAfterConversionToEntityInvoke(id, document, entity);
+            return entity;
         }
         
         internal bool CheckIfAllChangeVectorsAreAlreadyIncluded(IEnumerable<string> changeVectors)

--- a/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
@@ -81,6 +81,7 @@ namespace Raven.Client.Documents.Session.Operations
                 Metadata = metadata,
                 Entity = entity
             };
+            _session.OnAfterConversionToEntityInvoke(id, document, entity);
 
             return entity;
         }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
@@ -66,8 +66,6 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 if (id != null)
                     _session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, id);
 
-                _session.OnAfterConversionToEntityInvoke(id, json, entity);
-
                 return entity;
             }
             catch (Exception ex)

--- a/test/SlowTests/Issues/RavenDB-17154.cs
+++ b/test/SlowTests/Issues/RavenDB-17154.cs
@@ -1,0 +1,99 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17154 : RavenTestBase
+    {
+        public RavenDB_17154(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task InvokeOnAfterConversionToEntityAfterTrackingEntityInSession()
+        {
+            var listenerOneCalled = 0;
+            var listenerOneDocExists = 0;
+            var listenerTwoCalled = 0;
+            var listenerTwoDocExists = 0;
+
+            using (var store = GetDocumentStore())
+            {
+                // Register listener 1
+                store.OnAfterConversionToEntity += (sender, args) =>
+                {
+                    Interlocked.Increment(ref listenerOneCalled);
+                    var metadata = args.Session.GetMetadataFor((Entity)(args.Entity));
+                    if (metadata != null)
+                        Interlocked.Increment(ref listenerOneDocExists);
+                };
+
+                // Insert data
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Entity("bob", "bob"));
+                    await session.SaveChangesAsync();
+                }
+
+                // FIRST LOAD
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    // Register listener 2
+                    session.Advanced.OnAfterConversionToEntity += (sender, args) =>
+                    {
+                        Interlocked.Increment(ref listenerTwoCalled);
+                        var metadata = args.Session.GetMetadataFor((Entity)(args.Entity));
+                        if (metadata != null)
+                            Interlocked.Increment(ref listenerTwoDocExists);
+                    };
+
+                    Entity entity = await session.LoadAsync<Entity>("bob");
+                    Assert.Equal("bob", entity.Id);
+                }
+
+                // SECOND LOAD
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    // Register listener 2
+                    session.Advanced.OnAfterConversionToEntity += (sender, args) =>
+                    {
+                        Interlocked.Increment(ref listenerTwoCalled);
+                        var metadata = args.Session.GetMetadataFor((Entity)(args.Entity));
+                        if (metadata != null)
+                            Interlocked.Increment(ref listenerTwoDocExists);
+                    };
+
+                    Entity entity = await session.LoadAsync<Entity>("bob");
+                    Assert.Equal("bob", entity.Id);
+                }
+
+                Assert.Equal(2, listenerOneCalled);
+                Assert.Equal(2, listenerTwoCalled);
+                Assert.Equal(2, listenerOneDocExists);
+                Assert.Equal(2, listenerTwoDocExists);
+            }
+        }
+
+        private class Entity
+        {
+            public Entity(string id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+
+            private Entity()
+            {
+            }
+
+            public string Id { get; }
+
+            public string Name { get; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17154/Invoke-the-OnAfterConversionToEntity-event-after-entity-has-been-tracked

### Additional description

Invoke the OnAfterConversionToEntity event after entity has been tracked,
Then we can use session methods on it (such GetMetadataFor) that depend on the tracked documents inside the event.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
