### PR TITLE
RavenDB-18373 - Waiting for index doesn't work for cluster wide trans…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -557,7 +557,7 @@ namespace Raven.Server.Documents
                     {
                         indexTask = BatchHandler.WaitForIndexesAsync(DocumentsStorage.ContextPool, this, options.WaitForIndexesTimeout.Value,
                             options.SpecifiedIndexesQueryString, options.WaitForIndexThrow,
-                            mergedCommands.LastChangeVector, mergedCommands.LastTombstoneEtag, mergedCommands.ModifiedCollections);
+                            mergedCommands.LastDocumentEtag, mergedCommands.LastTombstoneEtag, mergedCommands.ModifiedCollections);
                     }
 
                     var result = new BatchHandler.ClusterTransactionCompletionResult

--- a/test/SlowTests/Issues/RavenDB-18373.cs
+++ b/test/SlowTests/Issues/RavenDB-18373.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18373 : RavenTestBase
+    {
+        public RavenDB_18373(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+
+        private class Simple_Map_Index : AbstractIndexCreationTask<TestObj>
+        {
+            public Simple_Map_Index()
+            {
+                Map = companies => from c in companies
+                    select new
+                    {
+                        Name = ""
+                    };
+            }
+        }
+
+        [Theory]
+        [InlineData(TransactionMode.ClusterWide)] //Fails
+        [InlineData(TransactionMode.SingleNode)] //Succeeds
+        public async Task TestCase(TransactionMode transactionMode)
+        {
+            using var store = GetDocumentStore();
+
+            await new Simple_Map_Index().ExecuteAsync(store);
+            await store.Maintenance.SendAsync(new StopIndexingOperation());
+
+            using (var session = store.OpenAsyncSession(new SessionOptions {
+                       TransactionMode = transactionMode
+            }))
+            {
+                session.Advanced.WaitForIndexesAfterSaveChanges(TimeSpan.FromSeconds(3));
+
+                await session.StoreAsync(new TestObj(), "testObjs/0");
+                await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+            }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-18373.cs
+++ b/test/SlowTests/Issues/RavenDB-18373.cs
@@ -73,7 +73,6 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = transactionMode }))
             {
-                session.Advanced.WaitForReplicationAfterSaveChanges();
                 session.Advanced.WaitForIndexesAfterSaveChanges(TimeSpan.FromSeconds(3));
                 await session.StoreAsync(new TestObj(), "testObjs/0");
                 await session.StoreAsync(new TestObj(), "testObjs/1");

--- a/test/SlowTests/Issues/RavenDB-18373.cs
+++ b/test/SlowTests/Issues/RavenDB-18373.cs
@@ -41,9 +41,9 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [InlineData(TransactionMode.ClusterWide)] //Fails
-        [InlineData(TransactionMode.SingleNode)] //Succeeds
-        public async Task TestCase(TransactionMode transactionMode)
+        [InlineData(TransactionMode.ClusterWide)]
+        [InlineData(TransactionMode.SingleNode)]
+        public async Task Waiting_For_Index_Doesnt_Work_For_ClusterWideTransaction(TransactionMode transactionMode)
         {
             using var store = GetDocumentStore();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18373

### Additional description

Fixing Waiting for an index doesn't work for cluster-wide transaction.
When we use ```WaitForIndexesAfterSaveChanges``` in ```session``` we ask for ```bulkhandler``` to save and wait for indexing.
The 'indexing' part uses the ```Etag``` of the ```merged command``` as a boundary (cutoff), which is extracted from the command change vector by taking the number that comes after the database id in the change vector.
In a cluster-wide transaction, The merge command change vector is a raft transaction change vector that doesn't contain the database id (which is unique for every node in the database topology) so that ```Etag``` gets value of ```0``` (every index is already done for ```Etag``` 0 ).
The solution was to save the ```Etag``` of the merged command in every node and use it instead of getting it from the raft change vector (which doesn't contain the database id).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
