### PR TITLE
RavenDB-17854 Throw when `WithOptions` is used with `ByRange`

### DIFF
--- a/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
@@ -100,6 +100,9 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IFacetOperations<T> WithOptions(FacetOptions options)
         {
+            if (_range is not null)
+                throw new NotSupportedException($"Method {nameof(WithOptions)} is not supported for aggregation '{nameof(ByRanges)}'");
+            
             Facet.Options = options;
             return this;
         }

--- a/test/SlowTests/Issues/RavenDB-17854.cs
+++ b/test/SlowTests/Issues/RavenDB-17854.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Facets;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17854 : RavenTestBase
+{
+    private const string Exception = "Method WithOptions is not supported for aggregation 'ByRanges'";
+    
+    public RavenDB_17854(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Facets)]
+    public void CanMixByRangeAndByField()
+    {
+        IAggregationQuery<DataForAggregation> Query(IDocumentSession session) =>
+            session.Query<DataForAggregation, Index>()
+                .AggregateBy(builder => builder.ByField(i => i.Name))
+                .AndAggregateBy(builder => builder.ByRanges(i => i.Age < 23, aggregation => aggregation.Age >= 24));
+
+        RunTest(Query);
+    }
+
+    [RavenFact(RavenTestCategory.Facets)]
+    public void UseOptionsForByFieldButNotForByRange()
+    {
+        IAggregationQuery<DataForAggregation> Query(IDocumentSession session) =>
+            session.Query<DataForAggregation, Index>()
+                .AggregateBy(builder => builder.ByField(i => i.Name).WithOptions(new FacetOptions(){IncludeRemainingTerms = true}))
+                .AndAggregateBy(builder => builder.ByRanges(i => i.Age < 23, aggregation => aggregation.Age >= 24));
+        
+        RunTest(Query);
+    }
+    
+    [RavenFact(RavenTestCategory.Facets)]
+    public void CanUseOptionWithByField()
+    {
+        IAggregationQuery<DataForAggregation> Query(IDocumentSession session) =>
+            session.Query<DataForAggregation, Index>()
+                .AggregateBy(builder => builder.ByField(i => i.Name).WithOptions(new FacetOptions(){IncludeRemainingTerms = true}));
+        
+        RunTest(Query, assertByRange: false);
+    }
+    
+    
+    [RavenFact(RavenTestCategory.Facets)]
+    public void UseOptionWithByRangeWillCauseAException()
+    {
+        IAggregationQuery<DataForAggregation> Query(IDocumentSession session) =>
+            session.Query<DataForAggregation, Index>()
+                .AggregateBy(builder => builder.ByRanges(i => i.Age < 23, aggregation => aggregation.Age >= 24).WithOptions(new FacetOptions(){IncludeRemainingTerms = true}));
+
+
+        var exception = Assert.ThrowsAny<NotSupportedException>(() => RunTest(Query, assertByField: false));
+        Assert.True(exception.Message.Contains(Exception));
+    }
+
+    [RavenFact(RavenTestCategory.Facets)]
+    public void UseOptionInByRangeAndByFieldWillCauseAException()
+    {
+        IAggregationQuery<DataForAggregation> Query(IDocumentSession session) =>
+            session.Query<DataForAggregation, Index>()
+                .AggregateBy(builder => builder.ByField(i => i.Name).WithOptions(new FacetOptions(){IncludeRemainingTerms = true}))
+                .AndAggregateBy(builder => builder.ByRanges(i => i.Age < 23, aggregation => aggregation.Age >= 24).WithOptions(new FacetOptions(){IncludeRemainingTerms = true}));
+
+
+        var exception = Assert.ThrowsAny<NotSupportedException>(() => RunTest(Query));
+        Assert.True(exception.Message.Contains(Exception));
+    }
+    
+    private void RunTest(Func<IDocumentSession, IAggregationQuery<DataForAggregation>> query, bool assertByField = true, bool assertByRange = true)
+    {
+        using var store = GetStoreWithPreparedData();
+        {
+            using var session = store.OpenSession();
+            var results = query(session).Execute();
+            if (assertByField)
+                Assert.Equal(2, results["Name"].Values.Count);
+            
+            if (assertByRange)
+                Assert.Equal(2, results["Age"].Values.Count);
+        }
+    }
+    
+    private IDocumentStore GetStoreWithPreparedData()
+    {
+        var store = GetDocumentStore();
+        {
+            using var session = store.OpenSession();
+            session.Store(new DataForAggregation() {Age = 21, Name = "Matt"});
+            session.Store(new DataForAggregation() {Age = 24, Name = "Tom"});
+            session.SaveChanges();
+        }
+
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+        return store;
+    }
+
+    private class DataForAggregation
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<DataForAggregation>
+    {
+        public Index()
+        {
+            Map = enumerable => enumerable.Select(i => new DataForAggregation() {Name = i.Name, Age = i.Age});
+        }
+    }
+}

--- a/test/SlowTests/MailingList/Wade.cs
+++ b/test/SlowTests/MailingList/Wade.cs
@@ -76,7 +76,6 @@ namespace SlowTests.MailingList
                                     person => person.BirthDate >= d1960 && person.BirthDate < d1969,
                                     person => person.BirthDate >= d1970 && person.BirthDate < d1979
                                 )
-                                .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 
@@ -148,7 +147,6 @@ namespace SlowTests.MailingList
                                     person => person.Spouse.BirthDate >= d1960 && person.Spouse.BirthDate < d1969,
                                     person => person.Spouse.BirthDate >= d1970 && person.Spouse.BirthDate < d1979
                                 )
-                            .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 
@@ -218,7 +216,6 @@ namespace SlowTests.MailingList
                                     person => person.Children.Any(child => child.BirthDate >= d2000 && child.BirthDate < d2009),
                                     person => person.Children.Any(child => child.BirthDate >= d2010 && child.BirthDate < d2019)
                                 )
-                                .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17854 

### Additional description

We're not applying any config when performing facet operations by ranges. Removing this from API requires creating at least two new interfaces for facet builder so I believe it is better just to throw an expcetion about it.

https://github.com/ravendb/ravendb/blob/7e2cd718ef7917de0fd94fd805b15549b01c1b2c/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs#L240-L246

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Breaking change


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
