### PR TITLE
RavenDB-19467 Dynamic query with term comparison can use Exact autoindex | Linq support for case-sensitive string comparisons 

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -489,7 +489,7 @@ namespace Raven.Client.Documents.Linq
                     var isSimpleCompare = nameof(string.Compare) == methodCallExpression.Method.Name;
                     var argumentsCount = methodCallExpression.Arguments.Count;
                     
-                    if (isSimpleCompare == false && argumentsCount != 2)
+                    if (isSimpleCompare == false && argumentsCount > 2)
                         throw new NotSupportedException($"We do not support such overloads in '{methodCallExpression.Method.Name}'.");
                     if (isSimpleCompare)
                     {

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -249,25 +249,62 @@ namespace FastTests.Client
                 using (var newSession = store.OpenSession())
                 {
                     newSession.Store(new User { Name = "John" }, "users/1");
-                    newSession.Store(new User { Name = "Jane" }, "users/2");
-                    newSession.Store(new User { Name = "Tarzan" }, "users/3");
+                    newSession.Store(new User { Name = "john" }, "users/2");
+                    newSession.Store(new User { Name = "Jane" }, "users/3");
+                    newSession.Store(new User { Name = "jane" }, "users/4");
+                    newSession.Store(new User { Name = "Tarzan" }, "users/5");
+                    newSession.Store(new User { Name = "tarzan" }, "users/6");
                     newSession.SaveChanges();
 
                     var queryResult = newSession.Query<User>()
                         .Where(x => x.Name.StartsWith("J"))
                         .ToList();
+                    Assert.Equal(queryResult.Count, 4);
 
-                    var queryResult2 = newSession.Query<User>()
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.StartsWith('j'))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 4);
+
+                    queryResult = newSession.Query<User>()
                         .Where(x => x.Name.Equals("Tarzan"))
                         .ToList();
+                    Assert.Equal(queryResult.Count, 2);
 
-                    var queryResult3 = newSession.Query<User>()
+                    queryResult = newSession.Query<User>()
                         .Where(x => x.Name.EndsWith("n"))
                         .ToList();
+                    Assert.Equal(queryResult.Count, 4);
 
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.EndsWith('n'))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 4);
+
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.StartsWith("j", StringComparison.InvariantCulture))
+                        .ToList();
                     Assert.Equal(queryResult.Count, 2);
-                    Assert.Equal(queryResult2.Count, 1);
-                    Assert.Equal(queryResult3.Count, 2);
+
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.StartsWith("J", StringComparison.InvariantCulture))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 2);
+
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.Equals("tarzan", StringComparison.Ordinal))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 1);
+
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.EndsWith("n", StringComparison.InvariantCulture))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 4);
+
+                    queryResult = newSession.Query<User>()
+                        .Where(x => x.Name.EndsWith("N", StringComparison.InvariantCulture))
+                        .ToList();
+                    Assert.Equal(queryResult.Count, 0);
                 }
             }
         }
@@ -332,105 +369,142 @@ namespace FastTests.Client
 
             using var store = GetDocumentStore(options);
             using var session = store.OpenAsyncSession();
-            
+
             await session.StoreAsync(new User { Name = "John" });
             await session.StoreAsync(new User { Name = "Jane" });
             await session.StoreAsync(new User { Name = varStrToQuery });
