### PR TITLE
RavenDB-19514: Full backup shouldn't backup tombstones

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -570,8 +570,11 @@ namespace Raven.Server.Documents.PeriodicBackup
                             IncludeArtificial = true // we want to include artificial in backup
                         };
 
-                        options.OperateOnTypes |= DatabaseItemType.Tombstones;
-                        options.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
+                        if (_isFullBackup == false)
+                        {
+                            options.OperateOnTypes |= DatabaseItemType.Tombstones;
+                            options.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
+                        }
 
                         var currentBackupResult = CreateBackup(options, tempBackupFilePath, startEtag, startRaftIndex);
 

--- a/test/SlowTests/Issues/RavenDB_19514.cs
+++ b/test/SlowTests/Issues/RavenDB_19514.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19514 : RavenTestBase
+{
+    public RavenDB_19514(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact, Trait("Category", "Smuggler")]
+    public async Task FullBackupShouldNotBackupTombstones()
+    {
+        const string userId = "user/1";
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        var config = Backup.CreateBackupConfiguration(backupPath);
+
+        using (var store = GetDocumentStore())
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Lev" }, userId);
+            await session.SaveChangesAsync();
+
+            var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+            var loadedUser = await session.LoadAsync<User>(userId);
+            session.Delete(loadedUser);
+            await session.SaveChangesAsync();
+
+            // Incremental backups are including tombstones
+            var backupOperation = store.Maintenance.ForDatabase(store.Database).Send(new StartBackupOperation(isFullBackup: false, taskId: backupTaskId));
+            var backupResult = await backupOperation.WaitForCompletionAsync() as BackupResult;
+            Assert.NotNull(backupResult);
+            Assert.Equal(1, backupResult.Tombstones.ReadCount);
+
+            // But full backups does not
+            backupOperation = store.Maintenance.ForDatabase(store.Database).Send(new StartBackupOperation(isFullBackup: true, taskId: backupTaskId));
+            backupResult = await backupOperation.WaitForCompletionAsync() as BackupResult;
+            Assert.NotNull(backupResult);
+            Assert.Equal(0, backupResult.Tombstones.ReadCount);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19514/Full-backup-shouldnt-backup-tombstones

### Additional description

Including the tombstones in a full backup makes no sense, and some customers come across with difficulty due to a large number of tombstones.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective and that the feature works.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed