### PR TITLE
RavenDB-19504_5.2: Fixed ravendb 5.2 crashes on importing dump with timeseries on encrypted

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -1026,14 +1026,17 @@ namespace Raven.Server.Documents.Handlers
                 return changes;
             }
 
-            public void AddToDictionary(TimeSeriesItem item)
+            public bool AddToDictionary(TimeSeriesItem item)
             {
+                bool newItem = false;
                 if (_dictionary.TryGetValue(item.DocId, out var itemsList) == false)
                 {
                     _dictionary[item.DocId] = itemsList = new List<TimeSeriesItem>();
+                    newItem = true;
                 }
 
                 itemsList.Add(item);
+                return newItem;
             }
 
             public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -2146,7 +2146,14 @@ namespace Raven.Server.Smuggler.Documents
 
             private void AddToBatch(TimeSeriesItem item)
             {
-                _cmd.AddToDictionary(item);
+                if (_cmd.AddToDictionary(item))
+                {
+                    // RavenDB-19504 - if we have a lot of _small_ updates, that can add up quickly, but it won't 
+                    // be accounted for that if we look at segment size alone. So we assume that any new item means
+                    // updating the whole segment. This is especially important for encrypted databases, where we need
+                    // to keep all the modified data in memory in one shot
+                    _segmentsSize.Add(2, SizeUnit.Kilobytes);
+                }
                 _segmentsSize.Add(item.Segment.NumberOfBytes, SizeUnit.Bytes);
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19504

### Additional description

In the specified scenario, we had a file to export with many small time series.
We accounted for the size of the actual segments. However, we actually modify a page in each scenario, which can lead to a disconnect between the actual size being modified and the batch size we try to build.

This PR adds 2KB accounting for each time series segment that is new. That is enough to reduce the memory usage by a significant amount.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing
