### PR TITLE
RavenDB-19436 - improve the performance of the restore process

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/BackupUtils.cs
+++ b/src/Raven.Client/Documents/Smuggler/BackupUtils.cs
@@ -26,8 +26,12 @@ namespace Raven.Client.Documents.Smuggler
         {
             var extension = Path.GetExtension(filePath);
 
-            return IsSnapshot(extension) ||
-                   Constants.Documents.PeriodicBackup.FullBackupExtension.Equals(extension, StringComparison.OrdinalIgnoreCase) ||
+            return IsFullBackup(extension) || IsSnapshot(extension);
+        }
+
+        internal static bool IsFullBackup(string extension)
+        {
+            return Constants.Documents.PeriodicBackup.FullBackupExtension.Equals(extension, StringComparison.OrdinalIgnoreCase) ||
                    Constants.Documents.PeriodicBackup.EncryptedFullBackupExtension.Equals(extension, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -48,9 +48,7 @@ using Sparrow.Json.Sync;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Server;
-using Sparrow.Server.Json.Sync;
 using Sparrow.Server.Meters;
-using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
@@ -455,7 +453,7 @@ namespace Raven.Server.Documents
                     using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        await ExecuteClusterTransaction(context);
+                        await ExecuteClusterTransaction(context, 1);
                     }
                 }
                 catch (Exception e)
@@ -468,13 +466,13 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async Task ExecuteClusterTransaction(TransactionOperationContext context)
+        public async Task<List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> ExecuteClusterTransaction(TransactionOperationContext context, int batchSize)
         {
             var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
-                ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: 256));
+                ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: batchSize));
 
             if (batch.Count == 0)
-                return;
+                return batch;
 
             var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(this, batch);
             try
@@ -490,12 +488,14 @@ namespace Raven.Server.Documents
                     _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
                 }
                 await ExecuteClusterTransactionOneByOne(batch);
-                return;
             }
+
             foreach (var command in batch)
             {
                 OnClusterTransactionCompletion(command, mergedCommands);
             }
+
+            return batch;
         }
 
         private async Task ExecuteClusterTransactionOneByOne(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -494,6 +494,7 @@ namespace Raven.Server.Documents
                     _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
                 }
                 await ExecuteClusterTransactionOneByOne(batch);
