### PR TITLE
RavenDB-19495 Use `Backup.TempPath` on one time backup

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             _serverStore = serverStore;
             _logger = LoggingSource.Instance.GetLogger<PeriodicBackupRunner>(_database.Name);
             _cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
-            _tempBackupPath = (_database.Configuration.Backup.TempPath ?? _database.Configuration.Storage.TempPath ?? _database.Configuration.Core.DataDirectory).Combine("PeriodicBackupTemp");
+            _tempBackupPath = BackupUtils.GetBackupTempPath(_database.Configuration, "PeriodicBackupTemp");
 
             // we pass wakeup-1 to ensure the backup will run right after DB woke up on wakeup time, and not on the next occurrence.
             // relevant only if it's the first backup after waking up

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -7,6 +7,8 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server.Config;
+using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.NotificationCenter.Notifications;
@@ -277,6 +279,11 @@ internal static class BackupUtils
                 DelayPeriod = serverStore.Configuration.Backup.LowMemoryBackupDelay.AsTimeSpan
             };
         }
+    }
+    
+    public static PathSetting GetBackupTempPath(RavenConfiguration configuration, string dir)
+    {
+        return (configuration.Backup.TempPath ?? configuration.Storage.TempPath ?? configuration.Core.DataDirectory).Combine(dir);
     }
 
     public class NextBackupOccurrenceParameters

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -462,7 +462,7 @@ namespace Raven.Server.Web.System
                         OperationId = operationId,
                         BackupToLocalFolder = BackupConfiguration.CanBackupUsing(backupConfiguration.LocalSettings),
                         IsFullBackup = true,
-                        TempBackupPath = (Database.Configuration.Storage.TempPath ?? Database.Configuration.Core.DataDirectory).Combine("OneTimeBackupTemp"),
+                        TempBackupPath = BackupUtils.GetBackupTempPath(Database.Configuration, "OneTimeBackupTemp"),
                         Name = backupName
                     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19495

### Additional description

When running a periodic backup we check if the `Backup.TempPath` configuration is set and using it.
If not we fall back to `Storage.TempPath` and then to `Core.DataDirectory`.
When running a one-time backup we don't check `Backup.TempPath`.

_Please delete below the options that are not relevant_

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
