### PR TITLE
RavenDB-18588 Add enums to known types.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1021,15 +1021,18 @@ namespace Raven.Client.Documents.Indexes
                 }
             }
 
+            if (type.IsEnum) // enum is known type
+                return true;
+            
+            if (type.Assembly == typeof(HashSet<>).Assembly) // System.Core
+                return true;
+            
             if (type.Assembly == typeof(object).Assembly) // mscorlib
                 return true;
 
             if (type.Assembly == typeof(Uri).Assembly) // System assembly
                 return true;
-
-            if (type.Assembly == typeof(HashSet<>).Assembly) // System.Core
-                return true;
-
+            
             if (type.Assembly == typeof(Regex).Assembly) // System.Text.RegularExpressions
                 return true;
 

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1007,7 +1007,9 @@ namespace Raven.Client.Documents.Indexes
             return type.FullName;
         }
 
-        private bool TypeExistsOnServer(Type type)
+        private bool TypeExistsOnServer(Type type) => TypeExistsOnServer(type, false);
+        
+        private bool TypeExistsOnServer(Type type, bool isGenericArgument)
         {
             if (_insideWellKnownType)
                 return true;
@@ -1016,12 +1018,12 @@ namespace Raven.Client.Documents.Indexes
             {
                 foreach (Type genericArgument in type.GetGenericArguments())
                 {
-                    if (TypeExistsOnServer(genericArgument) == false)
+                    if (TypeExistsOnServer(genericArgument, true) == false)
                         return false;
                 }
             }
-
-            if (type.IsEnum) // enum is known type
+            
+            if (type.IsEnum && isGenericArgument) // enum is known type when it is a generic argument
                 return true;
             
             if (type.Assembly == typeof(HashSet<>).Assembly) // System.Core

--- a/test/SlowTests/Issues/RavenDB_18588.cs
+++ b/test/SlowTests/Issues/RavenDB_18588.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using SlowTests.Core.Commands;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18588 : RavenTestBase
+{
+    public RavenDB_18588(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void EnumListIsProperlyCreatedInIndex()
+    {
+        using var store = GetDocumentStore();
+        var id = "secret_id";
+        {
+            using var session = store.OpenSession();
+            session.Store(new DocPage()
+            {
+                Language = Language.Csharp
+            }, id);    
+            session.SaveChanges();
+        }
+        
+        new IndexWithList().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        {
+            using var session = store.OpenSession();
+            var docPage = session.Query<DocPage, IndexWithList>().Single(i => i.Language == Language.Csharp);
+            Assert.Equal(docPage.Id, id);
+        }
+        
+    }
+
+    private class IndexWithList : AbstractIndexCreationTask<DocPage>
+    {
+        public IndexWithList()
+        {
+            Map = pages => from page in pages
+                select new
+                {
+                    Language = new List<Language> {page.Language}
+                };
+        }
+    }
+    
+    private enum Language
+    {
+        [Description("C#")]
+        Csharp,
+        [Description("Java")]
+        Java,
+    }
+    
+    private class DocPage
+    {
+        public string Id { get; set; }
+        public Language Language { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18588 

### Additional description

Due to changes made in  [RavenDB-17087 ](https://issues.hibernatingrhinos.com/issue/RavenDB-17087/IndexCompilationException-in-index-with-recurse) https://github.com/ravendb/ravendb/pull/12613 we stopped detecting `enums` as server known type which is not true. 

### Type of change

- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
