### PR TITLE
RavenDB-19563 - Index mismatch after snapshot restore

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1120,6 +1120,8 @@ namespace Raven.Server.Documents
                 switch (storageEnvironmentWithType.Type)
                 {
                     case StorageEnvironmentWithType.StorageEnvironmentType.Documents:
+                        ForTestingPurposes?.BeforeSnapshotOfDocuments?.Invoke();
+
                         yield return new FullBackup.StorageEnvironmentInformation
                         {
                             Name = string.Empty,
@@ -1127,7 +1129,7 @@ namespace Raven.Server.Documents
                             Env = storageEnvironmentWithType.Environment
                         };
 
-                        ForTestingPurposes?.AfterSnapshotOfDocuments.Invoke();
+                        ForTestingPurposes?.AfterSnapshotOfDocuments?.Invoke();
 
                         break;
 
@@ -1878,6 +1880,9 @@ namespace Raven.Server.Documents
             internal Action AfterTxMergerDispose;
 
             internal Action BeforeExecutingClusterTransactions;
+
+            internal Action AfterSnapshotOfDocuments;
+            internal Action BeforeSnapshotOfDocuments;
 
             internal Action AfterSnapshotOfDocuments;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -433,6 +433,20 @@ namespace Raven.Server.Documents
         private int _clusterTransactionDelayOnFailure = 1000;
         private FileLocker _fileLocker;
 
+        private static readonly List<StorageEnvironmentWithType.StorageEnvironmentType> DefaultStorageEnvironmentTypes = new()
+        {
+            StorageEnvironmentWithType.StorageEnvironmentType.Documents,
+            StorageEnvironmentWithType.StorageEnvironmentType.Configuration,
+            StorageEnvironmentWithType.StorageEnvironmentType.Index
+        };
+
+        private static readonly List<StorageEnvironmentWithType.StorageEnvironmentType> DefaultStorageEnvironmentTypesForBackup = new()
+        {
+            StorageEnvironmentWithType.StorageEnvironmentType.Index,
+            StorageEnvironmentWithType.StorageEnvironmentType.Documents,
+            StorageEnvironmentWithType.StorageEnvironmentType.Configuration,
+        };
+
         private async Task ExecuteClusterTransactionTask()
         {
             while (DatabaseShutdown.IsCancellationRequested == false)
@@ -1056,37 +1070,52 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<StorageEnvironmentWithType> GetAllStoragesEnvironment()
+        public IEnumerable<StorageEnvironmentWithType> GetAllStoragesEnvironment(List<StorageEnvironmentWithType.StorageEnvironmentType> types = null)
         {
-            // TODO :: more storage environments ?
-            var documentsStorage = DocumentsStorage;
-            if (documentsStorage != null)
-                yield return
-                    new StorageEnvironmentWithType(Name, StorageEnvironmentWithType.StorageEnvironmentType.Documents,
-                        documentsStorage.Environment);
-            var configurationStorage = ConfigurationStorage;
-            if (configurationStorage != null)
-                yield return
-                    new StorageEnvironmentWithType("Configuration",
-                        StorageEnvironmentWithType.StorageEnvironmentType.Configuration, configurationStorage.Environment);
+            types ??= DefaultStorageEnvironmentTypes;
 
-            //check for null to prevent NRE when disposing the DocumentDatabase
-            foreach (var index in (IndexStore?.GetIndexes()).EmptyIfNull())
+            // TODO :: more storage environments ?
+            foreach (var type in types)
             {
-                var env = index?._indexStorage?.Environment();
-                if (env != null)
-                    yield return
-                        new StorageEnvironmentWithType(index.Name,
-                            StorageEnvironmentWithType.StorageEnvironmentType.Index, env)
+                switch (type)
+                {
+                    case StorageEnvironmentWithType.StorageEnvironmentType.Documents:
+                        var documentsStorage = DocumentsStorage;
+                        if (documentsStorage != null)
+                            yield return
+                                new StorageEnvironmentWithType(Name, StorageEnvironmentWithType.StorageEnvironmentType.Documents,
+                                    documentsStorage.Environment);
+                        break;
+                    
+                    case StorageEnvironmentWithType.StorageEnvironmentType.Configuration:
+                        var configurationStorage = ConfigurationStorage;
+                        if (configurationStorage != null)
+                            yield return
+                                new StorageEnvironmentWithType("Configuration",
+                                    StorageEnvironmentWithType.StorageEnvironmentType.Configuration, configurationStorage.Environment);
+                        break;
+
+                    case StorageEnvironmentWithType.StorageEnvironmentType.Index:
+                        //check for null to prevent NRE when disposing the DocumentDatabase
+                        foreach (var index in (IndexStore?.GetIndexes()).EmptyIfNull())
                         {
-                            LastIndexQueryTime = index.GetLastQueryingTime()
-                        };
+                            var env = index?._indexStorage?.Environment();
+                            if (env != null)
+                                yield return
+                                    new StorageEnvironmentWithType(index.Name,
+                                        StorageEnvironmentWithType.StorageEnvironmentType.Index, env)
+                                    {
+                                        LastIndexQueryTime = index.GetLastQueryingTime()
+                                    };
+                        }
+                        break;
+                }
             }
         }
 
         private IEnumerable<FullBackup.StorageEnvironmentInformation> GetAllStoragesForBackup(bool excludeIndexes)
         {
-            foreach (var storageEnvironmentWithType in GetAllStoragesEnvironment())
+            foreach (var storageEnvironmentWithType in GetAllStoragesEnvironment(DefaultStorageEnvironmentTypesForBackup))
             {
                 switch (storageEnvironmentWithType.Type)
                 {
@@ -1097,6 +1126,9 @@ namespace Raven.Server.Documents
                             Folder = Constants.Documents.PeriodicBackup.Folders.Documents,
                             Env = storageEnvironmentWithType.Environment
                         };
+
+                        ForTestingPurposes?.AfterSnapshotOfDocuments.Invoke();
+
                         break;
 
                     case StorageEnvironmentWithType.StorageEnvironmentType.Index:
@@ -1846,6 +1878,8 @@ namespace Raven.Server.Documents
             internal Action AfterTxMergerDispose;
 
             internal Action BeforeExecutingClusterTransactions;
+
+            internal Action AfterSnapshotOfDocuments;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1890,7 +1890,6 @@ namespace Raven.Server.Documents
 
             internal Action BeforeExecutingClusterTransactions;
 
-            internal Action AfterSnapshotOfDocuments;
             internal Action BeforeSnapshotOfDocuments;
 
             internal Action AfterSnapshotOfDocuments;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1165,6 +1165,15 @@ namespace Raven.Server.Documents
         {
             SmugglerResult smugglerResult;
 
+            long lastTombstoneEtag = 0;
+            using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                //TODO: add counters and time series
+                lastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(ctx.Transaction.InnerTransaction);
+            }
+
+            using (TombstoneCleaner.PreventTombstoneCleaning(lastTombstoneEtag))
             using (var file = SafeFileStream.Create(backupPath, FileMode.Create))
             using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1173,7 +1173,7 @@ namespace Raven.Server.Documents
                 lastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(ctx.Transaction.InnerTransaction);
             }
 
-            using (TombstoneCleaner.PreventTombstoneCleaning(lastTombstoneEtag))
+            using (TombstoneCleaner.PreventTombstoneCleaningUpToEtag(lastTombstoneEtag))
             using (var file = SafeFileStream.Create(backupPath, FileMode.Create))
             using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1169,7 +1169,6 @@ namespace Raven.Server.Documents
             using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
-                //TODO: add counters and time series
                 lastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(ctx.Transaction.InnerTransaction);
             }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1063,6 +1063,9 @@ namespace Raven.Server.Documents.Handlers
                                 //[nameof(Constants.Fields.CommandData.DocumentChangeVector)] = tsCmd.LastDocumentChangeVector
                             });
 
