### PR TITLE
RavenDB-19557 added equality comparer for distinct operations to handle case when enumerable has mixed LSV and string values

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -853,7 +853,7 @@ namespace Raven.Client.Documents.Indexes
             StringExtensions.EscapeString(_out, value);
         }
 
-        
+
 
         private void OutLiteral(char c)
         {
@@ -1008,12 +1008,12 @@ namespace Raven.Client.Documents.Indexes
         }
 
         private bool TypeExistsOnServer(Type type) => TypeExistsOnServer(type, false);
-        
+
         private bool TypeExistsOnServer(Type type, bool isGenericArgument)
         {
             if (_insideWellKnownType)
                 return true;
-            
+
             if (type.IsGenericType)
             {
                 foreach (Type genericArgument in type.GetGenericArguments())
@@ -1022,19 +1022,19 @@ namespace Raven.Client.Documents.Indexes
                         return false;
                 }
             }
-            
+
             if (type.IsEnum && isGenericArgument) // enum is known type when it is a generic argument
                 return true;
-            
+
             if (type.Assembly == typeof(HashSet<>).Assembly) // System.Core
                 return true;
-            
+
             if (type.Assembly == typeof(object).Assembly) // mscorlib
                 return true;
 
             if (type.Assembly == typeof(Uri).Assembly) // System assembly
                 return true;
-            
+
             if (type.Assembly == typeof(Regex).Assembly) // System.Text.RegularExpressions
                 return true;
 
@@ -1870,6 +1870,7 @@ namespace Raven.Client.Documents.Indexes
                     case "Union":
                     case "Concat":
                     case "Intersect":
