### PR TITLE
RavenDB-19441 Error when saving revisions config

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
@@ -258,8 +258,8 @@ class revisions extends viewModelBase {
             .done(() => {
                 this.dirtyFlag().reset();
                 
-                this.defaultConflictConfiguration().dirtyFlag().reset();
-                this.defaultDocumentConfiguration().dirtyFlag().reset();
+                this.defaultConflictConfiguration()?.dirtyFlag().reset();
+                this.defaultDocumentConfiguration()?.dirtyFlag().reset();
                 this.perCollectionConfigurations().forEach(item => item.dirtyFlag().reset());
                 
                 messagePublisher.reportSuccess(`Revisions configuration has been saved`);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19441 

### Additional description

Fix save button on revisions page

### Type of change

- Regression bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### UI work

- No UI work is needed