+            await session.StoreAsync(new User { Name = varStrToQuery.ToLowerInvariant() });
             await session.SaveChangesAsync();
 
             var queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => string.Equals(x.Name, varStrToQuery))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => string.Equals(x.Name, varStrToQuery, StringComparison.OrdinalIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
                 .Where(x => string.Equals(x.Name, constStrToQuery))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
                 .Where(x => string.Equals(x.Name, constStrToQuery, StringComparison.CurrentCultureIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => string.Equals(varStrToQuery, x.Name))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => string.Equals(varStrToQuery, x.Name, StringComparison.CurrentCultureIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //constStrToQuery - ExpressionType.Constant, x.Name - ExpressionType.MemberAccess, 
                 .Where(x => string.Equals(constStrToQuery, x.Name))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //constStrToQuery - ExpressionType.Constant, x.Name - ExpressionType.MemberAccess, 
                 .Where(x => string.Equals(constStrToQuery, x.Name, StringComparison.CurrentCultureIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //varStrToQuery - ExpressionType.MemberAccess, x.Name - ExpressionType.MemberAccess
                 .Where(x => varStrToQuery.Equals(x.Name))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //varStrToQuery - ExpressionType.MemberAccess, x.Name - ExpressionType.MemberAccess
                 .Where(x => varStrToQuery.Equals(x.Name, StringComparison.OrdinalIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //varStrToQuery - ExpressionType.Constant, x.Name - ExpressionType.MemberAccess
                 .Where(x => constStrToQuery.Equals(x.Name))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
-            
+            Assert.Equal(queryResult.Count, 2);
+
             queryResult = await session.Query<User>()
                 //varStrToQuery - ExpressionType.Constant, x.Name - ExpressionType.MemberAccess
                 .Where(x => constStrToQuery.Equals(x.Name, StringComparison.OrdinalIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.Name.Equals(varStrToQuery))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.Name.Equals(varStrToQuery, StringComparison.OrdinalIgnoreCase))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
                 .Where(x => x.Name.Equals(constStrToQuery))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<User>()
                 //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
                 .Where(x => x.Name.Equals(constStrToQuery, StringComparison.CurrentCultureIgnoreCase))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 2);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(varStrToQuery, StringComparison.CurrentCulture))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(constStrToQuery, StringComparison.CurrentCulture))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(varStrToQuery, StringComparison.Ordinal))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(constStrToQuery, StringComparison.Ordinal))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, varStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(varStrToQuery, StringComparison.InvariantCulture))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<User>()
+                //x.Name - ExpressionType.MemberAccess, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.Name.Equals(constStrToQuery, StringComparison.InvariantCulture))
                 .ToListAsync();
             Assert.Equal(queryResult.Count, 1);
         }
@@ -453,101 +527,174 @@ namespace FastTests.Client
             await session.StoreAsync(new Test {StrList = new[]{"John"}});
             await session.StoreAsync(new Test {StrList = new[]{"Jane"}});
             await session.StoreAsync(new Test {StrList = new[]{varStrToQuery}});
