### PR TITLE
RavenDB-19361 Improper tracking of NumberOfEntries at the Set

### DIFF
--- a/src/Voron/Data/Sets/PForDecoder.cs
+++ b/src/Voron/Data/Sets/PForDecoder.cs
@@ -64,9 +64,9 @@ namespace Voron.Data.Sets
             state.BufferSize = bufferLength;
         }
 
-        public static DecoderState Initialize(Span<byte> inputBuffer)
+        public static DecoderState Initialize(int length)
         {
-            return new DecoderState(inputBuffer.Length);
+            return new DecoderState(length);
         }
 
         private static ReadOnlySpan<byte> NumberOfValues => new byte[] { 1, 32, 64, 128 };
@@ -307,7 +307,7 @@ namespace Voron.Data.Sets
             Span<int> scratch = stackalloc int[128];
             
             var list = new List<int>();
-            var state = Initialize(buf);
+            var state = Initialize(buf.Length);
             while (true)
             {
                 var len = Decode(ref state, buf, scratch);

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -250,6 +250,7 @@ namespace Voron.Impl
             {
                 foreach (Set set in _sets.Values)
                 {
+                    set.PrepareForCommit();
                     using (_lowLevelTransaction.RootObjects.DirectAdd(set.Name, sizeof(SetState), out byte* ptr))
                     {
                         Span<byte> span = new Span<byte>(ptr, sizeof(SetState));

--- a/test/FastTests/Corax/Bugs/RavenDB-19361.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19361.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+using FastTests.Voron;
+using Voron.Data.Sets;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_19361 : StorageTest
+{
+    public RavenDB_19361(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void EnsureProperNumberOfItemsInSetIsAccurate()
+    {
+        using (var wtx = Env.WriteTransaction())
+        {
+            var set = wtx.OpenSet("test");
+
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < SetLeafPage.MaxNumberOfRawValues +1; j++)
+                {
+                    set.Add(j + 1);
+                }
+            }
+            wtx.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var set = rtx.OpenSet("test");
+            Assert.Equal(SetLeafPage.MaxNumberOfRawValues + 1, set.State.NumberOfEntries);
+        }
+    }
+}

--- a/test/FastTests/Corax/Bugs/RavenDB-19361.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19361.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using FastTests.Voron;
 using Voron.Data.Sets;
 using Xunit;
@@ -33,6 +34,45 @@ public class RavenDB_19361 : StorageTest
         {
             var set = rtx.OpenSet("test");
             Assert.Equal(SetLeafPage.MaxNumberOfRawValues + 1, set.State.NumberOfEntries);
+        }
+    }
+    
+    [Fact]
+    public void ProperRemovals()
+    {
+        var mem = new HashSet<long>();
+        using (var wtx = Env.WriteTransaction())
+        {
+            var set = wtx.OpenSet("test");
+
+            for (int j = 0; j < SetLeafPage.MaxNumberOfRawValues * 4; j++)
+            {
+                mem.Add(j + 1);
+                set.Add(j + 1);
+            }
+            wtx.Commit();
+        }
+        
+        using (var wtx = Env.WriteTransaction())
+        {
+            var set = wtx.OpenSet("test");
+
+            set.Add(10_000);
+            mem.Add(10_000);
+            
+            set.Remove(10_000);
+            mem.Remove(10_000);
+            set.Remove(20_000);
+            mem.Remove(20_000);
+
+            wtx.Commit();
+        }
+
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var set = rtx.OpenSet("test");
+            Assert.Equal(mem.Count, set.State.NumberOfEntries);
         }
     }
 }

--- a/test/FastTests/Corax/Bugs/SetAddRemoval.cs
+++ b/test/FastTests/Corax/Bugs/SetAddRemoval.cs
@@ -6,6 +6,7 @@ using FastTests.Voron;
 using SharpCompress.Compressors;
 using SharpCompress.Compressors.Deflate;
 using Voron;
+using Voron.Data.Sets;
 using Voron.Debugging;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,11 +42,14 @@ public class SetAddRemoval : StorageTest
         }
     }
 
-    [Fact]
-    public void AdditionsAndRemovalWork()
+    [Theory]
+    [InlineData(300)]
+    [InlineData(5000)]
+    [InlineData(int.MaxValue)]
+    public void AdditionsAndRemovalWork(int size)
     {
         var maxSize = 0;
-        List<long> items = ReadNumbersFromResource("Corax.Set.Adds.txt");
+        List<long> items = ReadNumbersFromResource("Corax.Set.Adds.txt").Take(size).ToList();
         items.Sort();
         
         maxSize = items.Count;

--- a/test/FastTests/Voron/Sets/SetLeafPageTests.cs
+++ b/test/FastTests/Voron/Sets/SetLeafPageTests.cs
@@ -39,11 +39,12 @@ namespace Tryouts
             var list = new List<long>();
             var buf = new int[] {12, 18};
             var start = 24;
+            long entries = 0;
             for (int i = 0; i < size; i++)
             {
                 start += buf[i % buf.Length];
                 list.Add(start);
-                Assert.True(leaf.Add(_llt, start));
+                Assert.True(leaf.Add(_llt, start, ref entries));
             }
             Assert.Equal(list, leaf.GetDebugOutput(_llt));
         }
@@ -60,17 +61,18 @@ namespace Tryouts
             leaf.Init(0);
             var buf = new int[] {12, 18};
             var start = 24;
+            long entries = 0;
             for (int i = 0; i < size; i++)
             {
                 start += buf[i % buf.Length];
-                Assert.True(leaf.Add(_llt, start));
+                Assert.True(leaf.Add(_llt, start, ref entries));
             }
             
             start = 24;
             for (int i = 0; i < size; i++)
             {
                 start += buf[i % buf.Length];
-                Assert.True(leaf.Remove(_llt, start));
+                Assert.True(leaf.Remove(_llt, start, ref entries));
             }
             Assert.Empty(leaf.GetDebugOutput(_llt));
         }
@@ -89,13 +91,14 @@ namespace Tryouts
             var list = new List<long>();
             var buf = new int[] {12, 18};
             var start = 24;
+            long entries = 0;
             for (int i = 0; i < size; i++)
             {
                 list.Add(start);
-                Assert.True(leaf.Add(_llt, start));
+                Assert.True(leaf.Add(_llt, start, ref entries));
                 start += buf[i % buf.Length];
             }
-            Assert.True(leaf.Add(_llt, 24)); // should be no op
+            Assert.True(leaf.Add(_llt, 24, ref entries)); // should be no op
             Assert.Equal(list, leaf.GetDebugOutput(_llt));
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19361

Implemented the initial fixups to set's number of entries at both leaf re-compression time and during tx commit.

However, there are some scenarios that lead to problems, see the `ProperRemovals` failing test which need more overview to figure out how to properly handle.

### Additional description

### Type of change

- Bug fix

### How risky is the change?

- High

Pretty complex change and impact at a very low level.

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
