### PR TITLE
RavenDB-19552: Boosting match causes buffer overflow and crash.

### DIFF
--- a/src/Corax/Queries/BoostingMatch.cs
+++ b/src/Corax/Queries/BoostingMatch.cs
@@ -155,7 +155,7 @@ namespace Corax.Queries
             }
 
             // Allocate the new buffer
-            var bufferHandler = _searcher.Allocator.Allocate(size, out var buffer);
+            var bufferHandler = _searcher.Allocator.Allocate(size * sizeof(long), out var buffer);
             
             // Ensure we copy the content and then switch the buffers. 
             new Span<long>(_buffer, _bufferIdx).CopyTo(new Span<long>(buffer.Ptr, size));

--- a/test/StressTests/Corax/Bugs/GrowableBuffersTests.cs
+++ b/test/StressTests/Corax/Bugs/GrowableBuffersTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Corax.Bugs;
+
+public class GrowableBuffersTests : RavenTestBase
+{
+    public GrowableBuffersTests(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void GrowableBufferInBoostingMatchWillCreateBufferWithProperSize(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < 16 * 1024; ++i)
+                {
+                    bulkInsert.Store(new Item() {Name = $"Name{i}", Number = i});
+                }
+            }
+
+            {
+                using var session = store.OpenSession();
+                var list = session.Advanced.RawQuery<Item>("from Items where boost(Number > -1, 1.0) and startsWith(Name, 'n')").NoTracking().NoCaching();
+                Indexes.WaitForIndexing(store);
+            }
+            
+            Parallel.ForEach(Enumerable.Range(0, 128), RavenTestHelper.DefaultParallelOptions, i =>
+            {
+                using var _ = store.SetRequestTimeout(TimeSpan.FromMinutes(2));
+                using var session = store.OpenSession();
+                var list = session.Advanced.RawQuery<Item>("from Items where boost(Number > -1, 1.0) and startsWith(Name, 'n')").NoCaching().NoTracking().ToList();
+                Assert.NotEmpty(list);
+            });
+        }
+    }
+    
+    private class Item
+    {
+        public string Name { get; set; }
+        public long Number { get; set; }
+    }
+    
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19552

### Type of change
- Bug fix

### How risky is the change?

- Low 

### Backward compatibility
- Non breaking change