+                return batch;
             }
 
             foreach (var command in batch)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -628,16 +628,9 @@ namespace Raven.Server.Documents.Handlers
                                 case CommandType.PUT:
                                     if (current < count)
                                     {
-                                        NonPersistentDocumentFlags nonPersistentDocumentFlags = NonPersistentDocumentFlags.None;
-
-                                        if (cmd.FromBackup)
-                                        {
-                                            // if the document came from backup it must have the same collection
-                                            // the only thing that we update is the change vector
-                                            // in this case, we can skip revision creation
-                                            nonPersistentDocumentFlags = NonPersistentDocumentFlags.SkipRevisionCreation;
-                                        }
-                                        else
+                                        // if the document came from a full backup it must have the same collection
+                                        // the only thing that we update is the change vector
+                                        if (cmd.FromFullBackup == false)
                                         {
                                             // delete the document to avoid exception if we put new document in a different collection.
                                             // TODO: document this behavior
@@ -649,7 +642,7 @@ namespace Raven.Server.Documents.Handlers
                                         }
 
                                         var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document.Clone(context), changeVector: changeVector,
-                                            flags: DocumentFlags.FromClusterTransaction, nonPersistentFlags: nonPersistentDocumentFlags);
+                                            flags: DocumentFlags.FromClusterTransaction);
                                         context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);
                                         AddPutResult(putResult);
                                     }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -633,7 +633,6 @@ namespace Raven.Server.Documents.Handlers
                                         if (cmd.FromFullBackup == false)
                                         {
                                             // delete the document to avoid exception if we put new document in a different collection.
-                                            // TODO: document this behavior
                                             using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
                                             {
                                                 Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, expectedChangeVector: null,

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -23,6 +23,7 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.Rachis;
@@ -630,7 +631,7 @@ namespace Raven.Server.Documents.Handlers
                                     {
                                         // if the document came from a full backup it must have the same collection
                                         // the only thing that we update is the change vector
-                                        if (cmd.FromFullBackup == false)
+                                        if (cmd.FromBackup is not BackupKind.Full)
                                         {
                                             // delete the document to avoid exception if we put new document in a different collection.
                                             using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
@@ -1191,7 +1192,7 @@ namespace Raven.Server.Documents.Handlers
 
             private void EtlGetDocIdFromPrefixIfNeeded(ref string docId, BatchRequestParser.CommandData cmd, DocumentsStorage.PutOperationResults? lastPutResult)
             {
-                if (cmd.FromEtl==false || docId[^1] != Database.IdentityPartsSeparator)
+                if (cmd.FromEtl == false || docId[^1] != Database.IdentityPartsSeparator)
                     return;
                 // counter/time-series/attachments sent by Raven ETL, only prefix is defined
 

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers
             public bool IdPrefixed;
             public long Index;
             public bool FromEtl;
-            public bool FromBackup;
+            public bool FromFullBackup;
             public bool ReturnDocument;
 
             public bool SeenCounters;
@@ -670,7 +670,7 @@ namespace Raven.Server.Documents.Handlers
                         commandData.FromEtl = state.CurrentTokenType == JsonParserToken.True;
                         break;
 
-                    case CommandPropertyName.FromBackup:
+                    case CommandPropertyName.FromFullBackup:
                         while (parser.Read() == false)
                             await RefillParserBuffer(stream, buffer, parser, token);
 
@@ -679,7 +679,7 @@ namespace Raven.Server.Documents.Handlers
                             ThrowUnexpectedToken(JsonParserToken.True, state);
                         }
 
-                        commandData.FromBackup = state.CurrentTokenType == JsonParserToken.True;
+                        commandData.FromFullBackup = state.CurrentTokenType == JsonParserToken.True;
                         break;
 
                     case CommandPropertyName.AttachmentType:
@@ -925,7 +925,7 @@ namespace Raven.Server.Documents.Handlers
             #endregion RavenData
 
             FromEtl,
-            FromBackup
+            FromFullBackup
 
             // other properties are ignore (for legacy support)
         }
@@ -985,10 +985,6 @@ namespace Raven.Server.Documents.Handlers
                         *(short*)(state.StringBuffer + sizeof(long)) == 29541)
                         return CommandPropertyName.TimeSeries;
 
-                    if (*(long*)state.StringBuffer == 7738135522684400198 &&
-                        *(short*)(state.StringBuffer + sizeof(long)) == 28789)
-                        return CommandPropertyName.FromBackup;
-
                     return CommandPropertyName.NoSuchProperty;
 
                 case 11:
@@ -1026,14 +1022,22 @@ namespace Raven.Server.Documents.Handlers
                         *(long*)(state.StringBuffer + sizeof(int)) == 7598543892411468136 &&
                         *(short*)(state.StringBuffer + sizeof(int) + sizeof(long)) == 26478)
                         return CommandPropertyName.PatchIfMissing;
+
                     if (*(int*)state.StringBuffer == 1970562386 &&
                         *(long*)(state.StringBuffer + sizeof(int)) == 7308626840221150834 &&
                         *(short*)(state.StringBuffer + sizeof(int) + sizeof(long)) == 29806)
                         return CommandPropertyName.ReturnDocument;
+
                     if (*(int*)state.StringBuffer == 1635021889 &&
                         *(long*)(state.StringBuffer + sizeof(int)) == 8742740794129868899 &&
                         *(short*)(state.StringBuffer + sizeof(int) + sizeof(long)) == 25968)
                         return CommandPropertyName.AttachmentType;
+
+                    if (*(int*)state.StringBuffer == 1836020294 &&
+                        *(long*)(state.StringBuffer + sizeof(int)) == 7738135522667427142 &&
+                        *(short*)(state.StringBuffer + sizeof(int) + sizeof(long)) == 28789)
+                        return CommandPropertyName.FromFullBackup;
+
                     return CommandPropertyName.NoSuchProperty;
 
                 case 15:

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupKind.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupKind.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Server.Documents.PeriodicBackup;
+
+public enum BackupKind
+{
+    None,
+    Full,
+    Incremental
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -36,6 +36,7 @@ using Sparrow.Utils;
 using Voron.Data.Tables;
 using Voron.Impl.Backup;
 using Voron.Util.Settings;
+using BackupUtils = Raven.Client.Documents.Smuggler.BackupUtils;
 using Index = Raven.Server.Documents.Indexes.Index;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
@@ -844,7 +845,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     database.Time, options, result: restoreResult, onProgress: onProgress, token: _operationCancelToken.Token)
                 {
                     OnIndexAction = onIndexAction,
-                    OnDatabaseRecordAction = onDatabaseRecordAction
+                    OnDatabaseRecordAction = onDatabaseRecordAction,
+                    FromFullBackup = BackupUtils.IsFullBackup(Path.GetExtension(filePath))
                 };
                 await smuggler.ExecuteAsync(ensureStepsProcessed: false, isLastFile);
             }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -912,7 +912,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         {
                             var source = new StreamSource(uncompressed, context, database);
                             var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,
-                                database.Time, smugglerOptions, onProgress: onProgress, token: _operationCancelToken.Token);
+                                database.Time, smugglerOptions, onProgress: onProgress, token: _operationCancelToken.Token)
+                            {
+                                BackupType = BackupType.Incremental
+                            };
 
                             await smuggler.ExecuteAsync(ensureStepsProcessed: true, isLastFile: true);
                         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -867,17 +867,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 {
                     OnIndexAction = onIndexAction,
                     OnDatabaseRecordAction = onDatabaseRecordAction,
-                    BackupType = BackupUtils.IsFullBackup(Path.GetExtension(filePath)) ? BackupType.Full : BackupType.Incremental
+                    BackupKind = BackupUtils.IsFullBackup(Path.GetExtension(filePath)) ? BackupKind.Full : BackupKind.Incremental
                 };
                 await smuggler.ExecuteAsync(ensureStepsProcessed: false, isLastFile);
             }
