### PR TITLE
RavenDB-19562 Fixing 'Ensure 'ThreadStatic' is only used with static fields' warning in Voron

### DIFF
--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -681,18 +681,18 @@ namespace Voron.Data.BTrees
             return SearchForPage(key, allowCompressed, out cursor, out node);
         }
         [ThreadStatic]
-        private FastList<long> _cursorPathBuffer;
+        private static FastList<long> CursorPathBuffer;
 
         private TreePage SearchForPage(Slice key, out TreeNodeHeader* node)
         {
             var p = GetReadOnlyTreePage(State.RootPageNumber);
 
-            if (_cursorPathBuffer == null)
-                _cursorPathBuffer = new FastList<long>();
+            if (CursorPathBuffer == null)
+                CursorPathBuffer = new FastList<long>();
             else
-                _cursorPathBuffer.Clear();
+                CursorPathBuffer.Clear();
 
-            _cursorPathBuffer.Add(p.PageNumber);
+            CursorPathBuffer.Add(p.PageNumber);
 
             bool rightmostPage = true;
             bool leftmostPage = true;
@@ -721,7 +721,7 @@ namespace Voron.Data.BTrees
                 Debug.Assert(pageNode->PageNumber == p.PageNumber,
                     string.Format("Requested Page: #{0}. Got Page: #{1}", pageNode->PageNumber, p.PageNumber));
 
-                _cursorPathBuffer.Add(p.PageNumber);
+                CursorPathBuffer.Add(p.PageNumber);
             }
 
             if (p.IsLeaf == false)
@@ -732,7 +732,7 @@ namespace Voron.Data.BTrees
 
             node = p.Search(_llt, key); // will set the LastSearchPosition
 
-            AddToRecentlyFoundPages(_cursorPathBuffer, p, leftmostPage, rightmostPage);
+            AddToRecentlyFoundPages(CursorPathBuffer, p, leftmostPage, rightmostPage);
 
             return p;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19562/Voron-Warning-Ensure-ThreadStatic-is-only-used-with-static-fields

### Additional description

The idea was to reduce the number of allocations: 
https://github.com/ravendb/ravendb/commit/1e590b2247d824d78300d55789c2a93f16da50db

### Type of change

- Optimization

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify the change

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