+                            if (tsCmd.DocCollection != null)
+                                ModifiedCollections?.Add(tsCmd.DocCollection);
+
                             break;
 
                         case CommandType.TimeSeriesCopy:

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1110,6 +1110,15 @@ namespace Raven.Server.Documents.Handlers
                                 [nameof(CountersDetail)] = counterBatchCmd.CountersDetail.ToJson(),
                                 [nameof(Constants.Fields.CommandData.DocumentChangeVector)] = counterBatchCmd.LastDocumentChangeVector
                             });
+
+                            if (counterBatchCmd.DocumentCollections != null)
+                            {
+                                foreach (var collection in counterBatchCmd.DocumentCollections)
+                                {
+                                    ModifiedCollections?.Add(collection);
+                                }
+                            }
+
                             break;
 
                         case CommandType.ForceRevisionCreation:

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents.Handlers
             public bool HasWrites;
             public string LastChangeVector;
             public string LastDocumentChangeVector;
+            public HashSet<string> DocumentCollections;
 
             public CountersDetail CountersDetail = new CountersDetail
             {
@@ -83,6 +84,8 @@ namespace Raven.Server.Documents.Handlers
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
+                DocumentCollections?.Clear();
+                
                 var countersToAdd = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
                 var countersToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -180,6 +183,8 @@ namespace Raven.Server.Documents.Handlers
                     docId = counterOperation.DocumentId;
 
                     docCollection = GetDocumentCollection(docId, _database, context, _fromEtl, out doc);
+                    DocumentCollections ??= new HashSet<string>();
+                    DocumentCollections.Add(docCollection);
                 }
 
                 ApplyChangesForPreviousDocument(context, doc, docId, countersToAdd, countersToRemove);

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -877,6 +877,7 @@ namespace Raven.Server.Documents.Handlers
             private readonly bool _fromEtl;
 
             public string LastChangeVector;