-        }
-
-        public enum BackupType
-        {
-            None,
-            Full,
-            Incremental
         }
 
         /// <summary>
@@ -914,7 +907,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                             var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,
                                 database.Time, smugglerOptions, onProgress: onProgress, token: _operationCancelToken.Token)
                             {
-                                BackupType = BackupType.Incremental
+                                BackupKind = BackupKind.Incremental
                             };
 
                             await smuggler.ExecuteAsync(ensureStepsProcessed: true, isLastFile: true);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -738,6 +738,27 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     // need to enable revisions before import
                     database.DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(smugglerDatabaseRecord);
                 });
+
+            long totalExecutedCommands = 0;
+
+            //when restoring from a backup, the database doesn't exist yet and we cannot rely on the DocumentDatabase to execute the database cluster transaction commands
+            while (true)
+            {
+                _operationCancelToken.Token.ThrowIfCancellationRequested();
+
+                using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
+                using (serverContext.OpenReadTransaction())
+                {
+                    // the commands are already batched (10k or 8MB), so we are executing only 1 at a time
+                    var executed = await database.ExecuteClusterTransaction(serverContext, batchSize: 1);
+                    if (executed.Count == 0)
+                        break;
+
+                    totalExecutedCommands += executed.Sum(x => x.Commands.Length);
+                    result.AddInfo($"Executed {totalExecutedCommands:#,#;;0} cluster transaction commands.");
+                    onProgress.Invoke(result.Progress);
+                }
+            }
         }
 
         private bool IsDefaultDataDirectory(string dataDirectory, string databaseName)
