### PR TITLE
RavenDB-17871: Allow to exclude indexes when creating a snapshot

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/SnapshotSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/SnapshotSettings.cs
@@ -7,11 +7,14 @@ namespace Raven.Client.Documents.Operations.Backups
     {
         public CompressionLevel CompressionLevel { get; set; }
 
+        public bool ExcludeIndexes { get; set; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                [nameof(CompressionLevel)] = CompressionLevel
+                [nameof(CompressionLevel)] = CompressionLevel,
+                [nameof(ExcludeIndexes)] = ExcludeIndexes
             };
         }
     }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1032,7 +1032,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private IEnumerable<FullBackup.StorageEnvironmentInformation> GetAllStoragesForBackup()
+        private IEnumerable<FullBackup.StorageEnvironmentInformation> GetAllStoragesForBackup(bool excludeIndexes)
         {
             foreach (var storageEnvironmentWithType in GetAllStoragesEnvironment())
             {
@@ -1048,6 +1048,9 @@ namespace Raven.Server.Documents
                         break;
 
                     case StorageEnvironmentWithType.StorageEnvironmentType.Index:
+                        if (excludeIndexes)
+                            break;
+
                         yield return new FullBackup.StorageEnvironmentInformation
                         {
                             Name = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(storageEnvironmentWithType.Name),
@@ -1072,7 +1075,7 @@ namespace Raven.Server.Documents
         }
 
         public SmugglerResult FullBackupTo(string backupPath, CompressionLevel compressionLevel = CompressionLevel.Optimal,
-            Action<(string Message, int FilesCount)> infoNotify = null, CancellationToken cancellationToken = default)
+            bool excludeIndexes = false, Action<(string Message, int FilesCount)> infoNotify = null, CancellationToken cancellationToken = default)
         {
             SmugglerResult smugglerResult;
 
@@ -1160,7 +1163,7 @@ namespace Raven.Server.Documents
 
                 infoNotify?.Invoke(("Backed up database values", 1));
 
-                BackupMethods.Full.ToFile(GetAllStoragesForBackup(), package, compressionLevel,
+                BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), package, compressionLevel,
                     infoNotify: infoNotify, cancellationToken: cancellationToken);
 
                 file.Flush(true); // make sure that we fully flushed to disk

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -607,7 +607,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                         var totalSw = Stopwatch.StartNew();
                         var sw = Stopwatch.StartNew();
                         var compressionLevel = _configuration.SnapshotSettings?.CompressionLevel ?? CompressionLevel.Optimal;
-                        var smugglerResult = _database.FullBackupTo(tempBackupFilePath, compressionLevel,
+                        var excludeIndexes = _configuration.SnapshotSettings?.ExcludeIndexes ?? false;
+                        var smugglerResult = _database.FullBackupTo(tempBackupFilePath, compressionLevel, excludeIndexes,
                             info =>
                             {
                                 AddInfo(info.Message);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17871/Allow-to-exclude-indexes-when-creating-a-snapshot

### Additional description

When executing backup on a large database the read transaction is held for a long time.
If the server has writes during the backup the mount of scratch files will increase.
On a high write rate (or system with little memory) it will cause low memory.
Large backups at a high write rate can be handled by creating a snapshot instead of a backup.
In the case of using a snapshot instead of a backup to deal with the long read transaction, the indexes included in the snapshot are not relevant.
In this pull request, we are adding an option to exclude indexes in the snapshot.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update.

### Testing 

- Tests have been added that prove the feature works.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio