### PR TITLE
RavenDB-17624 set _sessionOpened to false when we reuse the batch

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -199,6 +199,8 @@ namespace Raven.Client.Documents.Subscriptions
 
         internal string Initialize(BatchFromServer batch)
         {
+            _sessionOpened = false;
+
             _includes = batch.Includes;
             _counterIncludes = batch.CounterIncludes;
             _timeSeriesIncludes = batch.TimeSeriesIncludes;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17624

### Additional description

The subscription worker reuse the batch instance so we need to set the `_sessionOpened` back to false

### Type of change

- Bug fix

### How risky is the change?

- Low 
### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
