### PR TITLE
RavenDB-19470 Handle the leaks of RqlQueries on the SYNC Postgre message

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/HardcodedQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/HardcodedQuery.cs
@@ -96,8 +96,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 var statementName = normalizedQuery.Split("\"")[1];
                 if (session.NamedStatements.TryRemove(statementName, out var statement) == false)
                     throw new InvalidOperationException($"Failed to remove prepared statement '{statementName}'");
-                statement.IsNamedStatement = false;
-                statement.Dispose();
+                statement.Dispose(); // precaution - query context should be already disposed
                 result = new PgTable();
             }
                 

--- a/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
@@ -82,7 +82,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Messages
             {
                 if (transaction.Session.NamedStatements.TryAdd(StatementName, transaction._currentQuery) == false)
                     throw new ArgumentException($"Failed to store statement under the name '{StatementName}', there is already a statement with such name.");
-
+                transaction._currentQuery.IsNamedStatement = true;
             }
             await writer.WriteAsync(messageBuilder.ParseComplete(), token);
         }

--- a/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
@@ -80,7 +80,6 @@ namespace Raven.Server.Integrations.PostgreSQL.Messages
             transaction.Init(cleanQueryText, ParametersDataTypes);
             if (!string.IsNullOrEmpty(StatementName))
             {
-                transaction._currentQuery.IsNamedStatement = true;
                 if (transaction.Session.NamedStatements.TryAdd(StatementName, transaction._currentQuery) == false)
                     throw new ArgumentException($"Failed to store statement under the name '{StatementName}', there is already a statement with such name.");
 

--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -23,6 +23,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         public Dictionary<string, object> Parameters;
         protected readonly Dictionary<string, PgColumn> Columns;
         private short[] _resultColumnFormatCodes;
+        public bool IsNamedStatement { get; set; } = false;
 
         protected PgQuery(string queryString, int[] parametersDataTypes)
         {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -23,7 +23,6 @@ namespace Raven.Server.Integrations.PostgreSQL
         public Dictionary<string, object> Parameters;
         protected readonly Dictionary<string, PgColumn> Columns;
         private short[] _resultColumnFormatCodes;
-        internal bool IsNamedStatement { get; set; }
 
         protected PgQuery(string queryString, int[] parametersDataTypes)
         {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgTransaction.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgTransaction.cs
@@ -82,8 +82,8 @@ namespace Raven.Server.Integrations.PostgreSQL
         public void Sync()
         {
             State = TransactionState.Idle;
-            _currentQuery = null;
             _currentQuery?.Dispose();
+            _currentQuery = null;
         }
 
         public void Dispose()

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -197,7 +197,12 @@ namespace Raven.Server.Integrations.PostgreSQL
                 }
 
                 if (_result == null)
-                    throw new InvalidOperationException("RqlQuery.Execute was called when _results = null");
+                {
+                    if (IsNamedStatement)
+                        _result = await RunRqlQuery();
+                    else
+                        throw new InvalidOperationException("RqlQuery.Execute was called when _results = null");
+                }
 
                 if (_limit == 0 || _result == null || _result.Count == 0)
                 {
@@ -360,6 +365,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             GC.SuppressFinalize(this);
             _queryOperationContext?.Dispose();
             _queryOperationContext = null;
+            _result = null;
         }
     }
 }

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -282,8 +282,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             }
             finally
             {
-                _queryOperationContext?.Dispose();
-                _queryOperationContext = null;
+                ReleaseQueryResources();
             }
             
         }
@@ -360,12 +359,17 @@ namespace Raven.Server.Integrations.PostgreSQL
             return null;
         }
 
-        public override void Dispose()
+        public void ReleaseQueryResources()
         {
-            GC.SuppressFinalize(this);
             _queryOperationContext?.Dispose();
             _queryOperationContext = null;
             _result = null;
+        }
+        
+        public override void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            ReleaseQueryResources();
         }
     }
 }

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -32,10 +32,10 @@ namespace Raven.Server.Integrations.PostgreSQL
 
         ~RqlQuery()
         {
-            Logger.Operations($"Query '{this.QueryString}' wasn't disposed properly.\n" +
-                            $"Query was run: {_queryWasRun}\n" +
-                            $"Are transactions still opened: {_queryOperationContext.AreTransactionsOpened()}\n");
-
+            if(Logger.IsOperationsEnabled)
+                Logger.Operations($"Query '{QueryString}' wasn't disposed properly.{Environment.NewLine}" +
+                                $"Query was run: {_queryWasRun}{Environment.NewLine}" +
+                                $"Are transactions still opened: {_queryOperationContext.AreTransactionsOpened()}{Environment.NewLine}");
             Dispose();
         }
         

--- a/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB-19470.cs
+++ b/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB-19470.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL
+{
+    public class RavenDB_19470 : PostgreSqlIntegrationTestBase
+    {
+        public RavenDB_19470(ITestOutputHelper output) : base(output)
+        {
+        }
+        private List<string> GetColumnNames(DataTable dataTable)
+        {
+            return dataTable.Columns
+                .Cast<DataColumn>()
+                .Select(x => x.ColumnName)
+                .ToList();
+        }
+        
+        [Fact]
+        public async Task ForSpecificDatabase_AndSpecificQuery_GetCorrectSelectedFields_NamedStatements()
+        {
+            const string firstField = "FirstName";
+            const string secondField = "LastName";
+            string query = $"from Employees select {firstField}, {secondField}";
+
+            DoNotReuseServer(EnablePostgresSqlSettings);
+
+            using (var store = GetDocumentStore())
+            {
+                Samples.CreateNorthwindDatabase(store);
+
+                var result = await Act(store, query, Server, prepareExecute: true);
+
+                Assert.NotNull(result);
+                Assert.NotEmpty(result.Columns);
+
+                var columns = GetColumnNames(result);
+                Assert.Contains(firstField, columns);
+                Assert.Contains(secondField, columns);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19470/Suddenly-220GB-of-scratch-buffers-created-taking-all-space

### Previous PR  (based on v5.4)
https://github.com/ravendb/ravendb/pull/15226

### Additional description

The scratch buffers were created by multiple hanging read transactions, that were created inside the PowerBI integration `RqlQuery `class, which executes queries using a `QueryOperationContext`.
While calling `RqlQuery.Dispose()`, `QueryOperationContext` should be disposed and thus transactions should be closed but we've leaked `RqlQuery` inside the `Sync()` method of the `PgTransaction` class.
As a result of the leak query contexts weren't disposed and transactions remained open.

After the fix, we don't leak RqlQueries anymore and dispose them properly on the SYNC messages.
In addition, I've added an 'emergency' RqlQuery _destructor_ that'll log such errors in the future and handle the leaks.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
