### PR TITLE
RavenDB-19438 Use ReadTree instead of CreateTree in SuggestionProvider.

### DIFF
--- a/src/Corax/Queries/SuggestionTermProvider.cs
+++ b/src/Corax/Queries/SuggestionTermProvider.cs
@@ -283,8 +283,8 @@ namespace Corax.Queries
                 var maxDistance = provider._distance;
 
                 // We get the actual field tree. 
-                var fields = provider._searcher.Transaction.CreateTree(Constants.IndexWriter.FieldsSlice);
-                var fieldTree = fields.CompactTreeFor(provider._binding.FieldName);
+                var fields = provider._searcher.Transaction.ReadTree(Constants.IndexWriter.FieldsSlice);
+                var fieldTree = fields?.CompactTreeFor(provider._binding.FieldName);
                 if (fieldTree == null)
                     goto NoResults;
 

--- a/test/SlowTests/Issues/RavenDB-12902.cs
+++ b/test/SlowTests/Issues/RavenDB-12902.cs
@@ -119,7 +119,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task AfterSuggestionQueryExecutedShouldBeExecutedOnlyOnce(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -399,7 +399,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task AfterLazySuggestionQueryExecutedShouldBeExecutedOnlyOnce(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -556,7 +556,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task CanGetValidStatisticsInSuggestionQuery(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19438

### Additional description

`SuggestionProvide`r is made for reading, not for indexing so `transaction` will always be `Read`. In case when suggestions don't exist it will throw on `CreateTree` call.

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
