### PR TITLE
RavenDB-19488 Return empty results when skipped more docs than queried index size

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexQueryingScope.cs
@@ -91,6 +91,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             if (search.ScoreDocs.Length <= _alreadyScannedForDuplicates)
                 return;
 
+            if (search.ScoreDocs.Length <= _query.Start)
+                return;
+            
             for (; _alreadyScannedForDuplicates < _query.Start; _alreadyScannedForDuplicates++)
             {
                 var scoreDoc = search.ScoreDocs[_alreadyScannedForDuplicates];

--- a/test/SlowTests/Issues/RavenDB-19488.cs
+++ b/test/SlowTests/Issues/RavenDB-19488.cs
@@ -1,0 +1,62 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+using FastTests;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19488 : RavenTestBase
+    {
+        
+        public RavenDB_19488(ITestOutputHelper output) : base(output)
+        {
+        }     
+        
+        [Fact]
+        public async Task ShouldReturnEmptyResultsWhenSkippedMoreDocsThanCollectionSize()
+        {
+            using var store = GetDocumentStore();
+            {
+                using var session = store.OpenAsyncSession();
+                await session.StoreAsync(new Data { Name = "Test" });
+                await session.SaveChangesAsync();
+            }
+            var index = new DataIndex();
+            await index.ExecuteAsync(store);
+            Indexes.WaitForIndexing(store);
+            {
+                using var session = store.OpenAsyncSession();
+
+                var query = session.Advanced.AsyncDocumentQuery<Data, DataIndex>()
+
+                    .Skip(2).Take(1)
+                    .SelectFields<Data>("Name") //This is mandatory for reproducing, without this statement query executes and returns empty result as expected
+                    .Distinct(); //This is mandatory for reproducing, without this statement query executes and returns an empty result as expected; //Skip 2 rows (only 1 row exists in collection), for values less than 2 works as expected
+                Assert.Empty(await query.ToListAsync()); // Raven.Client.Exceptions.RavenException System.IndexOutOfRangeException: Index was outside the bounds of the array.
+                
+                query = session.Advanced.AsyncDocumentQuery<Data, DataIndex>()
+                
+                    .Skip(1).Take(1)
+                    .SelectFields<Data>("Name") 
+                    .Distinct(); 
+                Assert.Empty(await query.ToListAsync());
+            }
+        }
+
+        private class Data
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class DataIndex : AbstractIndexCreationTask<Data>
+        {
+            public DataIndex()
+            {
+                Map = datas => datas.Select(i => new { i.Name });
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19488/NRE-in-LuceneIndexQueryingScope-when-Skip-is-more-than-number-of-total-results

### Additional description

Skipping more documents than the total docs count resulted in IndexOutOfRangeException.
I've added an additional check for that. If there's a such case, we return empty results.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
