### PR TITLE
RavenDB-19518 Added support for providing SQL provider specific parameter types in SQL ETL scripts

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using MySql.Data.MySqlClient;
+using NpgsqlTypes;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Extensions.Streams;
@@ -35,6 +36,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
         private readonly DbTransaction _tx;
 
         private readonly List<Func<DbParameter, string, bool>> _stringParserList;
+        private readonly SqlProvider _providerType;
 
         private const int LongStatementWarnThresholdInMs = 3000;
 
@@ -45,6 +47,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
             _database = database;
             _logger = LoggingSource.Instance.GetLogger<RelationalDatabaseWriter>(_database.Name);
             _providerFactory = GetDbProviderFactory(etl.Configuration);
+            _providerType = SqlProviderParser.GetSupportedProvider(_etl.Configuration.Connection.FactoryName);
             _commandBuilder = _providerFactory.InitializeCommandBuilder();
             _connection = _providerFactory.CreateConnection();
             var connectionString = etl.Configuration.Connection.ConnectionString;
@@ -203,7 +206,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             continue;
                         var colParam = cmd.CreateParameter();
                         colParam.ParameterName = GetParameterName(column.Id);
-                        SetParamValue(colParam, column, _stringParserList);
+                        SetParamValue(colParam, column, _stringParserList, _providerType);
                         cmd.Parameters.Add(colParam);
                         sb.Append(GetParameterName(column.Id)).Append(", ");
                     }
@@ -438,7 +441,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
             return stats;
         }
 
