### PR TITLE
RavenDB-19463 Hide `InsufficientExecutionStackException` when it comes from `parameters.ToString()` inside InvalidQueryException.

### DIFF
--- a/src/Raven.Client/Exceptions/InvalidQueryException.cs
+++ b/src/Raven.Client/Exceptions/InvalidQueryException.cs
@@ -42,11 +42,22 @@ namespace Raven.Client.Exceptions
 
             if (parameters != null)
             {
-                result.Append(Environment.NewLine)
-                    .Append("Parameters: ")
-                    .Append(parameters);
-            }
+                string parametersString = null;
+                try
+                {
+                    parametersString = parameters.ToString();
+                }
+                catch (InsufficientExecutionStackException)
+                {
+                    parametersString = "Parameters are too big to attach them in exception.";
+                }
 
+                if (parametersString != null)
+                    result.Append(Environment.NewLine)
+                        .Append("Parameters: ")
+                        .Append(parametersString);
+            }
+            
             return result.ToString();
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19463

### Additional description

The test was failing because of a change made in RavenDB-18834. 
The case with `10_000` is working because it is failing in the parsing phase,
 so it would not try to materialize blittable into a string.

I decided to hide the `InsufficientExecutionStackException` because the main information/exception is much more useful for a user than knowing the parameters.

### Type of change

- Regression bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
