### PR TITLE
RavenDB-19516 - Delay Replication on missing attachments loop

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -784,7 +784,7 @@ namespace Raven.Server.Documents.Replication
                 _log.Info($"Starting sending replication batch ({_parent._database.Name}) with {_orderedReplicaItems.Count:#,#;;0} docs, and last etag {_lastEtag:#,#;;0}");
 
             if (_parent.ForTestingPurposes?.OnMissingAttachmentStream != null &&
-                 _parent.MissingAttachmentsRetries.Count > 0)
+                 _parent.MissingAttachmentsRetries > 0)
             {
                 var replicaAttachmentStreams = _replicaAttachmentStreams;
                 _parent.ForTestingPurposes?.OnMissingAttachmentStream?.Invoke(replicaAttachmentStreams);
@@ -826,16 +826,10 @@ namespace Raven.Server.Documents.Replication
             if (_log.IsInfoEnabled && _orderedReplicaItems.Count > 0)
                 _log.Info($"Finished sending replication batch. Sent {_orderedReplicaItems.Count:#,#;;0} documents and {_replicaAttachmentStreams.Count:#,#;;0} attachment streams in {sw.ElapsedMilliseconds:#,#;;0} ms. Last sent etag = {_lastEtag:#,#;;0}");
 
-            var (type, reply) = _parent.HandleServerResponse(getFullResponse: true);
+            var (type, _) = _parent.HandleServerResponse();
             if (type == ReplicationMessageReply.ReplyType.MissingAttachments)
             {
                 MissingAttachmentsInLastBatch = true;
-
-                if (_parent.MissingAttachmentsRetries.ContainsKey(reply.Exception) == false)
-                    _parent.MissingAttachmentsRetries.Add(reply.Exception, 1);
-                else
-                    _parent.MissingAttachmentsRetries[reply.Exception]++;
-                
                 return;
             }
             _parent._lastSentDocumentEtag = _lastEtag;

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
 using Raven.Server.Config;
+using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
@@ -684,6 +686,68 @@ namespace SlowTests.Server.Replication
                         }
                     }
                 }
+            }
+        }
+
+        // RavenDB-19516
+        [Fact]
+        public async Task ShouldDelayReplicationOnMissingAttachmentsLoop()
+        {
+            using (var source = GetDocumentStore())
+            using (var destination = GetDocumentStore())
+            {
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await session.StoreAsync(new User { Name = "Foo" }, "FoObAr/0");
+                    session.Advanced.Attachments.Store("FoObAr/0", "foo.png", fooStream, "image/png");
+                    await session.SaveChangesAsync();
+                }
+
+                var sourceDb = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(source.Database);
+                sourceDb.Configuration.Replication.RetryMaxTimeout = new TimeSetting((long)TimeSpan.FromMinutes(15).TotalMilliseconds, TimeUnit.Minutes);
+                sourceDb.ReplicationLoader.ForTestingPurposesOnly().OnOutgoingReplicationStart = (o) =>
+                {
+                    if (o.Destination.Database == destination.Database)
+                    {
+                        o.ForTestingPurposesOnly().OnMissingAttachmentStream = (replicaAttachmentStreams) =>
+                        {
+                            replicaAttachmentStreams.Clear();
+                        };
+                    }
+                };
+
+                await SetupReplicationAsync(source, destination);
+                await EnsureReplicatingAsync(source, destination);
+
+                var outgoingFailureInfo = sourceDb.ReplicationLoader.OutgoingFailureInfo.ToList();
+                Assert.Equal(1, outgoingFailureInfo.Count);
+                var defaultNextTimeOut = outgoingFailureInfo[0].Value.NextTimeout;
+
+                using (var session = destination.OpenAsyncSession())
+                {
+                    session.Delete("FoObAr/0");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream2 = new MemoryStream(new byte[] { 4, 5, 6 }))
+                {
+                    session.Advanced.Attachments.Store("FoObAr/0", "foo2.png", fooStream2, "image/png");
+                    await session.SaveChangesAsync();
+
+                    WaitForDocumentWithAttachmentToReplicate<User>(destination, "FoObAr/0", "foo2.png", 10_000);
+                }
+
+                outgoingFailureInfo = sourceDb.ReplicationLoader.OutgoingFailureInfo.ToList();
+                Assert.Equal(1, outgoingFailureInfo.Count);
+
+                var info = outgoingFailureInfo[0].Value;
+                var delayNextTimeOut = info.NextTimeout;
+                Assert.True(delayNextTimeOut > defaultNextTimeOut);
+
+                if (info.Errors.TryDequeue(out var exception))
+                    Assert.True(exception.Message.Contains("Destination reported missing attachments for same document more than once."));
             }
         }
     }

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -747,7 +747,7 @@ namespace SlowTests.Server.Replication
                 Assert.True(delayNextTimeOut > defaultNextTimeOut);
 
                 if (info.Errors.TryDequeue(out var exception))
-                    Assert.True(exception.Message.Contains("Destination reported missing attachments for same document more than once."));
+                    Assert.True(exception.Message.Contains("Destination reported missing attachments"));
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19516/Delay-Replication-on-missing-attachments-loop

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