+                    case nameof(Enumerable.Distinct):
                         return true;
                     case nameof(Enumerable.OrderBy):
                     case nameof(Enumerable.OrderByDescending):

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
@@ -13,24 +13,6 @@ namespace Raven.Server.Documents.Indexes.Static
     {
         private readonly IEnumerable<object> _inner;
 
-        private bool _contextSet;
-
-        private JsonOperationContext _context;
-
-        private JsonOperationContext Context
-        {
-            get
-            {
-                if (_contextSet == false)
-                {
-                    _context = CurrentIndexingScope.Current?.IndexContext;
-                    _contextSet = true;
-                }
-
-                return _context;
-            }
-        }
-
         public DynamicArray(IEnumerable inner)
             : this(inner.Cast<object>())
         {
@@ -94,7 +76,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             var resultObject = _inner.ElementAt(i);
 
-            result = TypeConverter.ToDynamicType(resultObject, Context);
+            result = TypeConverter.ToDynamicType(resultObject, CurrentIndexingScope.Current?.IndexContext);
             return true;
         }
 
@@ -140,7 +122,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public DynamicArrayIterator GetEnumerator()
         {
-            return new DynamicArrayIterator(_inner, Context);
+            return new DynamicArrayIterator(_inner, CurrentIndexingScope.Current?.IndexContext);
         }
 
         public int Count() => _inner.Count();

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
@@ -585,7 +585,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public IEnumerable<object> Distinct()
         {
-            return new DynamicArray(Enumerable.Distinct(this, new LazyStringEqualityComparer(CurrentIndexingScope.Current?.IndexContext)));
+            return new DynamicArray(Enumerable.Distinct(this, new LazyStringAwareEqualityComparerForDistinct(CurrentIndexingScope.Current?.IndexContext)));
         }
 
         public dynamic DefaultIfEmpty(object defaultValue = null)
@@ -841,11 +841,11 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
-        private class LazyStringEqualityComparer : IEqualityComparer<object>
+        private class LazyStringAwareEqualityComparerForDistinct : IEqualityComparer<object>
         {
             private readonly JsonOperationContext _context;
 
-            public LazyStringEqualityComparer(JsonOperationContext context)
+            public LazyStringAwareEqualityComparerForDistinct(JsonOperationContext context)
             {
                 _context = context;
             }

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicArray.cs
@@ -13,7 +13,23 @@ namespace Raven.Server.Documents.Indexes.Static
     {
         private readonly IEnumerable<object> _inner;
 
-        private Lazy<JsonOperationContext> _context = new(() => CurrentIndexingScope.Current?.IndexContext);
+        private bool _contextSet;
+
+        private JsonOperationContext _context;
+
+        private JsonOperationContext Context
+        {
+            get
+            {
+                if (_contextSet == false)
+                {
+                    _context = CurrentIndexingScope.Current?.IndexContext;
+                    _contextSet = true;
+                }
+
+                return _context;
+            }
+        }
 
         public DynamicArray(IEnumerable inner)
             : this(inner.Cast<object>())
@@ -78,7 +94,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             var resultObject = _inner.ElementAt(i);
 
-            result = TypeConverter.ToDynamicType(resultObject, _context.Value);
+            result = TypeConverter.ToDynamicType(resultObject, Context);
             return true;
         }
 
@@ -124,7 +140,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public DynamicArrayIterator GetEnumerator()
         {
-            return new DynamicArrayIterator(_inner, _context.Value);
+            return new DynamicArrayIterator(_inner, Context);
         }
 
         public int Count() => _inner.Count();

--- a/src/Raven.Server/Documents/Indexes/Static/Linq/DynamicEnumerable.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Linq/DynamicEnumerable.cs
@@ -7,6 +7,14 @@ namespace Raven.Server.Documents.Indexes.Static.Linq
 {
     public static class DynamicEnumerable
     {
+        public static IEnumerable<dynamic> Distinct(IEnumerable source)
+        {
+            if (source is DynamicArray array)
+                return array.Distinct();
+
+            return new DynamicArray((IEnumerable<object>)source).Distinct();
+        }
+
         public static IEnumerable<dynamic> Union(object source, object other)
         {
             return new DynamicArray(((IEnumerable<object>)source).Union((IEnumerable<object>)other));

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -496,13 +496,14 @@ namespace Raven.Server.Utils
             Type objectType = value.GetType();
             if (objectType == DynamicRules[(int)DynamicRuleTypeLocation.String])
             {
-                if (TryConvertStringValue((string)value, out object result))
+                var valueAsString = (string)value;
+
+                if (TryConvertStringValue(valueAsString, out object result))
                     return result;
 
                 if (context == null)
-                    return value;
-
-                var valueAsString = (string)value;
+                    return valueAsString;
+                
                 return context.GetLazyString(valueAsString);
             }
 

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -488,7 +488,7 @@ namespace Raven.Server.Utils
             BlittableJsonReaderArray = 4,
         }
 
-        public static dynamic ToDynamicType(object value, JsonOperationContext context = null)
+        public static dynamic ToDynamicType(object value)
         {
             if (value == null)
                 return DynamicNullObject.ExplicitNull;
@@ -501,10 +501,7 @@ namespace Raven.Server.Utils
                 if (TryConvertStringValue(valueAsString, out object result))
                     return result;
 
-                if (context == null)
-                    return valueAsString;
-                
-                return context.GetLazyString(valueAsString);
+                return valueAsString;
             }
 
             LazyStringValue lazyString = null;

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -488,7 +488,7 @@ namespace Raven.Server.Utils
             BlittableJsonReaderArray = 4,
         }
 
-        public static dynamic ToDynamicType(object value)
+        public static dynamic ToDynamicType(object value, JsonOperationContext context = null)
         {
             if (value == null)
                 return DynamicNullObject.ExplicitNull;
@@ -499,7 +499,11 @@ namespace Raven.Server.Utils
                 if (TryConvertStringValue((string)value, out object result))
                     return result;
 
-                return value;
+                if (context == null)
+                    return value;
+
+                var valueAsString = (string)value;
+                return context.GetLazyString(valueAsString);
             }
 
             LazyStringValue lazyString = null;

--- a/test/SlowTests/Issues/RavenDB_19557.cs
+++ b/test/SlowTests/Issues/RavenDB_19557.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19557 : RavenTestBase
+{
+    public RavenDB_19557(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class TestObj
+    {
+        public string[] Props { get; set; }
+        public string Prop { get; set; }
+    }
+
+    private class Index : AbstractMultiMapIndexCreationTask<Index.Result>
+    {
+        public class Result
+        {
+            public IEnumerable<string> MapProp { get; set; }
+        }
+        public Index()
+        {
+            AddMap<TestObj>(testObjs =>
+                from obj in testObjs
+                select new Result
+                {
+                    MapProp = obj.Props.Concat(new[] { obj.Prop }).Distinct()
+                });
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    [Fact]
+    public async Task TestCase()
+    {
+        using var store = GetDocumentStore();
+
+        await store.ExecuteIndexAsync(new Index());
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj
+            {
+                Props = new[] { "value1" },
+                Prop = "value1"
+            });
+
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var query = from r in session.Query<Index.Result, Index>()
+                        select new
+                        {
+                            R = r.MapProp.ToArray()
+                        };
+
+            var result = await query.SingleAsync();
+
+            // {"R":["value1","value1"]}
+            Assert.Single(result.R); //Fails here
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19557

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
