### PR TITLE
RavenDB-19255 : Sharding - Backup - periodic-backup/status EP returns null

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
@@ -1,5 +1,7 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Sparrow.Json;
@@ -45,14 +47,20 @@ namespace Raven.Client.Documents.Operations.Backups
                     ThrowInvalidResponse();
 
                 Result = JsonDeserializationClient.GetPeriodicBackupStatusOperationResult(response);
+                if (Result.IsSharded)
+                    throw new InvalidOperationException($"Database is sharded, can't use {nameof(GetPeriodicBackupStatusOperation)}, " +
+                                                        $"use {nameof(GetShardedPeriodicBackupStatusOperation)} instead");
             }
         }
     }
 
-    public class GetPeriodicBackupStatusOperationResult
+    public abstract class AbstractGetPeriodicBackupStatusOperationResult
+    {
+        public bool IsSharded;
+    }
+
+    public class GetPeriodicBackupStatusOperationResult : AbstractGetPeriodicBackupStatusOperationResult
     {
         public PeriodicBackupStatus Status;
-
-        public PeriodicBackupStatus[] StatusPerShard;
     }
 }

--- a/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
@@ -52,5 +52,7 @@ namespace Raven.Client.Documents.Operations.Backups
     public class GetPeriodicBackupStatusOperationResult
     {
         public PeriodicBackupStatus Status;
+
+        public PeriodicBackupStatus[] StatusPerShard;
     }
 }

--- a/src/Raven.Client/Documents/Operations/Backups/Sharding/GetShardedPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/Sharding/GetShardedPeriodicBackupStatusOperation.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.Backups.Sharding
+{
+    public class GetShardedPeriodicBackupStatusOperation : IMaintenanceOperation<GetShardedPeriodicBackupStatusOperationResult>
+    {
+        private readonly long _taskId;
+
+        public GetShardedPeriodicBackupStatusOperation(long taskId)
+        {
+            _taskId = taskId;
+        }
+
+        public RavenCommand<GetShardedPeriodicBackupStatusOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+        {
+            return new GetShardedPeriodicBackupStatusCommand(_taskId);
+        }
+
+        private class GetShardedPeriodicBackupStatusCommand : RavenCommand<GetShardedPeriodicBackupStatusOperationResult>
+        {
+            public override bool IsReadRequest => true;
+            private readonly long _taskId;
+
+            public GetShardedPeriodicBackupStatusCommand(long taskId)
+            {
+                _taskId = taskId;
+            }
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/periodic-backup/status?name={node.Database}&taskId={_taskId}";
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = JsonDeserializationClient.GetShardedPeriodicBackupStatusOperationResult(response);
+
+                if (Result.IsSharded == false)
+                    throw new InvalidOperationException($"Database is not sharded, can't use {nameof(GetShardedPeriodicBackupStatusOperation)}, " +
+                                                        $"use {nameof(GetPeriodicBackupStatusOperation)} instead");
+            }
+        }
+    }
+    public class GetShardedPeriodicBackupStatusOperationResult : AbstractGetPeriodicBackupStatusOperationResult
+    {
+        public PeriodicBackupStatus[] Statuses;
+    }
+}

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Identity;
@@ -9,12 +8,12 @@ using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Expiration;
-using Raven.Client.Documents.Operations.Integrations;
 using Raven.Client.Documents.Operations.Integrations.PostgreSQL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Refresh;
@@ -196,6 +195,8 @@ namespace Raven.Client.Json.Serialization
         internal static readonly Func<BlittableJsonReaderObject, StartBackupOperationResult> BackupDatabaseNowResult = GenerateJsonDeserializationRoutine<StartBackupOperationResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, GetPeriodicBackupStatusOperationResult> GetPeriodicBackupStatusOperationResult = GenerateJsonDeserializationRoutine<GetPeriodicBackupStatusOperationResult>();
+
+        internal static readonly Func<BlittableJsonReaderObject, GetShardedPeriodicBackupStatusOperationResult> GetShardedPeriodicBackupStatusOperationResult = GenerateJsonDeserializationRoutine<GetShardedPeriodicBackupStatusOperationResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, PeriodicBackupStatus> PeriodicBackupStatus = GenerateJsonDeserializationRoutine<PeriodicBackupStatus>();
 

--- a/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Commands.OngoingTasks;
 using Raven.Server.Routing;

--- a/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
+++ b/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -34,6 +35,9 @@ internal class BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus : Abstra
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
+                    writer.WritePropertyName(nameof(GetPeriodicBackupStatusOperationResult.IsSharded));
+                    writer.WriteBool(false);
+                    writer.WriteComma();
                     writer.WritePropertyName(nameof(GetPeriodicBackupStatusOperationResult.Status));
                     writer.WriteObject(statusBlittable);
                     writer.WriteEndObject();
@@ -52,7 +56,10 @@ internal class BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus : Abstra
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
                 writer.WriteStartObject();
-                writer.WriteArray(nameof(GetPeriodicBackupStatusOperationResult.StatusPerShard), statusPerShard);
+                writer.WritePropertyName(nameof(GetPeriodicBackupStatusOperationResult.IsSharded));
+                writer.WriteBool(true);
+                writer.WriteComma();
+                writer.WriteArray(nameof(GetShardedPeriodicBackupStatusOperationResult.Statuses), statusPerShard);
                 writer.WriteEndObject();
             }
 

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -109,6 +109,7 @@ export class TasksStubs {
                     "A:8806-9igKNP9Qh0WWnuROUXOVjQ, A:2568-F9I6Egqwm0Kz+K0oFVIR9Q, A:13366-IG4VwBTOnkqoT/uwgm2OQg, A:2568-OSKWIRBEDEGoAxbEIiFJeQ",
                 IsEncrypted: false,
             },
+            IsSharded: false,
         };
     }
 

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -65,7 +65,7 @@ namespace FastTests.Client
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand",
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand",
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand",
-                "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand",
+                "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand,"
                 "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand"
             }.OrderBy(t => t);
 

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -65,7 +65,7 @@ namespace FastTests.Client
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand",
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand",
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand",
-                "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand,"
+                "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand",
                 "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand"
             }.OrderBy(t => t);
 

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -388,6 +388,7 @@ namespace SlowTests.Sharding.Backup
                 var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
 
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(backupTaskId + 3, TimeSpan.FromSeconds(10));
 
                 var dirs = Directory.GetDirectories(backupPath).ToList();
                 Assert.Equal(cluster.Nodes.Count, dirs.Count);

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -403,7 +403,7 @@ namespace SlowTests.Sharding.Backup
         }
 
         [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
-        public async Task ShouldThrowOnAttemptToGetShardedBackupStatusFromNonShardedDb()
+        public async Task ShouldThrowOnAttemptToGetNonShardedBackupStatusFromShardedDb()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
@@ -441,12 +441,11 @@ namespace SlowTests.Sharding.Backup
         }
 
         [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
-        public async Task ShouldThrowOnAttemptToGetNonShardedBackupStatusFromShardedDb()
+        public async Task ShouldThrowOnAttemptToGetShardedBackupStatusFromNonShardedDb()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
             using (var store = GetDocumentStore())
             {
-                WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     for (int i = 0; i < 10; i++)

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Org.BouncyCastle.Math.EC;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19255

### Additional description

return a `StatusPerShard` array when requesting to get periodic-backup status in a sharded database 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