@@ -846,10 +867,17 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 {
                     OnIndexAction = onIndexAction,
                     OnDatabaseRecordAction = onDatabaseRecordAction,
-                    FromFullBackup = BackupUtils.IsFullBackup(Path.GetExtension(filePath))
+                    BackupType = BackupUtils.IsFullBackup(Path.GetExtension(filePath)) ? BackupType.Full : BackupType.Incremental
                 };
                 await smuggler.ExecuteAsync(ensureStepsProcessed: false, isLastFile);
             }
+        }
+
+        public enum BackupType
+        {
+            None,
+            Full,
+            Incremental
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -749,7 +749,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
                 using (serverContext.OpenReadTransaction())
                 {
-                    // the commands are already batched (10k or 8MB), so we are executing only 1 at a time
+                    // the commands are already batched (10k or 16MB), so we are executing only 1 at a time
                     var executed = await database.ExecuteClusterTransaction(serverContext, batchSize: 1);
                     if (executed.Count == 0)
                         break;

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -40,6 +40,7 @@ namespace Raven.Server.ServerWide.Commands
             public BlittableJsonReaderObject Document;
             public string ChangeVector;
             public long Index;
+            public bool FromBackup;
             public string Error;
 
             public static ClusterTransactionDataCommand FromCommandData(BatchRequestParser.CommandData command)
@@ -55,7 +56,8 @@ namespace Raven.Server.ServerWide.Commands
                     ChangeVector = command.OriginalChangeVector ?? command.ChangeVector,
                     Document = command.Document,
                     Index = command.Index,
-                    Type = command.Type
+                    Type = command.Type,
+                    FromBackup = command.FromBackup
                 };
             }
 
@@ -68,6 +70,7 @@ namespace Raven.Server.ServerWide.Commands
                     [nameof(Index)] = Index,
                     [nameof(ChangeVector)] = ChangeVector,
                     [nameof(Document)] = Document?.Clone(context),
+                    [nameof(FromBackup)] = FromBackup,
                     [nameof(Error)] = Error
                 };
             }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.ServerWide.Commands
             public BlittableJsonReaderObject Document;
             public string ChangeVector;
             public long Index;
-            public bool FromBackup;
+            public bool FromFullBackup;
             public string Error;
 
             public static ClusterTransactionDataCommand FromCommandData(BatchRequestParser.CommandData command)
@@ -57,7 +57,7 @@ namespace Raven.Server.ServerWide.Commands
                     Document = command.Document,
                     Index = command.Index,
                     Type = command.Type,
-                    FromBackup = command.FromBackup
+                    FromFullBackup = command.FromFullBackup
                 };
             }
 
@@ -70,7 +70,7 @@ namespace Raven.Server.ServerWide.Commands
                     [nameof(Index)] = Index,
                     [nameof(ChangeVector)] = ChangeVector,
                     [nameof(Document)] = Document?.Clone(context),
-                    [nameof(FromBackup)] = FromBackup,
+                    [nameof(FromFullBackup)] = FromFullBackup,
                     [nameof(Error)] = Error
                 };
             }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -104,7 +104,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface ICompareExchangeActions : INewCompareExchangeActions, IAsyncDisposable
     {
-        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value);
+        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, bool fromFullBackup);
 
         ValueTask WriteTombstoneKeyAsync(string key);
     }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -10,7 +10,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
-using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -35,7 +35,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         IKeyValueActions<long> Identities();
 
-        ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType, bool withDocuments);
+        ICompareExchangeActions CompareExchange(JsonOperationContext context, BackupKind? backupKind, bool withDocuments);
 
         ICompareExchangeActions CompareExchangeTombstones(JsonOperationContext context);
 

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.PeriodicBackup.Restore;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -34,7 +35,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         IKeyValueActions<long> Identities();
 
-        ICompareExchangeActions CompareExchange(JsonOperationContext context);
+        ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType);
 
         ICompareExchangeActions CompareExchangeTombstones(JsonOperationContext context);
 
@@ -104,7 +105,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface ICompareExchangeActions : INewCompareExchangeActions, IAsyncDisposable
     {
-        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, bool fromFullBackup);
+        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
 
         ValueTask WriteTombstoneKeyAsync(string key);
     }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         IKeyValueActions<long> Identities();
 
