### PR TITLE
RavenDB-17854 Removing FacetOptions from RangeFacet

### DIFF
--- a/src/Raven.Client/Documents/Queries/Facets/Facet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/Facet.cs
@@ -12,6 +12,8 @@ namespace Raven.Client.Documents.Queries.Facets
         /// Name of field the facet aggregate on
         /// </summary>
         public string FieldName { get; set; }
+        
+        public FacetOptions Options { get; set; }
 
         internal override FacetToken ToFacetToken(Func<object, string> addQueryParameter)
         {
@@ -40,6 +42,8 @@ namespace Raven.Client.Documents.Queries.Facets
         /// Name of field the facet aggregate on
         /// </summary>
         public Expression<Func<T, object>> FieldName { get; set; }
+
+        public FacetOptions Options { get; set; }
 
         public static implicit operator Facet(Facet<T> other)
         {

--- a/src/Raven.Client/Documents/Queries/Facets/FacetBase.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetBase.cs
@@ -15,9 +15,7 @@ namespace Raven.Client.Documents.Queries.Facets
         {
             Aggregations = new Dictionary<FacetAggregation, HashSet<FacetAggregationField>>();
         }
-
-        public FacetOptions Options { get; set; }
-
+        
         public Dictionary<FacetAggregation, HashSet<FacetAggregationField>> Aggregations { get; set; }
 
         /// <summary>
@@ -40,9 +38,9 @@ namespace Raven.Client.Documents.Queries.Facets
 
             if (json.TryGet(nameof(facet.DisplayFieldName), out string displayFieldName))
                 facet.DisplayFieldName = displayFieldName;
-
-            if (json.TryGet(nameof(facet.Options), out BlittableJsonReaderObject options) && options != null)
-                facet.Options = FacetOptions.Create(options);
+            
+            if (facet is Facet facetWithOptions && json.TryGet(nameof(facetWithOptions.Options), out BlittableJsonReaderObject options) && options != null)
+                facetWithOptions.Options = FacetOptions.Create(options);
 
             if (json.TryGet(nameof(facet.Aggregations), out BlittableJsonReaderObject aggregations) && aggregations != null)
             {

--- a/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
@@ -20,9 +20,22 @@ namespace Raven.Client.Documents.Queries.Facets
         IFacetOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
     }
 
+    public interface IFacetByRangesOperations<T>
+    {
+        IFacetByRangesOperations<T> WithDisplayName(string displayName);
+        
+        IFacetByRangesOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null);
+
+        IFacetByRangesOperations<T> MinOn(Expression<Func<T, object>> path, string displayName = null);
+
+        IFacetByRangesOperations<T> MaxOn(Expression<Func<T, object>> path, string displayName = null);
+
+        IFacetByRangesOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
+    }
+    
     public interface IFacetBuilder<T>
     {
-        IFacetOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths);
+        IFacetByRangesOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths);
 
         IFacetOperations<T> ByField(Expression<Func<T, object>> path);
 
@@ -31,7 +44,7 @@ namespace Raven.Client.Documents.Queries.Facets
         IFacetOperations<T> AllResults();
     }
 
-    internal class FacetBuilder<T> : IFacetBuilder<T>, IFacetOperations<T>
+    internal class FacetBuilder<T> : IFacetBuilder<T>, IFacetOperations<T>, IFacetByRangesOperations<T>
     {
         private RangeFacet<T> _range;
         private Facet _default;
@@ -47,7 +60,7 @@ namespace Raven.Client.Documents.Queries.Facets
             "UPDATE"
         };
 
-        public IFacetOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths)
+        public IFacetByRangesOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths)
         {
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
@@ -108,6 +121,37 @@ namespace Raven.Client.Documents.Queries.Facets
         {
             Facet.DisplayFieldName = displayName;
             return this;
+        }
+
+        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.SumOn(Expression<Func<T, object>> path, string displayName)
+        {
+            SumOn(path, displayName);
+            return this;
+        }
+
+        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.MinOn(Expression<Func<T, object>> path, string displayName)
+        {
+            MinOn(path, displayName);
+            return this;
+        }
+
+        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.MaxOn(Expression<Func<T, object>> path, string displayName)
+        {
+            MaxOn(path, displayName);
+            return this;
+        }
+
+        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.AverageOn(Expression<Func<T, object>> path, string displayName)
+        {
+            AverageOn(path, displayName);
+            return this;
+        }
+
+        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.WithDisplayName(string displayName)
+        {
+            WithDisplayName(displayName);
+            return this;
+            
         }
 
         public IFacetOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null)

--- a/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
@@ -20,22 +20,22 @@ namespace Raven.Client.Documents.Queries.Facets
         IFacetOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
     }
 
