### PR TITLE
RavenDB-18634 - Use TCP compression for the cluster communication

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -69,6 +69,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int HeartbeatsBaseLine = 20;
         public static readonly int Heartbeats41200 = 41_200;
         public static readonly int Heartbeats42000 = 42_000;
+        public static readonly int Heartbeats53000 = 53_000;
         public static readonly int ReplicationBaseLine = 31;
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
@@ -85,7 +86,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int TestConnectionBaseLine = 50;
 
         public static readonly int ClusterTcpVersion = TcpConnectionsWithCompression;
-        public static readonly int HeartbeatsTcpVersion = Heartbeats42000;
+        public static readonly int HeartbeatsTcpVersion = Heartbeats53000;
         public static readonly int ReplicationTcpVersion = ReplicationWithDeduplicatedAttachments;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
@@ -304,9 +305,10 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Heartbeats] = new List<int>
                 {
+                    Heartbeats53000,
                     Heartbeats42000,
                     Heartbeats41200,
-                    HeartbeatsBaseLine
+                    HeartbeatsBaseLine,
                 },
                 [OperationTypes.TestConnection] = new List<int>
                 {
@@ -484,6 +486,15 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Heartbeats] = new Dictionary<int, SupportedFeatures>
                 {
+                    [Heartbeats53000] = new SupportedFeatures(Heartbeats53000)
+                    {
+                        DataCompression = true,
+                        Heartbeats = new SupportedFeatures.HeartbeatsFeatures
+                        {
+                            IncludeServerInfo = true,
+                            SendChangesOnly = true
+                        }
+                    },
                     [Heartbeats42000] = new SupportedFeatures(Heartbeats42000)
                     {
                         Heartbeats = new SupportedFeatures.HeartbeatsFeatures

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -66,11 +66,11 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int DropBaseLine = -2;
         public static readonly int ClusterBaseLine = 10;
         public static readonly int ClusterWithMultiTree = 52_000;
-        public static readonly int ClusterWithTcpCompression = 53_000;
+        public static readonly int ClusterWithTcpCompression = 54_000;
         public static readonly int HeartbeatsBaseLine = 20;
         public static readonly int Heartbeats41200 = 41_200;
         public static readonly int Heartbeats42000 = 42_000;
-        public static readonly int HeartbeatsWithTcpCompression = 53_000;
+        public static readonly int HeartbeatsWithTcpCompression = 54_000;
         public static readonly int ReplicationBaseLine = 31;
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
@@ -300,7 +300,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new List<int>
                 {
-                    TcpConnectionsWithCompression,
+                    ClusterWithTcpCompression,
                     ClusterWithMultiTree,
                     ClusterBaseLine,
                 },
@@ -309,7 +309,7 @@ namespace Raven.Client.ServerWide.Tcp
                     HeartbeatsWithTcpCompression,
                     Heartbeats42000,
                     Heartbeats41200,
-                    HeartbeatsBaseLine,
+                    HeartbeatsBaseLine
                 },
                 [OperationTypes.TestConnection] = new List<int>
                 {
@@ -465,7 +465,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new Dictionary<int, SupportedFeatures>
                 {
-                    [TcpConnectionsWithCompression] = new SupportedFeatures(TcpConnectionsWithCompression)
+                    [ClusterWithTcpCompression] = new SupportedFeatures(ClusterWithTcpCompression)
                     {
                         DataCompression = true,
                         Cluster = new SupportedFeatures.ClusterFeatures

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -66,10 +66,11 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int DropBaseLine = -2;
         public static readonly int ClusterBaseLine = 10;
         public static readonly int ClusterWithMultiTree = 52_000;
+        public static readonly int ClusterWithTcpCompression = 53_000;
         public static readonly int HeartbeatsBaseLine = 20;
         public static readonly int Heartbeats41200 = 41_200;
         public static readonly int Heartbeats42000 = 42_000;
-        public static readonly int Heartbeats53000 = 53_000;
+        public static readonly int HeartbeatsWithTcpCompression = 53_000;
         public static readonly int ReplicationBaseLine = 31;
         public static readonly int ReplicationAttachmentMissing = 40_300;
         public static readonly int ReplicationAttachmentMissingVersion41 = 41_300;
@@ -85,8 +86,8 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int SubscriptionTimeSeriesIncludes = 51_000;
         public static readonly int TestConnectionBaseLine = 50;
 
-        public static readonly int ClusterTcpVersion = TcpConnectionsWithCompression;
-        public static readonly int HeartbeatsTcpVersion = Heartbeats53000;
+        public static readonly int ClusterTcpVersion = ClusterWithTcpCompression;
+        public static readonly int HeartbeatsTcpVersion = HeartbeatsWithTcpCompression;
         public static readonly int ReplicationTcpVersion = ReplicationWithDeduplicatedAttachments;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
@@ -305,7 +306,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Heartbeats] = new List<int>
                 {
-                    Heartbeats53000,
+                    HeartbeatsWithTcpCompression,
                     Heartbeats42000,
                     Heartbeats41200,
                     HeartbeatsBaseLine,
@@ -486,7 +487,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Heartbeats] = new Dictionary<int, SupportedFeatures>
                 {
-                    [Heartbeats53000] = new SupportedFeatures(Heartbeats53000)
+                    [HeartbeatsWithTcpCompression] = new SupportedFeatures(HeartbeatsWithTcpCompression)
                     {
                         DataCompression = true,
                         Heartbeats = new SupportedFeatures.HeartbeatsFeatures

--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -84,7 +84,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int SubscriptionTimeSeriesIncludes = 51_000;
         public static readonly int TestConnectionBaseLine = 50;
 
-        public static readonly int ClusterTcpVersion = ClusterWithMultiTree;
+        public static readonly int ClusterTcpVersion = TcpConnectionsWithCompression;
         public static readonly int HeartbeatsTcpVersion = Heartbeats42000;
         public static readonly int ReplicationTcpVersion = ReplicationWithDeduplicatedAttachments;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
@@ -298,6 +298,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new List<int>
                 {
+                    TcpConnectionsWithCompression,
                     ClusterWithMultiTree,
                     ClusterBaseLine,
                 },
@@ -461,6 +462,14 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Cluster] = new Dictionary<int, SupportedFeatures>
                 {
+                    [TcpConnectionsWithCompression] = new SupportedFeatures(TcpConnectionsWithCompression)
+                    {
+                        DataCompression = true,
+                        Cluster = new SupportedFeatures.ClusterFeatures
+                        {
+                            MultiTree = true
+                        }
+                    },
                     [ClusterWithMultiTree] = new SupportedFeatures(ClusterWithMultiTree)
                     {
                         Cluster = new SupportedFeatures.ClusterFeatures

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -43,7 +43,6 @@ namespace Raven.Server.Rachis
         where TStateMachine : RachisStateMachine, new()
     {
         private readonly ServerStore _serverStore;
-        //internal ServerStore ServerStore => _serverStore;
 
         public RachisConsensus(ServerStore serverStore, int? seed = null) : base(serverStore.Server.CipherSuitesPolicy, seed)
         {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -43,6 +43,7 @@ namespace Raven.Server.Rachis
         where TStateMachine : RachisStateMachine, new()
     {
         private readonly ServerStore _serverStore;
+        //internal ServerStore ServerStore => _serverStore;
 
         public RachisConsensus(ServerStore serverStore, int? seed = null) : base(serverStore.Server.CipherSuitesPolicy, seed)
         {
@@ -87,6 +88,7 @@ namespace Raven.Server.Rachis
         }
 
         public override X509Certificate2 ClusterCertificate => _serverStore.Server.Certificate?.Certificate;
+        public override ServerStore ServerStore => _serverStore;
 
         public override bool ShouldSnapshot(Slice slice, RootObjectType type)
         {
@@ -2247,6 +2249,8 @@ namespace Raven.Server.Rachis
         public bool IsEncrypted => _persistentState.Options.Encryption.IsEnabled;
 
         public abstract X509Certificate2 ClusterCertificate { get; }
+
+        public abstract ServerStore ServerStore { get; }
 
         public abstract bool ShouldSnapshot(Slice slice, RootObjectType type);
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2628,7 +2628,8 @@ namespace Raven.Server
                    header.LicensedFeatures?.DataCompression == true &&
                    (header.Operation == TcpConnectionHeaderMessage.OperationTypes.Replication ||
                     header.Operation == TcpConnectionHeaderMessage.OperationTypes.Subscription ||
-                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster);
+                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster ||
+                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Heartbeats);
         }
 
         private static void ThrowDatabaseShutdown(DocumentDatabase database)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2627,7 +2627,8 @@ namespace Raven.Server
             return supportedFeatures.DataCompression &&
                    header.LicensedFeatures?.DataCompression == true &&
                    (header.Operation == TcpConnectionHeaderMessage.OperationTypes.Replication ||
-                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Subscription);
+                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Subscription ||
+                    header.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster);
         }
 
         private static void ThrowDatabaseShutdown(DocumentDatabase database)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3621,7 +3621,7 @@ namespace Raven.Server.ServerWide
                     var result = await TcpUtils.ConnectSecuredTcpSocket(info, _parent.ClusterCertificate, _parent.CipherSuitesPolicy,
                         TcpConnectionHeaderMessage.OperationTypes.Cluster, 
                         (string destUrl, TcpConnectionInfo tcpInfo, Stream conn, JsonOperationContext ctx, List<string> _) => NegotiateProtocolVersionAsyncForCluster(destUrl, tcpInfo, conn, ctx, tag), 
-                        context, _parent.TcpConnectionTimeout, null, token);
+                        context, _parent.TcpConnectionTimeout, null, token); 
 
                     tcpClient = result.TcpClient;
                     stream = result.Stream;
@@ -3692,7 +3692,7 @@ namespace Raven.Server.ServerWide
                 DestinationServerId = info.ServerId,
                 LicensedFeatures = new LicensedFeatures
                 {
-                    DataCompression = compressionSupport
+                    DataCompression = compressionSupport && _parent.ServerStore.Configuration.Server.DisableTcpCompression == false
                 }
             };
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3674,11 +3674,9 @@ namespace Raven.Server.ServerWide
         private async Task<TcpConnectionHeaderMessage.SupportedFeatures> NegotiateProtocolVersionAsyncForCluster(string url, TcpConnectionInfo info, Stream stream, JsonOperationContext ctx, string tag)
         {
             bool compressionSupport = false;
-#if NETCOREAPP3_1_OR_GREATER
             var version = TcpConnectionHeaderMessage.ClusterTcpVersion;
-            if (version >= TcpConnectionHeaderMessage.TcpConnectionsWithCompression)
+            if (version >= TcpConnectionHeaderMessage.ClusterWithTcpCompression)
                 compressionSupport = true;
-#endif
 
             var parameters = new AsyncTcpNegotiateParameters
             {
@@ -3692,7 +3690,7 @@ namespace Raven.Server.ServerWide
                 DestinationServerId = info.ServerId,
                 LicensedFeatures = new LicensedFeatures
                 {
-                    DataCompression = compressionSupport && _parent.ServerStore.Configuration.Server.DisableTcpCompression == false
+                    DataCompression = compressionSupport && _parent.ServerStore.LicenseManager.LicenseStatus.HasTcpDataCompression && _parent.ServerStore.Configuration.Server.DisableTcpCompression == false
                 }
             };
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -505,7 +505,7 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 bool compressionSupport = false;
                 var version = TcpConnectionHeaderMessage.HeartbeatsTcpVersion;
-                if (version >= TcpConnectionHeaderMessage.TcpConnectionsWithCompression)
+                if (version >= TcpConnectionHeaderMessage.HeartbeatsWithTcpCompression)
                     compressionSupport = true;
 
                 var parameters = new AsyncTcpNegotiateParameters

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -485,7 +485,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     connection = result.Stream;
                     supportedFeatures = result.SupportedFeatures;
 
-                    if (result.SupportedFeatures != null && result.SupportedFeatures.DataCompression)
+                    if (result.SupportedFeatures.DataCompression)
                     {
                         connection = new ReadWriteCompressedStream(connection);
                     }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -470,7 +470,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 Stream connection;
                 TcpClient tcpClient;
 
-                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                using (_contextPool.AllocateOperationContext(out JsonOperationContext ctx))
                 {
                     var result = await TcpUtils.ConnectSecuredTcpSocket(
                         tcpConnectionInfo,

--- a/src/Sparrow/Utils/ReadWriteCompressedStream.cs
+++ b/src/Sparrow/Utils/ReadWriteCompressedStream.cs
@@ -150,14 +150,14 @@ namespace Sparrow.Utils
             return _input.Read(buffer);
         }
 
-        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = new CancellationToken())
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = new CancellationToken())
         {
-            return await _input.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return _input.ReadAsync(buffer, cancellationToken);
         }
 
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return await _input.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            return _input.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/test/SlowTests/RavenDB-18634.cs
+++ b/test/SlowTests/RavenDB-18634.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper.Configuration;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Core.AdminConsole;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests
+{
+    public class RavenDB_18634 : ClusterTestBase
+    {
+        public RavenDB_18634(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task DisableTcpCompressionIn1ServerOutOf2InCluster()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2);
+
+            // modify configuration
+            AdminJsConsoleTests.ExecuteScript(leader, database: null, "server.Configuration.Server.DisableTcpCompression = true;");
+            Assert.True(leader.Configuration.Server.DisableTcpCompression);
+
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 2});
+
+            var db0 = await nodes[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var db1 = await nodes[1].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            Assert.NotNull(db0);
+            Assert.NotNull(db1);
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18634/Use-TCP-compression-for-the-cluster-communication

### Additional description

Use TCP compression for the cluster communication.

_Please delete below the options that are not relevant_

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed

