### PR TITLE
RavenDB-19555 Reduce JsString allocations

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/Counters/CounterEntryObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/CounterEntryObjectInstance.cs
@@ -8,7 +8,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Raven.Server.Documents.Indexes.Static.Counters
 {
-    public class CounterEntryObjectInstance : ObjectInstance
+    public sealed class CounterEntryObjectInstance : ObjectInstance
     {
         private readonly DynamicCounterEntry _entry;
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentNameObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentNameObjectInstance.cs
@@ -9,7 +9,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Indexes.Static.JavaScript
 {
-    public class AttachmentNameObjectInstance : ObjectInstanceBase
+    public sealed class AttachmentNameObjectInstance : ObjectInstanceBase
     {
         private readonly Dictionary<JsValue, PropertyDescriptor> _properties = new Dictionary<JsValue, PropertyDescriptor>();
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
@@ -10,7 +10,7 @@ using Raven.Client.Documents.Indexes;
 
 namespace Raven.Server.Documents.Indexes.Static.JavaScript
 {
-    public class AttachmentObjectInstance : ObjectInstanceBase
+    public sealed class AttachmentObjectInstance : ObjectInstanceBase
     {
         private const string GetContentAsStringMethodName = "getContentAsString";
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -185,12 +185,13 @@ namespace Raven.Server.Documents.Indexes.Static
 
             if (MoreArguments != null)
             {
-                for (int i = 0; i < MoreArguments.Length; i++)
+                for (uint i = 0; i < MoreArguments.Length; i++)
                 {
-                    var arg = MoreArguments.Get(i.ToString()).As<FunctionInstance>();
+                    var arg = MoreArguments[i].As<FunctionInstance>();
 
-                    if (!(arg is ScriptFunctionInstance sfi))
+                    if (arg is not ScriptFunctionInstance sfi)
                         continue;
+
                     var moreFuncAst = sfi.FunctionDeclaration;
                     field = moreFuncAst.TryGetFieldFromSimpleLambdaExpression();
                     if (field != null)

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
@@ -340,7 +340,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
                     if (blockBody.Count == 1 && blockBody[0] is ReturnStatement returnStmt)
                     {
-                        if (returnStmt.ChildNodes.Count == 1 && returnStmt.ChildNodes[0] is ObjectExpression returnObjectExpression)
+                        if (returnStmt.Argument is ObjectExpression returnObjectExpression)
                         {
                             return _groupByFields = CreateFieldsFromObjectExpression(returnObjectExpression);
                         }

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/TimeSeriesSegmentObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/TimeSeriesSegmentObjectInstance.cs
@@ -10,7 +10,7 @@ using Raven.Client.Documents.Indexes.TimeSeries;
 
 namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 {
-    public class TimeSeriesSegmentObjectInstance : ObjectInstance
+    public sealed class TimeSeriesSegmentObjectInstance : ObjectInstance
     {
         private readonly DynamicTimeSeriesSegment _segment;
 
@@ -148,7 +148,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
                 for (var i = 0; i < values.Length; i++)
                     values[i] = entry._entry.Values.Span[i];
 
-                var array = engine.Array.Construct(Arguments.Empty);
+                var array = engine.Array.Construct(values.Length);
                 engine.Array.PrototypeObject.Push(array, values);
 
                 value.Set(nameof(entry.Value), values[0]);

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Patch
                     Context.ReadObject(metadata, boi.DocumentId);
                 
                 JsValue metadataJs = TranslateToJs(_scriptEngine, Context, metadata);
-                boi.Set(new JsString(Constants.Documents.Metadata.Key), metadataJs);
+                boi.Set(Constants.Documents.Metadata.Key, metadataJs);
 
                 return metadataJs;
             }
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.Patch
             for (var i = 0; i < values.Length; i++)
                 values[i] = new AttachmentObjectInstance(_scriptEngine, attachments[i]);
 
-            var array = _scriptEngine.Array.Construct(Arguments.Empty);
+            var array = _scriptEngine.Array.Construct(values.Length);
             _scriptEngine.Array.PrototypeObject.Push(array, values);
 
             return array;
@@ -318,35 +318,35 @@ namespace Raven.Server.Documents.Patch
                 return lng;
             if (o is BlittableJsonReaderArray bjra)
             {
-                var jsArray = engine.Array.Construct(Array.Empty<JsValue>());
-                var args = new JsValue[1];
+                var jsArray = engine.Array.Construct(bjra.Length);
+                var args = new JsValue[bjra.Length];
                 for (var i = 0; i < bjra.Length; i++)
                 {
-                    args[0] = TranslateToJs(engine, context, bjra[i]);
-                    engine.Array.PrototypeObject.Push(jsArray, args);
+                    args[i] = TranslateToJs(engine, context, bjra[i]);
                 }
+                engine.Array.PrototypeObject.Push(jsArray, args);
                 return jsArray;
             }
             if (o is List<object> list)
             {
-                var jsArray = engine.Array.Construct(Array.Empty<JsValue>());
-                var args = new JsValue[1];
+                var jsArray = engine.Array.Construct(list.Count);
+                var args = new JsValue[list.Count];
                 for (var i = 0; i < list.Count; i++)
                 {
-                    args[0] = TranslateToJs(engine, context, list[i]);
-                    engine.Array.PrototypeObject.Push(jsArray, args);
+                    args[i] = TranslateToJs(engine, context, list[i]);
                 }
+                engine.Array.PrototypeObject.Push(jsArray, args);
                 return jsArray;
             }
             if (o is List<Document> docList)
             {
-                var jsArray = engine.Array.Construct(Array.Empty<JsValue>());
-                var args = new JsValue[1];
+                var jsArray = engine.Array.Construct(docList.Count);
+                var args = new JsValue[docList.Count];
                 for (var i = 0; i < docList.Count; i++)
                 {
-                    args[0] = new BlittableObjectInstance(engine, null, Clone(docList[i].Data, context), docList[i]);
-                    engine.Array.PrototypeObject.Push(jsArray, args);
+                    args[i] = new BlittableObjectInstance(engine, null, Clone(docList[i].Data, context), docList[i]);
                 }
+                engine.Array.PrototypeObject.Push(jsArray, args);
                 return jsArray;
             }
             // for admin

--- a/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
+++ b/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
@@ -446,7 +446,7 @@ namespace Raven.Server.Documents.Patch
                     obj.Blittable.GetPropertyByIndex(propIndex, ref prop);
 
                     BlittableObjectInstance.BlittableObjectProperty modifiedValue = default;
-                    JsValue key = prop.Name.ToString();
+                    string key = prop.Name.ToString();
                     var existInObject = obj.OwnValues?
                         .TryGetValue(key, out modifiedValue) == true;
 
@@ -482,20 +482,19 @@ namespace Raven.Server.Documents.Patch
             foreach (var modificationKvp in obj.OwnValues)
             {
                 //We already iterated through those properties while iterating the original properties set.
-                if (modifiedProperties != null && modifiedProperties.Contains(modificationKvp.Key.AsString()))
+                if (modifiedProperties != null && modifiedProperties.Contains(modificationKvp.Key))
                     continue;
 
                 var propertyName = modificationKvp.Key;
-                var propertyNameAsString = propertyName.AsString();
-                if (ShouldFilterProperty(filterProperties, propertyNameAsString))
+                if (ShouldFilterProperty(filterProperties, propertyName))
                     continue;
 
                 if (modificationKvp.Value.Changed == false)
                     continue;
 
-                _writer.WritePropertyName(propertyNameAsString);
+                _writer.WritePropertyName(propertyName);
                 var blittableObjectProperty = modificationKvp.Value;
-                WriteJsonValue(obj, isRoot, propertyNameAsString, blittableObjectProperty.Value);
+                WriteJsonValue(obj, isRoot, propertyName, blittableObjectProperty.Value);
             }
         }
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerResult.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerResult.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Patch
 
         public readonly JsValue Instance;
 
-        public ObjectInstance GetOrCreate(JsValue property)
+        public ObjectInstance GetOrCreate(string property)
         {
             if (Instance.AsObject() is BlittableObjectInstance b)
                 return b.GetOrCreate(property);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19555

### Additional description

Extracted safe but beneficial optimizations from https://github.com/ravendb/ravendb/pull/14936 which do not require Jint upgrade and are quite self-evident:

* seal custom ObjectInstance types for performance (odd that everything in RavenDB.Server is not sealed by default for performance)
* use `string `as Blittable data key instead of `JsValue`, Jint object keys are either `JsString` or `JsSymbol`, I can't imagine a use case to support symbol keys for document data types, they usually are found in prototypes - no need to convert back and forth, lookups are faster with plain `string`
* pre-allocate arrays when possible
* `JintNullPropagationReferenceResolver` was doing implicit `string` to `JsString` conversion when checking for equality, always allocating a new `JsString`
* create fast path for `BlittableObjectInstance.Set`, default Jint path checks for all sorts of things and validates property descriptor based on prototypes and configuration - this is not needed when backing data is own dictionary

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests cover the change

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
