### PR TITLE
RavenDB-17893 Support `Ticks` for dates. 

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -52,7 +52,7 @@ namespace Corax
             private static readonly byte[] LongTreeSuffixBytes = new byte[]  { (byte)'-', (byte)'L' };
 
             
-            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice;
+            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice, TimeFieldsSlice;
             public const int IntKnownFieldMask = unchecked((int)0x80000000);
             public const short ShortKnownFieldMask = unchecked((short)0x8000);
             public const byte ByteKnownFieldMask = unchecked((byte)0x80);
@@ -68,6 +68,7 @@ namespace Corax
                     Slice.From(ctx, "SuggestionFields", ByteStringType.Immutable, out SuggestionsFieldsSlice);
                     Slice.From(ctx, "IndexVersion", ByteStringType.Immutable, out IndexVersionSlice);
                     Slice.From(ctx, "DynamicFieldsAnalyzers", ByteStringType.Immutable, out DynamicFieldsAnalyzersSlice);
+                    Slice.From(ctx, "TimeFieldsSlice", ByteStringType.Immutable, out TimeFieldsSlice);
                 }
             }
         }

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -709,7 +709,7 @@ namespace Corax
                             }
                             else
                             {
-                                ExactInsert(iterator.Sequence);
+                                Insert(iterator.Sequence);
                                 NumericInsert(iterator.Long, iterator.Double);
                             }
                         }
@@ -720,7 +720,7 @@ namespace Corax
                         if (_fieldReader.Read(out _, out long lVal, out double dVal, out Span<byte> valueInEntry) == false)
                             break;
 
-                        ExactInsert(valueInEntry);
+                        Insert(valueInEntry);
                         NumericInsert(lVal, dVal);
                         break;
 

--- a/src/Corax/Queries/TermProviders/TermProvider.Range.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Range.cs
@@ -131,7 +131,6 @@ namespace Corax.Queries
 
         private const int TermBufferSize = 32;
         private fixed byte _termsBuffer[TermBufferSize];
-        private ByteStringContext<ByteStringMemoryCache>.ExternalScope _prevTermScope;
 
         public TermNumericRangeProvider(IndexSearcher searcher, FixedSizeTree<TVal> set,
             CompactTree tree, Slice fieldName, TVal low, TVal high)
@@ -143,7 +142,6 @@ namespace Corax.Queries
             _high = high;
             _set = set;
             _tree = tree;
-            _prevTermScope = default;
             _first = true;
         }
 
@@ -151,11 +149,8 @@ namespace Corax.Queries
         {
             _first = true;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Next(out TermMatch term) => Next(out term, out _);
-
-        public bool Next(out TermMatch term, out Slice termSlice)
+        
+        public bool Next(out TermMatch term)
         {
             bool wasFirst = false;
             bool hasNext;
@@ -178,7 +173,7 @@ namespace Corax.Queries
             {
                 if (wasFirst && curVal == _low)
                 {
-                    return Next(out term, out termSlice);
+                    return Next(out term);
                 }
             }     
 
@@ -190,38 +185,11 @@ namespace Corax.Queries
                 goto Empty;
             }
 
-            _prevTermScope.Dispose();
-            
-            fixed (byte* p = _termsBuffer)
-            {
-                int termLen;
-                if (typeof(TVal) == typeof(long))
-                {
-                    if (Utf8Formatter.TryFormat((long)(object)curVal, new Span<byte>(p, TermBufferSize), out termLen) == false)
-                    {
-                        throw new InvalidOperationException("Cannot format long value " + curVal);
-                    }
-                }
-                else if(typeof(TVal) == typeof(double))
-                {
-                    if (Utf8Formatter.TryFormat((double)(object)curVal, new Span<byte>(p, TermBufferSize), out termLen) == false)
-                    {
-                        throw new InvalidOperationException("Cannot format double value " + curVal);
-                    }
-                }
-                else
-                {
-                    throw new NotSupportedException("Unknown type: " + typeof(TVal));
-                }
-
-                _prevTermScope = Slice.External(_set.Llt.Allocator, p, termLen, ByteStringType.Immutable, out termSlice);
-
-                term = _searcher.TermQuery(_tree, termSlice);
-                return true;
-            }
+            var termId = _iterator.CreateReaderForCurrent().ReadLittleEndianInt64();
+            term = _searcher.TermQuery(termId);
+            return true;
 
             Empty:
-            termSlice = Slices.Empty;
             term = TermMatch.CreateEmpty(_searcher.Allocator);
             return false;
         }