-    public interface IFacetByRangesOperations<T>
+    public interface IRangeFacetOperations<T>
     {
-        IFacetByRangesOperations<T> WithDisplayName(string displayName);
+        IRangeFacetOperations<T> WithDisplayName(string displayName);
         
-        IFacetByRangesOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null);
+        IRangeFacetOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetByRangesOperations<T> MinOn(Expression<Func<T, object>> path, string displayName = null);
+        IRangeFacetOperations<T> MinOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetByRangesOperations<T> MaxOn(Expression<Func<T, object>> path, string displayName = null);
+        IRangeFacetOperations<T> MaxOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetByRangesOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
+        IRangeFacetOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
     }
     
     public interface IFacetBuilder<T>
     {
-        IFacetByRangesOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths);
+        IRangeFacetOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths);
 
         IFacetOperations<T> ByField(Expression<Func<T, object>> path);
 
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Queries.Facets
         IFacetOperations<T> AllResults();
     }
 
-    internal class FacetBuilder<T> : IFacetBuilder<T>, IFacetOperations<T>, IFacetByRangesOperations<T>
+    internal class FacetBuilder<T> : IFacetBuilder<T>, IFacetOperations<T>, IRangeFacetOperations<T>
     {
         private RangeFacet<T> _range;
         private Facet _default;
@@ -60,7 +60,7 @@ namespace Raven.Client.Documents.Queries.Facets
             "UPDATE"
         };
 
-        public IFacetByRangesOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths)
+        public IRangeFacetOperations<T> ByRanges(Expression<Func<T, bool>> path, params Expression<Func<T, bool>>[] paths)
         {
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
@@ -113,7 +113,10 @@ namespace Raven.Client.Documents.Queries.Facets
 
         public IFacetOperations<T> WithOptions(FacetOptions options)
         {
-            Facet.Options = options;
+            if (Facet is Facet facet)
+                facet.Options = options;
+            else if (Facet is Facet<T> facetT)
+                facetT.Options = options;
             return this;
         }
 
@@ -123,31 +126,31 @@ namespace Raven.Client.Documents.Queries.Facets
             return this;
         }
 
-        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.SumOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IRangeFacetOperations<T>.SumOn(Expression<Func<T, object>> path, string displayName)
         {
             SumOn(path, displayName);
             return this;
         }
 
-        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.MinOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IRangeFacetOperations<T>.MinOn(Expression<Func<T, object>> path, string displayName)
         {
             MinOn(path, displayName);
             return this;
         }
 
-        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.MaxOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IRangeFacetOperations<T>.MaxOn(Expression<Func<T, object>> path, string displayName)
         {
             MaxOn(path, displayName);
             return this;
         }
 
-        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.AverageOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IRangeFacetOperations<T>.AverageOn(Expression<Func<T, object>> path, string displayName)
         {
             AverageOn(path, displayName);
             return this;
         }
 
-        IFacetByRangesOperations<T> IFacetByRangesOperations<T>.WithDisplayName(string displayName)
+        IRangeFacetOperations<T> IRangeFacetOperations<T>.WithDisplayName(string displayName)
         {
             WithDisplayName(displayName);
             return this;

--- a/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/FacetFactory.cs
@@ -5,32 +5,27 @@ using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Queries.Facets
 {
-    public interface IFacetOperations<T>
+    public interface IFacetOperationsBase<T, out TSelf>
+        where TSelf : class
     {
-        IFacetOperations<T> WithDisplayName(string displayName);
+        TSelf WithDisplayName(string displayName);
 
-        IFacetOperations<T> WithOptions(FacetOptions options);
+        TSelf SumOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null);
+        TSelf MinOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetOperations<T> MinOn(Expression<Func<T, object>> path, string displayName = null);
+        TSelf MaxOn(Expression<Func<T, object>> path, string displayName = null);
 
-        IFacetOperations<T> MaxOn(Expression<Func<T, object>> path, string displayName = null);
-
-        IFacetOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
+        TSelf AverageOn(Expression<Func<T, object>> path, string displayName = null);
     }
 
-    public interface IRangeFacetOperations<T>
+    public interface IFacetOperations<T> : IFacetOperationsBase<T, IFacetOperations<T>>
     {
-        IRangeFacetOperations<T> WithDisplayName(string displayName);
-        
-        IRangeFacetOperations<T> SumOn(Expression<Func<T, object>> path, string displayName = null);
+        IFacetOperations<T> WithOptions(FacetOptions options);
+    }
 
-        IRangeFacetOperations<T> MinOn(Expression<Func<T, object>> path, string displayName = null);
-
-        IRangeFacetOperations<T> MaxOn(Expression<Func<T, object>> path, string displayName = null);
-
-        IRangeFacetOperations<T> AverageOn(Expression<Func<T, object>> path, string displayName = null);
+    public interface IRangeFacetOperations<T> : IFacetOperationsBase<T, IRangeFacetOperations<T>>
+    {
     }
     
     public interface IFacetBuilder<T>
@@ -126,31 +121,31 @@ namespace Raven.Client.Documents.Queries.Facets
             return this;
         }
 
