### PR TITLE
RavenDB-19395 Add avg request time to Cluster Dashboard's traffic per…

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/widgets/trafficWatchItem.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/trafficWatchItem.ts
@@ -6,6 +6,7 @@ class trafficWatchItem implements databaseAndNodeAwareStats {
     requestsPerSecond: number;
     writesPerSecond: number;
     dataWritesPerSecond: number;
+    averageDuration: number;
     noData: boolean;
     
     hideDatabaseName: boolean;
@@ -21,6 +22,7 @@ class trafficWatchItem implements databaseAndNodeAwareStats {
             this.requestsPerSecond = data.RequestsPerSecond;
             this.writesPerSecond = data.DocumentWritesPerSecond + data.AttachmentWritesPerSecond + data.CounterWritesPerSecond + data.TimeSeriesWritesPerSecond;
             this.dataWritesPerSecond = data.DocumentsWriteBytesPerSecond + data.AttachmentsWriteBytesPerSecond + data.CountersWriteBytesPerSecond + data.TimeSeriesWriteBytesPerSecond;
+            this.averageDuration = data.AverageRequestDuration;
         } else {
             this.noData = true;
         }

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseTrafficWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseTrafficWidget.ts
@@ -36,16 +36,19 @@ class databaseTrafficWidget extends abstractDatabaseAndNodeAwareTableWidget<Rave
     protected prepareColumns(): virtualColumn[] {
         const grid = this.gridController();
         return [
-            new textColumn<trafficWatchItem>(grid, x => x.hideDatabaseName ? "" : x.database, "Database", "35%"),
+            new textColumn<trafficWatchItem>(grid, x => x.hideDatabaseName ? "" : x.database, "Database", "30%"),
             new nodeTagColumn<trafficWatchItem>(grid, item => this.prepareUrl(item, "Traffic Watch View")),
-            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.requestsPerSecond), "Requests/s", "15%", {
+            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.requestsPerSecond), "Requests/s", "12%", {
                 headerTitle: "Requests made to node per second"
             }),
-            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.writesPerSecond), "Writes/s", "15%", {
+            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.writesPerSecond), "Writes/s", "12%", {
                 headerTitle: "Items written by node per second"
             }),
-            new textColumn<trafficWatchItem>(grid, x => x.noData ? "-" : generalUtils.formatBytesToSize(x.dataWritesPerSecond), "Data written/s", "15%", {
+            new textColumn<trafficWatchItem>(grid, x => x.noData ? "-" : generalUtils.formatBytesToSize(x.dataWritesPerSecond), "Data written/s", "12%", {
                 headerTitle: "Bytes written by node per second"
+            }),
+            new textColumn<trafficWatchItem>(grid, x => x.noData ? "-" : Math.round(x.averageDuration).toLocaleString() + " ms", "Avg Req Time", "12%", {
+                headerTitle: "Average request time"
             }),
         ];
     }


### PR DESCRIPTION
… database

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19395 

### Additional description

Exposed avg request time on cluster dashboard

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

