### PR TITLE
RavenDB-13110-2-new - Avoid cloning attachments on the orchestrator

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -237,7 +237,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             if (_initialized)
                 throw new InvalidOperationException();
 
-            TempFileCache = new TempFileCache(environment.Options);
+            TempFileCache = new TempFileCache(environment.Options.TempPath.FullPath, environment.Options.Encryption.IsEnabled);
 
             environment.NewTransactionCreated += SetStreamCacheInTx;
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -226,42 +226,6 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
         }
 
-        public class DataForReplicationCommand : IDisposable
-        {
-            internal string SourceDatabaseId { get; set; }
-
-            internal ReplicationBatchItem[] ReplicatedItems { get; set; }
-
-            internal Dictionary<Slice, AttachmentReplicationItem> ReplicatedAttachmentStreams { get; set; }
-
-            public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
-
-            public Logger Logger { get; set; }
-
-            public void Dispose()
-            {
-                if (ReplicatedAttachmentStreams != null)
-                {
-                    foreach (var item in ReplicatedAttachmentStreams.Values)
-                    {
-                        item?.Dispose();
-                    }
-
-                    ReplicatedAttachmentStreams?.Clear();
-                }
-
-                if (ReplicatedItems != null)
-                {
-                    foreach (var item in ReplicatedItems)
-                    {
-                        item?.Dispose();
-                    }
-                }
-
-                ReplicatedItems = null;
-            }
-        }
-
         public override LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
         {
             return ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 [nameof(ReplicationMessageHeader.Type)] = ReplicationMessageType.Documents,
                 [nameof(ReplicationMessageHeader.LastDocumentEtag)] = _lastEtag,
                 [nameof(ReplicationMessageHeader.ItemsCount)] = batch.Items.Count,
-                [nameof(ReplicationMessageHeader.AttachmentStreamsCount)] = batch.Attachments?.Count ?? 0,
+                [nameof(ReplicationMessageHeader.AttachmentStreamsCount)] = batch.AttachmentStreams?.Count ?? 0,
             };
 
             WriteToServer(headerJson);
@@ -129,9 +129,9 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 _lastEtag = item.Etag;
             }
 
