### PR TITLE
RavenDB-19235: Add the ability to cancel and delay ongoing backups by Operator

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
@@ -4,7 +4,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Sparrow.Json;
 
-namespace Raven.Client.Documents.Operations;
+namespace Raven.Client.Documents.Operations.Backups;
 
 public class DelayBackupOperation : IMaintenanceOperation<OperationState>
 {
@@ -36,7 +36,7 @@ public class DelayBackupOperation : IMaintenanceOperation<OperationState>
         public override bool IsReadRequest => true;
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/databases/{node.Database}/admin/backup-task/delay?taskId={_taskId}&duration={_duration}";
+            url = $"{node.Url}/admin/backup-task/delay?taskId={_taskId}&duration={_duration}&databaseName={node.Database}";
 
             return new HttpRequestMessage
             {

--- a/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
@@ -36,7 +36,7 @@ public class DelayBackupOperation : IMaintenanceOperation<OperationState>
         public override bool IsReadRequest => true;
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/admin/backup-task/delay?taskId={_taskId}&duration={_duration}&databaseName={node.Database}";
+            url = $"{node.Url}/admin/backup-task/delay?taskId={_taskId}&duration={_duration}&database={node.Database}";
 
             return new HttpRequestMessage
             {

--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -14,6 +14,8 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public string NodeTag { get; set; }
 
+        public DateTime? DelayUntil { get; set; }
+
         public DateTime? LastFullBackup { get; set; }
 
         public DateTime? LastIncrementalBackup { get; set; }
@@ -67,6 +69,7 @@ namespace Raven.Client.Documents.Operations.Backups
             json[nameof(BackupType)] = BackupType;
             json[nameof(IsFull)] = IsFull;
             json[nameof(NodeTag)] = NodeTag;
+            json[nameof(DelayUntil)] = DelayUntil;
             json[nameof(LastFullBackup)] = LastFullBackup;
             json[nameof(LastIncrementalBackup)] = LastIncrementalBackup;
             json[nameof(LastFullBackupInternal)] = LastFullBackupInternal;

--- a/src/Raven.Client/Documents/Operations/DelayBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DelayBackupOperation.cs
@@ -9,14 +9,14 @@ namespace Raven.Client.Documents.Operations;
 public class DelayBackupOperation : IMaintenanceOperation<OperationState>
 {
     private readonly long _runningBackupTaskId;
-    private readonly TimeSpan? _duration;
+    private readonly TimeSpan _duration;
 
-    public DelayBackupOperation(long runningBackupTaskId, TimeSpan? duration)
+    public DelayBackupOperation(long runningBackupTaskId, TimeSpan duration)
     {
         _runningBackupTaskId = runningBackupTaskId;
         _duration = duration;
     }
-        
+
     public RavenCommand<OperationState> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
         return new DelayBackupCommand(_runningBackupTaskId, _duration);
@@ -27,7 +27,7 @@ public class DelayBackupOperation : IMaintenanceOperation<OperationState>
         private readonly long _taskId;
         private readonly TimeSpan? _duration;
 
-        public DelayBackupCommand(long taskId, TimeSpan? duration)
+        public DelayBackupCommand(long taskId, TimeSpan duration)
         {
             _taskId = taskId;
             _duration = duration;

--- a/src/Raven.Client/Documents/Operations/DelayBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DelayBackupOperation.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations;
+
+public class DelayBackupOperation : IMaintenanceOperation<OperationState>
+{
+    private readonly long _runningBackupTaskId;
+    private readonly TimeSpan? _duration;
+
+    public DelayBackupOperation(long runningBackupTaskId, TimeSpan? duration)
+    {
+        _runningBackupTaskId = runningBackupTaskId;
+        _duration = duration;
+    }
+        
+    public RavenCommand<OperationState> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new DelayBackupCommand(_runningBackupTaskId, _duration);
+    }
+
+    private class DelayBackupCommand : RavenCommand<OperationState>
+    {
+        private readonly long _taskId;
+        private readonly TimeSpan? _duration;
+
+        public DelayBackupCommand(long taskId, TimeSpan? duration)
+        {
+            _taskId = taskId;
+            _duration = duration;
+        }
+
+        public override bool IsReadRequest => true;
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/backup-task/delay?taskId={_taskId}&duration={_duration}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post
+            };
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
@@ -370,6 +370,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
 
         public bool IsFull { get; set; }
 
+        public DateTime? OriginalBackupTime { get; set; }
+
         internal long TaskId { get; set; }
 
         public DynamicJsonValue ToJson()
@@ -378,7 +380,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             {
                 [nameof(TimeSpan)] = TimeSpan,
                 [nameof(DateTime)] = DateTime,
-                [nameof(IsFull)] = IsFull
+                [nameof(IsFull)] = IsFull,
+                [nameof(OriginalBackupTime)] = OriginalBackupTime
             };
         }
     }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents
             internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
         }
 
-        private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object _)
+        private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object changeState)
         {
             ForTestingPurposes?.BeforeHandleClusterDatabaseChanged?.Invoke(_serverStore);
 
@@ -164,7 +164,7 @@ namespace Raven.Server.Documents
                             break;
 
                         case ClusterDatabaseChangeType.ValueChanged:
-                            database.ValueChanged(index);
+                            database.ValueChanged(index, type, changeState);
                             break;
 
                         case ClusterDatabaseChangeType.PendingClusterTransactions:

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1277,7 +1277,7 @@ namespace Raven.Server.Documents
         /// </summary>
         public event Action<DatabaseRecord> DatabaseRecordChanged;
 
-        public void ValueChanged(long index)
+        public void ValueChanged(long index, string type, object changeState)
         {
             try
             {
@@ -1291,7 +1291,7 @@ namespace Raven.Server.Documents
                     record = _serverStore.Cluster.ReadDatabase(context, Name);
                 }
 
-                NotifyFeaturesAboutValueChange(record, index);
+                NotifyFeaturesAboutValueChange(record, index, type, changeState);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
             catch (Exception e)
@@ -1479,7 +1479,7 @@ namespace Raven.Server.Documents
             return false;
         }
 
-        private void NotifyFeaturesAboutValueChange(DatabaseRecord record, long index)
+        private void NotifyFeaturesAboutValueChange(DatabaseRecord record, long index, string type, object changeState)
         {
             if (CanSkipValueChange(record.DatabaseName, index))
                 return;
@@ -1503,6 +1503,7 @@ namespace Raven.Server.Documents
                     DatabaseShutdown.ThrowIfCancellationRequested();
                     SubscriptionStorage?.HandleDatabaseRecordChange(record);
                     EtlLoader?.HandleDatabaseValueChanged(record);
+                    PeriodicBackupRunner?.HandleDatabaseValueChanged(type, changeState);
 
                     LastValueChangeIndex = index;
                 }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -866,9 +866,6 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public static void SaveBackupStatus(PeriodicBackupStatus status, DocumentDatabase documentDatabase, Logger logger, BackupResult backupResult, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
         {
-            if (forTestingPurposes != null && forTestingPurposes.SkipBackupStatusSaving)
-                return;
-
             try
             {
                 var command = new UpdatePeriodicBackupStatusCommand(documentDatabase.Name, RaftIdGenerator.NewId())

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -220,18 +220,6 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 operationCanceled = TaskCancelToken.Token.IsCancellationRequested;
 
-                var backupStatus = _database.PeriodicBackupRunner.GetBackupStatus(runningBackupStatus.TaskId);
-                if (backupStatus.DelayUntil > DateTime.UtcNow)
-                {
-                    _database.NotificationCenter.Add(AlertRaised.Create(
-                        _database.Name,
-                        "The task was delayed",
-                        $"The backup task '{_taskName}' was delayed by user and will start again at {backupStatus.DelayUntil.Value.ToLocalTime():MMMM d, yyyy h:mm tt}.",
-                        AlertType.PeriodicBackup,
-                        NotificationSeverity.Info,
-                        details: new ExceptionDetails(oce)));
-                }
-
                 throw;
             }
             catch (Exception e)
@@ -278,7 +266,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         runningBackupStatus.Version = ++_previousBackupStatus.Version;
                         // save the backup status
                         AddInfo("Saving backup status");
-                        SaveBackupStatus(runningBackupStatus, _database, _logger, _backupResult, _forTestingPurposes);
+                        SaveBackupStatus(runningBackupStatus, _database, _logger, _backupResult);
                     }
                 }
             }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         NotificationSeverity.Info,
                         details: new ExceptionDetails(oce)));
                 }