--- a/src/Corax/Utils/TimeFields.cs
+++ b/src/Corax/Utils/TimeFields.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using Voron;
+using Voron.Impl;
+
+namespace Corax.Utils;
+
+/// <summary>
+/// Store fields names inside multitree. This allows us to be sure we can perform query over ticks (instead strings).
+/// </summary>
+public static class TimeFields
+{
+    public static HashSet<string> ReadTimeFieldsNames(Transaction tx)
+    {
+        var fieldsNames = new HashSet<string>();
+
+        var metadataTree = tx.ReadTree(Constants.IndexMetadata);
+        if (metadataTree != null)
+        {
+            using var iterator = metadataTree.MultiRead(Constants.IndexWriter.TimeFieldsSlice);
+            if (iterator.Seek(Slices.BeforeAllKeys))
+            {
+                do
+                {
+                    fieldsNames.Add(iterator.CurrentKey.ToString());
+                } while (iterator.MoveNext());
+            }
+                
+        }
+
+        return fieldsNames;
+    }
+
+    public static void WriteTimeFieldsNames(Transaction tx, HashSet<string> fieldsNames)
+    {
+        if (tx.IsWriteTransaction == false)
+            throw new InvalidDataException("Tried to write fields names but got non write transaction.");
+        
+        if (fieldsNames == null || fieldsNames.Count == 0)
+            return;
+
+        using var metadataTree = tx.CreateTree(Constants.IndexMetadata);
+        
+        foreach (var field in fieldsNames)
+            metadataTree.MultiAdd(Constants.IndexWriter.TimeFieldsSlice, field);
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using Corax;
+using Raven.Client.Documents.Indexes;
 using Raven.Server.ServerWide.Context;
+using Voron;
 
 namespace Raven.Server.Documents.Indexes
 {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxBooleanQuery.cs
@@ -35,7 +35,7 @@ public readonly struct CoraxBooleanItem : IQueryMatch
         Name = name;
         FieldId = fieldId;
         var ticks = default(long);
-        _isTime = term is not null && QueryBuilderHelper.TryGetTime(index, term, out ticks);
+        _isTime = term is not null && index.IndexFieldsPersistence.HasTimeValues(name) && QueryBuilderHelper.TryGetTime(index, term, out ticks);
         Term = _isTime ? ticks : term;
 
         Operation = operation;
@@ -63,7 +63,7 @@ public readonly struct CoraxBooleanItem : IQueryMatch
         
         if (_isTime) //found time at `Term1`, lets check if second item also contains time
         {
-            if (term2 != null && QueryBuilderHelper.TryGetTime(index, term2, out var ticks))
+            if (term2 != null && index.IndexFieldsPersistence.HasTimeValues(name) && QueryBuilderHelper.TryGetTime(index, term2, out var ticks))
             {
                 Term2 = ticks;
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexedEntriesReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexedEntriesReader.cs
@@ -89,7 +89,7 @@ public class CoraxIndexedEntriesReader : IDisposable
                     else
                     {
                         
-                        AddBytesAsItemToContainer(iterator.Sequence, null);
+                        AddBytesAsItemToContainer(iterator.Sequence, analyzer);
                     }
                 }
 
@@ -97,7 +97,7 @@ public class CoraxIndexedEntriesReader : IDisposable
             case IndexEntryFieldType.Tuple:
                 if (fieldReader.Read(out _, out long lVal, out double dVal, out Span<byte> valueInEntry) == false)
                     break;
-                AddBytesAsItemToContainer(valueInEntry, null);
+                AddBytesAsItemToContainer(valueInEntry, analyzer);
                 
                 break;
             case IndexEntryFieldType.SpatialPointList:

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -262,9 +262,9 @@ internal static class CoraxQueryBuilder
 
                         var match = valueType switch
                         {
-                            ValueTokenType.Double => new CoraxBooleanItem(indexSearcher, fieldName.Value, fieldId, value, operation, scoreFunction),
-                            ValueTokenType.Long => new CoraxBooleanItem(indexSearcher, fieldName.Value, fieldId, value, operation, scoreFunction),
-                            ValueTokenType.True or
+                            ValueTokenType.Double => new CoraxBooleanItem(indexSearcher, index, fieldName.Value, fieldId, value, operation, scoreFunction),
+                            ValueTokenType.Long =>  new CoraxBooleanItem(indexSearcher, index, fieldName.Value, fieldId, value, operation, scoreFunction),
+                                ValueTokenType.True or
                                 ValueTokenType.False or
                                 ValueTokenType.Null or
                                 ValueTokenType.String or
@@ -292,10 +292,10 @@ internal static class CoraxQueryBuilder
                             if (value == null)
                             {
                                 if (operation is UnaryMatchOperation.Equals)
-                                    return new CoraxBooleanItem(indexSearcher, fieldName, fieldId, null, UnaryMatchOperation.Equals, scoreFunction);
+                                    return  new CoraxBooleanItem(indexSearcher, index, fieldName, fieldId, null, UnaryMatchOperation.Equals, scoreFunction);
                                 else if (operation is UnaryMatchOperation.NotEquals)
                                     //Please consider if we ever need to support this.
-                                    return new CoraxBooleanItem(indexSearcher, fieldName, fieldId, null, UnaryMatchOperation.NotEquals, scoreFunction);
+                                    return  new CoraxBooleanItem(indexSearcher, index, fieldName, fieldId, null, UnaryMatchOperation.NotEquals, scoreFunction);
                                 else
                                     throw new NotSupportedException($"Unhandled operation: {operation}");
                             }
@@ -304,7 +304,7 @@ internal static class CoraxQueryBuilder
                             if (highlightingTerm != null)
                                 highlightingTerm.Values = valueAsString;
 
-                            return new CoraxBooleanItem(indexSearcher, fieldName.Value, fieldId, valueAsString, operation, scoreFunction);
+                            return  new CoraxBooleanItem(indexSearcher, index, fieldName.Value, fieldId, valueAsString, operation, scoreFunction);
                         }
                     }
             }
@@ -590,7 +590,7 @@ internal static class CoraxQueryBuilder
         return (valueFirstType, valueSecondType) switch
         {
             (ValueTokenType.String, ValueTokenType.String) => HandleStringBetween(),
-            _ => new CoraxBooleanItem(builderParameters.IndexSearcher, fieldName, fieldId, valueFirst, valueSecond, UnaryMatchOperation.Between, leftSideOperation, rightSideOperation, scoreFunction)
+            _ => new CoraxBooleanItem(builderParameters.IndexSearcher, index, fieldName, fieldId, valueFirst, valueSecond, UnaryMatchOperation.Between, leftSideOperation, rightSideOperation, scoreFunction)
         };
 
         CoraxBooleanItem HandleStringBetween()
@@ -605,7 +605,7 @@ internal static class CoraxQueryBuilder
                 builderParameters.HighlightingTerms[fieldName] = highlightingTerm;
             }
 
-            return new CoraxBooleanItem(builderParameters.IndexSearcher, fieldName, fieldId, valueFirstAsString, valueSecondAsString, UnaryMatchOperation.Between, leftSideOperation, rightSideOperation, scoreFunction);
+            return new CoraxBooleanItem(builderParameters.IndexSearcher, index, fieldName, fieldId, valueFirstAsString, valueSecondAsString, UnaryMatchOperation.Between, leftSideOperation, rightSideOperation, scoreFunction);
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
@@ -82,11 +82,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
 
         public void Write(string path, int field, ReadOnlySpan<byte> value, ref IndexEntryWriter entryWriter)
         {
-            if (_count.Longs != 0 || _count.Doubles != 0)
-                throw new InvalidOperationException("Cannot mix tuples writes with straightforward writes");
-
             if (_isDynamic)
                 FlushWhenNecessary(path, field, ref entryWriter);
+            
+            if (_count.Longs != 0 || _count.Doubles != 0)
+                throw new InvalidOperationException("Cannot mix tuples writes with straightforward writes");
             
             // Copy the value to write into memory allocated and controlled by the scope.  
             _allocator.Allocate(value.Length, out var buffer);

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.Queries
 
                                 exact |= valueType == ValueTokenType.Parameter;
 
-                                if (TryUseTime(index, fieldName, value, exact, out var ticks))
+                                if (QueryBuilderHelper.TryUseTime(index, fieldName, value, exact, out var ticks))
                                 {
                                     return TranslateDateRangeQuery(index, where, fieldName, ticks);
                                 }
@@ -486,7 +486,7 @@ namespace Raven.Server.Documents.Queries
                 case IndexFieldType.String:
                     exact = IsExact(index, exact, fieldName);
 
-                    if (TryUseTime(index, fieldName, valueFirst, valueSecond, exact, out var ticksFirst, out var ticksSecond))
+                    if (QueryBuilderHelper.TryUseTime(index, fieldName, valueFirst, valueSecond, exact, out var ticksFirst, out var ticksSecond))
                     {
                         luceneFieldName += Constants.Documents.Indexing.Fields.TimeFieldSuffix;
                         betweenQuery = index.Configuration.QueryClauseCacheDisabled
@@ -554,34 +554,7 @@ namespace Raven.Server.Documents.Queries
 
             return bq;
         }
-
-        private static bool TryUseTime(Index index, string fieldName, object valueFirst, object valueSecond, bool exact, out long ticksFirst, out long ticksSecond)
-        {
-            ticksFirst = -1;
-            ticksSecond = -1;
-
-            if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
-                return false;
-
-            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && QueryBuilderHelper.TryGetTime(index, valueFirst, out ticksFirst) && QueryBuilderHelper.TryGetTime(index, valueSecond, out ticksSecond))
-                return true;
-
-            return false;
-        }
-
-        private static bool TryUseTime(Index index, string fieldName, object value, bool exact, out long ticks)
-        {
-            ticks = -1;
-
-            if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
-                return false;
-
-            if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && QueryBuilderHelper.TryGetTime(index, value, out ticks))
-                return true;
-
-            return false;
-        }
-
+        
         private static bool IsExact(Index index, bool exact, QueryFieldName fieldName)
         {
             if (exact)

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -698,7 +698,34 @@ public static class QueryBuilderHelper
 
         return (SpatialUnits)su;
     }
