### PR TITLE
RavenDB-17215 IndexQueryServerSide.PageSize from int to long

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -186,7 +187,13 @@ namespace Raven.Client.Documents.Linq
         /// <returns></returns>
         TS IQueryProvider.Execute<TS>(Expression expression)
         {
-            return (TS)Execute(expression);
+            var result = Execute(expression);
+            // if (typeof(TS) == typeof(int) && result is long)
+            // {
+            //     return (TS)(object)Convert.ToInt32(result);
+            // }
+            
+            return (TS)result;
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -187,13 +187,7 @@ namespace Raven.Client.Documents.Linq
         /// <returns></returns>
         TS IQueryProvider.Execute<TS>(Expression expression)
         {
-            var result = Execute(expression);
-            // if (typeof(TS) == typeof(int) && result is long)
-            // {
-            //     return (TS)(object)Convert.ToInt32(result);
-            // }
-            
-            return (TS)result;
+            return (TS)Execute(expression);
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3935,8 +3935,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 case SpecialQueryType.LongCount:
                     {
                         var qr = finalQuery.GetQueryResult();
-                        if (_queryType != SpecialQueryType.Count)
-                            return qr.LongTotalResults;
+                        if (_queryType == SpecialQueryType.Count)
+                        {
+                            if (qr.TotalResults > int.MaxValue)
+                                DocumentSession.ThrowWhenResultsAreOverInt32(qr.TotalResults, "Count", "LongCount");
+                            return (int)qr.TotalResults;
+                        }
                         return qr.TotalResults;
                     }
                 default:

--- a/src/Raven.Client/Documents/Queries/IndexQuery.cs
+++ b/src/Raven.Client/Documents/Queries/IndexQuery.cs
@@ -111,7 +111,7 @@ namespace Raven.Client.Documents.Queries
 
     public abstract class IndexQueryBase<T> : IIndexQuery, IEquatable<IndexQueryBase<T>>
     {
-        private int _pageSize = int.MaxValue;
+        private long _pageSize = int.MaxValue;
 
         /// <summary>
         /// Whether the page size was explicitly set or still at its default value
@@ -131,13 +131,13 @@ namespace Raven.Client.Documents.Queries
         /// Number of records that should be skipped.
         /// </summary>
         [Obsolete("Use OFFSET in RQL instead")]
-        public int Start { get; set; }
+        public long Start { get; set; }
 
         /// <summary>
         /// Maximum number of records that will be retrieved.
         /// </summary>
         [Obsolete("Use LIMIT in RQL instead")]
-        public int PageSize
+        public long PageSize
         {
             get => _pageSize;
             set
@@ -193,7 +193,7 @@ namespace Raven.Client.Documents.Queries
                 var hashCode = PageSizeSet.GetHashCode();
 #pragma warning disable 618
                 hashCode = (hashCode * 397) ^ PageSize.GetHashCode();
-                hashCode = (hashCode * 397) ^ Start;
+                hashCode = (hashCode * 397) ^ Start.GetHashCode();
 #pragma warning restore 618
                 hashCode = (hashCode * 397) ^ (Query?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (WaitForNonStaleResultsTimeout != null ? WaitForNonStaleResultsTimeout.GetHashCode() : 0);
@@ -215,7 +215,7 @@ namespace Raven.Client.Documents.Queries
 
     public interface IIndexQuery
     {
-        int PageSize { set; get; }
+        long PageSize { set; get; }
 
         TimeSpan? WaitForNonStaleResultsTimeout { get; }
     }

--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Client.Documents.Session;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Queries
@@ -19,30 +20,25 @@ namespace Raven.Client.Documents.Queries
         /// <summary>
         /// Gets or sets the total results for this query
         /// </summary>
-        public int TotalResults { get; set; }
-
-        /// <summary>
-        /// Gets or sets the total results as int64 for this query
-        /// </summary>
-        public long LongTotalResults { get; set; }
-
+        public long TotalResults { get; set; }
+        
         /// <summary>
         /// The total results for the query, taking into account the 
         /// offset / limit clauses for this query
         /// </summary>
-        public int? CappedMaxResults { get; set; }
-
+        public long? CappedMaxResults { get; set; }
+        
         /// <summary>
         /// Gets or sets the skipped results
         /// </summary>
-        public int SkippedResults { get; set; }
+        public long SkippedResults { get; set; }
         
         /// <summary>
         /// The number of results (filtered or matches)
         /// that were scanned by the query. This is relevant
         /// only if you are using a filter clause in the query.
         /// </summary>
-        public int? ScannedResults { get; set; }
+        public long? ScannedResults { get; set; }
 
         /// <summary>
         /// Highlighter results (if requested).
@@ -84,7 +80,6 @@ namespace Raven.Client.Documents.Queries
                 SkippedResults = SkippedResults,
                 ScannedResults = ScannedResults,
                 TotalResults = TotalResults,
-                LongTotalResults = LongTotalResults,
                 Highlightings = Highlightings?.ToDictionary(pair => pair.Key, x => new Dictionary<string, string[]>(x.Value)),
                 Explanations = Explanations?.ToDictionary(x => x.Key, x => x.Value),
                 Timings = Timings?.Clone(),

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -89,7 +89,7 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         ///   The page size to use when querying the index
         /// </summary>
-        protected int? PageSize;
+        protected long? PageSize;
 
         protected LinkedList<QueryToken> SelectTokens = new LinkedList<QueryToken>();
 
@@ -114,14 +114,14 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         ///   which record to start reading from
         /// </summary>
-        protected int Start;
+        protected long Start;
 
         private readonly DocumentConventions _conventions;
 
         /// <summary>
         /// Limits filter clause.
         /// </summary>
-        protected int? FilterLimit;
+        protected long? FilterLimit;
 
         /// <summary>
         /// Timeout for this query
@@ -538,7 +538,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         /// </summary>
         /// <param name = "count">The count.</param>
         /// <returns></returns>
-        public void Take(int count)
+        public void Take(long count)
         {
             PageSize = count;
         }
@@ -548,7 +548,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         /// </summary>
         /// <param name = "count">The count.</param>
         /// <returns></returns>
-        public void Skip(int count)
+        public void Skip(long count)
         {
             Start = count;
         }
@@ -1981,11 +1981,11 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             return "$" + AddQueryParameter(value);
         }
 
-        internal void AddFilterLimit(int filterLimit)
+        internal void AddFilterLimit(long filterLimit)
         {
             if (filterLimit <= 0)
                 throw new InvalidDataException("filter_limit needs to be positive and bigger than 0.");
-            if (filterLimit is not int.MaxValue)
+            if (filterLimit is not long.MaxValue)
                 FilterLimit = filterLimit;
         }
     }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -58,28 +58,28 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Take(int count)
+        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Take(long count)
         {
             Take(count);
             return this;
         }
 
         /// <inheritdoc />
-        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.Take(int count)
+        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.Take(long count)
         {
             Take(count);
             return this;
         }
 
         /// <inheritdoc />
-        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Skip(int count)
+        IAsyncDocumentQuery<T> IQueryBase<T, IAsyncDocumentQuery<T>>.Skip(long count)
         {
             Skip(count);
             return this;
         }
 
         /// <inheritdoc />
-        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.Skip(int count)
+        IAsyncRawDocumentQuery<T> IQueryBase<T, IAsyncRawDocumentQuery<T>>.Skip(long count)
         {
             Skip(count);
             return this;
@@ -955,7 +955,12 @@ namespace Raven.Client.Documents.Session
         {
             Take(0);
             var result = await GetQueryResultAsync(token).ConfigureAwait(false);
-            return result.TotalResults;
+            var value = result.TotalResults;
+            
+            if (value > int.MaxValue)
+                DocumentSession.ThrowWhenResultsAreOverInt32(value, nameof(IAsyncDocumentQueryBase<T>.CountAsync), nameof(IAsyncDocumentQueryBase<T>.LongCountAsync));
+
+            return (int)value;
         }
 
         /// <inheritdoc />
@@ -963,7 +968,7 @@ namespace Raven.Client.Documents.Session
         {
             Take(0);
             var result = await GetQueryResultAsync(token).ConfigureAwait(false);
-            return result.LongTotalResults;
+            return result.TotalResults;
         }
 
         /// <inheritdoc />

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -381,28 +381,28 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.Take(int count)
+        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.Take(long count)
         {
             Take(count);
             return this;
         }
 
         /// <inheritdoc />
-        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.Take(int count)
+        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.Take(long count)
         {
             Take(count);
             return this;
         }
 
         /// <inheritdoc />
-        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.Skip(int count)
+        IDocumentQuery<T> IQueryBase<T, IDocumentQuery<T>>.Skip(long count)
         {
             Skip(count);
             return this;
         }
 
         /// <inheritdoc />
-        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.Skip(int count)
+        IRawDocumentQuery<T> IQueryBase<T, IRawDocumentQuery<T>>.Skip(long count)
         {
             Skip(count);
             return this;
@@ -892,14 +892,14 @@ namespace Raven.Client.Documents.Session
             return queryResult.TotalResults > 0;
         }
 
-        private List<T> ExecuteQueryOperation(int? take)
+        private List<T> ExecuteQueryOperation(long? take)
         {
             ExecuteQueryOperationInternal(take);
 
             return QueryOperation.Complete<T>();
         }
 
-        private T[] ExecuteQueryOperationAsArray(int? take)
+        private T[] ExecuteQueryOperationAsArray(long? take)
         {
             ExecuteQueryOperationInternal(take);
 
@@ -907,7 +907,7 @@ namespace Raven.Client.Documents.Session
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ExecuteQueryOperationInternal(int? take)
+        private void ExecuteQueryOperationInternal(long? take)
         {
             if (take.HasValue && (PageSize.HasValue == false || PageSize > take))
                 Take(take.Value);
@@ -920,7 +920,11 @@ namespace Raven.Client.Documents.Session
         {
             Take(0);
             var queryResult = GetQueryResult();
-            return queryResult.TotalResults;
+            var value = queryResult.TotalResults;
+            if (value > int.MaxValue)
+                DocumentSession.ThrowWhenResultsAreOverInt32(value, nameof(IDocumentQueryBase<T>.Count), nameof(IDocumentQueryBase<T>.LongCount));
+
+            return (int)queryResult.TotalResults;
         }
 
         /// <inheritdoc />
@@ -928,7 +932,7 @@ namespace Raven.Client.Documents.Session
         {
             Take(0);
             var queryResult = GetQueryResult();
-            return queryResult.LongTotalResults;
+            return queryResult.TotalResults;
         }
 
         /// <inheritdoc />

--- a/src/Raven.Client/Documents/Session/DocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Lazy.cs
@@ -155,6 +155,25 @@ namespace Raven.Client.Documents.Session
             var lazyValue = new Lazy<int>(() =>
             {
                 ExecuteAllPendingLazyOperations();
+
+                var value = operation.QueryResult.TotalResults;
+                if (value > int.MaxValue)
+                    ThrowWhenResultsAreOverInt32(value, nameof(AddLazyCountOperation), nameof(AddLazyLongCountOperation));
+                
+                return (int)operation.QueryResult.TotalResults;
+            });
+
+            return lazyValue;
+        }
+        
+        internal Lazy<long> AddLazyLongCountOperation(ILazyOperation operation)
+        {
+            PendingLazyOperations.Add(operation);
+            var lazyValue = new Lazy<long>(() =>
+            {
+                ExecuteAllPendingLazyOperations();
+                
+                
                 return operation.QueryResult.TotalResults;
             });
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -253,5 +253,10 @@ namespace Raven.Client.Documents.Session
             return false;
         }
 
+        internal static void ThrowWhenResultsAreOverInt32(long value, string caller, string suggestedMethod)
+        {
+            if (int.MaxValue < value)
+                throw new OverflowException($"Value '{value}' from '{caller}' method exceeds max Int32 value ('{value}'). You should use '{suggestedMethod}' instead.");
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -85,14 +85,14 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         /// <param name = "count">The count.</param>
         /// <returns></returns>
-        void Take(int count);
+        void Take(long count);
 
         /// <summary>
         ///   Skips the specified count.
         /// </summary>
         /// <param name = "count">The count.</param>
         /// <returns></returns>
-        void Skip(int count);
+        void Skip(long count);
 
         /// <summary>
         ///   Matches value

--- a/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
@@ -69,7 +69,7 @@ namespace Raven.Client.Documents.Session
         ///     Skips the specified count.
         /// </summary>
         /// <param name="count">Number of items to skip.</param>
-        TSelf Skip(int count);
+        TSelf Skip(long count);
 
         /// <summary>
         ///     Provide statistics about the query, such as total count of matching records
@@ -80,7 +80,7 @@ namespace Raven.Client.Documents.Session
         ///     Takes the specified count.
         /// </summary>
         /// <param name="count">Maximum number of items to take.</param>
-        TSelf Take(int count);
+        TSelf Take(long count);
 
         /// <summary>
         ///     Select the default operator to use for this query

--- a/src/Raven.Client/Documents/Session/QueryStatistics.cs
+++ b/src/Raven.Client/Documents/Session/QueryStatistics.cs
@@ -28,24 +28,19 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// What was the total count of the results that matched the query
         /// </summary>
-        public int TotalResults { get; set; }
-
-        /// <summary>
-        /// What was the total count of the results that matched the query as int64
-        /// </summary>
-        public long LongTotalResults { get; set; }
-
+        public long TotalResults { get; set; }
+        
         /// <summary>
         /// Gets or sets the skipped results
         /// </summary>
-        public int SkippedResults { get; set; }
+        public long SkippedResults { get; set; }
         
         /// <summary>
         /// The number of results (filtered or matches)
         /// that were scanned by the query. This is relevant
         /// only if you are using a filter clause in the query.
         /// </summary>
-        public int? ScannedResults { get; set; }
+        public long? ScannedResults { get; set; }
 
         /// <summary>
         /// The time when the query results were unstale.
@@ -82,7 +77,6 @@ namespace Raven.Client.Documents.Session
             IsStale = qr.IsStale;
             DurationInMs = qr.DurationInMs;
             TotalResults = qr.TotalResults;
-            LongTotalResults = qr.LongTotalResults;
             SkippedResults = qr.SkippedResults;
             ScannedResults = qr.ScannedResults;
             Timestamp = qr.IndexTimestamp;

--- a/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
@@ -26,5 +26,5 @@ public abstract class AbstractDatabaseRequestHandler<TOperationContext> : Reques
 
     public abstract bool ShouldAddPagingPerformanceHint(long numberOfResults);
 
-    public abstract void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration, long totalDocumentsSizeInBytes);
+    public abstract void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, long pageSize, long duration, long totalDocumentsSizeInBytes);
 }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents
             return numberOfResults > Database.Configuration.PerformanceHints.MaxNumberOfResults;
         }
 
-        public override void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration, long totalDocumentsSizeInBytes)
+        public override void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, long pageSize, long duration, long totalDocumentsSizeInBytes)
         {
             if (ShouldAddPagingPerformanceHint(numberOfResults))
                 Database.NotificationCenter.Paging.Add(operation, action, details, numberOfResults, pageSize, duration, totalDocumentsSizeInBytes);

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -427,7 +427,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
 
                 var retriever = new MapReduceQueryResultRetriever(null, null, null, null, context, SearchEngineType.Lucene, fieldsToFetch, null, null, null);
                 var result = reader
-                     .Query(query, null, fieldsToFetch, new Reference<int>(), new Reference<int>(), new Reference<int>(), retriever, ctx, null, CancellationToken.None)
+                     .Query(query, null, fieldsToFetch, new Reference<long>(), new Reference<long>(), new Reference<long>(), retriever, ctx, null, CancellationToken.None)
                     .ToList();
 
                 if (result.Count == 0)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3166,9 +3166,9 @@ namespace Raven.Server.Documents.Indexes
                                     fillScope = includesScope.For(nameof(QueryTimingsScope.Names.Fill), start: false);
                                 }
 