-                
+
                 throw;
             }
             catch (Exception e)
@@ -278,7 +278,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         runningBackupStatus.Version = ++_previousBackupStatus.Version;
                         // save the backup status
                         AddInfo("Saving backup status");
-                        SaveBackupStatus(runningBackupStatus, _database, _logger, _backupResult);
+                        SaveBackupStatus(runningBackupStatus, _database, _logger, _backupResult, _forTestingPurposes);
                     }
                 }
             }
@@ -864,8 +864,11 @@ namespace Raven.Server.Documents.PeriodicBackup
             _database.NotificationCenter.Dismiss(id);
         }
 
-        public static void SaveBackupStatus(PeriodicBackupStatus status, DocumentDatabase documentDatabase, Logger logger, BackupResult backupResult)
+        public static void SaveBackupStatus(PeriodicBackupStatus status, DocumentDatabase documentDatabase, Logger logger, BackupResult backupResult, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
         {
+            if (forTestingPurposes != null && forTestingPurposes.SkipBackupStatusSaving)
+                return;
+
             try
             {
                 var command = new UpdatePeriodicBackupStatusCommand(documentDatabase.Name, RaftIdGenerator.NewId())

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -9,6 +9,7 @@ using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.Util;
 using Raven.Server.Config.Settings;
@@ -209,15 +210,28 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 return _backupResult;
             }
-            catch (OperationCanceledException)
-            {
-                operationCanceled = TaskCancelToken.Token.IsCancellationRequested;
-                throw;
-            }
             catch (ObjectDisposedException)
             {
                 // shutting down, probably
                 operationCanceled = true;
+                throw;
+            }
+            catch (Exception e) when (e.ExtractSingleInnerException() is OperationCanceledException oce)
+            {
+                operationCanceled = TaskCancelToken.Token.IsCancellationRequested;
+
+                var backupStatus = _database.PeriodicBackupRunner.GetBackupStatus(runningBackupStatus.TaskId);
+                if (backupStatus.DelayUntil > DateTime.UtcNow)
+                {
+                    _database.NotificationCenter.Add(AlertRaised.Create(
+                        _database.Name,
+                        "The task was delayed",
+                        $"The backup task '{_taskName}' was delayed by user and will start again at {backupStatus.DelayUntil.Value.ToLocalTime():MMMM d, yyyy h:mm tt}.",
+                        AlertType.PeriodicBackup,
+                        NotificationSeverity.Info,
+                        details: new ExceptionDetails(oce)));
+                }
+                
                 throw;
             }
             catch (Exception e)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             _database = database;
             _serverStore = serverStore;
             _logger = LoggingSource.Instance.GetLogger<PeriodicBackupRunner>(_database.Name);
-            _auditLog = LoggingSource.AuditLog.GetLogger("PeriodicBackupRunner", "Audit");
+            _auditLog = LoggingSource.AuditLog.GetLogger(_database.Name, "Audit");
             _cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
             _tempBackupPath = BackupUtils.GetBackupTempPath(_database.Configuration, "PeriodicBackupTemp");
 
@@ -382,7 +382,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 return;
             }
 
-            throw new ArgumentException($"Backup task {taskId} isn't registered");
+            throw new InvalidOperationException($"Fail to delay backup task with task id '{taskId}', the operation with that number isn't registered");
         }
 
         public DateTime? GetWakeDatabaseTimeUtc(string databaseName)

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -139,7 +139,7 @@ namespace Raven.Server.ServerWide
 
             [nameof(EditLockModeCommand)] = 52_000,
             [nameof(PutRollingIndexCommand)] = 52_000,