-        ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType);
+        ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType, bool withDocuments);
 
         ICompareExchangeActions CompareExchangeTombstones(JsonOperationContext context);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -584,7 +584,7 @@ namespace Raven.Server.Smuggler.Documents
                 _clusterTransactionCommandsSize = new Size(0, SizeUnit.Megabytes);
             }
 
-            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value)
+            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, bool fromFullBackup)
             {
                 if (_compareExchangeValuesSize >= _compareExchangeValuesBatchSize || _compareExchangeAddOrUpdateCommands.Count >= BatchSize)
                 {
@@ -611,7 +611,7 @@ namespace Raven.Server.Smuggler.Documents
                         Document = doc.Data,
                         Type = CommandType.PUT,
                         OriginalChangeVector = ctx.GetLazyString(doc.ChangeVector),
-                        FromBackup = true
+                        FromFullBackup = fromFullBackup
                     });
 
                     _clusterTransactionCommandsSize.Add(doc.Data.Size, SizeUnit.Bytes);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -606,7 +606,13 @@ namespace Raven.Server.Smuggler.Documents
                     if (doc == null)
                         return;
 
-                    _clusterTransactionCommands.Push(new BatchRequestParser.CommandData { Id = doc.Id, Document = doc.Data, Type = CommandType.PUT, OriginalChangeVector = ctx.GetLazyString(doc.ChangeVector) });
+                    _clusterTransactionCommands.Push(new BatchRequestParser.CommandData {
+                        Id = doc.Id,
+                        Document = doc.Data,
+                        Type = CommandType.PUT,
+                        OriginalChangeVector = ctx.GetLazyString(doc.ChangeVector),
+                        FromBackup = true
+                    });
 
                     _clusterTransactionCommandsSize.Add(doc.Data.Size, SizeUnit.Bytes);
                 }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -114,7 +114,25 @@ namespace Raven.Server.Smuggler.Documents
 
         public ICompareExchangeActions CompareExchange(JsonOperationContext context, BackupKind? backupKind, bool withDocuments)
         {
-            return new DatabaseCompareExchangeActions(_database, context, backupKind, _token);
+            if (withDocuments == false)
+                return CreateActions();
+
+            switch (backupKind)
+            {
+                case null:
+                case BackupKind.None:
+                    return null; // do not optimize for Import
+                case BackupKind.Full:
+                case BackupKind.Incremental:
+                    return CreateActions();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(backupKind), backupKind, null);
+            }
+
+            DatabaseCompareExchangeActions CreateActions()
+            {
+                return new DatabaseCompareExchangeActions(_database, context, backupKind, _token);
+            }
         }
 
         public ICompareExchangeActions CompareExchangeTombstones(JsonOperationContext context)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -672,10 +672,10 @@ namespace Raven.Server.Smuggler.Documents
                     await SendRemoveCommandsAsync(_context);
 
                     if (_lastAddOrUpdateOrRemoveResultIndex != null)
-                        await _database.ServerStore.Cluster.WaitForIndexNotification(_lastAddOrUpdateOrRemoveResultIndex.Value, TimeSpan.FromMinutes(5));
+                        await _database.ServerStore.Cluster.WaitForIndexNotification(_lastAddOrUpdateOrRemoveResultIndex.Value, TimeSpan.FromSeconds(1));
 
                     if (_lastClusterTransactionIndex != null)
-                        await _database.ServerStore.Cluster.WaitForIndexNotification(_lastClusterTransactionIndex.Value, TimeSpan.FromMinutes(5));
+                        await _database.ServerStore.Cluster.WaitForIndexNotification(_lastClusterTransactionIndex.Value, TimeSpan.FromMinutes(1));
                 }
             }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Smuggler.Documents
             return new DatabaseKeyValueActions(_database);
         }
 