+    
+    internal static bool TryUseTime(Index index, string fieldName, object valueFirst, object valueSecond, bool exact, out long ticksFirst, out long ticksSecond)
+    {
+        ticksFirst = -1;
+        ticksSecond = -1;
 
+        if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+            return false;
+
+        if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, valueFirst, out ticksFirst) && TryGetTime(index, valueSecond, out ticksSecond))
+            return true;
+
+        return false;
+    }
+
+    internal static bool TryUseTime(Index index, string fieldName, object value, bool exact, out long ticks)
+    {
+        ticks = -1;
+
+        if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+            return false;
+
+        if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))
+            return true;
+
+        return false;
+    }
+    
     internal static MethodExpression FindMoreLikeThisExpression(QueryExpression expression)
     {
         if (expression == null)

--- a/test/SlowTests/Issues/RDBC-631.cs
+++ b/test/SlowTests/Issues/RDBC-631.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FastTests;
 using Microsoft.Azure.Documents.SystemFunctions;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using TimeOnly = System.TimeOnly;
@@ -16,11 +17,12 @@ public class RDBC_631 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void CanProjectOnlyDateOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanProjectOnlyDateOnly(Options options)
     {
         var datesOnly = new List<DateOnly>();
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var bulkInsert = store.BulkInsert();
             foreach (var i in Enumerable.Range(0, 100))
@@ -32,21 +34,21 @@ public class RDBC_631 : RavenTestBase
         }
         new DateOnlyIndex().Execute(store);
         Indexes.WaitForIndexing(store);
-
         {
             using var session = store.OpenSession();
-            var datesFromRaven = session.Query<Mock<DateOnly>, DateOnlyIndex>().Select(i => i.Date).ToList();
+            var datesFromRaven = session.Query<Mock<DateOnly>, DateOnlyIndex>().Where(i => i.Date >= DateOnly.MinValue).Select(i => i.Date).ToList();
             datesOnly.Sort();
             datesFromRaven.Sort();
             Assert.True(datesFromRaven.SequenceEqual(datesOnly));
         }
     }
     
