### PR TITLE
RavenDB-17871 Allow to exclude indexes when creating a snapshot

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -80,6 +80,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             this.mentorNode,
             this.pinMentorNode,
             this.snapshot().compressionLevel,
+            this.snapshot().excludeIndexes,
             this.retentionPolicy().dirtyFlag().isDirty,
             this.encryptionSettings().dirtyFlag().isDirty,
             this.anyBackupTypeIsDirty

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/snapshot.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/snapshot.ts
@@ -14,9 +14,12 @@ class snapshot {
 
     compressionLevel = ko.observable<string>();
 
+    excludeIndexes = ko.observable<boolean>(false);
+    
     constructor(dto: Raven.Client.Documents.Operations.Backups.SnapshotSettings) {
         const compressionLevel = snapshot.compressionLevelDictionary.find(x => x.fullName === dto.CompressionLevel);
         this.compressionLevel(compressionLevel.name);
+        this.excludeIndexes(dto.ExcludeIndexes);
     }
 
     useCompression(option: string) {
@@ -28,7 +31,7 @@ class snapshot {
 
         return {
             CompressionLevel: compressionLevel.fullName,
-            ExcludeIndexes: false
+            ExcludeIndexes: this.excludeIndexes()
         }
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -44,20 +44,35 @@
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>
             </div>
-            <div class="row margin-bottom" data-bind="visible: isSnapshot, with: snapshot">
-                <label class="control-label col-sm-4 col-lg-2">Compression</label>
-                <div class="col-sm-4">
-                    <div class="dropdown btn-block">
-                        <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
-                            <span data-bind="text: compressionLevel"></span>
-                            <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" data-bind="foreach: compressionLevelOptions">
-                            <li><a href="#" data-bind="text: $data, click: $parent.useCompression.bind($parent, $data)"></a></li>
-                        </ul>
+            <div data-bind="visible: isSnapshot, with: snapshot">
+                <div class="row margin-bottom">
+                    <label class="control-label col-sm-4 col-lg-2">Compression</label>
+                    <div class="col-sm-4">
+                        <div class="dropdown btn-block">
+                            <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
+                                <span data-bind="text: compressionLevel"></span>
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu" data-bind="foreach: compressionLevelOptions">
+                                <li><a href="#" data-bind="text: $data, click: $parent.useCompression.bind($parent, $data)"></a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="row margin-bottom">
+                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                        <div class="toggle">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" 
+                                 title="Skip backup of indexed data. Only index definitions are exported. After restore server starts automatic re-indexing." 
+                                 data-animation="true">
+                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
+                                <label for="excludeIndexes">Exclude indexes data</label>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
+            
             <div class="row">
                 <div class="col-sm-offset-4 col-lg-offset-2 col-lg-4" data-bind="validationElement: hasDestination">
                     <div class="help-block" data-bind="validationMessage: hasDestination"></div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -45,17 +45,31 @@
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>
             </div>
-            <div class="row margin-bottom" data-bind="visible: isSnapshot, with: snapshot">
-                <label class="control-label col-sm-4 col-lg-2">Compression</label>
-                <div class="col-sm-4">
-                    <div class="dropdown btn-block">
-                        <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
-                            <span data-bind="text: compressionLevel"></span>
-                            <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" data-bind="foreach: compressionLevelOptions">
-                            <li><a href="#" data-bind="text: $data, click: $parent.useCompression.bind($parent, $data)"></a></li>
-                        </ul>
+            <div data-bind="visible: isSnapshot, with: snapshot">
+                <div class="row margin-bottom">
+                    <label class="control-label col-sm-4 col-lg-2">Compression</label>
+                    <div class="col-sm-4">
+                        <div class="dropdown btn-block">
+                            <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
+                                <span data-bind="text: compressionLevel"></span>
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu" data-bind="foreach: compressionLevelOptions">
+                                <li><a href="#" data-bind="text: $data, click: $parent.useCompression.bind($parent, $data)"></a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="row margin-bottom">
+                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                        <div class="toggle">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip"
+                                 title="Skip backup of indexed data. Only index definitions are exported. After restore server starts automatic re-indexing."
+                                 data-animation="true">
+                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
+                                <label for="excludeIndexes">Exclude indexes data</label>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17871

### Additional description

Ability to exclude indexing data during backup - studio part. 

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

