### PR TITLE
RavenDB-19174 - SlowTests.Server.Replication.ReplicationWithRevisions…

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationWithRevisions.cs
+++ b/test/SlowTests/Server/Replication/ReplicationWithRevisions.cs
@@ -756,12 +756,13 @@ namespace SlowTests.Server.Replication
                 {
                     Assert.Equal(1, WaitForValue(() => session.Advanced.Revisions.GetMetadataFor("users/1").Count, 1, interval: 128));
                 }
+
+                Assert.True(WaitForDocument(storeB, "users/1"));
                 using (var session = storeB.OpenSession())
                 {
                     Assert.Equal(1, WaitForValue(() => session.Advanced.Revisions.GetMetadataFor("users/1").Count, 1, interval: 128));
                 }
-                Assert.True(WaitForDocument(storeB, "users/1"));
-
+                
                 await SetupReplicationAsync(storeA, storeC);
                 await SetupReplicationAsync(storeB, storeC);
 


### PR DESCRIPTION
….UpdateTheSameRevisionWhenGettingExistingRevision

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19174/SlowTestsServerReplicationReplicationWithRevisionsUpdateTheSameRevisionWhenGettingExistingRevision

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
