### PR TITLE
RavenDB-19497 - Throw NotSupportedException on attempt of Incremental Time Series bulk insert

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -690,10 +690,10 @@ namespace Raven.Client.Documents.BulkInsert
         private static void ValidateTimeSeriesName(string name)
         {
             if (string.IsNullOrEmpty(name))
-                throw new ArgumentException("Time Series name must contain at least one character");
+                throw new ArgumentException("Time series name cannot be null or empty,", nameof(name));
 
             if (name.StartsWith(Constants.Headers.IncrementalTimeSeriesPrefix, StringComparison.OrdinalIgnoreCase) && name.Contains('@') == false)
-                throw new ArgumentException($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix");
+                throw new ArgumentException($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix,", nameof(name));
         }
 
         public struct CountersBulkInsert

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -672,8 +672,7 @@ namespace Raven.Client.Documents.BulkInsert
             if (string.IsNullOrEmpty(id))
                 throw new ArgumentException("Document id cannot be null or empty", nameof(id));
 
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentException("Time series name cannot be null or empty", nameof(name));
+            ValidateTimeSeriesName(name);
 
             return new TimeSeriesBulkInsert(this, id, name);
         }
@@ -684,10 +683,18 @@ namespace Raven.Client.Documents.BulkInsert
                 throw new ArgumentException("Document id cannot be null or empty", nameof(id));
 
             var tsName = name ?? TimeSeriesOperations.GetTimeSeriesName<TValues>(_conventions);
-            if (string.IsNullOrEmpty(tsName))
-                throw new ArgumentException("Time series name cannot be null or empty", nameof(name));
+            ValidateTimeSeriesName(tsName);
 
             return new TypedTimeSeriesBulkInsert<TValues>(this, id, tsName);
+        }
+
+        private static void ValidateTimeSeriesName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new InvalidDataException("Time Series name must contain at least one character");
+
+            if (name.StartsWith(Constants.Headers.IncrementalTimeSeriesPrefix, StringComparison.OrdinalIgnoreCase) && name.Contains('@') == false)
+                throw new InvalidDataException($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix");
         }
 
         public struct CountersBulkInsert

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
@@ -691,10 +690,10 @@ namespace Raven.Client.Documents.BulkInsert
         private static void ValidateTimeSeriesName(string name)
         {
             if (string.IsNullOrEmpty(name))
-                throw new InvalidDataException("Time Series name must contain at least one character");
+                throw new ArgumentException("Time Series name must contain at least one character");
 
             if (name.StartsWith(Constants.Headers.IncrementalTimeSeriesPrefix, StringComparison.OrdinalIgnoreCase) && name.Contains('@') == false)
-                throw new InvalidDataException($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix");
+                throw new ArgumentException($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix");
         }
 
         public struct CountersBulkInsert

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
@@ -1303,7 +1304,7 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
         {
             using (var store = GetDocumentStore())
             {
-                Assert.Throws<ArgumentException>(() =>
+                var exception = Assert.Throws<ArgumentException>(() =>
                 {
                     var baseline = RavenTestHelper.UtcToday.EnsureMilliseconds();
 
@@ -1319,6 +1320,8 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                         }
                     }
                 });
+
+                Assert.True(exception.Message.Contains($"Time Series name cannot start with {Constants.Headers.IncrementalTimeSeriesPrefix} prefix"));
             }
         }
     }

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
@@ -1297,5 +1297,29 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                 }
             }
         }
+
+        [Fact]
+        public void CreateTimeSeriesWithInvalidNameShouldThrow()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    var baseline = RavenTestHelper.UtcToday.EnsureMilliseconds();
+
+                    const string documentId = "users/ayende";
+
+                    using (var bulkInsert = store.BulkInsert())
+                    {
+                        bulkInsert.Store(new { Name = "Oren" }, documentId);
+
+                        using (var timeSeriesBulkInsert = bulkInsert.TimeSeriesFor(documentId, "INC:Heartrate"))
+                        {
+                            timeSeriesBulkInsert.Append(baseline.AddMinutes(1), 59d, "watches/fitbit");
+                        }
+                    }
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19497/Throw-NotSupportedException-on-attempt-of-Incremental-Time-Series-bulk-insert

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
