### PR TITLE
RavenDB-19420 / RavenDB-19278 Making sure that we handle the recovery as intended on encrypted storage as well. Adjusting the recovery error message when using encryption.

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -507,7 +507,7 @@ namespace Voron.Impl.Journal
                     }
 
                     RequireHeaderUpdate = true;
-                    options.InvokeRecoveryError(this, "Transaction " + current->TransactionId + " was not committed", ex);
+                    options.InvokeRecoveryError(this, $"Could not decrypt transaction {current->TransactionId}. It could be not committed", ex);
 
                     return false;
                 }

--- a/test/SlowTests/Voron/Issues/RavenDB_19278.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_19278.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using FastTests.Voron;
+using Sparrow.Server;
 using Sparrow.Utils;
 using Voron;
 using Voron.Global;
@@ -16,11 +18,13 @@ public class RavenDB_19278 : StorageTest
 {
     private List<string> _onRecoveryErrorMessages = new();
 
+    private bool _encrypted;
+
     public RavenDB_19278(ITestOutputHelper output) : base(output)
     {
     }
 
-
+    private readonly byte[] _masterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
     protected override void Configure(StorageEnvironmentOptions options)
     {
         options.InitialLogFileSize = 4 * Constants.Size.Megabyte;
@@ -33,11 +37,18 @@ public class RavenDB_19278 : StorageTest
         options.ManualSyncing = true;
         options.ManualFlushing = true;
         options.MaxScratchBufferSize = 1 * Constants.Size.Gigabyte;
+
+        if (_encrypted)
+            options.Encryption.MasterKey = _masterKey.ToArray();
     }
 
-    [Fact]
-    public void StopRecoveryAndRaisePartiallyRecoveredAlertAfterGettingInvalidHashOfTransaction()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StopRecoveryAndRaisePartiallyRecoveredAlertAfterGettingInvalidHashOfTransaction(bool encrypted)
     {
+        _encrypted = encrypted;
+
         RequireFileBasedPager();
 
         using (var tx = Env.WriteTransaction())
@@ -77,7 +88,7 @@ public class RavenDB_19278 : StorageTest
 
         var journalToCorrupt = Env.Journal.GetCurrentJournalInfo().CurrentJournal - 3;
 
-        StopDatabase(); 
+        StopDatabase();
 
         CorruptJournal(journalToCorrupt, 10 * Constants.Size.Kilobyte * 4 - 1000); // it will corrupt tx 9
 
@@ -85,7 +96,14 @@ public class RavenDB_19278 : StorageTest
 
         Assert.Equal(2, _onRecoveryErrorMessages.Count);
 
-        Assert.Contains($"Invalid hash signature for transaction: HeaderMarker: Valid, TransactionId: {corruptedTx}", _onRecoveryErrorMessages[0]);
+        string message;
+
+        if (encrypted == false)
+            message = $"Invalid hash signature for transaction: HeaderMarker: Valid, TransactionId: {corruptedTx}";
+        else
+            message = $"Could not decrypt transaction {corruptedTx}. It could be not committed";
+
+        Assert.Contains(message, _onRecoveryErrorMessages[0]);
         Assert.Contains("Database recovered partially. Some data was lost.", _onRecoveryErrorMessages[1]);
 
         using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
@@ -117,7 +135,7 @@ public class RavenDB_19278 : StorageTest
             random.NextBytes(buffer);
 
             tx.CreateTree("tree").Add("new", new MemoryStream(buffer));
-            
+
             tx.Commit();
         }
 
@@ -129,12 +147,18 @@ public class RavenDB_19278 : StorageTest
     }
 
     [Theory]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    [InlineData(true, true)]
-    public void PartialRecoveryMustUpdateEnvironmentHeaderAndEraseCorruptedDataInJournal(bool syncAfterRestart, bool limitMaxJournalSizeAfterRestart)
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, true)]
+    [InlineData(true, true, true)]
+    public void PartialRecoveryMustUpdateEnvironmentHeaderAndEraseCorruptedDataInJournal(bool syncAfterRestart, bool limitMaxJournalSizeAfterRestart, bool encrypted)
     {
+        _encrypted = encrypted;
+
         RequireFileBasedPager();
 
         using (var tx = Env.WriteTransaction())
@@ -196,7 +220,14 @@ public class RavenDB_19278 : StorageTest
 
         Assert.Equal(2, _onRecoveryErrorMessages.Count);
 
-        Assert.Contains($"Invalid hash signature for transaction: HeaderMarker: Valid, TransactionId: {corruptedTx}", _onRecoveryErrorMessages[0]);
+        string message;
+
+        if (encrypted == false)
+            message = $"Invalid hash signature for transaction: HeaderMarker: Valid, TransactionId: {corruptedTx}";
+        else
+            message = $"Could not decrypt transaction {corruptedTx}. It could be not committed";
+
+        Assert.Contains(message, _onRecoveryErrorMessages[0]);
         Assert.Contains("Database recovered partially. Some data was lost.", _onRecoveryErrorMessages[1]);
 
         if (syncAfterRestart)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19420

### Additional description

Adding test cases to verify that the recovery works properly on encrypted storage

### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