-            [nameof(DelayBackupCommand)] = 52_000
+            [nameof(DelayBackupCommand)] = 52_001
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -139,6 +139,7 @@ namespace Raven.Server.ServerWide
 
             [nameof(EditLockModeCommand)] = 52_000,
             [nameof(PutRollingIndexCommand)] = 52_000,
+            [nameof(DelayBackupCommand)] = 52_000
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -438,6 +438,7 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdateSubscriptionClientConnectionTime):
                     case nameof(UpdateSnmpDatabaseIndexesMappingCommand):
                     case nameof(RemoveEtlProcessStateCommand):
+                    case nameof(DelayBackupCommand):
                         SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out _);
                         break;
 
@@ -534,7 +535,7 @@ namespace Raven.Server.ServerWide
                         var parameters = UpdateValue<ToggleServerWideTaskStateCommand.Parameters>(context, type, cmd, index, skipNotifyValueChanged: true);
                         ToggleServerWideTaskState(cmd, parameters, context, type, index);
                         break;
-
+                        
                     case nameof(PutCertificateWithSamePinningHashCommand):
                         PutCertificate(context, type, cmd, index, serverStore);
                         if (cmd.TryGet(nameof(PutCertificateWithSamePinningHashCommand.Name), out string thumbprint))
@@ -3952,7 +3953,7 @@ namespace Raven.Server.ServerWide
             // we don't mind indexForValueChanges for ServerWideExternalReplication
             ApplyDatabaseRecordUpdates(toUpdate, type, serverWideExternalReplication.TaskId, index, items, context);
         }
