### PR TITLE
RavenDB-19542 - add debug info with more info for each tombstone subscription

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2120,7 +2120,7 @@ namespace Raven.Server.Documents
         private void ThrowNotSupportedExceptionForCreatingTombstoneWhenItExistsForDifferentCollection(Slice lowerId, CollectionName collectionName,
             CollectionName tombstoneCollectionName, VoronConcurrencyErrorException e)
         {
-            var tombstoneCleanerState = DocumentDatabase.TombstoneCleaner.GetState();
+            var tombstoneCleanerState = DocumentDatabase.TombstoneCleaner.GetState().Tombstones;
             if (tombstoneCleanerState.TryGetValue(tombstoneCollectionName.Name, out var item) && item.Documents.Component != null)
                 throw new NotSupportedException($"Could not delete document '{lowerId}' from collection '{collectionName.Name}' because tombstone for that document already exists but in a different collection ('{tombstoneCollectionName.Name}'). Did you change the document's collection recently? If yes, please give some time for other system components (e.g. Indexing, Replication, Backup) and tombstone cleaner to process that change. At this point of time the component that holds the tombstone is '{item.Documents.Component}' with etag '{item.Documents.Etag}' and tombstone cleaner is executed every '{DocumentDatabase.Configuration.Tombstones.CleanupInterval.AsTimeSpan.TotalMinutes}' minutes.", e);
 

--- a/test/SlowTests/Issues/RavenDB_15240.cs
+++ b/test/SlowTests/Issues/RavenDB_15240.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 
                 var tombstoneCleaner = database.TombstoneCleaner;
-                var state = tombstoneCleaner.GetState();
+                var state = tombstoneCleaner.GetState().Tombstones;
 
                 Assert.Equal(0, state["Companies"].Documents.Etag);
                 Assert.Equal(2, state["Companies"].TimeSeries.Etag);
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store);
 
-                state = tombstoneCleaner.GetState();
+                state = tombstoneCleaner.GetState().Tombstones;
 
                 Assert.Equal(0, state["Companies"].Documents.Etag);
                 Assert.Equal(8, state["Companies"].TimeSeries.Etag);
@@ -72,7 +72,7 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store);
 
-                state = tombstoneCleaner.GetState();
+                state = tombstoneCleaner.GetState().Tombstones;
 
                 Assert.Equal(10, state["Companies"].Documents.Etag);
                 Assert.Equal(8, state["Companies"].TimeSeries.Etag);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19542/Add-more-info-for-the-debug-tombstones-state-endpoint

### Additional description

Add debug info with more info for each tombstone subscription.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing