### PR TITLE
RavenDB-19537 Remove word 'Count' from stats page

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
@@ -74,7 +74,7 @@ class replicationAccessBaseModel {
     }
     
     getSingleDocumentPatternWarning() {
-        return "Path patterns that do Not end with * (asterisk) will match only a single document";
+        return "Path patterns that do not end with * (asterisk) will match only a single document";
     }
 
     addHubToSinkInputPrefixWithBlink() {

--- a/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
@@ -63,19 +63,19 @@
         <div class="row">
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-documents"></i> <span>Documents Count</span></div>
+                    <div class="name"><i class="icon-documents"></i> <span>Documents</span></div>
                     <div class="value"><span data-bind="text: countOfDocuments"></span></div>
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-new-counter"></i><span>Counters Count</span></div>
+                    <div class="name"><i class="icon-new-counter"></i><span>Counters</span></div>
                     <div class="value"><span data-bind="text: countOfCounters"></span></div>
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-identities"></i><span>Identities Count</span></div>
+                    <div class="name"><i class="icon-identities"></i><span>Identities</span></div>
                     <div class="value"><span data-bind="text: countOfIdentities"></span></div>
                 </div>
             </div>
@@ -83,19 +83,19 @@
         <div class="row">
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-indexing"></i><span>Indexes Count</span></div>
+                    <div class="name"><i class="icon-indexing"></i><span>Indexes</span></div>
                     <div class="value"><span data-bind="text: countOfIndexes"></span></div>
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-revisions"></i><span>Revisions Count</span></div>
+                    <div class="name"><i class="icon-revisions"></i><span>Revisions</span></div>
                     <div class="value"><span data-bind="text: countOfRevisions"></span></div>
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-conflicts"></i><span>Conflicts Count</span></div>
+                    <div class="name"><i class="icon-conflicts"></i><span>Conflicts</span></div>
                     <div class="value"><span data-bind="text: countOfDocumentsConflicts"></span></div>
                 </div>
             </div>
@@ -103,7 +103,7 @@
         <div class="row">
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-attachment"></i><span>Attachments Count</span></div>
+                    <div class="name"><i class="icon-attachment"></i><span>Attachments</span></div>
                     <div class="value">
                         <span data-bind="text: countOfAttachments"></span>
                         <span data-bind="visible: countOfAttachments !== countOfUniqueAttachments" class="text-muted"> / </span>
@@ -115,13 +115,13 @@
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-cmp-xchg"></i><span>Compare Exchange Count</span></div>
+                    <div class="name"><i class="icon-cmp-xchg"></i><span>Compare Exchange</span></div>
                     <div class="value"><span data-bind="text: countOfCompareExchange"></span></div>
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-zombie"></i><span>Tombstones Count</span></div>
+                    <div class="name"><i class="icon-zombie"></i><span>Tombstones</span></div>
                     <div class="value"><span data-bind="text: countOfTombstones"></span></div>
                 </div>
             </div>
@@ -129,7 +129,7 @@
         <div class="row">
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item">
-                    <div class="name"><i class="icon-timeseries-settings"></i><span>Time Series Segments Count</span>
+                    <div class="name"><i class="icon-timeseries-settings"></i><span>Time Series Segments</span>
                         <span class="margin-left margin-left-sm js-timeseries-segments has-info-icon"><i class="icon-info text-info"></i></span>
                     </div>
                     <div class="value"><span data-bind="text: countOfTimeSeriesSegments"></span></div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19537

### Additional description
* Remove word `Count` from stats page
* Fixed `Not => not` (as discussed in https://github.com/ravendb/ravendb/pull/15010#discussion_r982157373)

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