-
+        
         private static unsafe HashSet<string> GetAllSeverWideExternalReplicationNames(ClusterOperationContext context)
         {
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1353,7 +1353,7 @@ namespace Raven.Server.ServerWide
             finally
             {
                 LogCommand(type, index, exception, updateCommand);
-                NotifyDatabaseAboutChanged(context, updateCommand?.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged, null);
+                NotifyDatabaseAboutChanged(context, updateCommand?.DatabaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged, updateCommand?.GetState());
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Raven.Client.Documents.Operations.Backups;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands;
+
+public class DelayBackupCommand : UpdateValueForDatabaseCommand
+{
+    public long TaskId;
+    public DateTime? DelayUntil;
+
+    // ReSharper disable once UnusedMember.Local
+    private DelayBackupCommand()
+    {
+        // for deserialization
+    }
+
+    public DelayBackupCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+    {
+    }
+
+    public override string GetItemId()
+    {
+        return PeriodicBackupStatus.GenerateItemName(DatabaseName, TaskId);
+    }
+
+    public override void FillJson(DynamicJsonValue json)
+    {
+        json[nameof(TaskId)] = TaskId;
+        json[nameof(DelayUntil)] = DelayUntil;
+    }
+
+    protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+    {
+        if (existingValue != null)
+        {
+            existingValue.Modifications = new DynamicJsonValue
+            {
+                [nameof(DelayUntil)] = DelayUntil
+            };
+            return context.ReadObject(existingValue, GetItemId());
+        }
+
+        var status = new PeriodicBackupStatus
+        {
+            DelayUntil = DelayUntil
+        };
+        return context.ReadObject(status.ToJson(), GetItemId());
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.ServerWide.Commands;
 public class DelayBackupCommand : UpdateValueForDatabaseCommand
 {
     public long TaskId;
-    public DateTime? DelayUntil;
+    public DateTime DelayUntil;
 
     // ReSharper disable once UnusedMember.Local
     private DelayBackupCommand()

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -48,4 +48,19 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
         };
         return context.ReadObject(status.ToJson(), GetItemId());
     }
+
+    public override object GetState()
+    {
+        return new DelayBackupCommandState
+        {
+            TaskId = TaskId,
+            DelayUntil = DelayUntil
+        };
+    }
+
+    public class DelayBackupCommandState
+    {
+        public long TaskId;
+        public DateTime DelayUntil;
+    }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -53,6 +53,11 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
+        public virtual object GetState()
+        {
+            return null;
+        }
+
         public virtual object GetResult()
         {
             return null;

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -227,7 +227,8 @@ namespace Raven.Server.ServerWide
             [nameof(DeleteServerWideAnalyzerCommand)] = GenerateJsonDeserializationRoutine<DeleteServerWideAnalyzerCommand>(),
             [nameof(PutServerWideSorterCommand)] = GenerateJsonDeserializationRoutine<PutServerWideSorterCommand>(),
             [nameof(DeleteServerWideSorterCommand)] = GenerateJsonDeserializationRoutine<DeleteServerWideSorterCommand>(),
-            [nameof(EditLockModeCommand)] = GenerateJsonDeserializationRoutine<EditLockModeCommand>()
+            [nameof(EditLockModeCommand)] = GenerateJsonDeserializationRoutine<EditLockModeCommand>(),
+            [nameof(DelayBackupCommand)] = GenerateJsonDeserializationRoutine<DelayBackupCommand>()
         };
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -664,6 +664,8 @@ namespace Raven.Server.Web.System
 
             var databaseName = GetStringQueryString("database");
             var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName).ConfigureAwait(false);
+            if (database == null)
+                DatabaseDoesNotExistException.Throw(databaseName);
 
             await database.PeriodicBackupRunner.DelayAsync(id, delay.Value, GetCurrentCertificate());
             

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -662,10 +662,12 @@ namespace Raven.Server.Web.System
             if (delay <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(delay));
 
-            var databaseName = GetStringQueryString("databaseName");
+            var databaseName = GetStringQueryString("database");
             var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName).ConfigureAwait(false);
 
             await database.PeriodicBackupRunner.DelayAsync(id, delay.Value, GetCurrentCertificate());
+            
+            NoContentStatus();
         }
 
         [RavenAction("/admin/databases", "DELETE", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -30,7 +30,6 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Migration;
 using Raven.Client.Util;
 using Raven.Server.Config;
-using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes.Auto;
@@ -653,6 +652,20 @@ namespace Raven.Server.Web.System
                     writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);
                 }
             }
