### PR TITLE
RavenDB-19461 - StressTests.Issues.RavenDB_17340.SendingDocumentWithL…

### DIFF
--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -78,6 +78,9 @@ namespace Sparrow.Json
 
         public bool GrowAllocation(AllocatedMemoryData allocation, int sizeIncrease)
         {
+            if (allocation.SizeInBytes + sizeIncrease > MaxArenaSize)
+                return false;
+
             // we need to keep the total allocation size as power of 2
             var totalAllocation = Bits.PowerOf2(allocation.SizeInBytes + sizeIncrease);
             var index = Bits.MostSignificantBit(totalAllocation) - 1;

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -78,11 +78,12 @@ namespace Sparrow.Json
 
         public bool GrowAllocation(AllocatedMemoryData allocation, int sizeIncrease)
         {
-            if (allocation.SizeInBytes + sizeIncrease > MaxArenaSize)
+            var newAllocationSize = allocation.SizeInBytes + sizeIncrease;
+            if (newAllocationSize > MaxArenaSize)
                 return false;
 
             // we need to keep the total allocation size as power of 2
-            var totalAllocation = Bits.PowerOf2(allocation.SizeInBytes + sizeIncrease);
+            var totalAllocation = Bits.PowerOf2(newAllocationSize);
             var index = Bits.MostSignificantBit(totalAllocation) - 1;
             if (_freed[index] != null)
             {
@@ -130,7 +131,7 @@ namespace Sparrow.Json
             if (size < 0)
                 throw new ArgumentOutOfRangeException(nameof(size), size,
                     $"Size cannot be negative");
-            
+
             if (size > MaxArenaSize)
                 throw new ArgumentOutOfRangeException(nameof(size), size,
                     $"Requested size {size} while maximum size is {MaxArenaSize}");


### PR DESCRIPTION
…argeFieldInBulkInsert(sizeInMb: 600)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19461/StressTestsIssuesRavenDB17340SendingDocumentWithLargeFieldInBulkInsertsizeInMb-600


### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