-                                Reference<int> totalResults = new Reference<int>();
-                                Reference<int> skippedResults = new Reference<int>();
-                                Reference<int> scannedResults = new Reference<int>();
+                                Reference<long> totalResults = new();
+                                Reference<long> skippedResults = new();
+                                Reference<long> scannedResults = new();
                                 IncludeCountersCommand includeCountersCommand = null;
                                 IncludeTimeSeriesCommand includeTimeSeriesCommand = null;
                                 IncludeRevisionsCommand includeRevisionsCommand = new(DocumentDatabase, queryContext.Documents, query.Metadata.RevisionIncludes);
@@ -3264,12 +3264,12 @@ namespace Raven.Server.Documents.Indexes
                                         {
                                             var document = enumerator.Current;
 
-                                            resultToFill.LongTotalResults = resultToFill.TotalResults = totalResults.Value;
+                                            resultToFill.TotalResults = totalResults.Value;
 
                                             if (query.Offset != null || query.Limit != null)
                                             {
                                                 resultToFill.CappedMaxResults = Math.Min(
-                                                    query.Limit ?? int.MaxValue,
+                                                    query.Limit ?? long.MaxValue,
                                                     totalResults.Value - (query.Offset ?? 0)
                                                 );
                                             }
@@ -3326,7 +3326,6 @@ namespace Raven.Server.Documents.Indexes
                                 resultToFill.RegisterSpatialProperties(query);
 
                                 resultToFill.TotalResults = Math.Max(totalResults.Value, resultToFill.Results.Count);
-                                resultToFill.LongTotalResults = resultToFill.TotalResults;
                                 resultToFill.SkippedResults = skippedResults.Value;
                                 resultToFill.ScannedResults = scannedResults.Value;
                                 resultToFill.IncludedPaths = query.Metadata.Includes;
@@ -3415,12 +3414,11 @@ namespace Raven.Server.Documents.Indexes
 
                         using (var reader = IndexPersistence.OpenIndexReader(indexTx.InnerTransaction))
                         {
-                            var totalResults = new Reference<int>();
+                            var totalResults = new Reference<long>();
 
                             foreach (var indexEntry in reader.IndexEntries(query, totalResults, queryContext.Documents, GetOrAddSpatialField, ignoreLimit, token.Token))
                             {
                                 resultToFill.TotalResults = totalResults.Value;
-                                resultToFill.LongTotalResults = totalResults.Value;
                                 await resultToFill.AddResultAsync(indexEntry, token.Token);
                             }
                         }
@@ -3550,7 +3548,6 @@ namespace Raven.Server.Documents.Indexes
                                     }
 
                                     result.TotalResults = result.Results.Count;
