### PR TITLE
RavenDB-19434 - generate the debug information only if needed

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -719,7 +719,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, updateCommand?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, updateCommand);
             }
         }
 
@@ -820,7 +820,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(commandType, index, exception, compareExchange?.AdditionalDebugInformation(exception));
+                LogCommand(commandType, index, exception, compareExchange);
             }
         }
 
@@ -874,7 +874,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(nameof(CleanUpClusterStateCommand), index, exception, cleanCommand?.AdditionalDebugInformation(exception));
+                LogCommand(nameof(CleanUpClusterStateCommand), index, exception, cleanCommand);
             }
         }
 
@@ -917,7 +917,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(nameof(ClusterTransactionCommand), index, exception, clusterTransaction?.AdditionalDebugInformation(exception));
+                LogCommand(nameof(ClusterTransactionCommand), index, exception, clusterTransaction);
             }
         }
 
@@ -1231,7 +1231,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(nameof(RemoveNodeFromClusterCommand), index, exception, removedCmd?.AdditionalDebugInformation(exception));
+                LogCommand(nameof(RemoveNodeFromClusterCommand), index, exception, removedCmd);
             }
         }
 
@@ -1351,7 +1351,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, updateCommand?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, updateCommand);
                 NotifyDatabaseAboutChanged(context, updateCommand?.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged, null);
             }
         }
@@ -1413,7 +1413,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(nameof(RemoveNodeFromDatabaseCommand), index, exception, remove?.AdditionalDebugInformation(exception));
+                LogCommand(nameof(RemoveNodeFromDatabaseCommand), index, exception, remove);
             }
         }
 
@@ -1632,7 +1632,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(nameof(AddDatabaseCommand), index, exception, addDatabaseCommand.AdditionalDebugInformation(exception));
+                LogCommand(nameof(AddDatabaseCommand), index, exception, addDatabaseCommand);
                 NotifyDatabaseAboutChanged(context, addDatabaseCommand.Name, index, nameof(AddDatabaseCommand),
                     addDatabaseCommand.IsRestore
                         ? DatabasesLandlord.ClusterDatabaseChangeType.RecordRestored
@@ -1833,7 +1833,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, delCmd?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, delCmd);
                 NotifyValueChanged(context, type, index);
             }
         }
@@ -1951,7 +1951,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, delCmd?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, delCmd);
                 NotifyValueChanged(context, type, index);
             }
         }
@@ -1992,7 +1992,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, command?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, command);
 
                 if (skipNotifyValueChanged == false)
                     NotifyValueChanged(context, type, index);
@@ -2069,7 +2069,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, command.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, command);
                 NotifyValueChanged(context, type, index);
             }
         }
@@ -2361,25 +2361,25 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, updateCommand?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, updateCommand);
                 NotifyDatabaseAboutChanged(context, databaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged, updateCommand);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void LogCommand(string type, long index, Exception exception, string additionalDebugInformation = null)
+        private void LogCommand(string type, long index, Exception exception, CommandBase commandBase = null)
         {
             if (_parent.Log.IsInfoEnabled)
             {
-                LogCommandInternal(type, index, exception, additionalDebugInformation);
+                LogCommandInternal(type, index, exception, commandBase);
             }
         }
 
-        private void LogCommandInternal(string type, long index, Exception exception, string additionalDebugInformation)
+        private void LogCommandInternal(string type, long index, Exception exception, CommandBase commandBase)
         {
             var successStatues = exception != null ? "has failed" : "was successful";
             var msg = $"Apply of {type} with index {index} {successStatues}.";
-            var additionalDebugInfo = additionalDebugInformation;
+            var additionalDebugInfo = commandBase?.AdditionalDebugInformation(exception);
             if (additionalDebugInfo != null)
             {
                 msg += $" AdditionalDebugInformation: {additionalDebugInfo}.";
@@ -2799,7 +2799,7 @@ namespace Raven.Server.ServerWide
             }
             finally
             {
-                LogCommand(type, index, exception, compareExchange?.AdditionalDebugInformation(exception));
+                LogCommand(type, index, exception, compareExchange);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19434/Compare-exchange-execution-produces-a-log-of-debug-information

### Additional description

Generate the debug information only if `Information` logs are turned on

### Type of change

- Bug fix

### How risky is the change?

- Low 
