### PR TITLE
RavenDB-19160 : Sharding - Backup - Preserve bucket ranges

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/src/Raven.Client/ServerWide/Sharding/ShardBucketRange.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardBucketRange.cs
@@ -1,8 +1,19 @@
-﻿namespace Raven.Client.ServerWide.Sharding;
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Client.ServerWide.Sharding;
 
 public class ShardBucketRange
 {
     public int BucketRangeStart;
 
     public int ShardNumber;
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(BucketRangeStart)] = BucketRangeStart, 
+            [nameof(ShardNumber)] = ShardNumber
+        };
+    }
 }

--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -277,7 +277,7 @@ namespace Raven.Server.Dashboard
             if (collectOngoingTasks)
             {
                 yield return databasesOngoingTasksInfo;
-        }
+            }
         }
 
         private static DatabaseOngoingTasksInfoItem GetOngoingTasksInfoItem(DocumentDatabase database, ServerStore serverStore, TransactionOperationContext context, out long ongoingTasksCount)

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using NetTopologySuite.Utilities;
 using Nito.AsyncEx;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1681,7 +1681,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public virtual DatabaseRecord ReadDatabaseRecord()
+        public DatabaseRecord ReadDatabaseRecord()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1681,7 +1681,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public DatabaseRecord ReadDatabaseRecord()
+        public virtual DatabaseRecord ReadDatabaseRecord()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/SmugglerHandlerProcessorForExport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/SmugglerHandlerProcessorForExport.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
             using (token)
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var source = new DatabaseSource(RequestHandler.Database, startDocumentEtag, startRaftIndex, Logger);
+                var source = RequestHandler.Database.Smuggler.CreateSource(startDocumentEtag, startRaftIndex, Logger);
                 await using (var outputStream = GetOutputStream(RequestHandler.ResponseBodyStream(), options))
                 {
                     var destination = new StreamDestination(outputStream, context, source);

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -744,6 +744,9 @@ namespace Raven.Server.Documents.PeriodicBackup
         private InternalBackupResult CreateBackup(
             DatabaseSmugglerOptionsServerSide options, string backupFilePath, long? startDocumentEtag, long? startRaftIndex)
         {
+            if (ShardHelper.TryGetShardNumber(_database.Name, out var number) && number > 0)
+                return new InternalBackupResult();
+
             // the last etag is already included in the last backup
             var currentBackupResults = new InternalBackupResult();
             startDocumentEtag = startDocumentEtag == null ? 0 : ++startDocumentEtag;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -25,7 +25,6 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Utils;
-using Raven.Server.Web;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -299,6 +298,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.ElasticSearchConnectionStrings = smugglerDatabaseRecord.ElasticSearchConnectionStrings;
                     databaseRecord.QueueEtls = smugglerDatabaseRecord.QueueEtls;
                     databaseRecord.QueueConnectionStrings = smugglerDatabaseRecord.QueueConnectionStrings;
+
+                    if (smugglerDatabaseRecord.IsSharded)
+                    {
+                        databaseRecord.Sharding.BucketRanges = smugglerDatabaseRecord.Sharding.BucketRanges;
+                    }
 
                     // need to enable revisions before import
                     database.DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(smugglerDatabaseRecord);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -12,7 +12,6 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
-using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -16,13 +16,11 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
-using Raven.Server.Web;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using Voron.Data.Tables;
 using Voron.Impl.Backup;
 using Voron.Util.Settings;
-using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
 using Index = Raven.Server.Documents.Indexes.Index;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
@@ -71,8 +72,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
             if (_shardNumber > 0)
                 smuggler._options.OperateOnTypes &= ~DatabaseItemType.Subscriptions;
 
-            smuggler.OnDatabaseRecordAction += smugglerDatabaseRecord => 
-                RestoreSettings.DatabaseRecord.Sharding.BucketRanges = smugglerDatabaseRecord.Sharding?.BucketRanges;
+            smuggler.OnDatabaseRecordAction += smugglerDatabaseRecord =>
+                RestoreSettings.DatabaseRecord.Sharding.BucketRanges = 
+                    smugglerDatabaseRecord.Sharding?.BucketRanges ?? throw new InvalidDataException(
+                        $"'{nameof(DatabaseRecord.Sharding.BucketRanges)}' is missing in backup file '{filePath}'. Aborting the restore process");
         }
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
@@ -9,9 +9,7 @@ using Raven.Server.Config;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
-using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Utils;
-using Sparrow.Json;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -88,15 +88,6 @@ public class ShardedDocumentDatabase : DocumentDatabase
         }
     }
 
-    public override DatabaseRecord ReadDatabaseRecord()
-    {
-        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-        using (context.OpenReadTransaction())
-        {
-            return ServerStore.Cluster.ReadDatabase(context, ShardedDatabaseName);
-        }
-    }
-
     protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -88,6 +88,15 @@ public class ShardedDocumentDatabase : DocumentDatabase
         }
     }
 