-                                    result.LongTotalResults = result.Results.Count;
 
                                     return result;
                                 }
@@ -3658,7 +3655,6 @@ namespace Raven.Server.Documents.Indexes
                             }
 
                             result.TotalResults = result.Results.Count;
-                            result.LongTotalResults = result.Results.Count;
                             return result;
                         }
                     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexQueryingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexQueryingScope.cs
@@ -25,7 +25,7 @@ public class CoraxIndexQueryingScope : IndexQueryingScopeBase<UnmanagedSpan>
         _fieldsMapping = fieldsMapping;
     }
 
-    public int RecordAlreadyPagedItemsInPreviousPage(Span<long> ids, IQueryMatch match, Reference<int> totalResults, out int read, ref int queryStart,
+    public int RecordAlreadyPagedItemsInPreviousPage(Span<long> ids, IQueryMatch match, Reference<long> totalResults, out int read, ref long queryStart,
         CancellationToken token)
     {
         read = match.Fill(ids);
@@ -53,7 +53,7 @@ public class CoraxIndexQueryingScope : IndexQueryingScopeBase<UnmanagedSpan>
         
         queryStart -= limit;
 
-        var distinctIds = ids.Slice(0, limit);
+        var distinctIds = ids.Slice(0, (int)limit);
 
         // we are paging, we need to check that we don't have duplicates in the previous pages
         // see here for details: http://groups.google.com/group/ravendb/browse_frm/thread/d71c44aa9e2a7c6e
@@ -70,7 +70,7 @@ public class CoraxIndexQueryingScope : IndexQueryingScopeBase<UnmanagedSpan>
 
         if (_fieldsToFetch.IsDistinct == false)
         {
-            return limit;
+            return (int)limit;
         }
 
         foreach (var id in distinctIds)
@@ -100,7 +100,7 @@ public class CoraxIndexQueryingScope : IndexQueryingScopeBase<UnmanagedSpan>
             }
         }
 