-        public ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType)
+        public ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType, bool withDocuments)
         {
             return new DatabaseCompareExchangeActions(_database, context, backupType, _token);
         }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -675,7 +675,15 @@ namespace Raven.Server.Smuggler.Documents
                         await _database.ServerStore.Cluster.WaitForIndexNotification(_lastAddOrUpdateOrRemoveResultIndex.Value, TimeSpan.FromSeconds(1));
 
                     if (_lastClusterTransactionIndex != null)
+                    {
                         await _database.ServerStore.Cluster.WaitForIndexNotification(_lastClusterTransactionIndex.Value, TimeSpan.FromMinutes(1));
+
+                        if (_backupType == RestoreBackupTaskBase.BackupType.None)
+                        {
+                            // waiting for the commands to be applied
+                            await _database.RachisLogIndexNotifications.WaitForIndexNotification(_lastClusterTransactionIndex.Value, _token);
+                        }
+                    }
                 }
             }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -34,6 +34,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public Action<IndexDefinitionAndType> OnIndexAction;
         public Action<DatabaseRecord> OnDatabaseRecordAction;
+        public bool FromFullBackup;
 
         public const string PreV4RevisionsDocumentId = "/revisions/";
 
@@ -857,7 +858,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     try
                     {
-                        await actions.WriteKeyValueAsync(kvp.Key.Key, kvp.Value);
+                        await actions.WriteKeyValueAsync(kvp.Key.Key, kvp.Value, FromFullBackup);
                         result.CompareExchange.LastEtag = kvp.Index;
                     }
                     catch (Exception e)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -754,7 +754,7 @@ namespace Raven.Server.Smuggler.Documents
                     if (SkipDocument(buildType, isPreV4Revision, item, result, ref legacyIdsToDelete))
                         continue;
 
