### PR TITLE
RavenDB-19474: Hanging on CompareExchange after Database.Initialize

### DIFF
--- a/test/SlowTests/Issues/RavenDB_19474.cs
+++ b/test/SlowTests/Issues/RavenDB_19474.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+using System;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Client.Documents.Session;
+using System.Threading;
+using FastTests.Graph;
+using Raven.Client.Documents;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19474 : RavenTestBase
+{
+    public RavenDB_19474(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task CanCreateCompareExchangeThenDatabaseUnloadThenCreateCompareExchange()
+    {
+        var value = new User { Id = Guid.NewGuid().ToString(), Name = "Lev" };
+        const string key1 = "The first";
+        const string key2 = "The second";
+        
+        using (var store = GetDocumentStore())
+        {
+            await CreateCompareExchangeValue(store, key1, value);
+
+            (await Server.ServerStore.DatabasesLandlord.UnloadAndLockDatabase(store.Database, "Forcibly unloading the database to trigger its subsequent initialization")).Dispose();
+
+            await CreateCompareExchangeValue(store, key2, value);
+        }
+    }
+
+    internal async Task CreateCompareExchangeValue(DocumentStore store, string key, object value)
+    {
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
+
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, value);
+            await session.SaveChangesAsync(cts.Token);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19474.cs
+++ b/test/SlowTests/Issues/RavenDB_19474.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Session;
 using System.Threading;
 using FastTests.Graph;
 using Raven.Client.Documents;
+using Microsoft.Azure.Documents.Spatial;
 
 namespace SlowTests.Issues;
 
@@ -33,11 +34,9 @@ public class RavenDB_19474 : RavenTestBase
         }
     }
 
-    internal async Task CreateCompareExchangeValue(DocumentStore store, string key, object value)
+    private async Task CreateCompareExchangeValue(DocumentStore store, string key, object value)
     {
-        var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromSeconds(30));
-
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
         using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
         {
             session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, value);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19474/Hanging-on-ClusterTransactionCreateCompareExchangeValue

### Additional description

There was a problem with executing cluster-wide transactions with `CompareExchange` inside after the database unloading (because of a server reboot or idle, for example). After the initialization of the database, the index calculation was not correct.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed