### PR TITLE
RavenDB-19377 since we are taking whole segment from the _internalRea…

### DIFF
--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -922,7 +922,10 @@ namespace Sparrow.Server
                 if (segment != null)
                 {
                     _currentlyAllocated += allocationUnit;
-                    return Create(segment.Current, length, allocationUnit, type);
+
+                    Debug.Assert(segment.Size == segment.SizeLeft, $"{segment.Size} == {segment.SizeLeft}");
+
+                    return Create(segment.Current, length, segment.SizeLeft, type);
                 }
 
                 goto AllocateWhole;

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -921,7 +921,7 @@ namespace Sparrow.Server
                 var segment = GetFromReadyToUseMemorySegments(allocationUnit);
                 if (segment != null)
                 {
-                    _currentlyAllocated += allocationUnit;
+                    _currentlyAllocated += segment.SizeLeft;
 
                     Debug.Assert(segment.Size == segment.SizeLeft, $"{segment.Size} == {segment.SizeLeft}");
 


### PR DESCRIPTION
…dyToUseMemorySegments and allocating ByteString from it then the size of that ByteString needs to be SizeLeft, so we will return same amount to the _internalReadyToUseMemorySegments on release

This was reproduced during the export/backup of a database with large number of huge revisions (with different sizes varying from small to large), because the allocations there were caused by decompression buffers (revisions are compressed by default), but this case could happen also for compressed documents with exact same result.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19377

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