+            await session.StoreAsync(new Test {StrList = new[]{varStrToQuery.ToLowerInvariant()}});
             await session.SaveChangesAsync();
 
             var queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => string.Equals(x1, varStrToQuery)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => string.Equals(x1, varStrToQuery, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //x.Name - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
                 .Where(x => x.StrList.Any(x1 => string.Equals(x1, constStrToQuery)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //x.Name - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
                 .Where(x => x.StrList.Any(x1 => string.Equals(x1, constStrToQuery, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.Parameter, x1 - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => string.Equals(varStrToQuery, x1)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.Parameter, x1 - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => string.Equals(varStrToQuery, x1, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //constStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter, 
                 .Where(x => x.StrList.Any(x1 => string.Equals(constStrToQuery, x1)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //constStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter, 
                 .Where(x => x.StrList.Any(x1 => string.Equals(constStrToQuery, x1, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.MemberAccess, x1 - ExpressionType.Parameter
                 .Where(x => x.StrList.Any(x1 => varStrToQuery.Equals(x1)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.MemberAccess, x1 - ExpressionType.Parameter
                 .Where(x => x.StrList.Any(x1 => varStrToQuery.Equals(x1, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter
                 .Where(x => x.StrList.Any(x1 => constStrToQuery.Equals(x1)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //varStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter
                 .Where(x => x.StrList.Any(x1 => constStrToQuery.Equals(x1, StringComparison.OrdinalIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
+            Assert.Equal(queryResult.Count, 2);
             
             queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => x1.Equals(varStrToQuery)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
-            
+            Assert.Equal(queryResult.Count, 2);
+
             queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
                 .Where(x => x.StrList.Any(x1 => x1.Equals(varStrToQuery, StringComparison.CurrentCultureIgnoreCase)))
                 .ToListAsync();
-            Assert.Equal(queryResult.Count, 1);
-            
+            Assert.Equal(queryResult.Count, 2);
+
             queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
                 .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 2);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery, StringComparison.CurrentCultureIgnoreCase)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 2);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
+                .Where(x => x.StrList.Any(x1 => x1.Equals(varStrToQuery, StringComparison.InvariantCultureIgnoreCase)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 2);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery, StringComparison.InvariantCultureIgnoreCase)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 2);
+
+            queryResult = await session.Query<Test>()
+              //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
+              .Where(x => x.StrList.Any(x1 => string.Equals(x1, varStrToQuery, StringComparison.Ordinal)))
+              .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //x.Name - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.StrList.Any(x1 => string.Equals(x1, constStrToQuery, StringComparison.Ordinal)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //varStrToQuery - ExpressionType.Parameter, x1 - ExpressionType.MemberAccess
+                .Where(x => x.StrList.Any(x1 => string.Equals(varStrToQuery, x1, StringComparison.Ordinal)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //constStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter,
+                .Where(x => x.StrList.Any(x1 => string.Equals(constStrToQuery, x1, StringComparison.Ordinal)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //varStrToQuery - ExpressionType.MemberAccess, x1 - ExpressionType.Parameter
+                .Where(x => x.StrList.Any(x1 => varStrToQuery.Equals(x1, StringComparison.Ordinal)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //varStrToQuery - ExpressionType.Constant, x1 - ExpressionType.Parameter
+                .Where(x => x.StrList.Any(x1 => constStrToQuery.Equals(x1, StringComparison.Ordinal)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
+                .Where(x => x.StrList.Any(x1 => x1.Equals(varStrToQuery, StringComparison.CurrentCulture)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
+                .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery, StringComparison.CurrentCulture)))
+                .ToListAsync();
+            Assert.Equal(queryResult.Count, 1);
+
+            queryResult = await session.Query<Test>()
+                //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
+                .Where(x => x.StrList.Any(x1 => x1.Equals(varStrToQuery, StringComparison.InvariantCulture)))
                 .ToListAsync();
             Assert.Equal(queryResult.Count, 1);
             
             queryResult = await session.Query<Test>()
                 //x1 - ExpressionType.Parameter, constStrToQuery - ExpressionType.Constant
-                .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery, StringComparison.CurrentCultureIgnoreCase)))
+                .Where(x => x.StrList.Any(x1 => x1.Equals(constStrToQuery, StringComparison.InvariantCulture)))
                 .ToListAsync();
             Assert.Equal(queryResult.Count, 1);
         }
@@ -569,51 +716,22 @@ namespace FastTests.Client
             await session.StoreAsync(new Test {StrList = new[]{"Jane"}});
             await session.StoreAsync(new Test {StrList = new[]{toQuery}});
             await session.SaveChangesAsync();
-            
+
             await Assert.ThrowsAsync<NotSupportedException>(async () =>
             {
                 await session.Query<User>()
                     .Where(x => string.Equals(x.Name, x.LastName))
                     .ToListAsync();
             });
-            
-            await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            {
-                await session.Query<User>()
-                    .Where(x => string.Equals(x.Name, toQuery, StringComparison.Ordinal))
-                    .ToListAsync();
-            });
-            
+
             await Assert.ThrowsAsync<NotSupportedException>(async () =>
             {
                 await session.Query<User>()
                     .Where(x => x.Name.Equals(x.LastName))
                     .ToListAsync();
             });
-            
-            await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            {
-                await session.Query<User>()
-                    .Where(x => x.Name.Equals(toQuery, StringComparison.CurrentCulture))
-                    .ToListAsync();
-            });
-
-            await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            {
-                await session.Query<Test>()
-                    .Where(x => x.StrList.Any(x1 => string.Equals(x1, toQuery, StringComparison.CurrentCulture)))
-                    .ToListAsync();
-            });
-
-            await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            {
-                await session.Query<Test>()
-                    //x1 - ExpressionType.Parameter, varStrToQuery - ExpressionType.MemberAccess
-                    .Where(x => x.StrList.Any(x1 => x1.Equals(toQuery, StringComparison.Ordinal)))
-                    .ToListAsync();
-            });
         }
-        
+
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void Query_With_Customize(Options options)

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -242,7 +242,7 @@ namespace FastTests.Client
 
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-        public void Query_With_Where_Clause(Options options)
+        public void StringComparisonStringOrdinalWorks(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
@@ -305,6 +305,31 @@ namespace FastTests.Client
                         .Where(x => x.Name.EndsWith("N", StringComparison.InvariantCulture))
                         .ToList();
                     Assert.Equal(queryResult.Count, 0);
+                }
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void StringComparisonStringCompareOrdinalWorks(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var newSession = store.OpenSession())
+                {
+                    newSession.Store(new User { Name = "John" }, "users/1");
+                    newSession.Store(new User { Name = "john" }, "users/2");
+                    newSession.Store(new User { Name = "Jane" }, "users/3");
+                    newSession.Store(new User { Name = "jane" }, "users/4");
+                    newSession.Store(new User { Name = "Tarzan" }, "users/5");
+                    newSession.Store(new User { Name = "tarzan" }, "users/6");
+                    newSession.SaveChanges();
+                    
+
+                    var queryResult = newSession.Query<User>()
+                        .Where(x => string.Compare(x.Name, "tarzan", StringComparison.Ordinal) == 0);
+                    Assert.Equal("from 'Users' where exact(Name = $p0)", queryResult.ToString());
+                    Assert.Equal(queryResult.Count(), 1);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-19467.cs
+++ b/test/SlowTests/Issues/RavenDB-19467.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Threading;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19467 : RavenTestBase
+{
+    private const string Term = "Kaszebe";
+    
+    public RavenDB_19467(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WhenAutoIndexWithExactExistsRavenWillNotCreateAnotherIndexForSameField(bool shouldAddDocument)
+    {
+        using var store = PrepareStoreForTest(shouldAddDocument);
+        //This should create Auto/Exact(Name)
+        CreateAutoIndex(true);
+        //This should not create any index but use Auto/Dtos/ByExact(Name) because Exact(Name) in backend is indexing two fields (with exact analyzer and standard)
+        CreateAutoIndex(false);
+
+        var indexes = store.Maintenance.Send(new GetIndexesOperation(0, 25));
+        Assert.Equal(1, indexes.Length);
+        Assert.Equal("Auto/Dtos/ByExact(Name)", indexes[0].Name);
+        
+        void CreateAutoIndex(bool exact)
+        {
+            using var session = store.OpenSession();
+            var result = session.Query<Dto>().Where(i => i.Name == Term, exact).ToList();
+        }
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AutoIndexWithoutExactWillBeDeletedAndRavenWillCreateNewIndexForBothFields(bool shouldAddDocument)
+    {
+        using var store = PrepareStoreForTest(shouldAddDocument);
+        //This should create Auto/Dtis/Name
+        CreateAutoIndex(false);
+        var indexes = store.Maintenance.Send(new GetIndexesOperation(0, 25));
+        Assert.Equal(1, indexes.Length);
+        Assert.Equal("Auto/Dtos/ByName", indexes[0].Name);
+        
+        //This should delete Auto/Dtos/Name and create Auto/Dtos/ByExact(Name)
+        CreateAutoIndex(true);
+        indexes = store.Maintenance.Send(new GetIndexesOperation(0, 25));
+        Assert.Equal(1, indexes.Length);
+        Assert.Equal("Auto/Dtos/ByExact(Name)", indexes[0].Name);
+        
+        //Should not create anything
+        CreateAutoIndex(false);
+        indexes = store.Maintenance.Send(new GetIndexesOperation(0, 25));
+        Assert.Equal(1, indexes.Length);
+        Assert.Equal("Auto/Dtos/ByExact(Name)", indexes[0].Name);
+        
+        void CreateAutoIndex(bool exact)
+        {
+            using var session = store.OpenSession();
+            var result = session.Query<Dto>().Customize(i=> i.WaitForNonStaleResults()).Where(i => i.Name == Term, exact).ToList();
+        }
+    }
+
+    private IDocumentStore PrepareStoreForTest(bool shouldAddDocument)
+    {
+        var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.TimeBeforeDeletionOfSupersededAutoIndex)] = "0";
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle)] = "0";
+            }
+        });
+
+        if (shouldAddDocument)
+        {
+            using var session = store.OpenSession();
+            session.Store(new Dto() {Name = Term});
+            session.SaveChanges();
+        }
+
+        return store;
+    }
+    
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/MailingList/WhereStringEqualsInCollection.cs
+++ b/test/SlowTests/MailingList/WhereStringEqualsInCollection.cs
@@ -19,6 +19,7 @@ namespace SlowTests.MailingList
             using (var session = store.OpenSession())
             {
                 session.Store(new MyEntity { StringData = "Entity with collection", StringCollection = new List<string> { "CollectionItem1", "CollectionItem2" } });
+                session.Store(new MyEntity { StringData = "entity with collection", StringCollection = new List<string> { "collectionitem1", "collectionitem2" } });
                 session.SaveChanges();
             }
         }
@@ -36,7 +37,7 @@ namespace SlowTests.MailingList
                         .Customize(customization => customization.WaitForNonStaleResults())
                         .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1")));
 
-                    Assert.Equal(1, count);
+                    Assert.Equal(2, count);
                 }
             }
         }
@@ -54,7 +55,7 @@ namespace SlowTests.MailingList
                         .Customize(customization => customization.WaitForNonStaleResults())
                         .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.OrdinalIgnoreCase)));
 
-                    Assert.Equal(1, count);
+                    Assert.Equal(2, count);
                 }
             }
         }
@@ -68,9 +69,14 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
-                    Assert.Throws<NotSupportedException>(() => session.Query<MyEntity>()
+                    var query = session.Query<MyEntity>()
                         .Customize(customization => customization.WaitForNonStaleResults())
-                        .Count(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.Ordinal))));
+                        .Where(o => o.StringCollection.Any(s => s.Equals("CollectionItem1", StringComparison.Ordinal)));
+
+                    Assert.Equal("from 'MyEntities' where exact(StringCollection = $p0)", query.ToString());
+                    var result = query.ToList();
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("Entity with collection", result.First().StringData);
 
                 }
             }

