### PR TITLE
RavenDB-19469 Return without throwing when license has only PostgreSql

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
@@ -213,9 +213,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
             if (Database.ServerStore.LicenseManager.CanUsePostgreSqlIntegration(withNotification: true))
             {
-                ServerStore.FeatureGuardian.Assert(Feature.PostgreSql, () => $"You have enabled the PostgreSQL integration via '{RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)}' configuration but " +
-                                                                             "this is an experimental feature and the server does not support experimental features. " +
-                                                                             $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
+                ServerStore.FeatureGuardian.Assert(Feature.PostgreSql, () => 
+                    $"You have enabled the PostgreSQL integration via '{RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)}' configuration but " +
+                    "this is an experimental feature and the server does not support experimental features. " +
+                    $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
+                return;
             }
 
             throw new LicenseLimitException("You cannot use this feature because your license doesn't allow neither PostgreSQL integration feature nor Power BI");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19469/

### Additional description
The AssertCanUsePostgreSqlIntegration throw if PostgreSql enable but not PowerBI

### Type of change
- Bug fix

### How risky is the change?
- Low 


### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
