### PR TITLE
RavenDB-18754 - Ensure order of the returned results for `/databases/…

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -139,7 +139,15 @@ internal class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
         Disposables.Add(streams);
 
-        var documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token);
+        IAsyncEnumerable<Document> documents;
+        if (startsWith != null)
+        {
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token);
+        }
+        else
+        {
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token);
+        }
 
         return new DocumentsResult
         {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -222,12 +222,20 @@ namespace Raven.Server.Documents.Sharding
 
             public async IAsyncEnumerable<Document> GetDocumentsAsync(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results")
             {
-                await foreach (var result in PagedShardedDocumentsByLastModified(documents, resultPropertyName, pagingContinuation))
+                await foreach (var result in PagedShardedDocumentsBlittableByLastModified(documents, resultPropertyName, pagingContinuation))
                 {
-                    yield return result.Item;
+                    yield return ShardResultConverter.BlittableToDocumentConverter(result.Item);
                 }
             }
-            
+
+            public async IAsyncEnumerable<Document> GetDocumentsAsyncById(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results")
+            {
+                await foreach (var result in PagedShardedDocumentsBlittableById(documents, resultPropertyName, pagingContinuation))
+                {
+                    yield return ShardResultConverter.BlittableToDocumentConverter(result.Item);
+                }
+            }
+
             public IEnumerable<T> PagedShardedItem<T, TInput>(
                 Memory<TInput> results,
                 Func<TInput, IEnumerable<T>> selector,


### PR DESCRIPTION
…*/docs`

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18754/Ensure-order-of-the-returned-results-for-databasesdocs

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