+            public string DocCollection;
 
             public ExecuteTimeSeriesBatchCommand(DocumentDatabase database, string documentId, TimeSeriesOperation operation, bool fromEtl)
             {
@@ -888,9 +889,9 @@ namespace Raven.Server.Documents.Handlers
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
-                string docCollection = GetDocumentCollection(_database, context, _documentId, _fromEtl);
+                DocCollection = GetDocumentCollection(_database, context, _documentId, _fromEtl);
 
-                if (docCollection == null)
+                if (DocCollection == null)
                     return 0L;
 
                 var changes = 0L;
@@ -903,7 +904,7 @@ namespace Raven.Server.Documents.Handlers
                         var deletionRange = new TimeSeriesStorage.DeletionRangeRequest
                         {
                             DocumentId = _documentId,
-                            Collection = docCollection,
+                            Collection = DocCollection,
                             Name = _operation.Name,
                             From = removal.From ?? DateTime.MinValue,
                             To = removal.To ?? DateTime.MaxValue
@@ -920,7 +921,7 @@ namespace Raven.Server.Documents.Handlers
 
                 LastChangeVector = tss.AppendTimestamp(context,
                     _documentId,
-                    docCollection,
+                    DocCollection,
                     _operation.Name,
                     _operation.Appends
                 );

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -194,6 +194,8 @@ namespace Raven.Server.Documents
             if (maxTombstoneEtagToDelete.HasValue)
             {
                 result.MinAllDocsEtag = Math.Min(result.MinAllDocsEtag, maxTombstoneEtagToDelete.Value);
+                result.MinAllCountersEtag = Math.Min(result.MinAllCountersEtag, maxTombstoneEtagToDelete.Value);
+                result.MinAllTimeSeriesEtag = Math.Min(result.MinAllTimeSeriesEtag, maxTombstoneEtagToDelete.Value);
             }
 
             return result;

--- a/test/SlowTests/Issues/RavenDB-19563.cs
+++ b/test/SlowTests/Issues/RavenDB-19563.cs
@@ -115,7 +115,7 @@ namespace SlowTests.Issues
 
                 var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                Assert.Equal(1, cleanedTombstones);
+                Assert.Equal(0, cleanedTombstones);
 
                 var databaseName = $"restored_database-{Guid.NewGuid()}";
 

--- a/test/SlowTests/Issues/RavenDB-19563.cs
+++ b/test/SlowTests/Issues/RavenDB-19563.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Counters;
+using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Utils;
 using SlowTests.Core.Utils.Entities;
@@ -139,6 +141,136 @@ namespace SlowTests.Issues
             }
         }
 