--- a/test/SlowTests/Tests/Linq/WhereStringEquals.cs
+++ b/test/SlowTests/Tests/Linq/WhereStringEquals.cs
@@ -22,10 +22,13 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    Assert.Throws<NotSupportedException>(() =>
-                        session.Query<MyEntity>()
-                            .Customize(customization => customization.WaitForNonStaleResults())
-                            .Count(o => string.Equals(o.StringData, "Some data", StringComparison.Ordinal)));
+                    var query = session.Query<MyEntity>()
+                        .Customize(customization => customization.WaitForNonStaleResults())
+                        .Where(o => string.Equals(o.StringData, "Some data", StringComparison.Ordinal));
+                    Assert.Equal("from 'MyEntities' where exact(StringData = $p0)", query.ToString());
+                    var result = query.ToList();
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("Some data", result.First().StringData);
                 }
             }
         }
@@ -165,11 +168,13 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    Assert.Throws<NotSupportedException>(() =>
-                        session.Query<MyEntity>()
+                    var query = session.Query<MyEntity>()
                         .Customize(customization => customization.WaitForNonStaleResults())
-                        .Count(o => "Some data".Equals(o.StringData, StringComparison.Ordinal)));
-
+                        .Where(o => "Some data".Equals(o.StringData, StringComparison.Ordinal));
+                    Assert.Equal("from 'MyEntities' where exact(StringData = $p0)", query.ToString());
+                    var result = query.ToList();
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("Some data", result.First().StringData);
                 }
             }
         }
@@ -183,10 +188,13 @@ namespace SlowTests.Tests.Linq
 
                 using (var session = store.OpenSession())
                 {
-                    Assert.Throws<NotSupportedException>(() =>
-                        session.Query<MyEntity>()
+                    var query = session.Query<MyEntity>()
                         .Customize(customization => customization.WaitForNonStaleResults())
-                        .Count(o => o.StringData.Equals("Some data", StringComparison.Ordinal)));
+                        .Where(o => o.StringData.Equals("Some data", StringComparison.Ordinal));
+                    Assert.Equal("from 'MyEntities' where exact(StringData = $p0)", query.ToString());
+                    var result = query.ToList();
+                    Assert.Equal(1, query.Count());
+                    Assert.Equal("Some data", query.First().StringData);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19467
https://github.com/ravendb/ravendb/pull/15126

### Additional description

This PR contains:
- Linq support for case-sensitive string comparisons 
- Verifying that dynamic query will not create another AutoIndex for term comparation when `Exact(Field)` already exists.
- Assertion if a user is not using unsupported overloads in `string.Compare`

### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