-    [Fact]
-    public void CanProjectOnlyTimeOnly()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanProjectOnlyTimeOnly(Options options)
     {
         var datesOnly = new List<TimeOnly>();
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         {
             using var bulkInsert = store.BulkInsert();
             foreach (var i in Enumerable.Range(0, 100))
@@ -61,7 +63,7 @@ public class RDBC_631 : RavenTestBase
 
         {
             using var session = store.OpenSession();
-            var datesFromRaven = session.Query<Mock<TimeOnly>, TimeOnlyIndex>().Select(i => i.Date).ToList();
+            var datesFromRaven = session.Query<Mock<TimeOnly>, TimeOnlyIndex>().Where(i => i.Date >= TimeOnly.MinValue).Select(i => i.Date).ToList();
             datesOnly.Sort();
             datesFromRaven.Sort();
             Assert.True(datesFromRaven.SequenceEqual(datesOnly));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17893

### Additional description

This PR contains two changes:
- `Ticks` support for dates in Corax. For such a case, we're using a tuple structure for saving it `['Date_as_string', Ticks-L , Ticks-D']`
- Optimization and fix of `RangeQueries`. We are saving `termId` in `FixedSizeTree` as the Value of the key from the very beginning. Instead of taking advantage of that, we were looking `termId` CompactTree via `Key` we found in `FixedSizeTree`. 
For `Ticks` that didn't make a trick because those are two different values.
### Type of change

- Bug fix
- Optimization
- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 (all range and date tests will check the correctness of that feature)

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
