### PR TITLE
RavenDB-19544 Check why spatial query with distance doesn't work on map/reduce query

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19544.cs
+++ b/test/SlowTests/Issues/RavenDB-19544.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19544 : RavenTestBase
+{
+    public RavenDB_19544(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task CanGetSpatialDistanceOnIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await store.ExecuteIndexAsync(new RestoIndex());
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Resto { Lat = 25.0676339, Lng = 55.141291 });
+
+                await session.SaveChangesAsync();
+            }
+
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenAsyncSession())
+            {
+                var projection = 
+                    from result in session.Query<RestoIndex.Result, RestoIndex>()
+                        .Spatial(x => x.Location, c => c.WithinRadius(100000, 25, 55))
+                        .OrderByDistance(x => x.Location, 25, 55)
+                    select new
+                    {
+                        Distance = (double?)((IMetadataDictionary)RavenQuery.Metadata(result)["@spatial"])["Distance"]
+                    };
+
+                var items = await projection.ToArrayAsync();
+                Assert.NotEmpty(items);
+                foreach (var item in items)
+                {
+                    Assert.NotNull(item.Distance);
+                }
+            }
+        }
+    }
+
+
+
+    public class Resto
+    {
+        public string Id { get; set; }
+
+        public double Lat { get; set; }
+
+        public double Lng { get; set; }
+    }
+
+    public class RestoIndex : AbstractMultiMapIndexCreationTask<RestoIndex.Result>
+    {
+        public class Result
+        {
+            public string Id { get; set; } = null!;
+
+            public double LocationLatitude { get; set; }
+
+            public double LocationLongitude { get; set; }
+
+            public object? Location { get; set; }
+        }
+
+        public RestoIndex()
+        {
+            AddMap<Resto>(restaurants => from restaurant in restaurants
+                select new Result
+                {
+                    Id = restaurant.Id, LocationLatitude = (double)restaurant.Lat, LocationLongitude = (double)restaurant.Lng, Location = null,
+                });
+
+            Reduce = results => from result in results
+                group result by result.Id
+                into g
+                let restaurant = g.FirstOrDefault()
+                select new Result
+                {
+                    Id = g.Key,
+                    LocationLatitude = restaurant.LocationLatitude,
+                    LocationLongitude = restaurant.LocationLongitude,
+                    Location = CreateSpatialField(restaurant.LocationLatitude, restaurant.LocationLongitude)
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19544.cs
+++ b/test/SlowTests/Issues/RavenDB-19544.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
 using Xunit;
@@ -36,7 +33,7 @@ public class RavenDB_19544 : RavenTestBase
             Indexes.WaitForIndexing(store);
             using (var session = store.OpenAsyncSession())
             {
-                var projection = 
+                var projection =
                     from result in session.Query<MapReduceRestoIndex.Result, MapReduceRestoIndex>()
                         .Spatial(x => x.Location, c => c.WithinRadius(100000, 25, 55))
                         .OrderByDistance(x => x.Location, 25, 55)
@@ -55,7 +52,7 @@ public class RavenDB_19544 : RavenTestBase
         }
     }
 
-    
+
     [Fact]
     public async Task CanGetSpatialDistanceOnIndex_Map()
     {
@@ -73,7 +70,7 @@ public class RavenDB_19544 : RavenTestBase
             Indexes.WaitForIndexing(store);
             using (var session = store.OpenAsyncSession())
             {
-                var projection = 
+                var projection =
                     from result in session.Query<RestoIndex.Result, RestoIndex>()
                         .Spatial(x => x.Location, c => c.WithinRadius(100000, 25, 55))
                         .OrderByDistance(x => x.Location, 25, 55)
@@ -98,21 +95,19 @@ public class RavenDB_19544 : RavenTestBase
         {
             public string Id { get; set; } = null!;
 
-            public object? Location { get; set; }
+            public object Location { get; set; }
         }
 
         public RestoIndex()
         {
             Map = restaurants => from restaurant in restaurants
-                select new Result
-                {
-                    Id = restaurant.Id,
-                    Location = CreateSpatialField(restaurant.Lat, restaurant.Lng)
-                };
+                                 select new Result
+                                 {
+                                     Id = restaurant.Id,
+                                     Location = CreateSpatialField(restaurant.Lat, restaurant.Lng)
+                                 };
         }
     }
-
-
 
     private class Resto
     {
@@ -133,28 +128,31 @@ public class RavenDB_19544 : RavenTestBase
 
             public double LocationLongitude { get; set; }
 
-            public object? Location { get; set; }
+            public object Location { get; set; }
         }
 
         public MapReduceRestoIndex()
         {
             AddMap<Resto>(restaurants => from restaurant in restaurants
-                select new Result
-                {
-                    Id = restaurant.Id, LocationLatitude = (double)restaurant.Lat, LocationLongitude = (double)restaurant.Lng, Location = null,
-                });
+                                         select new Result
+                                         {
+                                             Id = restaurant.Id,
+                                             LocationLatitude = (double)restaurant.Lat,
+                                             LocationLongitude = (double)restaurant.Lng,
+                                             Location = null,
+                                         });
 
             Reduce = results => from result in results
-                group result by result.Id
+                                group result by result.Id
                 into g
-                let restaurant = g.FirstOrDefault()
-                select new Result
-                {
-                    Id = g.Key,
-                    LocationLatitude = restaurant.LocationLatitude,
-                    LocationLongitude = restaurant.LocationLongitude,
-                    Location = CreateSpatialField(restaurant.LocationLatitude, restaurant.LocationLongitude)
-                };
+                                let restaurant = g.FirstOrDefault()
+                                select new Result
+                                {
+                                    Id = g.Key,
+                                    LocationLatitude = restaurant.LocationLatitude,
+                                    LocationLongitude = restaurant.LocationLongitude,
+                                    Location = CreateSpatialField(restaurant.LocationLatitude, restaurant.LocationLongitude)
+                                };
 
             StoreAllFields(FieldStorage.Yes);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19544 

### Additional description

Added `@metadata` support for map/reduce results on a javascript projection.
Enabling the ability to project distance results from the query.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
