### PR TITLE
RavenDB-14806 Prevent adding aliases into methods in RQL via Client.

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3469,14 +3469,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
         }
         private bool NeedToAddFromAliasToField(string field)
         {
-            return _addedDefaultAlias &&
-                   field.StartsWith($"{FromAlias}.") == false &&
-                   field.StartsWith("id(") == false &&
-                   field.StartsWith("counter(") == false &&
-                   field.StartsWith("counterRaw(") == false &&
-                   field.StartsWith("cmpxchg(") == false;
+            return _addedDefaultAlias && FieldTypeAllowToAddAlias(field);
         }
 
+        private bool FieldTypeAllowToAddAlias(string field)
+        {
+            return field.StartsWith($"{FromAlias}.") == false &&
+                field.StartsWith("id(") == false &&
+                field.StartsWith("counter(") == false &&
+                field.StartsWith("counterRaw(") == false &&
+                field.StartsWith("cmpxchg(") == false;
+        }
+        
         private void AddFromAliasToFieldToFetch(ref string field, ref string alias, bool quote = false)
         {
             if (field == alias)
@@ -3484,11 +3488,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 alias = null;
             }
 
-            if (field == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
-            {
-                field = $"id({FromAlias})";
+            if (FieldTypeAllowToAddAlias(field) == false)
                 return;
-            }
 
             field = quote
                 ? $"{FromAlias}.'{field}'"
@@ -3501,11 +3502,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             AddFromAlias(fromAlias);
             foreach (var fieldToFetch in FieldsToFetch)
             {
-                if (fieldToFetch.Name == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
-                {
-                    fieldToFetch.Name = $"id({fromAlias})";
-                }
-                else
+                if (FieldTypeAllowToAddAlias(fieldToFetch.Name))
                 {
                     fieldToFetch.Name = $"{fromAlias}.{fieldToFetch.Name}";
                 }

--- a/test/SlowTests/Issues/RavenDB-14806.cs
+++ b/test/SlowTests/Issues/RavenDB-14806.cs
@@ -1,40 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Issues
+namespace SlowTests.Issues;
+
+public class RavenDB_14806 : RavenTestBase
 {
-    public class RavenDB_14806 : RavenTestBase
+    public RavenDB_14806(ITestOutputHelper output) : base(output)
     {
-        public RavenDB_14806(ITestOutputHelper output) : base(output)
-        {
-        }
+    }
 
-        public class ContractClause
-        {
-            public string Id { get; set; }
-            public string Name { get; set; }
-            public string Description { get; set; }
-            public string CompanyId { get; set; }
-            public string Group { get; set; }
-            public int SortOrder { get; set; }
-        }
+    [Fact]
+    public async Task CanQueryOverReservedPropertieS()
+    {
+        string companyId = "companies/1-A";
 
-        [Fact]
-        public async Task CanQueryOverReservedPropertieS()
+        using var store = GetDocumentStore();
         {
-            using var store = GetDocumentStore();
-
             using var session = store.OpenAsyncSession();
-            string companyId = "companies/1-A";
-
-            await session.Query<ContractClause>()
+            await session.StoreAsync(new ContractClause() {CompanyId = companyId});
+            await session.SaveChangesAsync();
+        }
+        {
+            using var session = store.OpenAsyncSession();
+            var query = session.Query<ContractClause>()
                 .Where(c => c.CompanyId == companyId)
                 .OrderBy(c => c.Group)
                 .ThenBy(c => c.SortOrder)
@@ -45,17 +38,88 @@ namespace SlowTests.Issues
                     Group = c.Group,
                     SortOrder = c.SortOrder,
                     Description = c.Description
-                })
-                .ToListAsync();
-        }
+                });
 
-        public class ContractClauseListItem
-        {
-            public string Id { get; set; }
-            public string Name { get; set; }
-            public string Description { get; set; }
-            public string Group { get; set; }
-            public int SortOrder { get; set; }
+            var result = await query.ToListAsync();
+            Assert.Equal(1, result.Count);
         }
+    }
+
+    [Fact]
+    public async Task CanQueryWithGroupOverStaticIndex()
+    {
+        using var store = GetDocumentStore();
+        {
+            using var session = store.OpenSession();
+            session.Store(new Data() {Name = "Test"});
+            session.SaveChanges();
+        }
+        var index = new DataIndex();
+        await index.ExecuteAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var session = store.OpenAsyncSession();
+
+            var query = (IQueryable<Data>)session.Query<Data, DataIndex>();
+            query = query.ToAsyncDocumentQuery().WhereEquals(m => m.Name, "test").ToQueryable();
+            query = query.OrderBy(m => m.Name);
+            var q = (from cor in query
+                select new Dto {Id = cor.Id, Name = cor.Name, Group = cor.Group}).Take(100);
+            var results = (await q.ToListAsync()).OfType<ITestDto>();
+            foreach (var result in results)
+            {
+                Assert.Equal(result.Name, "Test");
+            }
+        }
+    }
+
+    interface ITestDto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public string Group { get; set; }
+    }
+
+    private class Data
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public string Group { get; set; }
+    }
+
+    private class DataIndex : AbstractIndexCreationTask<Data>
+    {
+        public DataIndex()
+        {
+            Map = datas => datas.Select(i => new {Name = i.Name});
+        }
+    }
+
+    private class ContractClauseListItem
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Group { get; set; }
+        public int SortOrder { get; set; }
+    }
+
+    private class ContractClause
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string CompanyId { get; set; }
+        public string Group { get; set; }
+        public int SortOrder { get; set; }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14806 

### Additional description

We unnecessarily added aliases to methods causing an exception from the evaluation on Server-side.

### Type of change

- Bug fix

### How risky is the change?


- Moderate 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
