### PR TITLE
RavenDB-19453 @spatial metadata value isn't exposed to javascript pro…

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -246,6 +246,7 @@ namespace Raven.Server.Documents.Patch
 
                 JavaScriptUtils = new JavaScriptUtils(_runner, ScriptEngine);
                 ScriptEngine.SetValue(GetMetadataMethod, new ClrFunctionInstance(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
+                ScriptEngine.SetValue("metadataFor", new ClrFunctionInstance(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
                 ScriptEngine.SetValue("id", new ClrFunctionInstance(ScriptEngine, "id", JavaScriptUtils.GetDocumentId));
 
                 ScriptEngine.SetValue("output", new ClrFunctionInstance(ScriptEngine, "output", OutputDebug));

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -138,6 +138,8 @@ namespace Raven.Server.Documents.Queries.Results
                     using (_projectionStorageScope = _projectionStorageScope?.Start() ?? _projectionScope?.For(nameof(QueryTimingsScope.Names.Storage)))
                         doc = DirectGet(ref retrieverInput, lowerId, DocumentFields.All);
 
+                    FinishDocumentSetup(doc, retrieverInput.Score);
+                    
                     if (doc == null)
                     {
                         if (FieldsToFetch.Projection.MustExtractFromDocument)

--- a/test/SlowTests/Issues/RavenDB-19453.cs
+++ b/test/SlowTests/Issues/RavenDB-19453.cs
@@ -1,0 +1,45 @@
+using System;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19453 : RavenTestBase
+{
+    public RavenDB_19453(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public double Lat, Lng;
+    }
+
+    [Fact]
+    public void CanGetSpatialDistanceFromJavaScriptProjection()
+    {
+        using var store = GetDocumentStore();
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item{Lng = 10, Lat = 10});
+            s.SaveChanges();
+        }
+
+
+        using (var s = store.OpenSession())
+        {
+            var i = s.Advanced.RawQuery<dynamic>($@"
+from Items as i
+order by spatial.distance(
+    spatial.point(i.Lng, i.Lat),
+    spatial.point(11,11)
+)
+select {{ Distance: getMetadata(i)['@spatial'].Distance }}
+").Single();
+            WaitForUserToContinueTheTest(store);
+            Assert.Equal(155.93, Math.Round((double)i.Distance, 2));
+        }
+    }
+}


### PR DESCRIPTION
…jections

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19453 

### Additional description

We now expose `@spatial` for JavaScript.
Also made `metadataFor()` apply for both projections and indexing calls, for consistency.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
