### PR TITLE
RavenDB-19363 - SlowTests.Issues.RavenDB_15430.MarkPolicyAfterRollup …

### DIFF
--- a/test/SlowTests/Issues/RavenDB_15430.cs
+++ b/test/SlowTests/Issues/RavenDB_15430.cs
@@ -112,7 +112,7 @@ namespace SlowTests.Issues
                 record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 var firstNode2 = record.Topology.Members[0];
 
-                Assert.True(await WaitForValueAsync(async () =>
+                await WaitForValueAsync(async () =>
                 {
                     record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                     var list = record.Topology.Members;
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
                     record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                     var firstNode3 = record.Topology.Members[0];
                     return firstNode3 != firstNode && firstNode3 != firstNode2;
-                }, true, interval: 333));
+                }, true, interval: 333);
 
                 await Task.Delay(1000);
 


### PR DESCRIPTION
…(fix test)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19363/SlowTestsIssuesRavenDB15430MarkPolicyAfterRollup

### Additional description

In my opinion, ensuring `Topology` reorder is not necessary in this case. The main goal here is to check that the Rollup is working correctly.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
