### PR TITLE
RavenDB-19535 when RAVEN_IS_RUNNING_ON_CI is set to true we require all connections to work

### DIFF
--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -100,7 +100,7 @@ loadToTestGuidEtls(item);"
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
 using Tests.Infrastructure.ConnectionString;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ namespace SlowTests.Server.Documents.ETL
         {
         }
 
-        [Fact]
+        [RequiresMsSqlFact]
         public void CanAddAndRemoveConnectionStrings()
         {
             using (var store = GetDocumentStore())
@@ -34,7 +35,7 @@ namespace SlowTests.Server.Documents.ETL
                 var sqlConnectionString = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
                 };
 
                 var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -73,7 +74,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [Fact]
+        [RequiresMsSqlFact]
         public void CanUpdateConnectionStrings()
         {
             using (var store = GetDocumentStore())
@@ -90,7 +91,7 @@ namespace SlowTests.Server.Documents.ETL
                 var sqlConnectionString = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
                 };
 
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -124,7 +125,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [Fact]
+        [RequiresMsSqlFact]
         public void CanGetAllConnectionStrings()
         {
             using (var store = GetDocumentStore())
@@ -142,7 +143,7 @@ namespace SlowTests.Server.Documents.ETL
                     var sqlConnectionStr = new SqlConnectionString
                     {
                         Name = $"SqlConnectionString{i}",
-                        ConnectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
                     };
 
                     ravenConnectionStrings.Add(ravenConnectionStr);
@@ -170,7 +171,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [Fact]
+        [RequiresMsSqlFact]
         public void CanGetConnectionStringByName()
         {
             using (var store = GetDocumentStore())
@@ -187,7 +188,7 @@ namespace SlowTests.Server.Documents.ETL
                 var sqlConnectionStr = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
                 };
 
                 ravenConnectionStrings.Add(ravenConnectionStr);

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -30,8 +30,8 @@ using Raven.Server.SqlMigration;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Server.Documents.Migration;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Tests.Infrastructure.ConnectionString;
-using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -66,7 +66,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 loadToOrders(orderData);
 ";
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task ReplicateMultipleBatches()
         {
             using (var store = GetDocumentStore())
@@ -141,7 +141,7 @@ CREATE TABLE [dbo].[Orders]
 
             using (var con = new SqlConnection())
             {
-                con.ConnectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value;
+                con.ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value;
                 con.Open();
 
                 foreach (var dbName in _dbNames)
@@ -157,7 +157,7 @@ DROP DATABASE [SqlReplication-{dbName}]";
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task SimpleTransformation()
         {
             using (var store = GetDocumentStore())
@@ -201,9 +201,7 @@ DROP DATABASE [SqlReplication-{dbName}]";
             }
         }
 
-
-
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task ShouldHandleCaseMismatchBetweenTableDefinitionAndLoadTo()
         {
             using (var store = GetDocumentStore())
@@ -257,7 +255,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanLoadToTableWithSchemaName()
         {
             using (var store = GetDocumentStore())
@@ -321,7 +319,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
             }
         }
 
-        [Fact]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task NullPropagation()
         {
             using (var store = GetDocumentStore())
@@ -370,7 +368,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task NullPropagation_WithExplicitNull()
         {
             using (var store = GetDocumentStore())
@@ -420,7 +418,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task RavenDB_3341()
         {
             using (var store = GetDocumentStore())
@@ -472,7 +470,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanUpdateToBeNoItemsInChildTable()
         {
             using (var store = GetDocumentStore())
@@ -517,7 +515,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanDelete()
         {
             using (var store = GetDocumentStore())
@@ -558,7 +556,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task RavenDB_3172()
         {
             using (var store = GetDocumentStore())
@@ -603,7 +601,7 @@ loadToOrders(orderData);");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task WillLog()
         {
             using (var client = new ClientWebSocket())
@@ -673,7 +671,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
             }
         }
 
-        [Theory]
+        [RequiresMsSqlRetryTheory(delayBetweenRetriesMs: 1000)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanTestScript(bool performRolledBackTransaction)
@@ -754,7 +752,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
             }
         }
 
-        [Theory]
+        [RequiresMsSqlRetryTheory(delayBetweenRetriesMs: 1000)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanTestDeletion(bool performRolledBackTransaction)
@@ -832,7 +830,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingSingleAttachment()
         {
             using (var store = GetDocumentStore())
@@ -901,7 +899,7 @@ loadToOrders(orderData);
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task Should_error_if_attachment_doesnt_exist()
         {
             using (var store = GetDocumentStore())
@@ -974,7 +972,7 @@ loadToOrders(orderData);
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingMultipleAttachments()
         {
             using (var store = GetDocumentStore())
@@ -1049,7 +1047,7 @@ for (var i = 0; i < attachments.length; i++)
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanSkipSettingFieldIfAttachmentDoesntExist()
         {
             using (var store = GetDocumentStore())
@@ -1106,7 +1104,7 @@ loadToOrders(orderData);
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task LoadingFromMultipleCollections()
         {
             using (var store = GetDocumentStore())
@@ -1153,7 +1151,7 @@ loadToOrders(orderData);
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanUseVarcharAndNVarcharFunctions()
         {
             using (var store = GetDocumentStore())
@@ -1223,7 +1221,7 @@ loadToUsers(
             }
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public void Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
         {
             using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxBatchSize)] = "5" }))

--- a/test/SlowTests/Server/Documents/Migration/AttachmentsTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/AttachmentsTest.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -83,7 +83,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]

--- a/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
+++ b/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -72,7 +72,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -136,7 +136,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -198,7 +198,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -249,7 +249,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -313,7 +313,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresMySqlInlineData]
         public async Task CanMigrateLinkOnChild(MigrationProvider provider)
@@ -384,7 +384,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -465,7 +465,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -541,7 +541,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -595,7 +595,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -652,7 +652,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]
@@ -692,7 +692,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
         [RequiresMySqlInlineData]

--- a/test/SlowTests/Server/Documents/Migration/MsSQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/MsSQLSchemaTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Raven.Server.SqlMigration;
 using Raven.Server.SqlMigration.Schema;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,7 +13,7 @@ namespace SlowTests.Server.Documents.Migration
         {
         }
 
-        [Fact]
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
         public void CanFetchSchema()
         {
             using (WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, includeData: false))
@@ -30,20 +31,20 @@ namespace SlowTests.Server.Documents.Migration
                 var noPkTable = tables.First(x => x.TableName == "NoPkTable");
                 Assert.NotNull(noPkTable);
 
-                Assert.Equal(new[] {"Id"}, noPkTable.Columns.Select(x => x.Name).ToList());
+                Assert.Equal(new[] { "Id" }, noPkTable.Columns.Select(x => x.Name).ToList());
                 Assert.Equal(0, noPkTable.PrimaryKeyColumns.Count);
 
                 // validate Order Table
                 var orderTable = tables.First(x => x.TableName == "Order");
 
                 Assert.Equal(4, orderTable.Columns.Count);
-                Assert.Equal(new[] {"Id", "OrderDate", "CustomerId", "TotalAmount"}, orderTable.Columns.Select(x => x.Name).ToList());
-                Assert.Equal(new[] {"Id"}, orderTable.PrimaryKeyColumns);
+                Assert.Equal(new[] { "Id", "OrderDate", "CustomerId", "TotalAmount" }, orderTable.Columns.Select(x => x.Name).ToList());
+                Assert.Equal(new[] { "Id" }, orderTable.PrimaryKeyColumns);
 
                 var orderReferences = orderTable.References;
                 Assert.Equal(1, orderReferences.Count);
                 Assert.Equal("OrderItem", orderReferences[0].Table);
-                Assert.Equal(new[] {"OrderId"}, orderReferences[0].Columns);
+                Assert.Equal(new[] { "OrderId" }, orderReferences[0].Columns);
 
                 // validate UnsupportedTable
 
@@ -53,11 +54,11 @@ namespace SlowTests.Server.Documents.Migration
                 // validate OrderItem (2 columns in PK)
 
                 var orderItemTable = tables.First(x => x.TableName == "OrderItem");
-                Assert.Equal(new[] {"OrderId", "ProductId"}, orderItemTable.PrimaryKeyColumns);
+                Assert.Equal(new[] { "OrderId", "ProductId" }, orderItemTable.PrimaryKeyColumns);
 
                 Assert.Equal(1, orderItemTable.References.Count);
                 Assert.Equal("Details", orderItemTable.References[0].Table);
-                Assert.Equal(new[] {"OrderId", "ProductId"}, orderItemTable.References[0].Columns);
+                Assert.Equal(new[] { "OrderId", "ProductId" }, orderItemTable.References[0].Columns);
 
                 // all types are supported (except UnsupportedTable)
                 Assert.True(tables.Where(x => x.TableName != "UnsupportedTable")

--- a/test/SlowTests/Server/Documents/Migration/PatchTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/PatchTest.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -107,7 +107,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]

--- a/test/SlowTests/Server/Documents/Migration/RecursiveMigrationTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/RecursiveMigrationTest.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -76,7 +76,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -129,7 +129,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]

--- a/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
+++ b/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
@@ -147,9 +147,9 @@ namespace SlowTests.Server.Documents.Migration
         private static DisposableAction WithMsSqlDatabase(out string connectionString, out string databaseName, string dataSet, bool includeData = true)
         {
             databaseName = "SqlTest_" + Guid.NewGuid();
-            connectionString = MssqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={databaseName}";
+            connectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={databaseName}";
 
-            using (var connection = new SqlConnection(MssqlConnectionString.Instance.VerifiedConnectionString.Value))
+            using (var connection = new SqlConnection(MsSqlConnectionString.Instance.VerifiedConnectionString.Value))
             {
                 connection.Open();
 
@@ -209,7 +209,7 @@ namespace SlowTests.Server.Documents.Migration
                 {
                     try
                     {
-                        using (var con = new SqlConnection(MssqlConnectionString.Instance.VerifiedConnectionString.Value))
+                        using (var con = new SqlConnection(MsSqlConnectionString.Instance.VerifiedConnectionString.Value))
                         {
                             con.Open();
 

--- a/test/SlowTests/Server/Documents/Migration/TestMigrationTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/TestMigrationTest.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
@@ -99,7 +99,7 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [NightlyBuildTheory]
-        [InlineData(MigrationProvider.MsSQL)]
+        [RequiresMsSqlInlineData]
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]

--- a/test/Tests.Infrastructure/AmazonGlacierFactAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonGlacierFactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -39,6 +40,9 @@ namespace Tests.Infrastructure
 
         public AmazonGlacierFactAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{GlacierCredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/AmazonGlacierTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonGlacierTheoryAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -39,6 +40,9 @@ namespace Tests.Infrastructure
 
         public AmazonGlacierTheoryAttribute([CallerMemberName] string memberName = "")
         {
+            //if (RavenTestHelper.IsRunningOnCI)
+            //    return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{GlacierCredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/AmazonS3FactAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonS3FactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -39,6 +40,9 @@ namespace Tests.Infrastructure
 
         public AmazonS3FactAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{S3CredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/AmazonS3TheoryAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonS3TheoryAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -39,6 +40,9 @@ namespace Tests.Infrastructure
 
         public AmazonS3TheoryAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{S3CredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/AzureFactAttribute.cs
+++ b/test/Tests.Infrastructure/AzureFactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -39,6 +40,9 @@ namespace Tests.Infrastructure
 
         public AzureFactAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{AzureCredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/AzureSasTokenFactAttribute.cs
+++ b/test/Tests.Infrastructure/AzureSasTokenFactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -19,6 +20,8 @@ namespace Tests.Infrastructure
         static AzureSasTokenFactAttribute()
         {
             var azureSettingsString = Environment.GetEnvironmentVariable(AzureCredentialEnvironmentVariable);
+            if (azureSettingsString == null)
+                return;
 
             try
             {
@@ -32,13 +35,16 @@ namespace Tests.Infrastructure
 
         public AzureSasTokenFactAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (string.IsNullOrEmpty(ParsingError) == false)
             {
                 Skip = $"Failed to parse the Azure settings, error: {ParsingError}";
                 return;
             }
 
-            if (AzureSettings == null)
+            if (_azureSettings == null)
             {
                 Skip = $"S3 {memberName} tests missing Azure settings.";
                 return;

--- a/test/Tests.Infrastructure/AzureTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/AzureTheoryAttribute.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using FastTests;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -36,20 +38,27 @@ namespace Tests.Infrastructure
             }
         }
 
-        public override string Skip
+        public AzureTheoryAttribute([CallerMemberName] string memberName = "")
         {
-            get
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (EnvVariableMissing)
             {
-                if (EnvVariableMissing)
-                    return $"Test is missing '{AzureCredentialEnvironmentVariable}' environment variable.";
+                Skip = $"Test is missing '{AzureCredentialEnvironmentVariable}' environment variable.";
+                return;
+            }
 
-                if (string.IsNullOrEmpty(ParsingError) == false)
-                    return $"Failed to parse the Azure settings, error: {ParsingError}";
+            if (string.IsNullOrEmpty(ParsingError) == false)
+            {
+                Skip = $"Failed to parse the Azure settings, error: {ParsingError}";
+                return;
+            }
 
-                if (_azureSettings == null)
-                    return $"Azure tests missing {nameof(AzureSettings)}.";
-
-                return null;
+            if (_azureSettings == null)
+            {
+                Skip = $"Azure {memberName} tests missing {nameof(AzureSettings)}.";
+                return;
             }
         }
     }

--- a/test/Tests.Infrastructure/ConnectionString/MongoDBConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MongoDBConnectionString.cs
@@ -7,7 +7,7 @@ namespace Tests.Infrastructure.ConnectionString
     public class MongoDBConnectionString
     {
         private static MongoDBConnectionString _instance;
-        public static MongoDBConnectionString Instance => _instance ?? (_instance = new MongoDBConnectionString());
+        public static MongoDBConnectionString Instance => _instance ??= new MongoDBConnectionString();
 
         public Lazy<string> ConnectionString { get; }
 
@@ -26,7 +26,11 @@ namespace Tests.Infrastructure.ConnectionString
         {
             try
             {
-                var client = new MongoClient(ConnectionString.Value);
+                var connectionString = ConnectionString.Value;
+                if (string.IsNullOrEmpty(connectionString))
+                    return false;
+
+                var client = new MongoClient(connectionString);
                 var adminDb = client.GetDatabase("admin");
                 var isMongoLive = adminDb.RunCommandAsync((Command<BsonDocument>)"{ping:1}").Wait(1000);
 

--- a/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
@@ -3,17 +3,17 @@ using System.Data.SqlClient;
 
 namespace Tests.Infrastructure.ConnectionString
 {
-    public class MssqlConnectionString : SqlConnectionString<SqlConnection>
+    public class MsSqlConnectionString : SqlConnectionString<SqlConnection>
     {
         private const string EnvironmentVariable = "RAVEN_MSSQL_CONNECTION_STRING";
 
-        public static readonly MssqlConnectionString Instance = new MssqlConnectionString();
+        public static readonly MsSqlConnectionString Instance = new MsSqlConnectionString();
 
-        private MssqlConnectionString() : base(EnvironmentVariable)
+        private MsSqlConnectionString() : base(EnvironmentVariable)
         {
         }
 
-        protected override string VerifiedConnectionStringFactor()
+        protected override string VerifiedConnectionStringFactory(string cs)
         {
             const string localConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3";
             if (TryConnect(localConnectionString, out var errorMessage))

--- a/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
@@ -5,7 +5,7 @@ namespace Tests.Infrastructure.ConnectionString
     public class MySqlConnectionString : SqlConnectionString<MySqlConnection>
     {
         private static MySqlConnectionString _instance;
-        public static MySqlConnectionString Instance => _instance ?? (_instance = new MySqlConnectionString());
+        public static MySqlConnectionString Instance => _instance ??= new MySqlConnectionString();
 
         private MySqlConnectionString() : base("RAVEN_MYSQL_CONNECTION_STRING")
         {

--- a/test/Tests.Infrastructure/ConnectionString/OracleConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/OracleConnectionString.cs
@@ -4,16 +4,16 @@ using Oracle.ManagedDataAccess.Client;
 
 namespace Tests.Infrastructure.ConnectionString
 {
-    public class OracleConnectionString :SqlConnectionString<OracleConnection>
+    public class OracleConnectionString : SqlConnectionString<OracleConnection>
     {
         private static OracleConnectionString _instance;
-        public static OracleConnectionString Instance => _instance ?? (_instance = new OracleConnectionString());
+        public static OracleConnectionString Instance => _instance ??= new OracleConnectionString();
 
         private OracleConnectionString() : base("RAVEN_ORACLESQL_CONNECTION_STRING")
         {
             AdditionFlags = "Pooling=false"; // have to use pooling=false, otherwise closed connections are kept IDLE.
         }
-        
+
         public string GetUserConnectionString(string newId, string newPassword)
         {
             var userConnectionString = Regex.Replace(VerifiedConnectionString.Value, "((?i:DBA Privilege)|(?i:User Id)|(?i:Password))=.+?(?:;|\\z)", (m) =>

--- a/test/Tests.Infrastructure/CustomS3FactAttribute.cs
+++ b/test/Tests.Infrastructure/CustomS3FactAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
@@ -42,6 +43,9 @@ namespace Tests.Infrastructure
 
         public CustomS3FactAttribute([CallerMemberName] string memberName = "")
         {
+            //if (RavenTestHelper.IsRunningOnCI)
+            //    return;
+
             if (EnvVariableMissing)
             {
                 Skip = $"Test is missing '{S3CredentialEnvironmentVariable}' environment variable.";

--- a/test/Tests.Infrastructure/GoogleCloudFactAttribute.cs
+++ b/test/Tests.Infrastructure/GoogleCloudFactAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using FastTests;
 using Raven.Client.Documents.Operations.Backups;
 using Xunit;
 
@@ -23,6 +24,9 @@ namespace Tests.Infrastructure
 
         public GoogleCloudFactAttribute([CallerMemberName] string memberName = "")
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (string.IsNullOrWhiteSpace(GoogleCloudSettings.BucketName))
             {
                 Skip = $"Google cloud {memberName} tests missing {BucketNameEnvironmentVariable} environment variable.";

--- a/test/Tests.Infrastructure/RequiresMongoDBFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMongoDBFactAttribute.cs
@@ -1,3 +1,4 @@
+using FastTests;
 using Tests.Infrastructure.ConnectionString;
 using Xunit;
 
@@ -7,6 +8,9 @@ namespace Tests.Infrastructure
     {
         public RequiresMongoDBFactAttribute()
         {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
             if (MongoDBConnectionString.Instance.CanConnect() == false)
                 Skip = "Test requires MongoDB";
         }

--- a/test/Tests.Infrastructure/RequiresMsSqlFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlFactAttribute.cs
@@ -1,0 +1,17 @@
+﻿using FastTests;
+using Tests.Infrastructure.ConnectionString;
+using Xunit;
+
+namespace Tests.Infrastructure;
+
+public class RequiresMsSqlFactAttribute : FactAttribute
+{
+    public RequiresMsSqlFactAttribute()
+    {
+        if (RavenTestHelper.IsRunningOnCI)
+            return;
+
+        if (MsSqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MsSQL database";
+    }
+}

--- a/test/Tests.Infrastructure/RequiresMsSqlInlineData.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlInlineData.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Reflection;
+using FastTests;
+using Raven.Server.SqlMigration;
+using Tests.Infrastructure.ConnectionString;
+using Xunit.Sdk;
+
+namespace Tests.Infrastructure;
+
+public class RequiresMsSqlInlineData : DataAttribute
+{
+    public RequiresMsSqlInlineData()
+    {
+        if (RavenTestHelper.IsRunningOnCI)
+            return;
+
+        if (MsSqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MsSQL database";
+    }
+
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        return new[] { new object[] { MigrationProvider.MsSQL } };
+    }
+}

--- a/test/Tests.Infrastructure/RequiresMsSqlRetryFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlRetryFactAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using FastTests;
+using Tests.Infrastructure.ConnectionString;
+using xRetry;
+
+namespace Tests.Infrastructure;
+
+public class RequiresMsSqlRetryFactAttribute : RetryFactAttribute
+{
+    public RequiresMsSqlRetryFactAttribute(int maxRetries = 3, int delayBetweenRetriesMs = 0, params Type[] skipOnExceptions)
+        : base(maxRetries, delayBetweenRetriesMs, skipOnExceptions)
+    {
+        if (RavenTestHelper.IsRunningOnCI)
+            return;
+
+        if (MySqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MySQL database";
+    }
+}

--- a/test/Tests.Infrastructure/RequiresMsSqlRetryTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlRetryTheoryAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using FastTests;
+using Tests.Infrastructure.ConnectionString;
+using xRetry;
+
+namespace Tests.Infrastructure;
+
+public class RequiresMsSqlRetryTheoryAttribute : RetryTheoryAttribute
+{
+    public RequiresMsSqlRetryTheoryAttribute(int maxRetries = 3, int delayBetweenRetriesMs = 0, params Type[] skipOnExceptions)
+        : base(maxRetries, delayBetweenRetriesMs, skipOnExceptions)
+    {
+        if (RavenTestHelper.IsRunningOnCI)
+            return;
+
+        if (MySqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MySQL database";
+    }
+}

--- a/test/Tests.Infrastructure/RequiresMySqlFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMySqlFactAttribute.cs
@@ -1,4 +1,5 @@
-﻿using Tests.Infrastructure.ConnectionString;
+﻿using FastTests;
+using Tests.Infrastructure.ConnectionString;
 using Xunit;
 
 namespace Tests.Infrastructure
@@ -7,7 +8,10 @@ namespace Tests.Infrastructure
     {
         public RequiresMySqlFactAttribute()
         {
-            if (MySqlConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (MySqlConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires MySQL database";
         }
     }

--- a/test/Tests.Infrastructure/RequiresMySqlInlineData.cs
+++ b/test/Tests.Infrastructure/RequiresMySqlInlineData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using FastTests;
 using Raven.Server.SqlMigration;
 using Tests.Infrastructure.ConnectionString;
 using Xunit.Sdk;
@@ -10,7 +11,10 @@ namespace Tests.Infrastructure
     {
         public RequiresMySqlInlineData()
         {
-            if (MySqlConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (MySqlConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires MySQL database";
         }
 

--- a/test/Tests.Infrastructure/RequiresNpgSqlFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresNpgSqlFactAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FastTests;
 using Npgsql;
 using Tests.Infrastructure.ConnectionString;
 using Xunit;
@@ -9,7 +10,10 @@ namespace Tests.Infrastructure
     {
         public RequiresNpgSqlFactAttribute()
         {
-            if (NpgSqlConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (NpgSqlConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires NpgSQL database";
         }
     }

--- a/test/Tests.Infrastructure/RequiresNpgSqlInlineData.cs
+++ b/test/Tests.Infrastructure/RequiresNpgSqlInlineData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using FastTests;
 using Raven.Server.SqlMigration;
 using Tests.Infrastructure.ConnectionString;
 using Xunit.Sdk;
@@ -10,7 +11,10 @@ namespace Tests.Infrastructure
     {
         public RequiresNpgSqlInlineData()
         {
-            if (NpgSqlConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (NpgSqlConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires NpgSQL database";
         }
 

--- a/test/Tests.Infrastructure/RequiresOracleSqlFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresOracleSqlFactAttribute.cs
@@ -1,4 +1,5 @@
-﻿using Tests.Infrastructure.ConnectionString;
+﻿using FastTests;
+using Tests.Infrastructure.ConnectionString;
 using Xunit;
 
 namespace Tests.Infrastructure
@@ -7,7 +8,10 @@ namespace Tests.Infrastructure
     {
         public RequiresOracleSqlFactAttribute()
         {
-            if (OracleConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (OracleConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires Oracle database";
         }
     }

--- a/test/Tests.Infrastructure/RequiresOracleSqlInlineData.cs
+++ b/test/Tests.Infrastructure/RequiresOracleSqlInlineData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using FastTests;
 using Raven.Server.SqlMigration;
 using Tests.Infrastructure.ConnectionString;
 using Xunit.Sdk;
@@ -10,7 +11,10 @@ namespace Tests.Infrastructure
     {
         public RequiresOracleSqlInlineData()
         {
-            if (OracleConnectionString.Instance.CanConnect() == false)
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (OracleConnectionString.Instance.CanConnect == false)
                 Skip = "Test requires Oracle database";
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19535

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