+    public override DatabaseRecord ReadDatabaseRecord()
+    {
+        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            return ServerStore.Cluster.ReadDatabase(context, ShardedDatabaseName);
+        }
+    }
+
     protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);

--- a/src/Raven.Server/Documents/Sharding/Smuggler/ShardedDatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Sharding/Smuggler/ShardedDatabaseSmugglerFactory.cs
@@ -8,6 +8,7 @@ using Raven.Server.Documents.Smuggler;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Sharding.Smuggler;
 
@@ -23,6 +24,11 @@ public class ShardedDatabaseSmugglerFactory : AbstractDatabaseSmugglerFactory
     public override DatabaseDestination CreateDestination(CancellationToken token = default)
     {
         return new ShardedDatabaseDestination(_database, token);
+    }
+
+    public override DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger)
+    {
+        return new ShardedDatabaseSource(_database, startDocumentEtag, startRaftIndex, logger);
     }
 
     public override SmugglerBase CreateForRestore(

--- a/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
@@ -6,12 +6,15 @@ using Raven.Client.ServerWide;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Smuggler;
 
 public abstract class AbstractDatabaseSmugglerFactory
 {
     public abstract DatabaseDestination CreateDestination(CancellationToken token = default);
+
+    public abstract DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger);
 
     public abstract SmugglerBase CreateForRestore(
         DatabaseRecord databaseRecord,

--- a/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
@@ -7,6 +7,7 @@ using Raven.Client.ServerWide;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Sparrow.Json;
+using Sparrow.Logging;
 using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
 
 namespace Raven.Server.Documents.Smuggler;
@@ -23,6 +24,11 @@ public class DatabaseSmugglerFactory : AbstractDatabaseSmugglerFactory
     public override DatabaseDestination CreateDestination(CancellationToken token = default)
     {
         return new DatabaseDestination(_database, token);
+    }
+
+    public override DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger)
+    {
+        return new DatabaseSource(_database, startDocumentEtag, startRaftIndex, logger);
     }
 
     public override SmugglerBase CreateForRestore(

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Smuggler.Documents
         private readonly DocumentDatabase _database;
         private DocumentsOperationContext _context;
         private ClusterOperationContext _serverContext;
-
+        
         private readonly long _startDocumentEtag;
         private readonly long _startRaftIndex;
         private readonly Logger _logger;
@@ -138,7 +138,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public Task<DatabaseRecord> GetDatabaseRecordAsync()
         {
-            var databaseRecord = _database.ReadDatabaseRecord();
+            var databaseRecord = ReadDatabaseRecord();
 
             // filter server-wide backup tasks
             for (var i = databaseRecord.PeriodicBackups.Count - 1; i >= 0; i--)
@@ -197,6 +197,11 @@ namespace Raven.Server.Smuggler.Documents
                     Document = enumerator.Current
                 };
             }
+        }
+
+        protected virtual DatabaseRecord ReadDatabaseRecord()
+        {
+            return _database.ReadDatabaseRecord();
         }
 
         private IEnumerable<Document> GetDocumentsFromCollections(DocumentsOperationContext context, DocumentsIterationState state)

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -33,7 +33,6 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
-using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Platform;

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSource.cs
@@ -1,0 +1,27 @@
+﻿using Raven.Client.ServerWide;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
+
+namespace Raven.Server.Smuggler.Documents
+{
+    public class ShardedDatabaseSource : DatabaseSource
+    {
+        private readonly ShardedDocumentDatabase _database;
+
+        public ShardedDatabaseSource(ShardedDocumentDatabase database, long startDocumentEtag, long startRaftIndex, Logger logger) 
+            : base(database, startDocumentEtag, startRaftIndex, logger)
+        {
+            _database = database;
+        }
+
+        protected override DatabaseRecord ReadDatabaseRecord()
+        {
+            using (_database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return _database.ServerStore.Cluster.ReadDatabase(context, _database.ShardedDatabaseName);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Smuggler/Documents/SingleShardDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/SingleShardDatabaseSmuggler.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Documents.Sharding;
@@ -50,7 +49,6 @@ namespace Raven.Server.Smuggler.Documents
                 return;
 
             await base.InternalProcessCompareExchangeAsync(result, kvp, actions);
-
         }
 
         protected override async Task InternalProcessCompareExchangeTombstonesAsync(SmugglerResult result, (CompareExchangeKey Key, long Index) key, ICompareExchangeActions actions)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -26,6 +25,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents;
@@ -445,14 +445,7 @@ namespace Raven.Server.Smuggler.Documents
                         {
                             _writer.WriteComma();
                             _writer.WritePropertyName(nameof(databaseRecord.Sharding));
-
-                            _writer.WriteStartObject();
-
-                            _writer.WritePropertyName(nameof(databaseRecord.Sharding.BucketRanges));
-                            _context.Write(_writer, new DynamicJsonArray(databaseRecord.Sharding.BucketRanges.Select(x => x.ToJson())));
-
-                            _writer.WriteEndObject();
-
+                            WriteShardingConfiguration(databaseRecord.Sharding);
                         }
 
                         break;
@@ -898,6 +891,19 @@ namespace Raven.Server.Smuggler.Documents
                     return;
                 }
                 _context.Write(_writer, postgreSqlConfig.ToJson());
+            }
+
+            private void WriteShardingConfiguration(ShardingConfiguration shardingConfiguration)
+            {
+                _writer.WriteStartObject();
+
+                _writer.WritePropertyName(nameof(shardingConfiguration.Shards));
+                _context.Write(_writer, new DynamicJsonArray(shardingConfiguration.Shards.Select(x => x.ToJson())));
+
+                _writer.WritePropertyName(nameof(shardingConfiguration.BucketRanges));
+                _context.Write(_writer, new DynamicJsonArray(shardingConfiguration.BucketRanges.Select(x => x.ToJson())));
+
+                _writer.WriteEndObject();
             }
 
             public ValueTask DisposeAsync()

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -438,6 +439,20 @@ namespace Raven.Server.Smuggler.Documents
                             }
 
                             _writer.WriteEndObject();