-            if (batch.Attachments != null)
+            if (batch.AttachmentStreams != null)
             {
-                foreach (var kvp in batch.Attachments)
+                foreach (var kvp in batch.AttachmentStreams)
                 {
                     using (stats.For(ReplicationOperation.Outgoing.AttachmentRead))
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -94,88 +94,78 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
         private void SendDocumentsBatch(TransactionOperationContext context, ReplicationBatch batch, OutgoingReplicationStatsScope stats)
         {
-            try
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "Unify this with the ReplicationDocumentSenderBase.SendDocumentsBatch");
+
+            if (batch.LastSentEtagFromSource > _lastEtag)
+                _lastEtag = _lastSentDocumentEtag = batch.LastSentEtagFromSource;
+
+            if (batch.Items.Count == 0)
             {
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "Unify this with the ReplicationDocumentSenderBase.SendDocumentsBatch");
+                SendHeartbeat(batch.LastAcceptedChangeVector ?? _lastAcceptedChangeVectorFromShard);
+                batch.LastAcceptedChangeVector = LastAcceptedChangeVector;
+                return;
+            }
 
-                if (batch.LastSentEtagFromSource > _lastEtag)
-                    _lastEtag = _lastSentDocumentEtag = batch.LastSentEtagFromSource;
+            var sw = Stopwatch.StartNew();
+            var headerJson = new DynamicJsonValue
+            {
+                [nameof(ReplicationMessageHeader.Type)] = ReplicationMessageType.Documents,
+                [nameof(ReplicationMessageHeader.LastDocumentEtag)] = _lastEtag,
+                [nameof(ReplicationMessageHeader.ItemsCount)] = batch.Items.Count,
+                [nameof(ReplicationMessageHeader.AttachmentStreamsCount)] = batch.Attachments?.Count ?? 0,
+            };
 
-                if (batch.Items.Count == 0)
+            WriteToServer(headerJson);
+
+            stats.RecordLastEtag(_lastEtag);
+
+            foreach (var item in batch.Items)
+            {
+                using (Slice.From(context.Allocator, item.ChangeVector, out var cv))
                 {
-                    SendHeartbeat(batch.LastAcceptedChangeVector ?? _lastAcceptedChangeVectorFromShard);
-                    batch.LastAcceptedChangeVector = LastAcceptedChangeVector;
-                    return;
+                    item.Write(cv, _stream, _tempBuffer, stats);
                 }
 
-                var sw = Stopwatch.StartNew();
-                var headerJson = new DynamicJsonValue
+                _lastEtag = item.Etag;
+            }
+
+            if (batch.Attachments != null)
+            {
+                foreach (var kvp in batch.Attachments)
                 {
-                    [nameof(ReplicationMessageHeader.Type)] = ReplicationMessageType.Documents,
-                    [nameof(ReplicationMessageHeader.LastDocumentEtag)] = _lastEtag,
-                    [nameof(ReplicationMessageHeader.ItemsCount)] = batch.Items.Count,
-                    [nameof(ReplicationMessageHeader.AttachmentStreamsCount)] = batch.Attachments?.Count ?? 0,
-                };
-
-                WriteToServer(headerJson);
-
-                stats.RecordLastEtag(_lastEtag);
-
-                foreach (var item in batch.Items)
-                {
-                    using (Slice.From(context.Allocator, item.ChangeVector, out var cv))
+                    using (stats.For(ReplicationOperation.Outgoing.AttachmentRead))
                     {
-                        item.Write(cv, _stream, _tempBuffer, stats);
-                    }
-
-                    _lastEtag = item.Etag;
-                }
-
-                if (batch.Attachments != null)
-                {
-                    foreach (var kvp in batch.Attachments)
-                    {
-                        using (stats.For(ReplicationOperation.Outgoing.AttachmentRead))
+                        using (var attachment = kvp.Value)
                         {
-                            using (var attachment = kvp.Value)
+                            try
                             {
-                                try
-                                {
-                                    attachment.WriteStream(_stream, _tempBuffer);
-                                    stats.RecordAttachmentOutput(attachment.Stream.Length);
-                                }
-                                catch
-                                {
-                                    if (Logger.IsInfoEnabled)
-                                        Logger.Info($"Failed to write Attachment stream {FromToString}");
+                                attachment.WriteStream(_stream, _tempBuffer);
+                                stats.RecordAttachmentOutput(attachment.Stream.Length);
+                            }
+                            catch
+                            {
+                                if (Logger.IsInfoEnabled)
+                                    Logger.Info($"Failed to write Attachment stream {FromToString}");
 
-                                    throw;
-                                }
+                                throw;
                             }
                         }
                     }
                 }
-
-                _stream.Flush();
-                sw.Stop();
-
-                var (type, reply) = HandleServerResponse(getFullResponse: true);
-
-                batch.LastAcceptedChangeVector = _lastAcceptedChangeVectorFromShard = reply.DatabaseChangeVector;
-                batch.LastEtagAccepted = _lastSentDocumentEtag = reply.LastEtagAccepted;
-
-                if (type == ReplicationMessageReply.ReplyType.MissingAttachments)
-                {
-                    MissingAttachmentsInLastBatch = true;
-                    MissingAttachmentMessage = reply?.Exception;
-                }
             }
-            finally
+
+            _stream.Flush();
+            sw.Stop();
+
+            var (type, reply) = HandleServerResponse(getFullResponse: true);
+
+            batch.LastAcceptedChangeVector = _lastAcceptedChangeVectorFromShard = reply.DatabaseChangeVector;
+            batch.LastEtagAccepted = _lastSentDocumentEtag = reply.LastEtagAccepted;
+
+            if (type == ReplicationMessageReply.ReplyType.MissingAttachments)
             {
-                foreach (var item in batch.Items)
-                {
-                    item.Dispose();
-                }
+                MissingAttachmentsInLastBatch = true;
+                MissingAttachmentMessage = reply?.Exception;
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -135,20 +135,18 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 {
                     using (stats.For(ReplicationOperation.Outgoing.AttachmentRead))
                     {
-                        using (var attachment = kvp.Value)
+                        var attachment = kvp.Value;
+                        try
                         {
-                            try
-                            {
-                                attachment.WriteStream(_stream, _tempBuffer);
-                                stats.RecordAttachmentOutput(attachment.Stream.Length);
-                            }
-                            catch
-                            {
-                                if (Logger.IsInfoEnabled)
-                                    Logger.Info($"Failed to write Attachment stream {FromToString}");
+                            attachment.WriteStream(_stream, _tempBuffer);
+                            stats.RecordAttachmentOutput(attachment.Stream.Length);
+                        }
+                        catch
+                        {
+                            if (Logger.IsInfoEnabled)
+                                Logger.Info($"Failed to write Attachment stream {FromToString}");
 
-                                throw;
-                            }
+                            throw;
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Sharding
     public class ReplicationBatch : IDisposable
     {
         public List<ReplicationBatchItem> Items = new();
-        public Dictionary<Slice, AttachmentReplicationItem> Attachments;
+        public Dictionary<Slice, AttachmentReplicationItem> AttachmentStreams;
         public TaskCompletionSource BatchSent;
         public string LastAcceptedChangeVector;
         public long LastEtagAccepted;
@@ -146,12 +146,12 @@ namespace Raven.Server.Documents.Sharding
                 item.Dispose();
             }
 
-            if (Attachments != null)
+            if (AttachmentStreams != null)
             {
-                foreach (var attachment in Attachments)
+                foreach (var attachment in AttachmentStreams)
                     attachment.Value?.Dispose();
 
-                Attachments.Clear();
+                AttachmentStreams.Clear();
             }
 
             Items.Clear();

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -149,7 +149,7 @@ namespace Raven.Server.Documents.Sharding
             if (Attachments != null)
             {
                 foreach (var attachment in Attachments)
-                    attachment.Value.Dispose();
+                    attachment.Value?.Dispose();
 
                 Attachments.Clear();
             }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.Documents.Sharding
         }
     }
 
-    public class ReplicationBatch
+    public class ReplicationBatch : IDisposable
     {
         public List<ReplicationBatchItem> Items = new();
         public Dictionary<Slice, AttachmentReplicationItem> Attachments;
@@ -138,6 +138,25 @@ namespace Raven.Server.Documents.Sharding
         public string LastAcceptedChangeVector;
         public long LastEtagAccepted;
         public long LastSentEtagFromSource;
+
+        public void Dispose()
+        {
+            foreach (var item in Items)
+            {
+                item.Dispose();
+            }
+
+            if (Attachments != null)
+            {
+                foreach (var attachment in Attachments)
+                    attachment.Value.Dispose();
+
+                Attachments.Clear();
+            }
+
+            Items.Clear();
+            BatchSent = null;
+        }
     }
 
     public class ShardReplicationNode : ExternalReplication

--- a/src/Raven.Server/Indexing/TempFileCache.cs
+++ b/src/Raven.Server/Indexing/TempFileCache.cs
@@ -266,7 +266,7 @@ namespace Raven.Server.Indexing
 
         public Stream CreateReaderStream()
         {
-            return new FileStream(InnerStream.Name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096);
+            return SafeFileStream.Create(InnerStream.SafeFileHandle, FileAccess.Read);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_15911.cs
+++ b/test/SlowTests/Issues/RavenDB_15911.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
 
             }
 
-            string temIndexFile = TempFileCache.GetTempFileName(Options);
+            string temIndexFile = TempFileCache.GetTempFileName(tempPath);
 
             using (File.Create(temIndexFile))
             {

--- a/test/SlowTests/Issues/RavenDB_9381.cs
+++ b/test/SlowTests/Issues/RavenDB_9381.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Issues
         public void Lucene_directory_must_be_aware_of_created_outputs()
         {
             using (var tx = Env.WriteTransaction())
-            using (var cache = new TempFileCache(Env.Options))
+            using (var cache = new TempFileCache(Env.Options.TempPath.FullPath, Env.Options.Encryption.IsEnabled))
             {
                 var dir = new LuceneVoronDirectory(tx, Env, cache, LuceneIndexInputType.Standard);
 

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -679,10 +679,10 @@ namespace SlowTests.Server.Replication
                         fooStream2.Seek(0, SeekOrigin.Begin);
                         session.Advanced.Attachments.Store(docId, "foo2.png", fooStream2, "image/png");
                         await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, docId, "foo2.png", 30 * 1000));
                     }
                 }
-
-                await EnsureReplicatingAsync(source, destination);
 
                 buffer = new byte[3];
                 using (var session = destination.OpenAsyncSession())
@@ -784,10 +784,10 @@ namespace SlowTests.Server.Replication
                         fooStream2.Seek(0, SeekOrigin.Begin);
                         session.Advanced.Attachments.Store(docId, "foo2.png", fooStream2, "image/png");
                         await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, docId, "foo2.png", 30 * 1000));
                     }
                 }