-        return limit;
+        return (int)limit;
     }
 
     private unsafe class UnmanagedSpanComparer : IEqualityComparer<UnmanagedSpan>

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
@@ -116,7 +116,7 @@ public abstract class IndexOperationBase : IDisposable
         return (int)pageSize;
     }
 
-    protected static int CoraxGetPageSize(global::Corax.IndexSearcher searcher, int pageSize, IndexQueryServerSide query, bool isBoolean = false)
+    protected static int CoraxGetPageSize(global::Corax.IndexSearcher searcher, long pageSize, IndexQueryServerSide query, bool isBoolean = false)
     {
         var numberOfEntries = searcher.NumberOfEntries;
         
@@ -141,8 +141,8 @@ public abstract class IndexOperationBase : IDisposable
             : DefaultBufferSizeForCorax;
     }
     
-    protected QueryFilter GetQueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<int> skippedResults,
-        Reference<int> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
+    protected QueryFilter GetQueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<long> skippedResults,
+        Reference<long> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
     {
         if (query.Metadata.FilterScript is null)
             return null;

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -45,11 +45,11 @@ namespace Raven.Server.Documents.Indexes.Persistence
         public abstract long EntriesCount();
 
         public abstract IEnumerable<QueryResult> Query(IndexQueryServerSide query, QueryTimingsScope queryTimings, FieldsToFetch fieldsToFetch,
-            Reference<int> totalResults, Reference<int> skippedResults, Reference<int> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext,
+            Reference<long> totalResults, Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext,
             Func<string, SpatialField> getSpatialField, CancellationToken token);
 
-        public abstract IEnumerable<QueryResult> IntersectQuery(IndexQueryServerSide query, FieldsToFetch fieldsToFetch, Reference<int> totalResults,
-            Reference<int> skippedResults, Reference<int> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField,
+        public abstract IEnumerable<QueryResult> IntersectQuery(IndexQueryServerSide query, FieldsToFetch fieldsToFetch, Reference<long> totalResults,
+            Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField,
             CancellationToken token);
 
         public abstract SortedSet<string> Terms(string field, string fromValue, long pageSize, CancellationToken token);
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
             DocumentsOperationContext context,
             CancellationToken token);
 
-        public abstract IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<int> totalResults, DocumentsOperationContext documentsContext,
+        public abstract IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<long> totalResults, DocumentsOperationContext documentsContext,
             Func<string, SpatialField> getSpatialField, bool ignoreLimit, CancellationToken token);
 
         public abstract IEnumerable<string> DynamicEntriesFields(HashSet<string> staticFields);

