### PR TITLE
RavenDB-19447 - Typed incremental time series client API

### DIFF
--- a/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeries.cs
@@ -88,6 +88,7 @@ namespace Raven.Client.Documents.Session
     public interface ISessionDocumentTypedIncrementalTimeSeries<TValues> :
         ITimeSeriesStreamingBase<TimeSeriesEntry<TValues>>,
         ISessionDocumentDeleteTimeSeriesBase,
+        ISessionDocumentIncrementTimeSeriesBase, // TODO: Remove - in 6.0 (breaking change - RavenDB-19447)
         ISessionDocumentTypedIncrementTimeSeriesBase<TValues>
         where TValues : new()
     {

--- a/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeries.cs
@@ -88,7 +88,7 @@ namespace Raven.Client.Documents.Session
     public interface ISessionDocumentTypedIncrementalTimeSeries<TValues> :
         ITimeSeriesStreamingBase<TimeSeriesEntry<TValues>>,
         ISessionDocumentDeleteTimeSeriesBase,
-        ISessionDocumentIncrementTimeSeriesBase
+        ISessionDocumentTypedIncrementTimeSeriesBase<TValues>
         where TValues : new()
     {
         /// <summary>

--- a/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
@@ -68,6 +68,14 @@ namespace Raven.Client.Documents.Session
 
     }
 
+    public interface ISessionDocumentTypedIncrementTimeSeriesBase<T> where T : new()
+    {
+        void Increment(DateTime timestamp, T entry);
+
+        void Increment(T entry);
+
+    }
+
     public interface ITimeSeriesStreamingBase<out T>
     {
         IEnumerator<T> Stream(DateTime? from = null, DateTime? to = null, TimeSpan? offset = null);

--- a/src/Raven.Client/Documents/Session/SessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/SessionDocumentTimeSeries.cs
@@ -147,5 +147,15 @@ namespace Raven.Client.Documents.Session
         {
             Increment(DateTime.UtcNow, new[] { value });
         }
+
+        public void Increment(DateTime timestamp, TValues entry)
+        {
+            _asyncSessionTimeSeries.Increment(timestamp, entry);
+        }
+
+        public void Increment(TValues entry)
+        {
+            _asyncSessionTimeSeries.Increment(DateTime.UtcNow, entry);
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/SessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/SessionDocumentTimeSeries.cs
@@ -148,12 +148,12 @@ namespace Raven.Client.Documents.Session
             Increment(DateTime.UtcNow, new[] { value });
         }
 
-        public void Increment(DateTime timestamp, TValues entry)
+        void ISessionDocumentTypedIncrementTimeSeriesBase<TValues>.Increment(DateTime timestamp, TValues entry)
         {
             _asyncSessionTimeSeries.Increment(timestamp, entry);
         }
 
-        public void Increment(TValues entry)
+        void ISessionDocumentTypedIncrementTimeSeriesBase<TValues>.Increment(TValues entry)
         {
             _asyncSessionTimeSeries.Increment(DateTime.UtcNow, entry);
         }

--- a/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
@@ -124,6 +124,18 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        public void Increment<TValues>(DateTime timestamp, TValues value)
+        {
+            if (value is IEnumerable<double> doubles)
+            {
+                Increment(timestamp, doubles);
+                return;
+            }
+
+            var values = TimeSeriesValuesHelper.GetValues(value);
+            Increment(timestamp, values);
+        }
+
         public void Increment(DateTime timestamp, IEnumerable<double> values)
         {
             if (Session.DocumentsById.TryGetValue(DocId, out DocumentInfo documentInfo) &&

--- a/test/SlowTests/Client/TimeSeries/Query/IncrementalTimeSeriesQueries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/IncrementalTimeSeriesQueries.cs
@@ -1302,7 +1302,15 @@ select out(p)
                         var rand = random.Next(1, 10) / 10.0;
                         var even = i % 2 == 0;
                         var add = even ? rand : -rand;
-                        tsf.Increment(baseline.AddHours(i), new[] { 45.37 + add, 45.72 + add, 45.99 + add, 45.21 + add, 719.636 + add });
+                        var sp = new StockPrice
+                        {
+                            Open = 45.37 + add,
+                            Close = 45.72 + add,
+                            High = 45.99 + add,
+                            Low = 45.21 + add,
+                            Volume = 719.636 + add
+                        };
+                        tsf.Increment(baseline.AddHours(i), sp);
                     }
 
                     session.SaveChanges();

--- a/test/SlowTests/Issues/RavenDB-19447.cs
+++ b/test/SlowTests/Issues/RavenDB-19447.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Client.Documents.Session.TimeSeries;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19447 : RavenTestBase
+    {
+        public RavenDB_19447(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void TesCase1(bool justCreate, bool register)
+        {
+            using (var store = GetDocumentStore())
+            {
+                var baseline = RavenTestHelper.UtcToday;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Oren" }, "users/ayende");
+                    session.SaveChanges();
+                }
+
+                //if justCreate is true - only create entity in the timeseries
+                // else - create and then increment
+                int mul = 2;
+                if (justCreate)
+                {
+                    mul = 1;
+                }
+
+                if(register)
+                    store.TimeSeries.Register<User, TestObj>("INC:Heartrate");
+
+                for (int i = 0; i < mul; i++)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.IncrementalTimeSeriesFor<TestObj>("users/ayende", "INC:Heartrate")
+                            .Increment(baseline.AddMinutes(2), new TestObj
+                            {
+                                A = 1.1,
+                                B = 2.2,
+                                C = 3.3
+                            });
+
+                        session.SaveChanges();
+                    }
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var val = session.IncrementalTimeSeriesFor("users/ayende", "INC:Heartrate")
+                        .Get(DateTime.MinValue, DateTime.MaxValue)
+                        .ToList();
+                    Assert.Equal(1, val.Count);
+
+                    var values = val[0].Values;
+                    Assert.Equal(3, values.Length);
+                    Assert.Equal(1.1 * mul, values[0]);
+                    Assert.Equal(2.2 * mul, values[1]);
+                    Assert.Equal(3.3 * mul, values[2]);
+                    
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var val = session.IncrementalTimeSeriesFor<TestObj>("users/ayende", "INC:Heartrate")
+                        .Get(DateTime.MinValue, DateTime.MaxValue)
+                        .ToList();
+                    Assert.Equal(1, val.Count);
+
+                    var entity = val[0].Value;
+                    Assert.NotNull(entity);
+                    Assert.Equal(1.1 * mul, entity.A);
+                    Assert.Equal(2.2 * mul, entity.B);
+                    Assert.Equal(3.3 * mul, entity.C);
+
+                }
+            }
+        }
+
+        public class TestObj
+        {
+            [TimeSeriesValue(0)]
+            public double A { get; set; }
+
+            [TimeSeriesValue(1)]
+            public double B { get; set; }
+
+            [TimeSeriesValue(2)]
+            public double C { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19447/Typed-incremental-time-series-client-API

### Additional description

Add client API for typed incremental time series.
It will also change the wrong behavior of getting typed incremental timeseries and increment it by a double array instead of an object (entity) like it should be. - look at the changes in ```IncrementalTimeSeriesQueries.cs``` (test: ```CanQueryIncrementalTimeSeriesUsingNamedValues```).

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