+        }
+
+        [RavenAction("/admin/backup-task/delay", "POST", AuthorizationStatus.Operator)]
+        public async Task DelayBackupTask()
+        {
+            var id = GetLongQueryString("taskId");
+            var delay = GetTimeSpanQueryString("duration");
+            if (delay <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(delay));
+
+            var databaseName = GetStringQueryString("databaseName");
+            var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName).ConfigureAwait(false);
+
+            await database.PeriodicBackupRunner.DelayAsync(id, delay.Value, GetCurrentCertificate());
         }
 
         [RavenAction("/admin/databases", "DELETE", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -305,6 +305,15 @@ namespace Raven.Server.Web.System
             return taskInfo;
         }
 
+        [RavenAction("/databases/*/admin/backup-task/delay", "POST", AuthorizationStatus.Operator)]
+        public async Task DelayBackupTask()
+        {
+            var id = GetLongQueryString("taskId");
+            var delayInHrs = GetTimeSpanQueryString("duration");
+            
+            await Database.PeriodicBackupRunner.Delay(id, delayInHrs, GetCurrentCertificate());
+        }
+
         [RavenAction("/databases/*/admin/periodic-backup/config", "GET", AuthorizationStatus.DatabaseAdmin)]
         public async Task GetConfiguration()
         {
@@ -337,7 +346,7 @@ namespace Raven.Server.Web.System
                 BackupDatabaseHandler.WriteEndOfTimers(writer, count);
             }
         }
