### PR TITLE
RavenDB-19462 Adding `Dispose` for writer and pager in `RavenDB_19273`.

### DIFF
--- a/test/StressTests/Issues/RavenDB_13528.cs
+++ b/test/StressTests/Issues/RavenDB_13528.cs
@@ -28,8 +28,8 @@ namespace StressTests.Issues
 
                 RequireFileBasedPager();
 
-                var writer = Env.Options.CreateJournalWriter(10, size);
-                writer.Write(1, (byte*)pos, (int)(size / _4Kb));
+                using (var writer = Env.Options.CreateJournalWriter(10, size))
+                    writer.Write(1, (byte*)pos, (int)(size / _4Kb));
             }
             finally
             {

--- a/test/StressTests/Voron/Issues/RavenDB_19273.cs
+++ b/test/StressTests/Voron/Issues/RavenDB_19273.cs
@@ -42,16 +42,15 @@ public class RavenDB_19273 : StorageTest
 
             RequireFileBasedPager();
 
-            var writer = Env.Options.CreateJournalWriter(10, size);
-            writer.Write(1, (byte*)pos, (int)(size / _4Kb));
+            using (var writer = Env.Options.CreateJournalWriter(10, size))
+                writer.Write(1, (byte*)pos, (int)(size / _4Kb));
         }
         finally
         {
             Marshal.FreeHGlobal(ptr);
         }
 
-        var pager = Env.Options.OpenJournalPager(10, default(JournalInfo));
-
+        using (var pager = Env.Options.OpenJournalPager(10, default(JournalInfo)))
         using (var tx = Env.ReadTransaction())
         {
             var readPtr = pager.AcquirePagePointer(tx.LowLevelTransaction, 0);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19462

### Additional description

Without disposing `writer` and `pager` process holds the disk space. 

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
