### PR TITLE
RavenDB-19377 we do not want to return previous revision for smuggler it causes two issues

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -245,15 +245,11 @@ namespace Raven.Server.Smuggler.Documents
             {
                 var etag = state.StartEtagByCollection[collection];
 
-                var collectionName = _database.DocumentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
-                if (collectionName == null)
-                    continue;
-
                 state.CurrentCollection = collection;
 
-                foreach (var document in _database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, collectionName, etag, long.MaxValue))
+                foreach (var document in _database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, collection, etag, long.MaxValue))
                 {
-                    yield return document.current;
+                    yield return document;
                 }
             }
         }


### PR DESCRIPTION
- we were performing a lot of additional work
- we were not disposing the previous document

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19377

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