-
+        
         [RavenAction("/databases/*/admin/periodic-backup", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task UpdatePeriodicBackup()
         {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -305,7 +305,7 @@ namespace Raven.Server.Web.System
             return taskInfo;
         }
 
-        [RavenAction("/databases/*/admin/backup-task/delay", "POST", AuthorizationStatus.Operator)]
+        [RavenAction("/databases/*/admin/backup-task/delay", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task DelayBackupTask()
         {
             var id = GetLongQueryString("taskId");

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -719,7 +719,7 @@ namespace Raven.Server.Web.System
                     }
 
                     break;
-
+                
                 default:
                     throw new NotSupportedException($"Unknown connection string type: {connectionStringType}");
             }
@@ -761,11 +761,11 @@ namespace Raven.Server.Web.System
             string etlConfigurationName = null;
 
             await DatabaseConfigurations((_, databaseName, etlConfiguration, guid) =>
-            {
-                var task = ServerStore.UpdateEtl(_, databaseName, id.Value, etlConfiguration, guid);
-                etlConfiguration.TryGet(nameof(RavenEtlConfiguration.Name), out etlConfigurationName);
-                return task;
-            }, "etl-update",
+                {
+                    var task = ServerStore.UpdateEtl(_, databaseName, id.Value, etlConfiguration, guid);
+                    etlConfiguration.TryGet(nameof(RavenEtlConfiguration.Name), out etlConfigurationName);
+                    return task;
+                }, "etl-update",
                 GetRaftRequestIdFromQuery(),
                 beforeSetupConfiguration: AssertCanAddOrUpdateEtl,
                 fillJson: (json, _, index) => json[nameof(EtlConfiguration<ConnectionString>.TaskId)] = index);
@@ -877,7 +877,7 @@ namespace Raven.Server.Web.System
                     };
                 }
             }
-
+            
             if (databaseRecord.OlapEtls != null)
             {
                 foreach (var olapEtl in databaseRecord.OlapEtls)
@@ -1054,7 +1054,7 @@ namespace Raven.Server.Web.System
                                 Error = sqlEtlError
                             });
                             break;
-
+                        
                         case OngoingTaskType.OlapEtl:
 
                             var olapEtl = name != null ?
@@ -1066,7 +1066,7 @@ namespace Raven.Server.Web.System
                                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                                 break;
                             }
