### PR TITLE
Option to specify node tag for initial node

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -277,7 +277,15 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/admin/cluster/bootstrap", "POST", AuthorizationStatus.ClusterAdmin)]
         public async Task Bootstrap()
         {
-            await ServerStore.EnsureNotPassiveAsync();
+            var tag = GetStringQueryString("tag", false);
+            if (tag == null)
+            {
+                await ServerStore.EnsureNotPassiveAsync();
+            }
+            else
+            {
+                await ServerStore.EnsureNotPassiveAsync(nodeTag: tag);
+            }
             NoContentStatus();
         }
 


### PR DESCRIPTION
### Issue link

https://github.com/ravendb/ravendb/discussions/15181

### Additional description

This allows for specifying the Node Tag for the initial node of a cluster. It's already possible to specify the Node Tag for subsequent nodes, but there is no other way through the API to specify the tag for the initial node.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
`tag` query string parameter is optional and the existing code path is called if the query string parameter is not supplied. 

Note that the default parameter on `EnsureNotPassiveAsync` for nodeTag is "A" so we can't make a single call to that method passing in the potentially `null` tag value (when the `tag` query string is not specified) as null is not valid on that call. Also, doing something like:
```
var tag = GetStringQueryString("tag", false) ?? "A";
```
would duplicate what the default value "A" is defined (both here and in the default parameter for the method) requiring changes in both places to keep them in sync. The if/else block implementation ensures that existing defaults are used to maintain existing behavior and only passes in a node tag override if one was provided in the API call.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
`tag` query string parameter is not documented

### Testing 

- Internal code path on `EnsureNotPassiveAsync` is being called with a node tag parameter in other use cases. 
- I don't see any existing end-to-end tests using the Bootstrap API endpoint to duplicate and add this API call change to.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
