### PR TITLE
help.ps1 expanded with missing build targets

### DIFF
--- a/scripts/help.ps1
+++ b/scripts/help.ps1
@@ -1,15 +1,24 @@
 
 function Help () {
-    Write-Host -NoNewline -ForegroundColor Cyan "-WinX64 "
+    Write-Host -NoNewline -ForegroundColor Cyan "-WinX64    "
     Write-Host " - build only Windows x64 artifacts"
 
-    Write-Host -NoNewline -ForegroundColor Cyan "-WinX86 "
+    Write-Host -NoNewline -ForegroundColor Cyan "-WinX86    "
     Write-Host " - build only Windows x86 artifacts"
 
-    Write-Host -NoNewline -ForegroundColor Cyan "-LinuxX64"
+    Write-Host -NoNewline -ForegroundColor Cyan "-LinuxX64  "
     Write-Host " - build only Linux x64 artifacts"
+
+    Write-Host -NoNewline -ForegroundColor Cyan "-LinuxArm64"
+    Write-Host " - build only Linux Arm64 artifacts"    
+
+    Write-Host -NoNewline -ForegroundColor Cyan "-MacOs     "
+    Write-Host " - build only MacOS artifacts"    
+
+    Write-Host -NoNewline -ForegroundColor Cyan "-Osx       "
+    Write-Host " - build only OS X artifacts"    
     
-    Write-Host -NoNewline -ForegroundColor Cyan "-Rpi"
+    Write-Host -NoNewline -ForegroundColor Cyan "-Rpi       "
     Write-Host " - build only Raspberry Pi artifacts"
 
     Write-Host -NoNewline -ForegroundColor Cyan "-DontRebuildStudio"


### PR DESCRIPTION
help.ps1 was missing

Linux ARM64
Mac OS
OS X
build targets.

Additionally, some alignment was added.