+                        }
+
+                        if (databaseRecord.IsSharded)
+                        {
+                            _writer.WriteComma();
+                            _writer.WritePropertyName(nameof(databaseRecord.Sharding));
+
+                            _writer.WriteStartObject();
+
+                            _writer.WritePropertyName(nameof(databaseRecord.Sharding.BucketRanges));
+                            _context.Write(_writer, new DynamicJsonArray(databaseRecord.Sharding.BucketRanges.Select(x => x.ToJson())));
+
+                            _writer.WriteEndObject();
+
                         }
 
                         break;

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -649,8 +649,14 @@ namespace Raven.Server.Smuggler.Documents
                     }
                     catch (Exception e)
                     {
+                        const string errorMessage = "Wasn't able to import Sharding configuration from smuggler file. Aborting.";
+
                         if (_log.IsInfoEnabled)
-                            _log.Info("Wasn't able to import the Sharding configuration from smuggler file. Skipping.", e);
+                        {
+                            _log.Info(errorMessage, e);
+                        }
+
+                        throw new InvalidDataException(errorMessage, e);
                     }
                 }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -22,15 +22,14 @@ using Raven.Client.Json.Serialization;
 using Raven.Client.Properties;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Integrations;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
-using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
-using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
 using Sparrow;
@@ -637,6 +636,21 @@ namespace Raven.Server.Smuggler.Documents
                     {
                         if (_log.IsInfoEnabled)
                             _log.Info("Wasn't able to import the PostgreSQL configuration from smuggler file. Skipping.", e);
+                    }
+                }
+
+
+                if (reader.TryGet(nameof(databaseRecord.Sharding), out BlittableJsonReaderObject sharding) &&
+                    sharding != null)
+                {
+                    try
+                    {
+                        databaseRecord.Sharding = JsonDeserializationCluster.ShardingConfiguration(sharding);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_log.IsInfoEnabled)
+                            _log.Info("Wasn't able to import the Sharding configuration from smuggler file. Skipping.", e);
                     }
                 }
 

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
@@ -829,7 +828,7 @@ namespace SlowTests.Sharding.Backup
                 var config = Backup.CreateBackupConfiguration(backupPath);
 
                 await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1666)));
+                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(3, dirs.Length);

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -868,16 +868,14 @@ namespace SlowTests.Sharding.Cluster
                         Equal(0, tombs.Count);
                     }
 
-                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Major,
-                        "Preserve bucket ranges on backup and restore : https://issues.hibernatingrhinos.com/issue/RavenDB-19160/");
-                    /*using (var session = store.OpenSession(restoredDatabaseName))
+                    using (var session = store.OpenSession(restoredDatabaseName))
                     {
                         for (int i = 1; i <= 11; i++)
                         {
                             var doc = session.Load<User>($"users/{i}${suffix}");
                             NotNull(doc);
                         }
-                    }*/
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19160

### Additional description

- preserve `Sharding.BucketRanges` on sharded database restore, instead of restoring to the default bucket distribution
- minor refactoring in `AbstractRestoreBackupTask` to allow `SingleShardRestoreTask` to customize smuggler settings and restore bucket ranges from backup file
 - introduced new `ShardedDatabaseSource` : `DatabaseSource` which exports sharded database record with sharding configuration instead of non-sharded one
 - added new `CreateSource` method to `AbstractDatabaseSmugglerFactory`  so that backup/export of sharded database will write bucket ranges to backup file
 - basic tests

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
