### PR TITLE
RavenDB-7070 Convert `actual` too in `AssertEqualRespectingNewLines` and `AssertStartsWithRespectingNewLines`

### DIFF
--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -157,16 +157,17 @@ namespace FastTests
 
         public static void AssertEqualRespectingNewLines(string expected, string actual)
         {
-            var converted = ConvertRespectingNewLines(expected);
-
-            Assert.Equal(converted, actual);
+            var convertedExpected = ConvertRespectingNewLines(expected);
+            var convertedActual = ConvertRespectingNewLines(actual);
+            Assert.Equal(convertedExpected, convertedActual);
         }
 
         public static void AssertStartsWithRespectingNewLines(string expected, string actual)
         {
-            var converted = ConvertRespectingNewLines(expected);
-
-            Assert.StartsWith(converted, actual);
+            var convertedExpected = ConvertRespectingNewLines(expected);
+            var convertedActual = ConvertRespectingNewLines(actual);
+            
+            Assert.StartsWith(convertedExpected, convertedActual);
         }
 
         public static void AreEquivalent<T>(IEnumerable<T> expected, IEnumerable<T> actual)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14857/ServerDocumentsIndexingRavenLinqOptimizerTestsCanOptimizeExpression-and-SlowTestsServerDocumentsIndexingIndexMerging-multiple

### Additional description

Fixing assertions in `IndexMerger` for Linux.

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
