### PR TITLE
RavenDB-19440 Throw when projection is done twice.

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -208,6 +208,9 @@ namespace Raven.Client.Documents.Linq
         /// </summary>
         public void FieldsToFetch(IEnumerable<string> fields)
         {
+            if (_provider.IsProjectInto)
+                throw new InvalidOperationException("'ProjectInto' was already called. You can perform this operation only once per query.");
+            
             _provider.IsProjectInto = true;
 
             foreach (var field in fields)

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1951,6 +1951,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                         else
                         {
+                            if (_insideSelect == 0 && FieldsToFetch.Count > 0)
+                                throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
                             _insideSelect++;
                             VisitSelect(operand);
                             _insideSelect--;

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1951,11 +1951,15 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                         else
                         {
-                            if (_insideSelect == 0 && FieldsToFetch.Count > 0)
-                                throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
+                            var initialSelect = _insideSelect;
+                            var initialCount = FieldsToFetch.Count;
+                            
                             _insideSelect++;
                             VisitSelect(operand);
                             _insideSelect--;
+                            
+                            if (initialSelect == 0 && initialCount > 0 && FieldsToFetch.Count != initialCount)
+                                throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
                         }
                         break;
                     }

--- a/test/SlowTests/Issues/RavenDB_19440.cs
+++ b/test/SlowTests/Issues/RavenDB_19440.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19440 : RavenTestBase
+{
+    public RavenDB_19440(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void QueryWillThrowWhenPerformingSelectAfterProjectInto()
+    {
+        using var store = GetDocumentStore();
+        {
+            using var session = store.OpenSession();
+            session.Store(new Data() {Name = "Test"});
+            session.SaveChanges();
+        }
+        var index = new DataIndex();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var session = store.OpenSession();
+            var query = (IQueryable<Data>)session.Query<Data, DataIndex>();
+            var q = query.ProjectInto<Dto>().Select(i => new Dto() {Id = i.Id, Name = i.Name});
+            AssertResult(() => q.ToString());
+        }
+    }
+
+    [Fact]
+    public void QueryWillThrowWhenTwoProjectionsAreIncludedInQuery()
+    {
+        using var store = GetDocumentStore();
+
+
+        using var session = store.OpenSession();
+        var q = session.Query<DtoExt>().Customize(customization => customization.WaitForNonStaleResults())
+            .Where(i => i.SecondName == "kaszebe")
+            .Select(i => new Dto2Ext() {Name = i.Name, SecondName = i.SecondName}).Select(i => new DtoExt() {Name = i.SecondName, SecondName = i.Name});
+        AssertResult(() => q.ToString());
+    }
+
+    private void AssertResult(Action queryToString)
+    {
+        var exception = Assert.ThrowsAny<InvalidOperationException>(queryToString);
+        Assert.True(exception.Message.Contains("Projection is already done. You should not project your result twice."));
+    }
+    
+    private class DtoExt
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string SecondName { get; set; }
+    }
+
+    private class Dto2Ext
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string SecondName { get; set; }
+    }
+
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+
+    private class Data
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class DataIndex : AbstractIndexCreationTask<Data>
+    {
+        public DataIndex()
+        {
+            Map = datas => datas.Select(i => new {Name = i.Name});
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19440 

### Additional description

Throw when a projection is done twice in a query.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
