### PR TITLE
RavenDB-17872 - Fixing an NRE when updating the metadata in compare exchange

### DIFF
--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -392,7 +392,7 @@ namespace Raven.Client.Documents.Session
                         var entity = CompareExchangeValueBlittableJsonConverter.ConvertToBlittable(_value.Value, conventions, context, jsonSerializer);
                         var entityJson = entity as BlittableJsonReaderObject;
                         BlittableJsonReaderObject metadata = null;
-                        _originalValue?.Value.TryGet(Constants.Documents.Metadata.Key, out metadata);
+                        _originalValue?.Value?.TryGet(Constants.Documents.Metadata.Key, out metadata);
                         var metadataHasChanged = false;
                         if (_value.HasMetadata && _value.Metadata.Count != 0)
                         {

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -376,7 +376,8 @@ namespace Raven.Server.ServerWide.Commands
             return null;
         }
 
-        const string RvnAtomicPrefix = "rvn-atomic/";
+        internal const string RvnAtomicPrefix = "rvn-atomic/";
+
         public static bool IsAtomicGuardKey(string id, out string docId)
         {
             if (id.StartsWith(RvnAtomicPrefix) == false)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -376,8 +376,7 @@ namespace Raven.Server.ServerWide.Commands
             return null;
         }
 
-        internal const string RvnAtomicPrefix = "rvn-atomic/";
-
+        const string RvnAtomicPrefix = "rvn-atomic/";
         public static bool IsAtomicGuardKey(string id, out string docId)
         {
             if (id.StartsWith(RvnAtomicPrefix) == false)

--- a/test/SlowTests/Issues/RavenDB-17872.cs
+++ b/test/SlowTests/Issues/RavenDB-17872.cs
@@ -245,7 +245,6 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 const string id = "users/1";
-                const string compareExchangeKey = $"{ClusterTransactionCommand.RvnAtomicPrefix}/{id}";
 
                 using (var session = store.OpenAsyncSession(new SessionOptions() { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -255,7 +254,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenAsyncSession(new SessionOptions() { TransactionMode = TransactionMode.ClusterWide }))
                 {
-                    var compareExchangeValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(compareExchangeKey)
+                    var compareExchangeValue = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(ClusterTransactionCommand.GetAtomicGuardKey(id))
                         .ConfigureAwait(false);
 
                     compareExchangeValue.Metadata.Add(Constants.Documents.Metadata.Expires, DateTime.UtcNow.AddHours(1));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19515/NRE-when-updating-the-metadata-of-a-compare-exchnage

### Additional description

Fixing an NRE when updating the metadata in compare exchange

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
