### PR TITLE
RavenDB-19413 Remove dynamic fields from RQL code assistance

### DIFF
--- a/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
+++ b/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
@@ -1,6 +1,7 @@
 import database = require("models/resources/database");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
 import getIndexEntriesFieldsCommand = require("commands/database/index/getIndexEntriesFieldsCommand");
+import index from "models/database/index";
 
 class remoteMetadataProvider implements queryCompleterProviders {
     
@@ -20,7 +21,7 @@ class remoteMetadataProvider implements queryCompleterProviders {
         new getIndexEntriesFieldsCommand(indexName, this.database(), false)
             .execute()
             .done(result => {
-                callback(result.Static);
+                callback(result.Static.filter(x => !index.FieldsToHideOnUi.includes(x)));
             });
     }
 

--- a/src/Raven.Studio/typescript/models/database/index/index.ts
+++ b/src/Raven.Studio/typescript/models/database/index/index.ts
@@ -4,6 +4,8 @@ import collectionsTracker = require("common/helpers/database/collectionsTracker"
 import generalUtils = require("common/generalUtils");
 
 class index {
+    static readonly FieldsToHideOnUi = ["_", "__"];
+    
     static readonly SideBySideIndexPrefix = "ReplacementOf/";
     static readonly AutoIndexPrefix = "Auto/";
     static readonly TestIndexPrefix = "Test/";

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -515,7 +515,7 @@ class editIndex extends viewModelBase {
         new getIndexFieldsFromMapCommand(this.activeDatabase(), map, additionalSourcesDto, additionalAssembliesDto)
             .execute()
             .done((fields: resultsDto<string>) => {
-                this.fieldNames(fields.Results);
+                this.fieldNames(fields.Results.filter(x => !index.FieldsToHideOnUi.includes(x)));
             });
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19413 

### Additional description

Removed `_` and `__` from code assistance

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change