-        IRangeFacetOperations<T> IRangeFacetOperations<T>.SumOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IFacetOperationsBase<T, IRangeFacetOperations<T>>.SumOn(Expression<Func<T, object>> path, string displayName)
         {
             SumOn(path, displayName);
             return this;
         }
 
-        IRangeFacetOperations<T> IRangeFacetOperations<T>.MinOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IFacetOperationsBase<T, IRangeFacetOperations<T>>.MinOn(Expression<Func<T, object>> path, string displayName)
         {
             MinOn(path, displayName);
             return this;
         }
 
-        IRangeFacetOperations<T> IRangeFacetOperations<T>.MaxOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IFacetOperationsBase<T, IRangeFacetOperations<T>>.MaxOn(Expression<Func<T, object>> path, string displayName)
         {
             MaxOn(path, displayName);
             return this;
         }
 
-        IRangeFacetOperations<T> IRangeFacetOperations<T>.AverageOn(Expression<Func<T, object>> path, string displayName)
+        IRangeFacetOperations<T> IFacetOperationsBase<T, IRangeFacetOperations<T>>.AverageOn(Expression<Func<T, object>> path, string displayName)
         {
             AverageOn(path, displayName);
             return this;
         }
 
-        IRangeFacetOperations<T> IRangeFacetOperations<T>.WithDisplayName(string displayName)
+        IRangeFacetOperations<T> IFacetOperationsBase<T, IRangeFacetOperations<T>>.WithDisplayName(string displayName)
         {
             WithDisplayName(displayName);
             return this;

--- a/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
@@ -79,7 +79,6 @@ namespace Raven.Client.Documents.Queries.Facets
             return new RangeFacet(other)
             {
                 Ranges = ranges,
-                Options = other.Options,
                 Aggregations = other.Aggregations,
                 DisplayFieldName = other.DisplayFieldName
             };

--- a/src/Raven.Client/Documents/Session/Tokens/FacetToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/FacetToken.cs
@@ -176,7 +176,11 @@ namespace Raven.Client.Documents.Session.Tokens
 
         private static string GetOptionsParameterName(FacetBase facet, Func<object, string> addQueryParameter)
         {
-            return facet.Options != null && facet.Options != FacetOptions.Default ? addQueryParameter(facet.Options) : null;
+            return facet switch
+            {
+                Facet facetWithOptions => facetWithOptions.Options != null && facetWithOptions.Options != FacetOptions.Default ? addQueryParameter(facetWithOptions.Options) : null,
+                _ => null
+            };
         }
 
         private class FacetAggregationToken : QueryToken

--- a/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
@@ -129,6 +129,9 @@ namespace Raven.Server.Documents.Queries.Facets
             }
             else if (facet is RangeFacet)
             {
+                if (facet.Options != null)
+                    ThrowWhenOptionsAreUsedForRangeFacet();
+                
                 Debug.Assert(facetRanges != null && facetRanges.Count > 0);
 
                 RangeType? rangeType = null;
@@ -601,6 +604,11 @@ namespace Raven.Server.Documents.Queries.Facets
             throw new InvalidOperationException($"Unsupported facet type: {facet.GetType().FullName}");
         }
 