-                    if (compareExchangeActions != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
+                    if (compareExchangeActions != null && item.Document.ChangeVector != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
                     {
                         var key = ClusterTransactionCommand.GetAtomicGuardKey(item.Document.Id);
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -14,7 +14,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
-using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Data;
@@ -37,7 +37,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public Action<IndexDefinitionAndType> OnIndexAction;
         public Action<DatabaseRecord> OnDatabaseRecordAction;
-        public RestoreBackupTaskBase.BackupType BackupType = RestoreBackupTaskBase.BackupType.None;
+        public BackupKind BackupKind = BackupKind.None;
 
         public const string PreV4RevisionsDocumentId = "/revisions/";
 
@@ -679,7 +679,7 @@ namespace Raven.Server.Smuggler.Documents
 
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var documentActions = _destination.Documents(throwOnCollectionMismatchError))
-            await using (var compareExchangeActions = _destination.CompareExchange(context, BackupType, withDocuments: true))
+            await using (var compareExchangeActions = _destination.CompareExchange(context, BackupKind, withDocuments: true))
             {
                 List<string> legacyIdsToDelete = null;
 
@@ -853,7 +853,7 @@ namespace Raven.Server.Smuggler.Documents
             result.CompareExchange.Start();
 
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var actions = _destination.CompareExchange(context, BackupType, withDocuments: false))
+            await using (var actions = _destination.CompareExchange(context, BackupKind, withDocuments: false))
             {
                 await foreach (var kvp in _source.GetCompareExchangeValuesAsync(actions))
                 {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -679,7 +679,7 @@ namespace Raven.Server.Smuggler.Documents
 
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var documentActions = _destination.Documents(throwOnCollectionMismatchError))
-            await using (var compareExchangeActions = _destination.CompareExchange(context, BackupType))
+            await using (var compareExchangeActions = _destination.CompareExchange(context, BackupType, withDocuments: true))
             {
                 List<string> legacyIdsToDelete = null;
 
@@ -853,7 +853,7 @@ namespace Raven.Server.Smuggler.Documents
             result.CompareExchange.Start();
 
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var actions = _destination.CompareExchange(context, BackupType))
+            await using (var actions = _destination.CompareExchange(context, BackupType, withDocuments: false))
             {
                 await foreach (var kvp in _source.GetCompareExchangeValuesAsync(actions))
                 {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1164,7 +1164,7 @@ namespace Raven.Server.Smuggler.Documents
             {
             }
 
-            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value)
+            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, bool fromFullBackup)
             {
                 using (value)
                 {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -26,7 +26,7 @@ using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
-using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
@@ -162,7 +162,7 @@ namespace Raven.Server.Smuggler.Documents
             return new StreamKeyValueActions<long>(_writer, nameof(DatabaseItemType.Identities));
         }
 
-        public ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType, bool withDocuments)
+        public ICompareExchangeActions CompareExchange(JsonOperationContext context, BackupKind? backupKind, bool withDocuments)
         {
             return withDocuments ? null : new StreamCompareExchangeActions(_writer, nameof(DatabaseItemType.CompareExchange));
         }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -162,11 +162,9 @@ namespace Raven.Server.Smuggler.Documents
             return new StreamKeyValueActions<long>(_writer, nameof(DatabaseItemType.Identities));
         }
 
-        public ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType)
+        public ICompareExchangeActions CompareExchange(JsonOperationContext context, RestoreBackupTaskBase.BackupType backupType, bool withDocuments)
         {
-            return backupType is RestoreBackupTaskBase.BackupType.Full or RestoreBackupTaskBase.BackupType.Incremental 
-                ? null
-                : new StreamCompareExchangeActions(_writer, nameof(DatabaseItemType.CompareExchange));
+            return withDocuments ? null : new StreamCompareExchangeActions(_writer, nameof(DatabaseItemType.CompareExchange));
         }
 
         public ICompareExchangeActions CompareExchangeTombstones(JsonOperationContext context)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -576,7 +576,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
                 config.SnapshotSettings = new SnapshotSettings { CompressionLevel = CompressionLevel.Fastest, ExcludeIndexes = false };
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                
+
                 // check that backup file consist Indexes folder
                 var backupLocation = Directory.GetDirectories(backupPath).First();
                 using (ReadOnly(backupLocation))
@@ -591,7 +591,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 config.SnapshotSettings.ExcludeIndexes = true;
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                
+
                 backupLocation = Directory.GetDirectories(backupPath).First();
                 using (ReadOnly(backupLocation))
                 {
@@ -647,7 +647,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDatabaseEtag;
             await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: lastEtag);
-            
+
             // restore the database with a different name
             string restoredDatabaseName = GetDatabaseName();
             var backupLocation = Directory.GetDirectories(backupPath).First();
@@ -670,7 +670,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var restoreStats = await destination.Maintenance.SendAsync(new GetDetailedStatisticsOperation());
                 Assert.Equal(sourceStats.CountOfCompareExchange, restoreStats.CountOfCompareExchange);
 
-                using (var session = destination.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide}))
+                using (var session = destination.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
                     var user = await session.LoadAsync<User>(ids[0]);
 
@@ -678,7 +678,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     await session.SaveChangesAsync();
                 }
-                
+
                 using (var session = destination.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
                     await session.StoreAsync(new User(), ids[0]);
@@ -2823,9 +2823,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 const string country = "Israel";
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
-                       {
-                           TransactionMode = TransactionMode.ClusterWide
-                       }))
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
                 {
                     await session.StoreAsync(new User
                     {
@@ -2838,18 +2838,18 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
-                       {
-                           TransactionMode = TransactionMode.ClusterWide
-                       }))
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
                 {
                     session.Delete("users/1");
                     await session.SaveChangesAsync();
                 }
 
                 using (var session = store.OpenAsyncSession(new SessionOptions
-                       {
-                           TransactionMode = TransactionMode.ClusterWide
-                       }))
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
                 {
                     await session.StoreAsync(new Address
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19436/High-usage-of-IO-during-import-of-Compare-Exchange

### Additional description

During the restore process, we first write the documents and then the atomic guards.
Atomic guards are saved with the relevant document in the cluster and the command is applied later.
In this flow, we write the document and then overwrite it later (the same document but with a different change vector).

During the restore of the documents, we identify the documents that have atomic guards and generate the relevant cluster command.

### Type of change

- Optimization

### How risky is the change?

- Medium

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
