### PR TITLE
RavenDB-19057 - Sharding - Replication - Server-Wide

### DIFF
--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -16,7 +16,6 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
@@ -1460,98 +1459,6 @@ namespace RachisTests.DatabaseCluster
                     TimeSpan.FromSeconds(10)));
                 Assert.True(await WaitForDocumentInClusterAsync<User>(new DatabaseTopology { Members = new List<string> { "A", "B" } }, store.Database, "users/1", null,
                     TimeSpan.FromSeconds(10)));
-            }
-        }
-
-        [Fact]
-        public async Task ServerWideExternalReplicationShouldWork_NonShardedToSharded()
-        {
-            var clusterSize = 3;
-            var dbName = GetDatabaseName();
-
-            var (_, leader) = await CreateRaftCluster(clusterSize);
-            var (shardNodes, shardsLeader) = await CreateRaftCluster(clusterSize);
-
-            await CreateDatabaseInCluster(dbName, 3, leader.WebUrl);
-            await ShardingCluster.CreateShardedDatabaseInCluster(dbName, 3, (shardNodes, shardsLeader));
-
-            using (var store = new DocumentStore() { Urls = new[] { leader.WebUrl }, Database = dbName }.Initialize())
-            {
-                var putConfiguration = new ServerWideExternalReplication
-                {
-                    MentorNode = leader.ServerStore.NodeTag,
-                    TopologyDiscoveryUrls = shardNodes.Select(s => s.WebUrl).ToArray(),
-                    Name = dbName
-                };
-
-                var result = await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(putConfiguration));
-                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideExternalReplicationOperation(result.Name));
-                Assert.NotNull(serverWideConfiguration);
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
-                Assert.Equal(1, record.ExternalReplications.Count);
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User
-                    {
-                        Name = "Karmel"
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                Assert.True(await WaitForDocumentInClusterAsync<User>(
-                    shardNodes,
-                    dbName,
-                    "users/1",
-                    u => u.Name.Equals("Karmel"),
-                    TimeSpan.FromSeconds(60)));
-            }
-        }
-
-        [Fact]
-        public async Task ServerWideExternalReplicationShouldWork_ShardedToNonSharded()
-        {
-            var clusterSize = 3;
-            var dbName = GetDatabaseName();
-
-            var (nodes, leader) = await CreateRaftCluster(clusterSize);
-            var (shardNodes, shardsLeader) = await CreateRaftCluster(clusterSize);
-
-            await CreateDatabaseInCluster(dbName, 3, leader.WebUrl);
-            await ShardingCluster.CreateShardedDatabaseInCluster(dbName, 3, (shardNodes, shardsLeader));
-
-            using (var store = new DocumentStore() { Urls = new[] { shardsLeader.WebUrl }, Database = dbName }.Initialize())
-            {
-                var putConfiguration = new ServerWideExternalReplication
-                {
-                    MentorNode = shardsLeader.ServerStore.NodeTag,
-                    TopologyDiscoveryUrls = nodes.Select(s => s.WebUrl).ToArray(),
-                    Name = dbName
-                };
-
-                var result = await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(putConfiguration));
-                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideExternalReplicationOperation(result.Name));
-                Assert.NotNull(serverWideConfiguration);
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
-                Assert.Equal(1, record.ExternalReplications.Count);
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User
-                    {
-                        Name = "Karmel"
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                Assert.True(await WaitForDocumentInClusterAsync<User>(
-                    nodes,
-                    dbName,
-                    "users/1",
-                    u => u.Name.Equals("Karmel"),
-                    TimeSpan.FromSeconds(60)));
             }
         }
     }

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Replication
+{
+    public class ShardedExternalReplicationTests : ReplicationTestBase
+    {
+        public ShardedExternalReplicationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ServerWideExternalReplicationShouldWork_NonShardedToSharded()
+        {
+            var clusterSize = 3;
+            var dbName = GetDatabaseName();
+
+            var (_, leader) = await CreateRaftCluster(clusterSize);
+            var (shardNodes, shardsLeader) = await CreateRaftCluster(clusterSize);
+
+            await CreateDatabaseInCluster(dbName, 3, leader.WebUrl);
+            await ShardingCluster.CreateShardedDatabaseInCluster(dbName, 3, (shardNodes, shardsLeader));
+
+            using (var store = new DocumentStore() { Urls = new[] { leader.WebUrl }, Database = dbName }.Initialize())
+            {
+                var putConfiguration = new ServerWideExternalReplication
+                {
+                    MentorNode = leader.ServerStore.NodeTag,
+                    TopologyDiscoveryUrls = shardNodes.Select(s => s.WebUrl).ToArray(),
+                    Name = dbName
+                };
+
+                var result = await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(putConfiguration));
+                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideExternalReplicationOperation(result.Name));
+                Assert.NotNull(serverWideConfiguration);
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.ExternalReplications.Count);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel"
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                Assert.True(await WaitForDocumentInClusterAsync<User>(
+                    shardNodes,
+                    dbName,
+                    "users/1",
+                    u => u.Name.Equals("Karmel"),
+                    TimeSpan.FromSeconds(60)));
+            }
+        }
+
+        [Fact]
+        public async Task ServerWideExternalReplicationShouldWork_ShardedToNonSharded()
+        {
+            var clusterSize = 3;
+            var dbName = GetDatabaseName();
+
+            var (nodes, leader) = await CreateRaftCluster(clusterSize);
+            var (shardNodes, shardsLeader) = await CreateRaftCluster(clusterSize);
+
+            await CreateDatabaseInCluster(dbName, 3, leader.WebUrl);
+            await ShardingCluster.CreateShardedDatabaseInCluster(dbName, 3, (shardNodes, shardsLeader));
+
+            using (var store = new DocumentStore() { Urls = new[] { shardsLeader.WebUrl }, Database = dbName }.Initialize())
+            {
+                var putConfiguration = new ServerWideExternalReplication
+                {
+                    MentorNode = shardsLeader.ServerStore.NodeTag,
+                    TopologyDiscoveryUrls = nodes.Select(s => s.WebUrl).ToArray(),
+                    Name = dbName
+                };
+
+                var result = await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(putConfiguration));
+                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideExternalReplicationOperation(result.Name));
+                Assert.NotNull(serverWideConfiguration);
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                Assert.Equal(1, record.ExternalReplications.Count);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel"
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                Assert.True(await WaitForDocumentInClusterAsync<User>(
+                    nodes,
+                    dbName,
+                    "users/1",
+                    u => u.Name.Equals("Karmel"),
+                    TimeSpan.FromSeconds(60)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19057/Sharding-Replication-Server-Wide

### Additional description

Tested manually "_Deleting the sharded database deletes the task leftovers as well_":
- After deleting the sharded database there are no exceptions related to the replication on the other side, and the task is not running (Replication from Sharded to Non-Sharded)

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
