### PR TITLE
RavenDB-19566 fixed WebSocket connections after migration to .NET 7

### DIFF
--- a/src/Raven.Client/Util/HttpMethods.cs
+++ b/src/Raven.Client/Util/HttpMethods.cs
@@ -10,6 +10,8 @@ namespace Raven.Client.Util
 {
     internal static class HttpMethods
     {
+        public static readonly HttpMethod Connect = new HttpMethod("CONNECT");
+
         public static readonly HttpMethod Reset = new HttpMethod("RESET");
 
         public static readonly HttpMethod Patch = new HttpMethod("PATCH");

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -26,6 +26,7 @@ using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using HttpMethods = Raven.Client.Util.HttpMethods;
 
 namespace Raven.Server.Routing
 {
@@ -227,8 +228,8 @@ namespace Raven.Server.Routing
             {
                 // CONNECT (https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT)
                 // starting from .NET 7 can be used by WS connections to establish a communication
-                if (string.Equals(context.Request.Method, "CONNECT", StringComparison.OrdinalIgnoreCase))
-                    tryMatch = _trie.TryMatch("GET", context.Request.Path.Value);
+                if (string.Equals(context.Request.Method, HttpMethods.Connect.Method, StringComparison.OrdinalIgnoreCase))
+                    tryMatch = _trie.TryMatch(HttpMethods.Get.Method, context.Request.Path.Value);
 
                 if (tryMatch.Value == null)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19566

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