+        [Fact]
+        public async Task Snapshot_should_have_correct_index_entries_after_snapshot_and_incremental_restore_counters()
+        {
+            var backupPath = NewDataPath();
+            IOExtensions.DeleteDirectory(backupPath);
+
+            using (var store = GetDocumentStore())
+            {
+                const string id = "users/1";
+                const string counterName = "Count";
+
+                await new UsersCountersMapReduceIndex().ExecuteAsync(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    session.CountersFor(id).Increment(counterName, 1);
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                long cleanedTombstones = 0;
+                database.ForTestingPurposesOnly().BeforeSnapshotOfDocuments = () =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Advanced.WaitForIndexesAfterSaveChanges();
+                        session.CountersFor(id).Delete(counterName);
+                        session.SaveChanges();
+                    }
+
+                    cleanedTombstones = database.TombstoneCleaner.ExecuteCleanup().GetAwaiter().GetResult();
+                };
+
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                Assert.Equal(0, cleanedTombstones);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                {
+                    BackupLocation = Directory.GetDirectories(backupPath).First(),
+                    DatabaseName = databaseName
+                }))
+                {
+                    Indexes.WaitForIndexing(store, databaseName);
+
+                    using (var session = store.OpenAsyncSession(databaseName))
+                    {
+                        var counter = await session.CountersFor(id).GetAsync(counterName);
+                        Assert.Null(counter);
+
+                        var usersCount = await session.Query<User, UsersCountersMapReduceIndex>().CountAsync();
+                        Assert.Equal(0, usersCount);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Snapshot_should_have_correct_index_entries_after_snapshot_and_incremental_restore_timeseries()
+        {
+            var backupPath = NewDataPath();
+            IOExtensions.DeleteDirectory(backupPath);
+
+            using (var store = GetDocumentStore())
+            {
+                const string id = "users/1";
+                const string timeSeriesName = "Count";
+
+                await new UsersTimeSeriesMapReduceIndex().ExecuteAsync(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    session.TimeSeriesFor(id, timeSeriesName).Append(DateTime.Today, 3);
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                long cleanedTombstones = 0;
+                database.ForTestingPurposesOnly().BeforeSnapshotOfDocuments = () =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Advanced.WaitForIndexesAfterSaveChanges();
+                        session.TimeSeriesFor(id, timeSeriesName).Delete();
+                        session.SaveChanges();
+                    }
+
+                    cleanedTombstones = database.TombstoneCleaner.ExecuteCleanup().GetAwaiter().GetResult();
+                };
+
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                Assert.Equal(0, cleanedTombstones);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                {
+                    BackupLocation = Directory.GetDirectories(backupPath).First(),
+                    DatabaseName = databaseName
+                }))
+                {
+                    Indexes.WaitForIndexing(store, databaseName);
+
+                    using (var session = store.OpenAsyncSession(databaseName))
+                    {
+                        var entries = await session.TimeSeriesFor(id, timeSeriesName).GetAsync();
+                        Assert.Null(entries);
+
+                        var usersCount = await session.Query<User, UsersTimeSeriesMapReduceIndex>().CountAsync();
+                        Assert.Equal(0, usersCount);
+                    }
+                }
+            }
+        }
+
         private class UsersIndex : AbstractIndexCreationTask<User>
         {
             public UsersIndex()
@@ -161,6 +293,50 @@ namespace SlowTests.Issues
                         Name = user.Name,
                         Count = 1
                     };
