### PR TITLE
RavenDB-19534: IndexEntryReader no longer uses spans and doesnt need to be a ref struct

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -104,7 +104,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
         rawSize = item.Length;
         int headerSize = size + len;
-        return new IndexEntryReader(new Span<byte>(item.Address + headerSize, item.Length - headerSize));
+        return new IndexEntryReader(item.Address + headerSize, item.Length - headerSize);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -118,7 +118,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         key = Encoding.UTF8.GetString(idSpan);
         
         int headerSize = size + len;
-        return new(new Span<byte>(item.Address + headerSize, item.Length - headerSize));
+        return new(item.Address + headerSize, item.Length - headerSize);
     }
 
     public string GetIdentityFor(long id)

--- a/src/Corax/Queries/SortingMatch/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatch/SortingMultiMatch.cs
@@ -351,7 +351,7 @@ namespace Corax.Queries
             {
                 UnmanagedSpan matchIndexEntry = searcher.GetIndexEntryPointer(matches[i]);
                 var read = typeof(TComparer1) == typeof(BoostingComparer) || 
-                           Get(new IndexEntryReader(matchIndexEntry), fieldId, matches[i], out matchesKeys[i].Value, in _comparer1);
+                           Get(new IndexEntryReader(matchIndexEntry.Address, matchIndexEntry.Length), fieldId, matches[i], out matchesKeys[i].Value, in _comparer1);
                 matchesKeys[i].Key = read ? matches[i] : -matches[i];
                 matchesKeys[i].Entry = matchIndexEntry;
 
@@ -389,7 +389,7 @@ namespace Corax.Queries
                 for (int i = 0; i < bTotalMatches; i++)
                 {
                     UnmanagedSpan matchIndexEntry = searcher.GetIndexEntryPointer(matches[i]);
-                    var read = Get(new IndexEntryReader(matchIndexEntry), fieldId, bValues[i], out bKeys[i].Value, in _comparer1);
+                    var read = Get(new IndexEntryReader(matchIndexEntry.Address, matchIndexEntry.Length), fieldId, bValues[i], out bKeys[i].Value, in _comparer1);
                     bKeys[i].Key = read ? bValues[i] : -bValues[i];
                     bKeys[i].Entry = matchIndexEntry;
                     
@@ -530,10 +530,10 @@ namespace Corax.Queries
         where TComparer : ISpatialComparer, IMatchComparer
         {
             var comparer = (TComparer)GetComparer(ref current, comparerIdx);
-            var readerX = new IndexEntryReader(item1);
+            var readerX = new IndexEntryReader(item1.Address, item1.Length);
             var readX = readerX.GetReaderFor(comparer.FieldId).Read(out (double lat, double lon) resultX);
 
-            var readerY = new IndexEntryReader(item2);
+            var readerY = new IndexEntryReader(item2.Address, item2.Length);
             var readY = readerY.GetReaderFor(comparer.FieldId).Read(out (double lat, double lon) resultY);
 
             if (readX && readY)
@@ -559,8 +559,8 @@ namespace Corax.Queries
             where TComparer : IMatchComparer
         {
             var comparer = (TComparer)GetComparer(ref current, comparerIdx);
-            var comp1Reader = new IndexEntryReader(item1);
-            var comp2Reader = new IndexEntryReader(item2);
+            var comp1Reader = new IndexEntryReader(item1.Address, item1.Length);
+            var comp2Reader = new IndexEntryReader(item2.Address, item2.Length);
 
             bool read1 = comp1Reader.GetReaderFor(comparer.FieldId).Read(out var sv1);
             bool read2 = comp2Reader.GetReaderFor(comparer.FieldId).Read(out var sv2);
@@ -585,8 +585,8 @@ namespace Corax.Queries
             where TComparer : IMatchComparer
         {
             var comparer = (TComparer)GetComparer(ref current, comparerIdx);
-            var comp1Reader = new IndexEntryReader(item1);
-            var comp2Reader = new IndexEntryReader(item2);
+            var comp1Reader = new IndexEntryReader(item1.Address, item1.Length);
+            var comp2Reader = new IndexEntryReader(item2.Address, item2.Length);
 
             bool read1, read2;
 

--- a/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
+++ b/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
@@ -30,7 +30,7 @@ public class IndexEntryReaderBigDoc : NoDisposalNeeded
     }
 
     [Fact]
-    public void CanCreateAndReadBigDocument()
+    public unsafe void CanCreateAndReadBigDocument()
     {
         using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
         var scope = new SingleEntryWriterScope(allocator);
@@ -53,7 +53,7 @@ public class IndexEntryReaderBigDoc : NoDisposalNeeded
 
         indexEntryWriter.Finish(out var output);
 
-        new IndexEntryReader(output.ToSpan()).GetReaderFor(0).Read(out var id);
+        new IndexEntryReader(output.Ptr, output.Length).GetReaderFor(0).Read(out var id);
     }
     
     private static JArray  ReadDocFromResource(string file)

--- a/test/FastTests/Corax/Bugs/RavenDB-19283.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19283.cs
@@ -20,7 +20,7 @@ public class RavenDB_19283 : StorageTest
     }
 
     [Fact]
-    public void CanReadAndWriteLargeEntries()
+    public unsafe void CanReadAndWriteLargeEntries()
     {
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
 
@@ -43,7 +43,7 @@ public class RavenDB_19283 : StorageTest
         writer.Write(0, Encoding.UTF8.GetBytes("users/1"));
         using var ___ = writer.Finish(out var element);
 
-        var reader = new IndexEntryReader(element.ToSpan());
+        var reader = new IndexEntryReader(element.Ptr, element.Length);
         reader.GetReaderFor(0).Read(out Span<byte> id);
         var it = reader.GetReaderFor(1).ReadMany();
         while (it.ReadNext())

--- a/test/FastTests/Corax/DynamicFieldsTests.cs
+++ b/test/FastTests/Corax/DynamicFieldsTests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace FastTests.Corax;
 
-public class DynamicFieldsTests : StorageTest
+public unsafe class DynamicFieldsTests : StorageTest
 {
     public DynamicFieldsTests(ITestOutputHelper output) : base(output)
     {
@@ -39,7 +39,7 @@ public class DynamicFieldsTests : StorageTest
         
         writer.WriteDynamic(fieldName, Encoding.UTF8.GetBytes(""));
         using var __ = writer.Finish(out ByteString element);
-        IndexEntryReader reader = new(element.ToSpan());
+        IndexEntryReader reader = new(element.Ptr, element.Length);
         
         var fieldReader = reader.GetReaderFor(Encoding.UTF8.GetBytes(fieldName));
         Assert.Equal(IndexEntryFieldType.Empty, fieldReader.Type);
@@ -74,7 +74,7 @@ public class DynamicFieldsTests : StorageTest
 
         using ByteStringContext<ByteStringMemoryCache>.InternalScope __ = writer.Finish(out ByteString element);
 
-        IndexEntryReader reader = new(element.ToSpan());
+        IndexEntryReader reader = new(element.Ptr, element.Length);
         reader.GetReaderFor(0).Read(out long longValue);
         Assert.Equal(1, longValue);
         reader.GetReaderFor(Encoding.UTF8.GetBytes("Name_123")).Read(out Span<byte> value);
@@ -214,7 +214,7 @@ public class DynamicFieldsTests : StorageTest
         entryBuilder.WriteSpatialDynamic("CoordinatesIndex", _points);
         using var _ = entryBuilder.Finish(out var buffer);
 
-        var reader = new IndexEntryReader(buffer.ToSpan());
+        var reader = new IndexEntryReader(buffer.Ptr, buffer.Length);
 
         var fieldReader = reader.GetReaderFor(Encoding.UTF8.GetBytes("CoordinatesIndex"));
 

--- a/test/FastTests/Corax/IndexEntryWriter.cs
+++ b/test/FastTests/Corax/IndexEntryWriter.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace FastTests.Corax
 {
-    public class IndexEntryWriterTest : StorageTest
+    public unsafe class IndexEntryWriterTest : StorageTest
     {
         public IndexEntryWriterTest(ITestOutputHelper output) : base(output)
         {
@@ -71,7 +71,7 @@ namespace FastTests.Corax
             writer.Write(3, Encoding.UTF8.GetBytes("DDDDDDDDDD"));
             using var __ = writer.Finish(out var element);
 
-            var reader = new IndexEntryReader(element.ToSpan());
+            var reader = new IndexEntryReader(element.Ptr, element.Length);
             reader.GetReaderFor(0).Read(out long longValue);
             Assert.Equal(1, longValue);
             reader.GetReaderFor(0).Read(out int intValue);
@@ -145,7 +145,7 @@ namespace FastTests.Corax
             writer.Write(2, Encoding.UTF8.GetBytes(values[3]));
             using var ___ = writer.Finish(out var element);
 
-            var reader = new IndexEntryReader(element.ToSpan());
+            var reader = new IndexEntryReader(element.Ptr, element.Length);
 
             // Get the first
             Assert.True(reader.GetReaderFor(1).TryReadMany( out var fieldIterator));
@@ -220,7 +220,7 @@ namespace FastTests.Corax
             writer.Write(1, new StringArrayIterator(values), longValues, doubleValues);
             using var ___ = writer.Finish(out var element);
 
-            var reader = new IndexEntryReader(element.ToSpan());                        
+            var reader = new IndexEntryReader(element.Ptr, element.Length);                        
             
             // Get the first
             Assert.True(reader.GetReaderFor(1).TryReadMany( out var fieldIterator));
@@ -326,7 +326,7 @@ namespace FastTests.Corax
             writer.Write(1, new StringArrayIterator(values), longValues, doubleValues);
             using var ___ = writer.Finish(out var element);
 
-            var reader = new IndexEntryReader(element.ToSpan());
+            var reader = new IndexEntryReader(element.Ptr, element.Length);
 
             Assert.True(reader.GetReaderFor(1).Read(out var type, out var longValue, out var doubleValue, out var sequenceValue));
             Assert.True(type.HasFlag(IndexEntryFieldType.Empty));
@@ -338,7 +338,7 @@ namespace FastTests.Corax
             Assert.True(type.HasFlag(IndexEntryFieldType.List));
             Assert.Equal(0, sequenceValue.Length);
 
-            reader = new IndexEntryReader(element.ToSpan());
+            reader = new IndexEntryReader(element.Ptr, element.Length);
             Assert.True(reader.GetReaderFor(1).TryReadMany( out var iterator));
             type = reader.GetFieldType(1, out var offset);
             Assert.True(type.HasFlag(IndexEntryFieldType.Empty));
@@ -440,7 +440,7 @@ namespace FastTests.Corax
             writer.Write(3, new StringArrayIterator(values), longs, doubles);
             using var ___ = writer.Finish(out var element);
 
-            var reader = new IndexEntryReader(element.ToSpan());
+            var reader = new IndexEntryReader(element.Ptr, element.Length);
 
             var iterator = reader.GetReaderFor(0).ReadMany();
             Assert.True(iterator.IsValid);

--- a/test/FastTests/Corax/SpatialTests.cs
+++ b/test/FastTests/Corax/SpatialTests.cs
@@ -16,6 +16,7 @@ using Voron;
 using Xunit;
 using Xunit.Abstractions;
 using Sparrow.Threading;
+using System.Xml.Linq;
 
 namespace FastTests.Corax;
 
@@ -115,8 +116,7 @@ public class SpatialTests : StorageTest
             _points[i] = new CoraxSpatialPointEntry(lat[i], lon[i], Spatial4n.Util.GeohashUtils.EncodeLatLon(lat[i], lon[i], 9));
         entryBuilder.WriteSpatial(CoordinatesIndex, _points);
         using var _ = entryBuilder.Finish(out var buffer);
-
-        var reader = new IndexEntryReader(buffer.ToSpan());
+        var reader = new IndexEntryReader(buffer.Ptr, buffer.Length);
 
         Assert.True(reader.GetFieldType(CoordinatesIndex, out var intOffset).HasFlag(IndexEntryFieldType.SpatialPointList));
         var iterator = reader.ReadManySpatialPoint(CoordinatesIndex);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19534
https://issues.hibernatingrhinos.com/issue/RavenDB-19531

### Additional description

Remove the underlying spans of `IndexReader` related structs. Now they are no longer `ref struct` ensuring we can pass references around as they were intended to be used. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
