### PR TITLE
RavenDB-18803 - Create Orchestrator Topology

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3446,11 +3446,11 @@ namespace Raven.Server.ServerWide
 
             if (ShardHelper.TryGetShardNumberAndDatabaseName(ref name, out var shardNumber))
             {
-                databaseRecord = BuildShardedDatabaseRecord(context, Read(context, "db/" + name.ToLowerInvariant(), out etag), shardNumber);
+                databaseRecord = BuildShardedDatabaseRecord(context, Read(context, Constants.Documents.Prefix + name.ToLowerInvariant(), out etag), shardNumber);
             }
             else
             {
-                databaseRecord = Read(context, "db/" + name.ToLowerInvariant(), out etag);
+                databaseRecord = Read(context, Constants.Documents.Prefix + name.ToLowerInvariant(), out etag);
             }
             if (databaseRecord == null)
                 return null;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18803

### Additional description

When given a sharded database name, this EP returns its orchestrator topology. in the info.
When given no name, returns all shards info each with respective topology.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Might need UI work