+        private static void ThrowWhenOptionsAreUsedForRangeFacet()
+        {
+            throw new NotSupportedException($"Options are not supported in range facets.");
+        }
+        
         private static void ThrowRangeDefinedOnDifferentFields(FacetQuery query, string fieldName, string differentField)
         {
             throw new InvalidQueryException($"Facet ranges must be defined on the same field while we got '{fieldName}' and '{differentField}' used in the same faced",

--- a/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Queries.Facets
             }
             else if (facet is RangeFacet)
             {
-                if (facet.Options != null)
+                if (facet.Options != null && facet.Options != FacetOptions.Default)
                     ThrowWhenOptionsAreUsedForRangeFacet();
                 
                 Debug.Assert(facetRanges != null && facetRanges.Count > 0);

--- a/test/SlowTests/Bugs/Facets/DateTimeFacets.cs
+++ b/test/SlowTests/Bugs/Facets/DateTimeFacets.cs
@@ -63,7 +63,6 @@ namespace SlowTests.Bugs.Facets
                 var n = facetsNewWay[i];
 
                 Assert.Equal(o.DisplayFieldName, n.DisplayFieldName);
-                Assert.Equal(o.Options, n.Options);
                 Assert.Equal(o.Ranges.Count, n.Ranges.Count);
 
                 for (int j = 0; j < o.Ranges.Count; j++)

--- a/test/SlowTests/Issues/RavenDB-17854.cs
+++ b/test/SlowTests/Issues/RavenDB-17854.cs
@@ -27,7 +27,7 @@ public class RavenDB_17854 : RavenTestBase
         IRawDocumentQuery<DataForAggregation> query(IDocumentSession session) => session.Advanced.RawQuery<DataForAggregation>($"from index 'Index' select facet(Age < 23, Age >= 24, '{optionsInJson}')");
         var exception = Assert.ThrowsAny<Exception>(() => RunTest(query));
 
-        Assert.Contains("Options are not supported in range facets.", exception.Message);
+        Assert.Contains(Exception, exception.Message);
     }
     
     private void RunTest(Func<IDocumentSession, IRawDocumentQuery<DataForAggregation>> query, bool assertByField = true, bool assertByRange = true)

--- a/test/SlowTests/Issues/RavenDB-17854.cs
+++ b/test/SlowTests/Issues/RavenDB-17854.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Facets;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17854 : RavenTestBase
+{
+    private const string Exception = "Options are not supported in range facets.";
+    
+    public RavenDB_17854(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Facets)]
+    public void QueryThrowsExceptionWhenOptionsAreIncludedInRangeFacet()
+    {
+        var optionsInJson = "{\"IncludeRemainingTerms\": true, \"PageSize\": 2147483647}";
+        IRawDocumentQuery<DataForAggregation> query(IDocumentSession session) => session.Advanced.RawQuery<DataForAggregation>($"from index 'Index' select facet(Age < 23, Age >= 24, '{optionsInJson}')");
+        var exception = Assert.ThrowsAny<Exception>(() => RunTest(query));
+
+        Assert.Contains("Options are not supported in range facets.", exception.Message);
+    }
+    
+    private void RunTest(Func<IDocumentSession, IRawDocumentQuery<DataForAggregation>> query, bool assertByField = true, bool assertByRange = true)
+    {
+        using var store = GetStoreWithPreparedData();
+        {
+            using var session = store.OpenSession();
+            var results = query(session).ExecuteAggregation();
+            if (assertByField)
+                Assert.Equal(2, results["Name"].Values.Count);
+            
+            if (assertByRange)
+                Assert.Equal(2, results["Age"].Values.Count);
+        }
+    }
+    
+    private IDocumentStore GetStoreWithPreparedData()
+    {
+        var store = GetDocumentStore();
+        {
+            using var session = store.OpenSession();
+            session.Store(new DataForAggregation() {Age = 21, Name = "Matt"});
+            session.Store(new DataForAggregation() {Age = 24, Name = "Tom"});
+            session.SaveChanges();
+        }
+
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+        return store;
+    }
+
+    private class DataForAggregation
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<DataForAggregation>
+    {
+        public Index()
+        {
+            Map = enumerable => enumerable.Select(i => new DataForAggregation() {Name = i.Name, Age = i.Age});
+        }
+    }
+}

--- a/test/SlowTests/MailingList/Wade.cs
+++ b/test/SlowTests/MailingList/Wade.cs
@@ -78,7 +78,6 @@ namespace SlowTests.MailingList
                                     person => person.BirthDate >= d1960 && person.BirthDate < d1969,
                                     person => person.BirthDate >= d1970 && person.BirthDate < d1979
                                 )
-                                .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 
@@ -150,7 +149,6 @@ namespace SlowTests.MailingList
                                     person => person.Spouse.BirthDate >= d1960 && person.Spouse.BirthDate < d1969,
                                     person => person.Spouse.BirthDate >= d1970 && person.Spouse.BirthDate < d1979
                                 )
-                            .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 
@@ -220,7 +218,6 @@ namespace SlowTests.MailingList
                                     person => person.Children.Any(child => child.BirthDate >= d2000 && child.BirthDate < d2009),
                                     person => person.Children.Any(child => child.BirthDate >= d2010 && child.BirthDate < d2019)
                                 )
-                                .WithOptions(new FacetOptions { IncludeRemainingTerms = true })
                         )
                         .Execute();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17854 

### Additional description

We're not applying any config when performing facet operations by ranges so since 6.0 we're removing this option from API.

This PR contains changes in:
- Client API (introduced a new branch of FacetBuilder for `ByRange` without WithOptions).
 -Server - throws when Options are used for `RangeFacets`.

https://github.com/ravendb/ravendb/blob/7e2cd718ef7917de0fd94fd805b15549b01c1b2c/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexFacetedReadOperation.cs#L240-L246

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Breaking change


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
