### PR TITLE
RavenDB-19433 Exclude index-data when creating Snapshot: Fix text

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -1,32 +1,38 @@
 ﻿class tasksCommonContent {
         
     static readonly generalBackupInfo =
-        "Differences between Backup and Snapshot:" +
-        "<ul>" +
-            "<li>Data" +
-                "<small><ul>" +
-                    "<li><strong>Backup</strong> includes documents, indexes definitions and identities.<br> " +
-                    "It doesn't include the index data itself, the indexes will be rebuilt after Restore, based on exported definitions.</li>" +
-                    "<li><strong>Snapshot</strong> contains the raw data including the indexes (definitions and data).</li>" +
-                "</ul></small>" +
-            "</li>" +
-            "<li>Speed" +
-                "<small><ul>" +
-                "   <li><strong>Backup</strong> is usually much faster than a <strong>Snapshot</strong></li>" +
-                "</ul></small>" +
-            "</li>" +
-            "<li>Size" +
-                "<small><ul>" +
-                 "<li><strong>Backup</strong> is much smaller than <strong>Snapshot</strong></li>" +
-                "</ul></small>" +
-            "</li>" +
-            "<li>Restore" +
-                "<small><ul>" +
-                    "<li>Restore of a <strong>Snapshot</strong> is faster than of a <strong>Backup</strong></li>" +
-                "</ul></small>" +
-            "</li>" +
-        "</ul></>" +
-        "Note: An incremental Snapshot is the same as an incremental Backup";
+        `<div class="margin-bottom">Differences between Backup and Snapshot:</div> 
+        <ul>
+            <li>Data
+                <small><ul>
+                    <li><strong>Backup</strong> includes documents, identities, and index definitions.<br />
+                        It doesn't include index data - indexes are rebuilt from the backed-up definitions when restoring the database.</li>
+                    <li><strong>Snapshot</strong> contains the raw data including the indexes (definitions and data, or definitions only).</li>
+                </ul></small>
+            </li>
+        </ul>
+        <div class="margin-bottom">Differences when Snapshot backs up both indexes definitions and indexes data:</div>
+        <ul>
+            <li>Speed
+                <small><ul>
+                   <li><strong>Backup</strong> is usually much faster than a <strong>Snapshot</strong></li>
+                </ul></small>
+            </li>
+            <li>Size
+                <small><ul>
+                    <li><strong>Backup</strong> is usually much smaller than <strong>Snapshot</strong></li>
+                </ul></small>
+            </li>
+            <li>Restore
+                <small><ul>
+                    <li>Restoring a <strong>Snapshot</strong> is usually faster than restoring a <strong>Backup</strong></li>
+                </ul></small>
+            </li>
+        </ul>
+        <div>Notes:</div>
+        <ul>
+            <li><small>An incremental Snapshot is the same as an incremental Backup</small></li>
+        </ul>`;
     
     static readonly backupAgeInfo = 
         "<ul>" +

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -44,7 +44,7 @@
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>
             </div>
-            <div data-bind="visible: isSnapshot, with: snapshot">
+            <div data-bind="collapse: isSnapshot, with: snapshot">
                 <div class="row margin-bottom">
                     <label class="control-label col-sm-4 col-lg-2">Compression</label>
                     <div class="col-sm-4">
@@ -59,20 +59,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row margin-bottom">
-                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
-                        <div class="toggle">
-                            <div class="toggle" data-placement="right" data-toggle="tooltip" 
-                                 title="Skip backup of indexed data. Only index definitions are exported. After restore server starts automatic re-indexing." 
-                                 data-animation="true">
-                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
-                                <label for="excludeIndexes">Exclude indexes data</label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             </div>
-            
             <div class="row">
                 <div class="col-sm-offset-4 col-lg-offset-2 col-lg-4" data-bind="validationElement: hasDestination">
                     <div class="help-block" data-bind="validationMessage: hasDestination"></div>
@@ -109,6 +96,20 @@
                     <div class="row margin-bottom small">
                         <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
                             <div data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div data-bind="collapse: isSnapshot, with: snapshot">
+                <div class="row margin-bottom">
+                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                        <div class="toggle">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip"
+                                 title="Back up index definitions only. Indexes will be rebuilt from these definitions upon Restore."
+                                 data-animation="true">
+                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
+                                <label for="excludeIndexes">Exclude indexes data</label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -45,7 +45,7 @@
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>
             </div>
-            <div data-bind="visible: isSnapshot, with: snapshot">
+            <div data-bind="collapse: isSnapshot, with: snapshot">
                 <div class="row margin-bottom">
                     <label class="control-label col-sm-4 col-lg-2">Compression</label>
                     <div class="col-sm-4">
@@ -57,18 +57,6 @@
                             <ul class="dropdown-menu" data-bind="foreach: compressionLevelOptions">
                                 <li><a href="#" data-bind="text: $data, click: $parent.useCompression.bind($parent, $data)"></a></li>
                             </ul>
-                        </div>
-                    </div>
-                </div>
-                <div class="row margin-bottom">
-                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
-                        <div class="toggle">
-                            <div class="toggle" data-placement="right" data-toggle="tooltip"
-                                 title="Skip backup of indexed data. Only index definitions are exported. After restore server starts automatic re-indexing."
-                                 data-animation="true">
-                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
-                                <label for="excludeIndexes">Exclude indexes data</label>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -108,6 +96,19 @@
                 <div class="row margin-bottom small">
                     <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
                         <div data-bind="compose: 'partial/pinResponsibleNodeTextScript.html'"></div>
+                    </div>
+                </div>
+            </div>
+            <div data-bind="collapse: isSnapshot, with: snapshot">
+                <div class="row margin-bottom-xs">
+                    <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                        <div class="toggle">
+                            <div class="toggle" data-placement="right" data-toggle="tooltip" data-animation="true"
+                                 title="Back up index definitions only. Indexes will be rebuilt from these definitions upon Restore.">
+                                <input id="excludeIndexes" type="checkbox" data-bind="checked: excludeIndexes">
+                                <label for="excludeIndexes">Exclude indexes data</label>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19433

### Additional description
1. Fix the tooltip + popup text
2. Move toggle location to be under 'set responsible node'
It makes more sense because:
    * Keep the 'responsible node' toggle location consistent across all tasks
    * In the Server-wide task, it is better that the 2 'exclude' toggles are one after the other

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update

- This change requires a documentation update. See[ RDoc-2284](https://issues.hibernatingrhinos.com/issue/RDoc-2284/Allow-to-exclude-indexes-when-creating-a-snapshot)

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