-
+                            
                             await WriteResult(context, new OngoingTaskOlapEtlDetails
                             {
                                 TaskId = olapEtl.TaskId,

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -305,18 +305,6 @@ namespace Raven.Server.Web.System
             return taskInfo;
         }
 
-        [RavenAction("/databases/*/admin/backup-task/delay", "POST", AuthorizationStatus.DatabaseAdmin)]
-        public async Task DelayBackupTask()
-        {
-            var id = GetLongQueryString("taskId");
-            var delay = GetTimeSpanQueryString("duration");
-
-            if (delay <= TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException(nameof(delay));
-
-            await Database.PeriodicBackupRunner.Delay(id, delay.Value, GetCurrentCertificate());
-        }
-
         [RavenAction("/databases/*/admin/periodic-backup/config", "GET", AuthorizationStatus.DatabaseAdmin)]
         public async Task GetConfiguration()
         {

--- a/src/Raven.Studio/typescript/commands/database/tasks/delayBackupCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/delayBackupCommand.ts
@@ -1,0 +1,25 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+
+class delayBackupCommand extends commandBase {
+    constructor(private db: database, private taskId: number, private duration: string) {
+        super();
+    }
+ 
+    execute(): JQueryPromise<Raven.Client.Documents.Operations.Backups.StartBackupOperationResult> {
+        const args = {
+            taskId: this.taskId,
+            duration: this.duration,
+            database: this.db.name
+        }
+        const url = endpoints.global.adminDatabases.adminBackupTaskDelay + this.urlEncodeArgs(args);
+        
+        return this.post(url, null, null,  { dataType: undefined })
+            .done(() => this.reportSuccess("Backup was delayed"))
+            .fail(response => this.reportError("Failed to delay backup task", response.responseText, response.statusText));
+    }
+}
+
+export = delayBackupCommand;

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskBackupListModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskBackupListModel.ts
@@ -133,7 +133,9 @@ class ongoingTaskBackupListModel extends ongoingTaskListModel {
             const backupType = this.getBackupType(this.backupType(), nextBackup.IsFull);
             const backupTypeText = backupType !== "Snapshot" ? `${backupType} Backup` : backupType;
             const formatDuration = generalUtils.formatDuration(moment.duration(diff), true, 2, true);
-            return `in ${formatDuration} (${backupTypeText})`;
+            const originalDate = this.nextBackup().OriginalBackupTime;
+            const originalDateText = originalDate ? ", delayed backup from: " + generalUtils.formatUtcDateAsLocal(originalDate) : "";
+            return `in ${formatDuration} (${backupTypeText}) ${originalDateText}`;
         });
 
         this.onGoingBackupHumanized = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -5,6 +5,8 @@ import notificationCenter = require("common/notifications/notificationCenter");
 import abstractOperationDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/abstractOperationDetails");
 import generalUtils = require("common/generalUtils");
 import genericProgress = require("common/helpers/database/genericProgress");
+import delayBackupCommand = require("commands/database/tasks/delayBackupCommand");
+import viewHelpers = require("common/helpers/view/viewHelpers");
 
 type smugglerListItemStatus = "processed" | "skipped" | "processing" | "pending" | "processedWithErrors";
 
@@ -38,6 +40,8 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
     itemsLastCount: dictionary<number> = {};
     lastProcessingSpeedText = smugglerDatabaseDetails.ProcessingText;
     
+    canDelay: KnockoutComputed<boolean>;
+    
     exportItems: KnockoutComputed<Array<smugglerListItem>>;
     uploadItems: KnockoutComputed<Array<uploadListItem>>;
     messages: KnockoutComputed<Array<string>>;
@@ -54,6 +58,13 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
 
     protected initObservables() {
         super.initObservables();
+        
+        this.canDelay = ko.pureComputed(() => {
+            const completed = this.op.isCompleted();
+            const isBackup = this.op.taskType() === "DatabaseBackup";
+            
+            return !completed && isBackup;
+        });
 
         this.exportItems = ko.pureComputed(() => {
             if (this.op.status() === "Faulted") {
@@ -223,6 +234,32 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
         if (this.operationFailed()) {
             this.detailsVisible(true);
         }
+    }
+
+    delayBackup(duration: string) {
+        if (!this.canDelay()) {
+            return;
+        }
+        
+        this.close();
+        
+        const durationFormatted = generalUtils.formatTimeSpan(duration, true);
+        
+        viewHelpers.confirmationMessage("Delay backup", "Do you want to delay backup by " + durationFormatted +  "?", {
+            buttons: ["Cancel", "Delay"]
+        })
+            .done(result => {
+                if (result.can) {
+                    new delayBackupCommand(this.op.database, this.op.operationId(), "01:00:00")
+                        .execute();
+                } else {
+                    this.openDetails();
+                }
+            })
+            .fail(() => {
+                this.openDetails();
+            })
+        
     }
     
     private static findCurrentlyProcessingItems(result: Array<smugglerListItem>): string[] {

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -106,7 +106,35 @@
                 </label>
             </div>
         </div>
-        <div class="modal-footer" data-bind="compose: 'common/notificationCenter/detailViewer/operations/footerPartial.html'">
+        <div class="modal-footer">
+            <div class="flex-horizontal">
+                <div data-bind="visible: canDelay">
+                    <div class="btn-group dropup">
+                        <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown"
+                                data-bind="requiredAccess: 'Operator'">
+                            <span>Delay backup</span><span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '01:00:00')"><span>1 hour</span></a></li>
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '03:00:00')"><span>3 hours</span></a></li>
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '06:00:00')"><span>6 hours</span></a></li>
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '1.00:00:00')"><span>1 day</span></a></li>
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '3.00:00:00')"><span>3 days</span></a></li>
+                            <li><a href="#" data-bind="click: _.partial(delayBackup, '7.00:00:00')"><span>7 days</span></a></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="flex-separator"></div>
+                <div>
+                    <button type="button" class="btn btn-default" data-bind="click: close" title="Close this dialog">
+                        <i class="icon-cancel"></i><span>Close</span>
+                    </button>
+                    <button type="button" class="btn btn-danger" title="Abort this operation"
+                            data-bind="click: killOperation, visible: killable, css: { 'btn-spinner': spinners.kill }, disable: spinners.kill">
+                        <i class="icon-stop"></i><span>Abort</span>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Http;
+using Raven.Server.ServerWide.Commands;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -48,10 +49,10 @@ namespace FastTests.Client
                 "ReorderDatabaseMembersCommand", "ReplaceClusterCertificateCommand", "ResetEtlCommand", "ResetIndexCommand", "SetDatabaseDynamicDistributionCommand",
                 "SetIndexLockCommand", "SetIndexPriorityCommand", "SetLogsConfigurationCommand", "StartIndexCommand", "StartIndexingCommand",
                 "StartTransactionsRecordingCommand", "StopIndexCommand", "StopIndexingCommand", "StopTransactionsRecordingCommand",
-                "UpdateUnusedDatabasesCommand", "WaitForRaftIndexCommand", "ConfigureTimeSeriesCommand", "ConfigureTimeSeriesPolicyCommand", 
+                "UpdateUnusedDatabasesCommand", "WaitForRaftIndexCommand", "ConfigureTimeSeriesCommand", "ConfigureTimeSeriesPolicyCommand",
                 "UpdateSubscriptionCommand", "RemoveTimeSeriesPolicyCommand", "GetTimeSeriesStatisticsCommand", "GetTimeSeriesCommand", "GetMultipleTimeSeriesCommand",
                 "GetAttachmentsCommand", "ConfigureTimeSeriesValueNamesCommand", "DeleteIndexErrorsCommand", "TimeSeriesBatchCommand", "GetRevisionsResultCommand", "SetIndexStateCommand",
-                "BackupCommand", "GetReplicationHubAccessCommand", "GetServerWideExternalReplicationCommand", "GetServerWideExternalReplicationsCommand", 
+                "BackupCommand", "GetReplicationHubAccessCommand", "GetServerWideExternalReplicationCommand", "GetServerWideExternalReplicationsCommand",
                 "PutServerWideBackupConfigurationCommand", "PutServerWideExternalReplicationCommand", "ConditionalGetDocumentsCommand",
                 "DeleteServerWideTaskCommand", "RegisterReplicationHubAccessCommand", "ToggleServerWideTaskStateCommand", "UnregisterReplicationHubAccessCommand", "GetRevisionsCountCommand",
                 "DeleteAnalyzerCommand", "PutAnalyzersCommand","UpdateDocumentCompressionConfigurationCommand",
@@ -60,7 +61,7 @@ namespace FastTests.Client
                 "SetDatabasesLockCommand",
                 "GetDatabaseSettingsCommand", "PutDatabaseConfigurationSettingsCommand",
                 "GetTrafficWatchConfigurationCommand", "SetTrafficWatchConfigurationCommand",
-                "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand"
+                "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand", "DelayBackupCommand",
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -2,16 +2,18 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using Org.BouncyCastle.Math.EC;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
 using Xunit;
 
 namespace FastTests
@@ -468,6 +470,38 @@ namespace FastTests
                             PrintBackupResultMessagesStatus(result));
                     }
                 }