-        public static void SetParamValue(DbParameter colParam, SqlColumn column, List<Func<DbParameter, string, bool>> stringParsers)
+        public static void SetParamValue(DbParameter colParam, SqlColumn column, List<Func<DbParameter, string, bool>> stringParsers, SqlProvider provider)
         {
             if (column.Value == null)
                 colParam.Value = DBNull.Value;
@@ -471,43 +474,86 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             if (objectValue.TryGetMember(nameof(SqlDocumentTransformer.VarcharFunctionCall.Type), out object dbType) &&
                                 objectValue.TryGetMember(nameof(SqlDocumentTransformer.VarcharFunctionCall.Value), out object fieldValue))
                             {
-                                var type = (DbType)Enum.Parse(typeof(DbType), dbType.ToString(), ignoreCase: false);
-                                var value = fieldValue.ToString();
+                                var dbTypeString = dbType.ToString() ?? string.Empty;
 
-                                try
+                                bool useGenericDbType = Enum.TryParse(dbTypeString, ignoreCase: false, out DbType type);
+
+                                if (useGenericDbType)
                                 {
-                                    colParam.DbType = type;
-                                } catch
-                                {
-                                    if (type == DbType.Guid && Guid.TryParse(value, out var guid1) && colParam is OracleParameter oracleParameter)
+                                    var value = fieldValue.ToString();
+
+                                    try
                                     {
-                                        var arr = guid1.ToByteArray();
-                                        oracleParameter.Value = arr;
-                                        oracleParameter.OracleDbType = OracleDbType.Raw;
-                                        oracleParameter.Size = arr.Length;
-                                        break;
+                                        colParam.DbType = type;
+                                    }
+                                    catch
+                                    {
+                                        if (type == DbType.Guid && Guid.TryParse(value, out var guid1) && colParam is OracleParameter oracleParameter)
+                                        {
+                                            var arr = guid1.ToByteArray();
+                                            oracleParameter.Value = arr;
+                                            oracleParameter.OracleDbType = OracleDbType.Raw;
+                                            oracleParameter.Size = arr.Length;
+                                            break;
+                                        }
+
+                                        throw;
                                     }
 
-                                    throw;
-                                }
-
-                                if (colParam.DbType == DbType.Guid && Guid.TryParse(value, out var guid))
-                                {
-                                    if (colParam is Npgsql.NpgsqlParameter || colParam is SqlParameter)
-                                        colParam.Value = guid;
-
-                                    if (colParam is MySqlParameter mySqlParameter)
+                                    if (colParam.DbType == DbType.Guid && Guid.TryParse(value, out var guid))
                                     {
-                                        var arr = guid.ToByteArray();
-                                        mySqlParameter.Value = arr;
-                                        mySqlParameter.MySqlDbType = MySqlDbType.Binary;
-                                        mySqlParameter.Size = arr.Length;
-                                        break;
+                                        if (colParam is Npgsql.NpgsqlParameter || colParam is SqlParameter)
+                                            colParam.Value = guid;
+
+                                        if (colParam is MySqlParameter mySqlParameter)
+                                        {
+                                            var arr = guid.ToByteArray();
+                                            mySqlParameter.Value = arr;
+                                            mySqlParameter.MySqlDbType = MySqlDbType.Binary;
+                                            mySqlParameter.Size = arr.Length;
+                                            break;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        colParam.Value = value;
                                     }
                                 }
                                 else
                                 {
-                                    colParam.Value = value;
+                                    // failed to parse db type - try to fallback to provider specific type
+
+                                    switch (provider)
+                                    {
+                                        case SqlProvider.SqlClient:
+                                            SqlDbType sqlDbType = ParseProviderSpecificParameterType<SqlDbType>(dbTypeString);
+                                            ((SqlParameter)colParam).SqlDbType = sqlDbType;
+                                            break;
+                                        case SqlProvider.Npgsql:
+                                            NpgsqlDbType npgsqlType = ParseProviderSpecificParameterType<NpgsqlDbType>(dbTypeString);
+                                            ((Npgsql.NpgsqlParameter)colParam).NpgsqlDbType = npgsqlType;
+                                            break;
+                                        case SqlProvider.MySqlClient:
+                                            MySqlDbType mySqlDbType = ParseProviderSpecificParameterType<MySqlDbType>(dbTypeString);
+                                            ((MySqlParameter)colParam).MySqlDbType = mySqlDbType;
+                                            break;
+                                        case SqlProvider.OracleClient:
+                                            OracleDbType oracleDbType = ParseProviderSpecificParameterType<OracleDbType>(dbTypeString);
+                                            ((OracleParameter)colParam).OracleDbType = oracleDbType;
+                                            break;
+                                        default:
+                                            ThrowProviderNotSupported();
+                                            break;
+                                    }
+
+                                    if (fieldValue is IEnumerable<object> enumerableValue)
+                                    {
+                                        colParam.Value = enumerableValue.Select(x => x.ToString()).ToArray();
+                                    }
+                                    else
+                                    {
+                                        colParam.Value = fieldValue.ToString();
+                                    }
                                 }
 
                                 if (objectValue.TryGetMember(nameof(SqlDocumentTransformer.VarcharFunctionCall.Size), out object size))
@@ -539,6 +585,37 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             throw new InvalidOperationException("Cannot understand how to save " + column.Type + " for " + colParam.ParameterName);
                         }
                 }
+            }
+
+            void ThrowProviderNotSupported()
+            {
+                throw new NotSupportedException($"Factory provider '{provider}' is not supported");
+            }
+        }
+
+        private static T ParseProviderSpecificParameterType<T>(string dbTypeString) where T : struct, Enum, IConvertible
+        {
+            if (dbTypeString.Contains("|"))
+            {
+                var multipleTypes = dbTypeString.Split('|').Select(e =>
+                {
+                    if (Enum.TryParse(e.Trim(), ignoreCase: true, out T singleProviderSpecificType) == false)
+                        ThrowCouldNotParseDbType();
+
+                    return singleProviderSpecificType;
+                }).ToList();
+
+                return multipleTypes.Aggregate((a, b) => (T)Enum.ToObject(typeof(T), Convert.ToInt32(a) | Convert.ToInt32(b)));
+            }
+
+            if (Enum.TryParse(dbTypeString, ignoreCase: true, out T providerSpecificType) == false)
+                ThrowCouldNotParseDbType();
+
+            return providerSpecificType;
+
+            void ThrowCouldNotParseDbType()
+            {
+                throw new InvalidOperationException(string.Format($"Couldn't parse '{dbTypeString}' as db type."));
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
@@ -1,0 +1,286 @@
+﻿using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
+using Raven.Server.Documents.ETL.Providers.SQL.Test;
+using Raven.Server.Documents.ETL.Providers.SQL;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.SqlMigration;
+using SlowTests.Server.Documents.Migration;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Xunit;
+using Xunit.Abstractions;
+using System.Threading;
+using System;
+using Tests.Infrastructure;
+using Npgsql;
+using xRetry;
+
+namespace SlowTests.Server.Documents.ETL.SQL;
+
+public class RavenDB_19518 : SqlAwareTestBase
+{
+    public RavenDB_19518(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+
+        public string[] Companies { get; set; }
+    }
+
+    [Fact]
+    public async Task CanTestSqlEtlScriptWithPostgresSpecificTypes()
+    {
+        using (var store = GetDocumentStore())
+        {
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Item
+                    {
+                        Companies = new[] { "DHL", "UPS" },
+                    });
+                    await session.SaveChangesAsync();
+                }
+
+                var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString()
+                {
+                    Name = "simulate",
+                    ConnectionString = "Server=127.0.0.1;Port=2345;Database=myDataBase;User Id=foo;Password=bar;",
+                    FactoryName = "Npgsql",
+                }));
+
+                Assert.NotNull(result1.RaftCommandIndex);
+
+                var database = GetDatabase(store.Database).Result;
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    using (SqlEtl.TestScript(
+                        new TestSqlEtlScript
+                        {
+                            PerformRolledBackTransaction = false,
+                            DocumentId = "items/1-A",
+                            Configuration = new SqlEtlConfiguration()
+                            {
+                                Name = "simulate",
+                                ConnectionStringName = "simulate",
+                                SqlTables =
+                                {
+                                    new SqlEtlTable {TableName = "Items", DocumentIdColumn = "Id"}
+                                },
+                                Transforms =
+                                {
+                                        new Transformation()
+                                        {
+                                            Collections = {"Items"}, Name = "Items", Script = @"
+var data = {
+    Companies:  {
+        Type : 'Array | Text',
+        Value : this.Companies.map(function(l) {return l;}),
+    }
+};
+loadToItems(data);"
+                                        }
+                                }
+                            }
+                        }, database, database.ServerStore, context, out var testResult))
+                    {
+                        var result = (SqlEtlTestScriptResult)testResult;
+                        Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.LoadErrors.Count);
+                        Assert.Equal(0, result.SlowSqlWarnings.Count);
+
+                        Assert.Equal(1, result.Summary.Count);
+
+                        var orderLines = result.Summary.First(x => x.TableName == "Items");
+
+                        Assert.Equal(2, orderLines.Commands.Length); // delete and insert
+                    }
+                }
+            }
+        }
+    }
+
+    private const string DefaultScript = @"
+var orderData = {
+    Id: documentId,
+    OrderLinesCount: this.OrderLines.length,
+    TotalCost: 0,
+    Quantities: { 
+        Type : 'Array | Double',
+        Value : this.OrderLines.map(function(l) {return l.Quantity;})
+    }
+};
+loadToorders(orderData);
+
+for (var i = 0; i < this.OrderLines.length; i++) {
+    var line = this.OrderLines[i];
+    orderData.TotalCost += line.Cost;
+    loadToorder_lines({
+        OrderId: documentId,
+        Qty: line.Quantity,
+        Product: line.Product,
+        Cost: line.Cost
+    });
+}";
+
+    [RetryTheory(delayBetweenRetriesMs: 1000)]
+    [RequiresNpgSqlInlineData]
+    public void CanReplicateToArraysInPostgresSQL(MigrationProvider provider)
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (WithSqlDatabase(provider, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+            {
+                CreateRdbmsSchema(connectionString);
+
+                var sqlEtlConfigurationName = "OrdersAndLines_" + Guid.NewGuid();
+                var connectionStringName = $"OrdersAndLines_{store.Database}";
+                var operation = new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                {
+                    Name = connectionStringName,
+                    FactoryName = @"Npgsql",
+                    ConnectionString = connectionString
+                });
+
+                store.Maintenance.Send(operation);
+
+                var etlDone = new ManualResetEventSlim();
+                var configuration = new SqlEtlConfiguration
+                {
+                    Name = sqlEtlConfigurationName,
+                    ConnectionStringName = connectionStringName,
+                    SqlTables = { new SqlEtlTable { TableName = "orders", DocumentIdColumn = "Id" }, new SqlEtlTable { TableName = "order_lines", DocumentIdColumn = "OrderId" } },
+                    Transforms =
+                        {
+                            new Transformation
+                            {
+                                Name = "OrdersAndLines",
+                                Collections = {"Orders"},
+                                Script = DefaultScript
+                            },
+                        }
+                };
+
+                store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
+                var database = GetDatabase(store.Database).Result;
+                var errors = 0;
+                database.EtlLoader.BatchCompleted += x =>
+                {
+                    if (x.ConfigurationName == sqlEtlConfigurationName && x.TransformationName == "OrdersAndLines")
+                    {
+                        if (x.Statistics.LoadSuccesses > 0)
+                        {
+                            errors = x.Statistics.LoadErrors;
+                            etlDone.Set();
+                        }
+                    }
+                };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        OrderLines = new List<OrderLine>
+                        {
+                            new OrderLine{Cost = 3, Product = "Milk", Quantity = 3},
+                            new OrderLine{Cost = 4, Product = "Bear", Quantity = 2},
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(5));
+                Assert.Equal(0, errors);
+
+                AssertCounts(connectionString, 1, 2, new[] { 3, 2 });
+            }
+        }
+    }
+
+    private void CreateRdbmsSchema(string connectionString)
+    {
+        using (var con = new NpgsqlConnection(connectionString))
+        {
+            con.Open();
+
+            using (var dbCommand = con.CreateCommand())
+            {
+                dbCommand.CommandText = @"
+
+DROP TABLE IF EXISTS order_lines;
+DROP TABLE IF EXISTS orders;
+";
+                dbCommand.ExecuteNonQuery();
+
+                dbCommand.CommandText = @"
+CREATE TABLE order_lines
+(
+    ""Id"" serial primary key,
+    ""OrderId"" text NOT NULL,
+    ""Qty"" int NOT NULL,
+    ""Product"" text NOT NULL,
+    ""Cost"" int NOT NULL
+);
+
+CREATE TABLE orders
+(
+    ""Id"" text NOT NULL,
+    ""OrderLinesCount"" int  NULL,
+    ""TotalCost"" int NOT NULL,
+    ""City"" text NULL,
+    ""Quantities"" int[] NULL
+);";
+                dbCommand.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private static void AssertCounts(string connectionString, long ordersCount, long orderLineCounts, int[] orderQuantities = null)
+    {
+        using (var con = new NpgsqlConnection(connectionString))
+        {
+            con.Open();
+            using (var dbCommand = con.CreateCommand())
+            {
+                dbCommand.CommandText = "SELECT COUNT(*) FROM orders";
+                Assert.Equal(ordersCount, dbCommand.ExecuteScalar());
+                dbCommand.CommandText = "SELECT COUNT(*) FROM order_lines";
+                Assert.Equal(orderLineCounts, dbCommand.ExecuteScalar());
+
+                if (orderQuantities != null)
+                {
+                    dbCommand.CommandText = "SELECT \"Quantities\" FROM orders LIMIT 1";
+                    var quantities = dbCommand.ExecuteScalar();
+                    Assert.Equal(orderQuantities, (int[])quantities);
+                }
+            }
+        }
+    }
+
+
+    private class Order
+    {
+        public Address Address { get; set; }
+        public string Id { get; set; }
+        public List<OrderLine> OrderLines { get; set; }
+    }
+
+    private class Address
+    {
+        public string City { get; set; }
+    }
+
+    private class OrderLine
+    {
+        public string Product { get; set; }
+        public int Quantity { get; set; }
+        public int Cost { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19518/SQL-ETL-Support-for-providing-SQL-factory-specific-parameter-types

### Additional description

We had the support for that in version 3.5 (it was added in https://github.com/ravendb/ravendb/commit/b0f083cdf95cffa3c0a38a929beecc431fb8dcab)

### Type of change

- Feature (that we already had in 3.5)

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