+
+                Reduce = results => from result in results
+                    group result by new { result.Name } into g
+                    select new
+                    {
+                        Name = g.Key.Name,
+                        Count = g.Sum(x => x.Count)
+                    };
+            }
+        }
+
+        private class UsersCountersMapReduceIndex : AbstractCountersIndexCreationTask<User>
+        {
+            public UsersCountersMapReduceIndex()
+            {
+                AddMapForAll(counters => from counter in counters
+                    select new
+                    {
+                        Name = counter.Name,
+                        Count = 1
+                    });
+
+                Reduce = results => from result in results
+                    group result by new { result.Name } into g
+                    select new
+                    {
+                        Name = g.Key.Name,
+                        Count = g.Sum(x => x.Count)
+                    };
+            }
+        }
+
+        private class UsersTimeSeriesMapReduceIndex : AbstractTimeSeriesIndexCreationTask<User>
+        {
+            public UsersTimeSeriesMapReduceIndex()
+            {
+                AddMapForAll(timeSeries => 
+                    from ts in timeSeries
+                    from entry in ts.Entries
+                    select new
+                    {
+                        Name = ts.Name,
+                        Count = 1
+                    });
 
                 Reduce = results => from result in results
                     group result by new { result.Name } into g

--- a/test/SlowTests/Issues/RavenDB-19563.cs
+++ b/test/SlowTests/Issues/RavenDB-19563.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Utils;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19563 : RavenTestBase
+    {
+        public RavenDB_19563(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Snapshot_should_have_correct_index_entries_after_restore()
+        {
+            var backupPath = NewDataPath();
+            IOExtensions.DeleteDirectory(backupPath);
+
+            using (var store = GetDocumentStore())
+            {
+                var id = "users/1";
+
+                await new UsersIndex().ExecuteAsync(store);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                database.ForTestingPurposesOnly().AfterSnapshotOfDocuments = () =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Advanced.WaitForIndexesAfterSaveChanges(TimeSpan.FromSeconds(5));
+                        session.Delete(id);
+                        session.SaveChanges();
+                    }
+                };
+
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                {
+                    BackupLocation = Directory.GetDirectories(backupPath).First(),
+                    DatabaseName = databaseName
+                }))
+                {
+                    Indexes.WaitForIndexing(store, databaseName);
+
+                    using (var session = store.OpenAsyncSession(databaseName))
+                    {
+                        var user = await session.LoadAsync<User>("users/1");
+                        Assert.NotNull(user);
+
+                        var usersCount = await session.Query<User, UsersIndex>().CountAsync();
+                        Assert.Equal(1, usersCount);
+                    }
+                }
+            }
+        }
+
+        private class UsersIndex : AbstractIndexCreationTask<User>
+        {
+            public UsersIndex()
+            {
+                Map = users => from user in users
+                               select new User
+                               {
+                                   Name = user.Name
+                               };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19634.cs
+++ b/test/SlowTests/Issues/RavenDB-19634.cs
@@ -2,10 +2,12 @@
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Indexes.Counters;
 using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using SlowTests.Core.Utils.Entities;
+using Sparrow.Server.Collections.LockFree;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,9 +25,38 @@ public class RavenDB_19634 : RavenTestBase
         using (var store = GetDocumentStore())
         {
             const string id = "users/1";
-            const string timeSeriesName = "Count";
 
             var index = new UsersTimeSeriesMapIndex();
+            await index.ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Name = "Grisha"
+                }, id);
+                await session.SaveChangesAsync();
+            }
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                session.TimeSeriesFor(id, "Count").Append(DateTime.Today, 3);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
+                await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Should_Wait_For_Counters_Index_Changes()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string id = "users/1";
+
+            var index = new UsersCountersIndex();
             await index.ExecuteAsync(store);
 
             using (var session = store.OpenAsyncSession())
@@ -41,10 +72,23 @@ public class RavenDB_19634 : RavenTestBase
 
             using (var session = store.OpenAsyncSession())
             {
-                session.TimeSeriesFor(id, timeSeriesName).Append(DateTime.Today, 3);
+                session.CountersFor(id).Increment("Count", 1);
                 session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
                 await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
             }
+        }
+    }
+
+    private class UsersCountersIndex : AbstractCountersIndexCreationTask<User>
+    {
+        public UsersCountersIndex()
+        {
+            AddMapForAll(counters => from counter in counters
+                select new
+                {
+                    Name = counter.Name,
+                    Count = 1
+                });
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB-19634.cs
+++ b/test/SlowTests/Issues/RavenDB-19634.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes.TimeSeries;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19634 : RavenTestBase
+{
+    public RavenDB_19634(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Wait_For_Time_Series_Index_Changes()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string id = "users/1";
+            const string timeSeriesName = "Count";
+
+            var index = new UsersTimeSeriesMapIndex();
+            await index.ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Name = "Grisha"
+                }, id);
+                await session.SaveChangesAsync();
+            }
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.TimeSeriesFor(id, timeSeriesName).Append(DateTime.Today, 3);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
+                await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
+            }
+        }
+    }
+
+    private class UsersTimeSeriesMapIndex : AbstractTimeSeriesIndexCreationTask<User>
+    {
+        public UsersTimeSeriesMapIndex()
+        {
+            AddMapForAll(timeSeries =>
+                from ts in timeSeries
+                from entry in ts.Entries
+                select new
+                {
+                    Name = ts.Name,
+                    Count = 1
+                });
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19563/Index-mismatch-after-snapshot-restore

### Additional description

Change the order in which we perform the snapshot backup - first the indexes then the documents.

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- Tests have been added that prove the fix is effective or that the feature works