### PR TITLE
RavenDB-19547 - Custom S3 URL stopped working after upgrading to the recent Nuget

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -66,16 +66,16 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             {
                 _usingCustomServerUrl = true;
 
-                config = new CustomS3Config(s3Settings.CustomServerUrl)
+                config = new AmazonS3Config
                 {
                     ForcePathStyle = s3Settings.ForcePathStyle,
-                    UseHttp = true
+                    ServiceURL = s3Settings.CustomServerUrl
                 };
 
                 if (string.IsNullOrWhiteSpace(s3Settings.AwsRegionName) == false)
                 {
                     // region for custom server url isn't mandatory
-                    config.RegionEndpoint = RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName);
+                    config.AuthenticationRegion = s3Settings.AwsRegionName;
                 }
             }
 
@@ -407,22 +407,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 case HttpStatusCode.Forbidden:
                     await AssertBucketPermissionsAsync();
                     break;
-            }
-        }
-
-        private class CustomS3Config : AmazonS3Config
-        {
-            private readonly string _customUrl;
-
-            public CustomS3Config(string customUrl)
-            {
-                _customUrl = customUrl;
-            }
-
-            [Obsolete("This operation is obsoleted because as of version 3.7.100 endpoint is resolved using a newer system that uses request level parameters to resolve the endpoint.")]
-            public override string DetermineServiceURL()
-            {
-                return _customUrl;
             }
         }
     }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/CustomS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/CustomS3.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Server.Documents.PeriodicBackup.Aws;
+﻿using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup.Aws;
 using SlowTests.Server.Documents.PeriodicBackup.Restore;
 using Tests.Infrastructure;
 using Xunit;
@@ -15,7 +16,7 @@ public class CustomS3 : RestoreFromS3
     [CustomS3Fact]
     public void can_use_custom_region()
     {
-        const string customUrl = "https://s3.pl-waw.scw.cloud";
+        const string customUrl = "https://s3.pl-waw.scw.cloud/";
         const string customRegion = "pl-waw";
 
         var settings = GetS3Settings();
@@ -24,10 +25,8 @@ public class CustomS3 : RestoreFromS3
 
         using (var client = new RavenAwsS3Client(settings, DefaultConfiguration))
         {
-#pragma warning disable CS0618
-            Assert.Equal(customUrl, client.Config.DetermineServiceURL());
-#pragma warning restore CS0618
-            Assert.Equal(customRegion, client.Config.RegionEndpoint.SystemName);
+            Assert.Equal(customUrl, client.Config.ServiceURL);
+            Assert.Equal(customRegion, client.Config.AuthenticationRegion);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19547/Custom-S3-URL-stopped-working-after-upgrading-to-the-recent-Nuget

### Additional description

Since `DetermineServiceURL` was deprecated we need to use the `ServiceURL` and the `AuthenticationRegion`

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing