### PR TITLE
RavenDB-19516 - Delay Replication on missing attachments loop

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1139,7 +1139,7 @@ namespace Raven.Server.Documents.Replication
                             case AttachmentReplicationItem attachment:
 
                                 var localAttachment = database.DocumentsStorage.AttachmentsStorage.GetAttachmentByKey(context, attachment.Key);
-                                if (_replicationInfo.ReplicatedAttachmentStreams.TryGetValue(attachment.Base64Hash, out var attachmentStream))
+                                if (_replicationInfo.ReplicatedAttachmentStreams != null && _replicationInfo.ReplicatedAttachmentStreams.TryGetValue(attachment.Base64Hash, out var attachmentStream))
                                 {
                                     if (database.DocumentsStorage.AttachmentsStorage.AttachmentExists(context, attachment.Base64Hash) == false)
                                     {

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -36,6 +36,9 @@ using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Sparrow.Utils;
+using Raven.Server.Exceptions;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Voron;
 
 namespace Raven.Server.Documents.Replication
 {
@@ -349,6 +352,10 @@ namespace Raven.Server.Documents.Replication
                 _parent.ForTestingPurposes?.OnOutgoingReplicationStart?.Invoke(this);
                 replicationAction();
             }
+            catch (MissingAttachmentException e)
+            {
+                HandleException(e);
+            }
             catch (AggregateException e)
             {
                 if (e.InnerExceptions.Count == 1)
@@ -425,6 +432,7 @@ namespace Raven.Server.Documents.Replication
         }
 
         public long NextReplicateTicks;
+        public int MissingAttachmentsRetries;
 
         private void Replicate()
         {
@@ -1140,6 +1148,10 @@ namespace Raven.Server.Documents.Replication
                     throw new InvalidOperationException(
                         $"Received failure reply for replication batch. Error string received = {replicationBatchReply.Exception}");
                 case ReplicationMessageReply.ReplyType.MissingAttachments:
+                    if (++MissingAttachmentsRetries > 1)
+                        RaiseAlertAndThrowMissingAttachmentException($"Failed to send batch successfully to {Destination.FromString()}. " +
+                                                                     $"Destination reported missing attachments {MissingAttachmentsRetries} times.");
+
                     if (_log.IsInfoEnabled)
                     {
                         _log.Info(
@@ -1154,6 +1166,24 @@ namespace Raven.Server.Documents.Replication
             }
 
             return replicationBatchReply;
+        }
+
+        private void RaiseAlertAndThrowMissingAttachmentException(string msg)
+        {
+            if (_log.IsInfoEnabled)
+            {
+                _log.Info(
+                    $"Received reply for replication batch from {Destination.FromString()}. Error string received = {msg}");
+            }
+
+            _parent._server.NotificationCenter.Add(AlertRaised.Create(
+                _database.Name,
+                "Replication delay due to a missing attachments loop",
+                msg,
+                AlertType.Replication,
+                NotificationSeverity.Error));
+
+            throw new MissingAttachmentException(msg);
         }
 
         private void OnDocumentChange(DocumentChange change)
@@ -1244,7 +1274,11 @@ namespace Raven.Server.Documents.Replication
 
         private void OnSuccessfulTwoWaysCommunication() => SuccessfulTwoWaysCommunication?.Invoke(this);
 
-        private void OnSuccessfulReplication() => SuccessfulReplication?.Invoke(this);
+        private void OnSuccessfulReplication()
+        {
+            SuccessfulReplication?.Invoke(this);
+            MissingAttachmentsRetries = 0;
+        }
 
         internal TestingStuff ForTestingPurposes;
 
@@ -1259,6 +1293,8 @@ namespace Raven.Server.Documents.Replication
         internal class TestingStuff
         {
             public Action OnDocumentSenderFetchNewItem;
+
+            public Action<Dictionary<Slice, AttachmentReplicationItem>> OnMissingAttachmentStream;
         }
     }
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1280,9 +1280,13 @@ namespace Raven.Server.Documents.Replication
         private void OnSuccessfulReplication()
         {
             SuccessfulReplication?.Invoke(this);
-            _parent._server.NotificationCenter.Dismiss(_missingAttachmentsAlert?.Id);
+            if (_missingAttachmentsAlert != null)
+            {
+                _parent._server.NotificationCenter.Dismiss(_missingAttachmentsAlert.Id);
+                _missingAttachmentsAlert = null;
+            }
+         
             MissingAttachmentsRetries = 0;
-            _missingAttachmentsAlert = null;
         }
 
         internal TestingStuff ForTestingPurposes;

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -695,6 +695,13 @@ namespace Raven.Server.Documents.Replication
             if (_log.IsInfoEnabled)
                 _log.Info($"Starting sending replication batch ({_parent._database.Name}) with {_orderedReplicaItems.Count:#,#;;0} docs, and last etag {_lastEtag:#,#;;0}");
 
+            if (_parent.ForTestingPurposes?.OnMissingAttachmentStream != null &&
+                _parent.MissingAttachmentsRetries > 0)
+            {
+                var replicaAttachmentStreams = _replicaAttachmentStreams;
+                _parent.ForTestingPurposes?.OnMissingAttachmentStream?.Invoke(replicaAttachmentStreams);
+            }
+
             var sw = Stopwatch.StartNew();
             var headerJson = new DynamicJsonValue
             {

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
 using Raven.Server.Config;
+using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
@@ -684,6 +686,68 @@ namespace SlowTests.Server.Replication
                         }
                     }
                 }