+            }
+            
+            public async Task FillDatabaseWithRandomDataAsync(int databaseSizeInMb, IAsyncDocumentSession session, int? timeout = default)
+            {
+                var random = new Random();
+                const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+                var timeoutTimeSpan = TimeSpan.FromMilliseconds(timeout ?? _reasonableTimeout);
+
+                using (var cts = new CancellationTokenSource(timeoutTimeSpan))
+                {
+                    for (int i = 0; i < databaseSizeInMb; i++)
+                    {
+                        var entry = new User
+                        {
+                            Name = new string(Enumerable.Repeat(chars, 1024 * 1024)
+                                .Select(s => s[random.Next(s.Length)]).ToArray())
+                        };
+                        await session.StoreAsync(entry, cts.Token);
+                    }
+                    await session.SaveChangesAsync(cts.Token);
+                }
+            }
+
+            public async Task FillClusterDatabaseWithRandomDataAsync(int databaseSizeInMb, DocumentStore store, int clusterSize, int? timeout = default)
+            {
+                var timeoutTimeSpan = TimeSpan.FromMilliseconds(timeout ?? _reasonableTimeout);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeoutTimeSpan, replicas: clusterSize - 1);
+                    await FillDatabaseWithRandomDataAsync(databaseSizeInMb, session, (int?)timeoutTimeSpan.TotalMilliseconds);
+                }   
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19235/Add-the-ability-to-cancel-and-delay-server-wide-backups-by-Operator

### Additional description

In case the backup is causing problems for the server, we need to be able to delay and cancel such operation for a set time

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio