### PR TITLE
RavenDB-17615 Adding unmanaged memory stats to index performance batch stats

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
@@ -31,7 +31,8 @@ namespace Raven.Client.Documents.Indexes
 
         public IndexingPerformanceBasicStats(TimeSpan duration)
         {
-            AllocatedBytes = new Size();
+            AllocatedManagedBytes = new Size();
+            AllocatedUnmanagedBytes = new Size();
             DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
         }
 
@@ -47,7 +48,9 @@ namespace Raven.Client.Documents.Indexes
 
         public double DurationInMs { get; }
 
-        public Size AllocatedBytes { get; set; }
+        public Size AllocatedManagedBytes { get; set; }
+        
+        public Size AllocatedUnmanagedBytes { get; set; }
         
         public Size DocumentsSize { get; set; }
     }

--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
@@ -48,6 +48,13 @@ namespace Raven.Client.Documents.Indexes
 
         public double DurationInMs { get; }
 
+        [Obsolete($"Use '{nameof(AllocatedManagedBytes)}' instead.")]
+        public Size AllocatedBytes
+        {
+            get { return AllocatedManagedBytes; }
+            set { AllocatedManagedBytes = value; }
+        }
+        
         public Size AllocatedManagedBytes { get; set; }
         
         public Size AllocatedUnmanagedBytes { get; set; }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2304,7 +2304,7 @@ namespace Raven.Server.Documents.Indexes
                             }
 
                             var current = new Size(GC.GetAllocatedBytesForCurrentThread(), SizeUnit.Bytes);
-                            stats.AddAllocatedBytes((current - _initialManagedAllocations).GetValue(SizeUnit.Bytes));
+                            stats.SetAllocatedManagedBytes((current - _initialManagedAllocations).GetValue(SizeUnit.Bytes));
 
                             if (writeOperation.IsValueCreated)
                             {
@@ -4450,7 +4450,7 @@ namespace Raven.Server.Documents.Indexes
             {
                 var currentManagedAllocations = new Size(GC.GetAllocatedBytesForCurrentThread(), SizeUnit.Bytes);
                 var diff = currentManagedAllocations - _initialManagedAllocations;
-                parameters.Stats.AddAllocatedBytes(diff.GetValue(SizeUnit.Bytes));
+                parameters.Stats.SetAllocatedManagedBytes(diff.GetValue(SizeUnit.Bytes));
 
                 if (diff > Configuration.ManagedAllocationsBatchLimit.Value)
                 {
@@ -4602,6 +4602,8 @@ namespace Raven.Server.Documents.Indexes
                         break;
                 }
             }
+            
+            stats?.SetAllocatedUnmanagedBytes(threadAllocations + txAllocations);
 
             var allocatedForProcessing = threadAllocations + indexWriterAllocations +
                                          // we multiple it to take into account additional work

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -23,7 +23,11 @@ namespace Raven.Server.Documents.Indexes
         public int ReduceErrors;
 
         public int IndexingOutputs;
-        public Size AllocatedBytes;
+        
+        public Size AllocatedManagedBytes;
+        
+        public Size AllocatedUnmanagedBytes;
+        
         public long DocumentsSize;
 
         public long? EntriesCount;

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -42,7 +42,8 @@ namespace Raven.Server.Documents.Indexes
                 SuccessCount = Stats.MapSuccesses + Stats.MapReferenceSuccesses,
                 FailedCount = Stats.MapErrors + Stats.MapReferenceErrors,
                 OutputCount = Stats.IndexingOutputs,
-                AllocatedBytes = Stats.AllocatedBytes,
+                AllocatedManagedBytes = Stats.AllocatedManagedBytes,
+                AllocatedUnmanagedBytes = Stats.AllocatedUnmanagedBytes,
                 DocumentsSize = new Size(Stats.DocumentsSize)
             };
         }
@@ -88,7 +89,8 @@ namespace Raven.Server.Documents.Indexes
                 FailedCount = Stats.MapErrors + Stats.MapReferenceErrors,
                 OutputCount = Stats.IndexingOutputs,
                 DocumentsSize = new Size(Stats.DocumentsSize),
-                AllocatedBytes = Stats.AllocatedBytes
+                AllocatedManagedBytes = Stats.AllocatedManagedBytes,
+                AllocatedUnmanagedBytes = Stats.AllocatedUnmanagedBytes
             };
         }
     }
@@ -123,9 +125,14 @@ namespace Raven.Server.Documents.Indexes
 
         public int TombstoneDeleteSuccesses => _stats.TombstoneDeleteSuccesses;
 
-        public void AddAllocatedBytes(long sizeInBytes)
+        public void SetAllocatedManagedBytes(long sizeInBytes)
         {
-            _stats.AllocatedBytes = new Size(sizeInBytes);
+            _stats.AllocatedManagedBytes = new Size(sizeInBytes);
+        }
+        
+        public void SetAllocatedUnmanagedBytes(long sizeInBytes)
+        {
+            _stats.AllocatedUnmanagedBytes = new Size(sizeInBytes);
         }
 
         public void AddCorruptionError(Exception e)

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -1222,8 +1222,8 @@ class indexPerformance extends viewModelBase {
                     countsDetails += `<div class="tooltip-li">Average Document Size: <div class="value">${generalUtils.formatBytesToSize(parentStats.DocumentsSize.SizeInBytes / parentStats.InputCount)}</div></div>`;
                 }
 
-                countsDetails += `<div class="tooltip-li">Managed Allocation Size (accumulated): <div class="value">${parentStats.AllocatedManagedBytes.HumaneSize}</div></div>`;
-                countsDetails += `<div class="tooltip-li">Unmanaged Allocation Size: <div class="value">${parentStats.AllocatedUnmanagedBytes.HumaneSize}</div></div>`;
+                countsDetails += `<div class="tooltip-li">Managed Allocations (accumulated): <div class="value">${parentStats.AllocatedManagedBytes.HumaneSize}</div></div>`;
+                countsDetails += `<div class="tooltip-li">Unmanaged Allocations: <div class="value">${parentStats.AllocatedUnmanagedBytes.HumaneSize}</div></div>`;
 
                 if (element.DurationInMs > 0) {
                     const durationInSec = element.DurationInMs / 1000;

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -1222,7 +1222,8 @@ class indexPerformance extends viewModelBase {
                     countsDetails += `<div class="tooltip-li">Average Document Size: <div class="value">${generalUtils.formatBytesToSize(parentStats.DocumentsSize.SizeInBytes / parentStats.InputCount)}</div></div>`;
                 }
 
-                countsDetails += `<div class="tooltip-li">Managed Allocation Size: <div class="value">${parentStats.AllocatedBytes.HumaneSize}</div></div>`;
+                countsDetails += `<div class="tooltip-li">Managed Allocation Size (accumulated): <div class="value">${parentStats.AllocatedManagedBytes.HumaneSize}</div></div>`;
+                countsDetails += `<div class="tooltip-li">Unmanaged Allocation Size: <div class="value">${parentStats.AllocatedUnmanagedBytes.HumaneSize}</div></div>`;
 
                 if (element.DurationInMs > 0) {
                     const durationInSec = element.DurationInMs / 1000;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17615 

### Additional description

![image](https://user-images.githubusercontent.com/86351904/199698799-e09ae464-243f-4f49-b912-0f18e98efe5c.png)


### Type of change

- New feature

### How risky is the change?


- Not relevant

### Backward compatibility

- Ensured. Please explain how has it been implemented?
The old variable is returning a value from the new one. Also marked as obsolete.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Done in this PR
