### PR TITLE
RavenDB-16225: NRE in backup pathfinder

### DIFF
--- a/src/Voron/Platform/Posix/PosixHelper.cs
+++ b/src/Voron/Platform/Posix/PosixHelper.cs
@@ -103,7 +103,10 @@ namespace Voron.Platform.Posix
         {
             if (path != null)
             {
-                var length = Path.GetPathRoot(path).Length;
+                var result = Path.GetPathRoot(path);
+                if (result == null) return path;
+
+                var length = result.Length;
                 if (length > 0)
                     path = "/" + path.Substring(length);
                 path = path.Replace('\\', '/');

--- a/src/Voron/Util/Settings/PathSettingBase.cs
+++ b/src/Voron/Util/Settings/PathSettingBase.cs
@@ -92,7 +92,9 @@ namespace Voron.Util.Settings
             if (PlatformDetails.RunningOnPosix)
                 result = PosixHelper.FixLinuxPath(result);
 
-            return Path.GetFullPath(result); // it will unify directory separators and sort out parent directories
+            return result != string.Empty || resultRoot == null ? 
+                Path.GetFullPath(result) :
+                Path.GetFullPath(resultRoot); // it will unify directory separators and sort out parent directories
         }
 
         public static bool IsSubDirectory(string userPath, string rootPath)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16225/NRE-in-backup-pathfinder

### Additional description

We got throwing `NullReferenceException` on each `'/'` typed in `Backup directory` field.
Now any incorrect input is handled and produces the expected result

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- We had different types of exceptions depending on the platform, but now it works correctly on any platform.

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed