### PR TITLE
RavenDB-15840 - SlowTests.Client.TimeSeries.Policies.TimeSeriesConfig…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
@@ -452,7 +452,14 @@ namespace Raven.Server.Documents.TimeSeries
                     return false;
 
                 if (nextEnd < to)
+                {
+                    if (currentStats.End.Add(next.AggregationTime).Add(next.RetentionTime) < to)
+                    {
+                        return false;
+                    }
+
                     return true;
+                }
             }
 
             return false;

--- a/test/StressTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTestsStress.cs
+++ b/test/StressTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTestsStress.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Tests.Core.Utils.Entities;
@@ -165,6 +167,157 @@ namespace StressTests.Client.TimeSeries.Policies
                     var user = session.Load<User>("users/karmel");
                     Assert.Equal(0, session.Advanced.GetTimeSeriesFor(user)?.Count ?? 0);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_15840()
+        {
+            var dbA = GetDatabaseName();
+            var dbB = GetDatabaseName();
+
+            using (var storeA = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = _ => dbA
+            }))
+            using (var storeB = GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = _ => dbB
+            }))
+            {
+                var raw = new RawTimeSeriesPolicy(TimeValue.FromSeconds(15));
+
+                var p1 = new TimeSeriesPolicy("By1", TimeValue.FromSeconds(1), raw.RetentionTime * 2);
+                var p2 = new TimeSeriesPolicy("By2", TimeValue.FromSeconds(2), raw.RetentionTime * 3);
+                var p3 = new TimeSeriesPolicy("By4", TimeValue.FromSeconds(4), raw.RetentionTime * 4);
+                var p4 = new TimeSeriesPolicy("By8", TimeValue.FromSeconds(8), raw.RetentionTime * 5);
+
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            RawPolicy = raw,
+                            Policies = new List<TimeSeriesPolicy>
+                            {
+                                p1,p2,p3,p4
+                            }
+                        }
+                    }
+                };
+
+                // create same TS on both databases
+                var now = DateTime.UtcNow;
+                CreateTimeSeriesForDatabase(storeA, now);
+                CreateTimeSeriesForDatabase(storeB, now);
+
+                await storeA.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+                await storeB.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+
+                var databaseA = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbA);
+                var databaseB = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbB);
+
+                var cts = new CancellationTokenSource();
+                cts.CancelAfter((TimeSpan)(p4.RetentionTime * 2));
+
+                // run rollup and retention until one of the policies (except raw policy) is deleted (from retention)
+                while (cts.IsCancellationRequested == false)
+                {
+                    await databaseB.TimeSeriesPolicyRunner.RunRollups();
+
+                    using (var sessionB = storeB.OpenSession())
+                    {
+                        var user = sessionB.Load<User>("users/karmel");
+                        var ts = sessionB.Advanced.GetTimeSeriesFor(user);
+
+                        if (ts.Contains("Heartrate@By1") == false ||
+                            ts.Contains("Heartrate@By2") == false ||
+                            ts.Contains("Heartrate@By4") == false ||
+                            ts.Contains("Heartrate@By8") == false)
+                            break;
+                    }
+
+                    await databaseA.TimeSeriesPolicyRunner.DoRetention();
+                }
+
+                // run some rollups and retentions from the other database.
+                // we are doing so because we want to reach the path of 'AppendEntireSegment'
+                // after we set up the replication between the databases (for that the conflict status must be 'Update')
+                for (int i = 0; i < 6; i++)
+                {
+                    await databaseA.TimeSeriesPolicyRunner.RunRollups();
+                    using (var sessionA = storeA.OpenSession())
+                    {
+                        var user = sessionA.Load<User>("users/karmel");
+                        var ts = sessionA.Advanced.GetTimeSeriesFor(user);
+
+                        if (ts.Contains("Heartrate") == false)
+                            break;
+                    }
+
+                    await databaseA.TimeSeriesPolicyRunner.DoRetention();
+                }
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                cts = new CancellationTokenSource();
+                cts.CancelAfter((TimeSpan)(p4.RetentionTime * 2));
+
+                int count = 0;
+                long rolled = 0;
+                while (cts.IsCancellationRequested == false)
+                {
+                    rolled = await databaseB.TimeSeriesPolicyRunner.RunRollups();
+                    await databaseB.TimeSeriesPolicyRunner.DoRetention();
+
+                    using (var sessionB = storeB.OpenSession())
+                    {
+                        var user = sessionB.Load<User>("users/karmel");
+                        count = sessionB.Advanced.GetTimeSeriesFor(user)?.Count ?? 0;
+                        if (count == 0 && rolled == 0)
+                            break;
+                    }
+                }
+
+                Assert.Equal(0, count);
+                Assert.Equal(0, rolled);
+
+                using (var sessionB = storeB.OpenSession())
+                {
+                    sessionB.Store(new User { Name = "Karmel" }, "marker/2");
+                    sessionB.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(storeA, "marker/2", timeout: 30_000, dbA));
+
+                using (var sessionA = storeA.OpenSession())
+                {
+                    var user = sessionA.Load<User>("users/karmel");
+                    Assert.Equal(0, sessionA.Advanced.GetTimeSeriesFor(user)?.Count ?? 0);
+                }
+            }
+        }
+
+        private void CreateTimeSeriesForDatabase(DocumentStore store, DateTime now)
+        {
+            var baseline = now.AddSeconds(-15 * 3);
+            var total = ((TimeSpan)TimeValue.FromSeconds(15 * 3)).TotalMilliseconds;
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Karmel" }, "users/karmel");
+
+                for (int i = 0; i <= total; i++)
+                {
+                    session.TimeSeriesFor("users/karmel", "Heartrate")
+                        .Append(baseline.AddMilliseconds(i), new[] { 29d * i, i }, "watches/fitbit");
+                }
+                session.SaveChanges();
             }
         }
     }


### PR DESCRIPTION
…urationTests.RapidRetentionAndRollupInACluster

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15840/SlowTestsClientTimeSeriesPoliciesTimeSeriesConfigurationTestsRapidRetentionAndRollupInACluster

### Additional description

**Failure scenario explanation with an example:**
- Assume we have a Cluster with 2 nodes [A, B]; Database Topology: {A, B}.
- Policies defined for "Heartrate" TS: 

1.    RawPolicy, RetentionTime: 1 hour.
2.   Policy By2, AggregationTime: 2 minutes, RetentionTime: 2 hours.

- Append entries to "Heartrate" from now till now + 1 hour.
- Initialize `TimeSeriesPolicyRunner`.

State after the first `RunRollups` (by A):

- Node A: existing TS: "Heartrate" , "Heartrate@By2".

- Node B: existing TS: "Heartrate" , "Heartrate@By2".

State after the first `DoRetention` (by A):

- Node A: existing TS: "Heartrate" , "Heartrate@By2" - all entries has deleted.

- Node B: existing TS: "Heartrate" , "Heartrate@By2" - all entries has deleted.


Update Database Topology. New Topology: {B, A}.

Node B `RunRollups` doesn't change anything because everything is already done.

- Node B runs `DoRetention`:
In `DoRetention` - we call `ApplyRetention` (https://github.com/ravendb/ravendb/blob/v5.2/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs#L362).
In `ApplyRetention` - we call `RequiredForNextPolicy` (https://github.com/ravendb/ravendb/blob/v5.2/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs#L412).
In `RequiredForNextPolicy` - we receive default stats for "Heartrate@By2" (all entries has deleted), but it still exists in the policies list. 
In that point the condition `nextEnd < to` (https://github.com/ravendb/ravendb/blob/v5.2/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs#L454) is true because:
nextEnd = DateTime.MinValue + 1 hour - 1 ms.
to = _database.Time.GetUtcNow() - 1 hour.
and we get stuck in a loop until the test fails. 

**My suggested solution:**

In case of default stats for next policy and when `nextEnd < to` is true - check if there are any deleted values - if true, return False (retention operation can execute for this policy).

@ayende @karmeli87 @ppekrol any thoughts about the solution? any cases that you can think of in which some deleted values exist but we should still wait? 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