+            }
+        }
+
+        // RavenDB-19516
+        [Fact]
+        public async Task ShouldDelayReplicationOnMissingAttachmentsLoop()
+        {
+            using (var source = GetDocumentStore())
+            using (var destination = GetDocumentStore())
+            {
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await session.StoreAsync(new User { Name = "Foo" }, "FoObAr/0");
+                    session.Advanced.Attachments.Store("FoObAr/0", "foo.png", fooStream, "image/png");
+                    await session.SaveChangesAsync();
+                }
+
+                var sourceDb = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(source.Database);
+                sourceDb.Configuration.Replication.RetryMaxTimeout = new TimeSetting((long)TimeSpan.FromMinutes(15).TotalMilliseconds, TimeUnit.Minutes);
+                sourceDb.ReplicationLoader.ForTestingPurposesOnly().OnOutgoingReplicationStart = (o) =>
+                {
+                    if (o.Destination.Database == destination.Database)
+                    {
+                        o.ForTestingPurposesOnly().OnMissingAttachmentStream = (replicaAttachmentStreams) =>
+                        {
+                            replicaAttachmentStreams.Clear();
+                        };
+                    }
+                };
+
+                await SetupReplicationAsync(source, destination);
+                await EnsureReplicatingAsync(source, destination);
+
+                var outgoingFailureInfo = sourceDb.ReplicationLoader.OutgoingFailureInfo.ToList();
+                Assert.Equal(1, outgoingFailureInfo.Count);
+                var defaultNextTimeOut = outgoingFailureInfo[0].Value.NextTimeout;
+
+                using (var session = destination.OpenAsyncSession())
+                {
+                    session.Delete("FoObAr/0");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream2 = new MemoryStream(new byte[] { 4, 5, 6 }))
+                {
+                    session.Advanced.Attachments.Store("FoObAr/0", "foo2.png", fooStream2, "image/png");
+                    await session.SaveChangesAsync();
+
+                    WaitForDocumentWithAttachmentToReplicate<User>(destination, "FoObAr/0", "foo2.png", 10_000);
+                }
+
+                outgoingFailureInfo = sourceDb.ReplicationLoader.OutgoingFailureInfo.ToList();
+                Assert.Equal(1, outgoingFailureInfo.Count);
+
+                var info = outgoingFailureInfo[0].Value;
+                var delayNextTimeOut = info.NextTimeout;
+                Assert.True(delayNextTimeOut > defaultNextTimeOut);
+
+                if (info.Errors.TryDequeue(out var exception))
+                    Assert.True(exception.Message.Contains("Destination reported missing attachments"));
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19516/Delay-Replication-on-missing-attachments-loop

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
