### PR TITLE
RavenDB-19281 Flush and sync journals `index side-by-side` before replacement.

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -447,7 +447,7 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]
         [IndexUpdateType(IndexUpdateType.None)]
-        [ConfigurationEntry("Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [ConfigurationEntry("Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex { get; protected set; }
         
         protected override void ValidateProperty(PropertyInfo property)

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -443,6 +443,13 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Lucene.IndexInputType", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public LuceneIndexInputType LuceneIndexInput { get; set; }
         
+        [Description("Max time to wait when forcing the storage environment flush and sync when replacing side-by-side index.")]
+        [DefaultValue(30)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public TimeSetting MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex { get; protected set; }
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1812,6 +1812,9 @@ namespace Raven.Server.Documents.Indexes
 
                     if (batchCompleted)
                     {
+                        
+                        FlushAndSync(_environment, (int)Configuration.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit.AsTimeSpan.TotalMilliseconds, tryCleanupRecycledJournals: true);
+
                         // this side-by-side index will be replaced in a second, notify about indexing success
                         // so we know that indexing batch is no longer in progress
                         NotifyAboutCompletedBatch(didWork);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1813,7 +1813,7 @@ namespace Raven.Server.Documents.Indexes
                     if (batchCompleted)
                     {
                         
-                        FlushAndSync(_environment, (int)Configuration.MaxTimeToWaitAfterFlushAndSyncWhenExceedingScratchSpaceLimit.AsTimeSpan.TotalMilliseconds, tryCleanupRecycledJournals: true);
+                        FlushAndSync(_environment, (int)Configuration.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex.AsTimeSpan.TotalMilliseconds, tryCleanupRecycledJournals: true);
 
                         // this side-by-side index will be replaced in a second, notify about indexing success
                         // so we know that indexing batch is no longer in progress

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -34,7 +34,7 @@ class configurationItem {
         "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
         "Indexing.Lucene.UseCompoundFileInMerging",
         "Indexing.Lucene.IndexInputType",
-        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex"
+        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -33,7 +33,8 @@ class configurationItem {
         "Indexing.TransactionSizeLimitInMb",
         "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
         "Indexing.Lucene.UseCompoundFileInMerging",
-        "Indexing.Lucene.IndexInputType"
+        "Indexing.Lucene.IndexInputType",
+        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -76,7 +76,7 @@ namespace FastTests.Issues
                 "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
                 "Indexing.Lucene.UseCompoundFileInMerging",
                 "Indexing.Lucene.IndexInputType",
-
+                "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex",
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -76,7 +76,7 @@ namespace FastTests.Issues
                 "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
                 "Indexing.Lucene.UseCompoundFileInMerging",
                 "Indexing.Lucene.IndexInputType",
-                "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex",
+                "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",

--- a/test/SlowTests/Issues/RavenDB_16511.cs
+++ b/test/SlowTests/Issues/RavenDB_16511.cs
@@ -82,7 +82,7 @@ namespace SlowTests.Issues
                         ((LuceneIndexPersistence)newIndex.IndexPersistence).TempFileCache.SetMemoryStreamCapacity(1);
                         testingStuff.RunFakeIndex(newIndex);
 
-                        Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)), "Index wasn't replaced");
+                        Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)), "Index wasn't replaced");
 
                         Assert.True(SpinWait.SpinUntil(() => newIndex.Status == IndexRunningStatus.Running, TimeSpan.FromSeconds(10)),
                             "newIndex.Status == IndexRunningStatus.Running");

--- a/test/SlowTests/Issues/RavenDB_17237.cs
+++ b/test/SlowTests/Issues/RavenDB_17237.cs
@@ -22,7 +22,10 @@ namespace SlowTests.Issues
         [Fact]
         public async Task MustNotDisableThrottlingTimerOnUpdatingIndexDefinitionOfThrottledIndex()
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(new Options()
+                   {
+                       ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "0"
+                   }))
             {
                 var indexDef = new Orders_ByOrderedAtAndShippedAt(storeFields: false)
                 {

--- a/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
+++ b/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
@@ -16,6 +16,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
+using Raven.Server.Config;
 using Raven.Server.ServerWide.Commands.Indexes;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -47,6 +48,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -144,6 +146,7 @@ namespace SlowTests.Rolling
             using (var store = GetDocumentStoreForRollingIndexes(
                        new Options
                        {
+                           ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                            Server = cluster.Leader,
                            ReplicationFactor = 3,
                        }))
@@ -218,6 +221,7 @@ namespace SlowTests.Rolling
             using (var store = GetDocumentStoreForRollingIndexes(
                        new Options
                        {
+                           ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                            Server = cluster.Leader,
                            ReplicationFactor = 3,
                        }))
@@ -325,12 +329,12 @@ namespace SlowTests.Rolling
 
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
-            using (var store = GetDocumentStoreForRollingIndexes(
-                       new Options
-                       {
-                           Server = cluster.Leader,
-                           ReplicationFactor = 3,
-                       }))
+            using (var store = GetDocumentStoreForRollingIndexes(new Options
+            {                           
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
+                Server = cluster.Leader,
+                ReplicationFactor = 3,
+            }))
             {
                 await CreateData(store);
                 await store.ExecuteIndexAsync(new MyRollingIndex() { DeploymentMode = IndexDeploymentMode.Parallel });
@@ -416,6 +420,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 2,
             }))
@@ -491,6 +496,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -530,6 +536,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -558,6 +565,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -594,6 +602,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
                 DeleteDatabaseOnDispose = false // we removing a node, which will break the infra deletion, because we will bootstrap the removed node
@@ -646,6 +655,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -689,7 +699,8 @@ namespace SlowTests.Rolling
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
-            {
+            {                           
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -743,6 +754,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -795,6 +807,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -842,6 +855,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))
@@ -896,6 +910,7 @@ namespace SlowTests.Rolling
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
             using (var store = GetDocumentStoreForRollingIndexes(new Options
             {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
                 Server = cluster.Leader,
                 ReplicationFactor = 3,
             }))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19281

### Additional description

We will try to flush and sync journals before replacement. This way we should spare time in the next startup.

### Type of change


- Optimization


### How risky is the change?

- Moderate 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

There is some low-level test of index replacement. It doesn't work unless we increased the timeout of waiting to completion.


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