-
-                await EnsureReplicatingAsync(source, destination);
 
                 buffer = new byte[3];
                 using (var session = destination.OpenAsyncSession())
@@ -910,10 +910,10 @@ namespace SlowTests.Server.Replication
                         fooStream2.Seek(0, SeekOrigin.Begin);
                         session.Advanced.Attachments.Store(docId, "foo2.png", fooStream2, "image/png");
                         await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, docId, "foo2.png", 30 * 1000));
                     }
                 }
-
-                await EnsureReplicatingAsync(source, destination);
 
                 using (var session = destination.OpenAsyncSession())
                 {

--- a/test/SlowTests/Tests/TempFileCacheTests.cs
+++ b/test/SlowTests/Tests/TempFileCacheTests.cs
@@ -29,11 +29,11 @@ namespace SlowTests.Tests
             var path = new VoronPathSetting(NewDataPath());
             var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
 
-            using (File.Create(TempFileCache.GetTempFileName(environment)))
+            using (File.Create(TempFileCache.GetTempFileName(environment.TempPath.FullPath)))
             {
             }
 
-            using (var cache = new TempFileCache(environment))
+            using (var cache = new TempFileCache(environment.TempPath.FullPath, environment.Encryption.IsEnabled))
             {
                 Assert.Equal(1, cache.FilesCount);
             }
@@ -47,7 +47,7 @@ namespace SlowTests.Tests
 
             for (var i = 0; i < TempFileCache.MaxFilesToKeepInCache; i++)
             {
-                using (File.Create(TempFileCache.GetTempFileName(environment)))
+                using (File.Create(TempFileCache.GetTempFileName(environment.TempPath.FullPath)))
                 {
                 }
             }
@@ -55,7 +55,7 @@ namespace SlowTests.Tests
             using (File.Create(Path.Combine(environment.TempPath.FullPath,
                 TempFileCache.FilePrefix + "Z" + StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.TempFileExtension)))
             {
-                using (new TempFileCache(environment))
+                using (var cache = new TempFileCache(environment.TempPath.FullPath, environment.Encryption.IsEnabled))
                 {
                 }
             }

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -179,6 +179,49 @@ public partial class RavenTestBase
             return true;
         }
 
+        public async Task<bool> AllShardHaveDocsAsync(RavenServer server, string databaseName, long count = 1L)
+        {
+            var databases = server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(databaseName);
+            foreach (var task in databases)
+            {
+                var documentDatabase = await task;
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var ids = documentDatabase.DocumentsStorage.GetNumberOfDocuments(context);
+                    if (ids < count)
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        public async Task<Dictionary<int, string>> GetOneDocIdForEachShardAsync(RavenServer server, string databaseName)
+        {
+            var docIdPerShard = new Dictionary<int, string>();
+            var databases = server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(databaseName);
+            foreach (var task in databases)
+            {
+                var documentDatabase = await task;
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var ids = documentDatabase.DocumentsStorage.GetNumberOfDocuments(context);
+                    if (ids < 1)
+                        return null;
+
+                    var randomId = documentDatabase.DocumentsStorage.GetAllIds(context).FirstOrDefault();
+                    if (randomId == null)
+                        return null;
+
+                    docIdPerShard.Add(documentDatabase.ShardNumber, randomId);
+                }
+            }
+
+            return docIdPerShard;
+        }
+
         public long GetDocsCountForCollectionInAllShards(IDictionary<string, List<DocumentDatabase>> servers, string collection)
         {
             var sum = 0L;
@@ -213,7 +256,7 @@ public partial class RavenTestBase
             return new ShardedOngoingTasksHandlerProcessorForGetOngoingTasks(handler);
         }
 
-        public class ShardedBackupTestsBase 
+        public class ShardedBackupTestsBase
         {
             internal readonly RavenTestBase _parent;
 
@@ -483,7 +526,7 @@ public partial class RavenTestBase
 
             public Task<long> UpdateConfigurationAndRunBackupAsync(RavenServer server, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)
             {
-                return UpdateConfigurationAndRunBackupAsync(new List<RavenServer>{server}, store, config, isFullBackup);
+                return UpdateConfigurationAndRunBackupAsync(new List<RavenServer> { server }, store, config, isFullBackup);
             }
 
             public async Task<long> UpdateConfigurationAndRunBackupAsync(List<RavenServer> servers, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19503/Sharding-External-Replication-Handle-missing-attachments

### Type of change

- Optimization

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