--- a/src/Raven.Server/Documents/Indexes/Persistence/QueryFilter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/QueryFilter.cs
@@ -20,15 +20,15 @@ public class QueryFilter : IDisposable
 {
     private readonly IndexQueryServerSide _query;
     private readonly DocumentsOperationContext _documentsContext;
-    private readonly Reference<int> _skippedResults;
-    private readonly Reference<int> _scannedDocuments;
+    private readonly Reference<long> _skippedResults;
+    private readonly Reference<long> _scannedDocuments;
     private readonly IQueryResultRetriever _retriever;
     private readonly QueryTimingsScope _queryTimings;
     private readonly ScriptRunner.SingleRun _filterScriptRun;
     private ScriptRunner.ReturnRun _filterSingleRun;
 
-    public QueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<int> skippedResults,
-        Reference<int> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
+    public QueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<long> skippedResults,
+        Reference<long> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
     {
         _query = query;
         _documentsContext = documentsContext;

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryResultsIterationState.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryResultsIterationState.cs
@@ -10,8 +10,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
         {
         }
 
-        public int Start;
-        public int Take;
+        public long Start;
+        public long Take;
 
         public override void OnMoveNext(Document current)
         {

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -252,8 +252,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 resultToFill.RegisterTimeSeriesFields(query, fieldsToFetch);
                 resultToFill.TotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
-                resultToFill.LongTotalResults = resultToFill.TotalResults;
-                resultToFill.SkippedResults = Convert.ToInt32(skippedResults.Value);
+                resultToFill.SkippedResults = skippedResults.Value;
                 resultToFill.ScannedResults = scannedResults.Value;
 
                 if (query.Offset != null || query.Limit != null)
@@ -307,7 +306,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     buffer[hasCounters ? 4 : 3] = DocumentsStorage.ReadLastTimeSeriesEtag(context.Documents.Transaction.InnerTransaction);
 
                 resultToFill.TotalResults = (int)numberOfDocuments;
-                resultToFill.LongTotalResults = numberOfDocuments;
             }
             else
             {
@@ -323,7 +321,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     buffer[hasCounters ? 4 : 3] = Database.DocumentsStorage.TimeSeriesStorage.GetLastTimeSeriesEtag(context.Documents, collection);
 
                 resultToFill.TotalResults = (int)collectionStats.Count;
-                resultToFill.LongTotalResults = collectionStats.Count;
             }
 
             if (hasCmpXchg)

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -32,13 +32,13 @@ namespace Raven.Server.Documents.Queries
         public bool ReturnMissingIncludeAsNull;
 
         [JsonDeserializationIgnore]
-        public int? Offset;
+        public long? Offset;
 
         [JsonDeserializationIgnore]
-        public int? Limit;
+        public long? Limit;
 
         [JsonDeserializationIgnore]
-        public int? FilterLimit { get; set; }
+        public long? FilterLimit { get; set; }
 
         [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
@@ -50,7 +50,7 @@ namespace Raven.Server.Documents.Queries
         public SpatialDistanceFieldComparatorSource.SpatialDistanceFieldComparator Distances;
 
 
-        public new int Start
+        public new long Start
         {
 #pragma warning disable 618
             get => base.Start;
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Queries
 #pragma warning restore 618
         }
 
-        public new int PageSize
+        public new long PageSize
         {
 #pragma warning disable 618
             get => base.PageSize;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -172,11 +172,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         private readonly Func<(JsonOperationContext, IDisposable)> _allocateJsonContext;
         private readonly IComparer<BlittableJsonReaderObject> _comparer;
         private readonly Dictionary<int, PostQueryStreamCommand> _queryStreamCommands;
-        private readonly int _skip;
-        private readonly int _take;
+        private readonly long _skip;
+        private readonly long _take;
         private readonly CancellationToken _token;
 
-        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, int skip, int take, CancellationToken token)
+        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, long skip, long take, CancellationToken token)
         {
             _httpContext = httpContext;
             _allocateJsonContext = allocateJsonContext;
@@ -221,7 +221,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             return (ApplySkipTake(mergedEnumerator, _skip, _take), queryStats);
         }
 
-        private IEnumerator<BlittableJsonReaderObject> ApplySkipTake(MergedEnumerator<BlittableJsonReaderObject> mergedEnumerator, int skip, int take)
+        private IEnumerator<BlittableJsonReaderObject> ApplySkipTake(MergedEnumerator<BlittableJsonReaderObject> mergedEnumerator, long skip, long take)
         {
             foreach (var item in mergedEnumerator)
             {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             return numberOfResults > DatabaseContext.Configuration.PerformanceHints.MaxNumberOfResults;
         }
 
-        public override void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration,
+        public override void AddPagingPerformanceHint(PagingOperationType operation, string action, string details, long numberOfResults, long pageSize, long duration,
             long totalDocumentsSizeInBytes)
         {
             if (ShouldAddPagingPerformanceHint(numberOfResults))

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -247,12 +248,17 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
     {
         if (_query.Offset is > 0 && result.Results.Count > _query.Offset)
         {
-            result.Results.RemoveRange(0, _query.Offset ?? 0);
+            var count = Math.Min(_query.Offset ?? 0, int.MaxValue);
+            result.Results.RemoveRange(0, (int)count);
         }
 
         if (_query.Limit is > 0 && result.Results.Count > _query.Limit)
         {
-            result.Results.RemoveRange(_query.Limit.Value, result.Results.Count - _query.Limit.Value);
+            var index = Math.Min(_query.Limit.Value, int.MaxValue);
+            var count = result.Results.Count - _query.Limit.Value;
+            if (count > int.MaxValue)
+                count = int.MaxValue; //todo: Grisha: take a look
+            result.Results.RemoveRange((int)index, (int)count);
         }
     }
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -508,11 +508,7 @@ namespace Raven.Server.Json
             writer.WritePropertyName(nameof(result.TotalResults));
             writer.WriteInteger(result.TotalResults);
             writer.WriteComma();
-
-            writer.WritePropertyName(nameof(result.LongTotalResults));
-            writer.WriteInteger(result.LongTotalResults);
-            writer.WriteComma();
-
+            
             if (result.CappedMaxResults != null)
             {
                 writer.WritePropertyName(nameof(result.CappedMaxResults));

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/PagingPerformanceDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/PagingPerformanceDetails.cs
@@ -70,7 +70,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             public long Duration { get; set; }
             public DateTime Occurrence { get; set; }
             public long NumberOfResults { get; set; }
-            public int PageSize { get; set; }
+            public long PageSize { get; set; }
             public long TotalDocumentsSizeInBytes { get; set; }
         }
     }

--- a/src/Raven.Server/NotificationCenter/Paging.cs
+++ b/src/Raven.Server/NotificationCenter/Paging.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.NotificationCenter
             _logger = LoggingSource.Instance.GetLogger(notificationCenter.Database, GetType().FullName);
         }
 
-        public void Add(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration, long totalDocumentsSizeInBytes)
+        public void Add(PagingOperationType operation, string action, string details, long numberOfResults, long pageSize, long duration, long totalDocumentsSizeInBytes)
         {
             var now = SystemTime.UtcNow;
             var update = _pagingUpdates[(int)operation];
@@ -185,12 +185,12 @@ namespace Raven.Server.NotificationCenter
             public string Action { get; }
             public string Details { get; }
             public long NumberOfResults { get; }
-            public int PageSize { get; }
+            public long PageSize { get; }
             public long Duration { get; }
             public DateTime Occurrence { get; }
             public long TotalDocumentsSizeInBytes { get; }
 
-            public PagingInformation(PagingOperationType type, string action, string details, long numberOfResults, int pageSize, long duration, DateTime occurrence, long totalDocumentsSizeInBytes)
+            public PagingInformation(PagingOperationType type, string action, string details, long numberOfResults, long pageSize, long duration, DateTime occurrence, long totalDocumentsSizeInBytes)
             {
                 Type = type;
                 Action = action;

--- a/test/SlowTests/Core/Querying/Paging.cs
+++ b/test/SlowTests/Core/Querying/Paging.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Core.Querying
                         .Where(c => c.Name.StartsWith("Company"))
                         .Select(c => c.Name)
                         .Distinct()
-                        .Skip(5 + skipped)
+                        .Skip(5 + (int)skipped)
                         .Take(5)
                         .ToArray();
                     Assert.Equal(7, stats.TotalResults);

--- a/test/SlowTests/Issues/RavenDB-19076.cs
+++ b/test/SlowTests/Issues/RavenDB-19076.cs
@@ -43,13 +43,13 @@ public class RavenDB_19076 : RavenTestBase
                 var pagging = new List<Order>();
                 int pageNumber = 0;
                 int pageSize = 101;
-                int skippedResults = 0;
+                long skippedResults = 0;
                 List<Order> results;
                 do
                 {
                     results = session.Advanced.RawQuery<Orders.Order>(query)
                         .Statistics(out QueryStatistics stats)
-                        .Skip((pageNumber * pageSize) + skippedResults)
+                        .Skip((pageNumber * pageSize) + (int)skippedResults)
                         .Take(pageSize)
                         .ToList();
 

--- a/test/SlowTests/Issues/RavenDB_17046.cs
+++ b/test/SlowTests/Issues/RavenDB_17046.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Issues
                     IList<T> results;
                     int pageNumber = 0;
                     int pageSize = 101;
-                    int skippedResults = 0;
+                    long skippedResults = 0;
                     do
                     {
                         results = session
@@ -86,7 +86,6 @@ namespace SlowTests.Issues
                         if (results.Count == pageSize)
                         {
                             Assert.Equal(-1, stats.TotalResults);
-                            Assert.Equal(-1, stats.LongTotalResults);
                         }
                     }
                     while (results.Count > 0);

--- a/test/SlowTests/MailingList/DistinctWithPaging.cs
+++ b/test/SlowTests/MailingList/DistinctWithPaging.cs
@@ -76,7 +76,7 @@ namespace SlowTests.MailingList
                                         .OrderBy(t => t.Val)
                                         .Select(t => t.Val)
                                         .Distinct()
-                                        .Skip(results.Count + skippedResults)
+                                        .Skip((int)(results.Count + skippedResults))
                                         .Take(10)
                                         .ToList();
 

--- a/test/SlowTests/MailingList/SkippedResults.cs
+++ b/test/SlowTests/MailingList/SkippedResults.cs
@@ -51,8 +51,8 @@ namespace SlowTests.MailingList
                 {
                     const int pageSize = 2;
                     int pageNumber = 0;
-                    int skippedResults = 0;
-                    int recordsToSkip = 0;
+                    long skippedResults = 0;
+                    long recordsToSkip = 0;
 
                     var providers = new List<Provider>();
 
@@ -65,7 +65,7 @@ namespace SlowTests.MailingList
                                       where p.Zip == "97520"
                                       select p)
                             .Take(pageSize)
-                            .Skip(recordsToSkip)
+                            .Skip((int)recordsToSkip)
                             .ToList();
 
                         providers.AddRange(result);

--- a/test/SlowTests/MailingList/Vlad.cs
+++ b/test/SlowTests/MailingList/Vlad.cs
@@ -142,7 +142,7 @@ namespace SlowTests.MailingList
                 {
                     int pageSize = 2;
                     int pageNumber = 0;
-                    int recordsToSkip = 0;
+                    long recordsToSkip = 0;
 
                     var posts = new List<Post>();
 
@@ -155,7 +155,7 @@ namespace SlowTests.MailingList
                             .Statistics(out stat)
                             .Where(x => x.Tag == "cloud")
                             .Take(pageSize)
-                            .Skip(recordsToSkip)
+                            .Skip((int)recordsToSkip)
                             .As<Post>()
                             .ToList();
 

--- a/test/SlowTests/MailingList/ZNS.cs
+++ b/test/SlowTests/MailingList/ZNS.cs
@@ -117,9 +117,9 @@ namespace SlowTests.MailingList
                 List<TestItem> pagedResult = new List<TestItem>();
                 QueryStatistics stats2;
 
-                int skip = 0;
+                long skip = 0;
                 var take = 10;
-                int page = 0;
+                long page = 0;
 
                 do
                 {

--- a/test/SlowTests/MailingList/ZNS2.cs
+++ b/test/SlowTests/MailingList/ZNS2.cs
@@ -126,9 +126,9 @@ namespace SlowTests.MailingList
                 List<TestItem> paged = new List<TestItem>();
                 QueryStatistics stats2;
 
-                int skip = 0;
-                var take = 10;
-                int page = 0;
+                long skip = 0;
+                long take = 10;
+                long page = 0;
 
                 do
                 {

--- a/test/SlowTests/SlowTests/Issues/RavenDB_2812.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_2812.cs
@@ -75,7 +75,7 @@ namespace SlowTests.SlowTests.Issues
             }
             Indexes.WaitForIndexing(store);
 
-            int skippedResults = 0;
+            long skippedResults = 0;
             var pagedResults = new List<User>();
 
             var page = 0;
@@ -90,7 +90,7 @@ namespace SlowTests.SlowTests.Issues
                     var results = session
                         .Query<User, UsersAndFiendsIndex>()
                         .Statistics(out stats)
-                        .Skip((page * pageSize) + skippedResults)
+                        .Skip((page * pageSize) + (int)skippedResults)
                         .Take(pageSize)
                         .Distinct()
                         .ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17215 

### Additional description

Corax gives us the possibility to index more than `int32` so we've to change API to allow users to stream a such a large amount of data.

### Type of change

- New feature

### How risky is the change?

- High


### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. 

### Testing 

- Uses current test base

### Is there any existing behavior change of other features due to this change?

- Yes.:
- - querying

### UI work

- No UI work is needed
