### PR TITLE
RavenDB-19561 - Replication leading to OOM - for customer

### DIFF
--- a/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
@@ -42,11 +42,5 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Replication.MaxSizeToSendInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size? MaxSizeToSend { get; set; }
-
-        [Description("Maximum number of data size to load from storage to memory before sending it")]
-        [DefaultValue(1024)]
-        [SizeUnit(SizeUnit.Megabytes)]
-        [ConfigurationEntry("Replication.MaxSizeToLoadFromStorage", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public Size? MaxSizeToLoadFromStorage { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ReplicationConfiguration.cs
@@ -42,5 +42,11 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Replication.MaxSizeToSendInMb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size? MaxSizeToSend { get; set; }
+
+        [Description("Maximum number of data size to load from storage to memory before sending it")]
+        [DefaultValue(1024)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [ConfigurationEntry("Replication.MaxSizeToLoadFromStorage", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public Size? MaxSizeToLoadFromStorage { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -304,8 +304,12 @@ namespace Raven.Server.Documents.Replication
                             }
 
                             replicationState.Size += item.Size;
-
                             replicationState.NumberOfItemsSent++;
+
+                            if (replicationState.Size >= _parent._database.Configuration.Replication.MaxSizeToLoadFromStorage?.GetValue(SizeUnit.Bytes))
+                            {
+                                break;
+                            }
                         }
                     }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -238,6 +238,7 @@ namespace Raven.Server.Documents.Replication
                         Delay = delay,
                         Context = documentsContext,
                         LastTransactionMarker = -1,
+                        NumberOfItemsSent = 0,
                         Size = 0L,
                         ScannedItems = 0
                     };
@@ -305,6 +306,7 @@ namespace Raven.Server.Documents.Replication
                             }
 
                             replicationState.Size += item.Size;
+                            replicationState.NumberOfItemsSent++;
                         }
                     }
 
@@ -431,7 +433,17 @@ namespace Raven.Server.Documents.Replication
 
             if (state.ScannedItems == 1)
             {
-                // always send at least one item
+                /*
+                 always scan at least one item.
+                after scanning 1 item we can move to the batch size limit check.
+                We need to check here the "ScannedItems" and not the "NumberOfItemsSent"
+                because there's an option that we will scan a lot of items (documents) but we won't send them.
+                When we load the items from an encrypted database, the memory is locked until the transaction is closed
+                (for preventing the decrypted data from being moved to the "swap-file" by the OS in case of low memory).
+                In that case, if we will check here if the "NumberOfItemsSent" is 0 instead, there's an option 
+                that we will load a lot of "not relevant" items to memory and it will be locked until we'll fill 
+                the batch and it can cause eventually to OOM.
+                 */
                 return true;
             }
 
@@ -439,10 +451,8 @@ namespace Raven.Server.Documents.Replication
             var totalSize =
                 state.Size + state.Context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
 
-            int numberOfItemsSent = state.ScannedItems - 1;
-
             if (state.MaxSizeToSend.HasValue && totalSize >= state.MaxSizeToSend.Value.GetValue(SizeUnit.Bytes) ||
-                state.BatchSize.HasValue && numberOfItemsSent >= state.BatchSize.Value)
+                state.BatchSize.HasValue && state.NumberOfItemsSent >= state.BatchSize.Value)
             {
                 return false;
             }
@@ -791,6 +801,7 @@ namespace Raven.Server.Documents.Replication
             public long CurrentNext;
             public long Size;
             public DocumentsOperationContext Context;
+            public int NumberOfItemsSent;
             public short LastTransactionMarker;
             public int? BatchSize;
             public Size? MaxSizeToSend;

--- a/test/SlowTests/Issues/RavenDB-19561.cs
+++ b/test/SlowTests/Issues/RavenDB-19561.cs
@@ -33,23 +33,19 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Replicate_2_Docs_Which_Is_Bigger_Then_Batch_Size()
         {
-            var nodes = new List<RavenServer>();
-            for (int i = 0; i < 2; i++)
+            var co = new ServerCreationOptions
             {
-                var co = new ServerCreationOptions
+                CustomSettings = new Dictionary<string, string>
                 {
-                    CustomSettings = new Dictionary<string, string>
-                    {
-                        [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
-                    }
-                };
-                nodes.Add(GetNewServer(co));
-            }
-            using var store1 = GetDocumentStore(new Options { RunInMemory = false, Server = nodes[0], ReplicationFactor = 1 });
-            using var store2 = GetDocumentStore(new Options { RunInMemory = false, Server = nodes[1], ReplicationFactor = 1 });
+                    [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
+                }
+            };
+            var node = GetNewServer(co);
+
+            using var store1 = GetDocumentStore(new Options { RunInMemory = false, Server = node, ReplicationFactor = 1 });
+            using var store2 = GetDocumentStore(new Options { RunInMemory = false, Server = node, ReplicationFactor = 1 });
 
             var docs = new List<User>();
-            int k = 0;
             using (var session = store1.OpenAsyncSession())
             {
                 var doc = new User
@@ -82,7 +78,7 @@ namespace SlowTests.Issues
             var waitForReplicationTasks = new List<Task>();
             foreach (var doc in docs)
             {
-                waitForReplicationTasks.Add(WaitForDocToReplicateAsync<User>(store2, doc.Id));
+                waitForReplicationTasks.Add(WaitAndAssertDocReplicationAsync<User>(store2, doc.Id));
             }
             Task.WaitAll(waitForReplicationTasks.ToArray());
 
@@ -103,20 +99,10 @@ namespace SlowTests.Issues
         }
 
 
-        private async Task WaitForDocToReplicateAsync<T>(DocumentStore store, string id, int timeout = 15_000_000) where T : class
+        private async Task WaitAndAssertDocReplicationAsync<T>(DocumentStore store, string id, int timeout = 15_000_000) where T : class
         {
-            var sw = Stopwatch.StartNew();
-            while (sw.Elapsed.Seconds <= timeout / 1_000_000)
-            {
-                using (var session = store.OpenAsyncSession(store.Database))
-                {
-                    var doc = await session.LoadAsync<T>(id);
-                    if (doc != null)
-                        return;
-                }
-            }
-            sw.Stop();
-            Assert.True(false, $"doc \"{id}\" didn't replicated");
+            var result = await WaitForDocumentToReplicateAsync<User>(store, id, timeout);
+            Assert.True(result!=null, $"doc \"{id}\" didn't replicated.");
         }
 
         class User

--- a/test/SlowTests/Issues/RavenDB-19561.cs
+++ b/test/SlowTests/Issues/RavenDB-19561.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents;
+using Raven.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Client.Documents.Operations.Replication;
+using System.Threading;
+using System.Collections.Concurrent;
+using System.IO;
+using Lucene.Net.Util;
+using Raven.Client.Documents.BulkInsert;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Config;
+using FastTests.Utils;
+using Sparrow;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19561 : ReplicationTestBase
+    {
+        public RavenDB_19561(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Replicate_2_Docs_Which_Is_Bigger_Then_Batch_Size()
+        {
+            var nodes = new List<RavenServer>();
+            for (int i = 0; i < 2; i++)
+            {
+                var co = new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()
+                    }
+                };
+                nodes.Add(GetNewServer(co));
+            }
+            using var store1 = GetDocumentStore(new Options { RunInMemory = false, Server = nodes[0], ReplicationFactor = 1 });
+            using var store2 = GetDocumentStore(new Options { RunInMemory = false, Server = nodes[1], ReplicationFactor = 1 });
+
+            var docs = new List<User>();
+            int k = 0;
+            using (var session = store1.OpenAsyncSession())
+            {
+                var doc = new User
+                {
+                    Id = $"Users/1-A",
+                    Name = $"User1",
+                    Info = GenRandomString(2_000_000)
+                };
+                docs.Add(doc);
+                await session.StoreAsync(doc);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                var doc = new User
+                {
+                    Id = $"Users/2-A",
+                    Name = $"User2",
+                    Info = GenRandomString(2_000_000)
+                };
+                docs.Add(doc);
+                await session.StoreAsync(doc);
+                await session.SaveChangesAsync();
+            }
+
+            var externalList = await SetupReplicationAsync(store1, store2);
+
+            // wait for replication from store1 to store2/3
+            var waitForReplicationTasks = new List<Task>();
+            foreach (var doc in docs)
+            {
+                waitForReplicationTasks.Add(WaitForDocToReplicateAsync<User>(store2, doc.Id));
+            }
+            Task.WaitAll(waitForReplicationTasks.ToArray());
+
+        }
+
+        private string GenRandomString(int size)
+        {
+            var sb = new StringBuilder(size);
+            var ran = new Random();
+            var firstCharAsInt = Convert.ToInt32('a');
+            var lastCharAsInt = Convert.ToInt32('z');
+            for (int i = 0; i < size; i++)
+            {
+                sb.Append(Convert.ToChar(ran.Next(firstCharAsInt, lastCharAsInt + 1)));
+            }
+
+            return sb.ToString();
+        }
+
+
+        private async Task WaitForDocToReplicateAsync<T>(DocumentStore store, string id, int timeout = 15_000_000) where T : class
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed.Seconds <= timeout / 1_000_000)
+            {
+                using (var session = store.OpenAsyncSession(store.Database))
+                {
+                    var doc = await session.LoadAsync<T>(id);
+                    if (doc != null)
+                        return;
+                }
+            }
+            sw.Stop();
+            Assert.True(false, $"doc \"{id}\" didn't replicated");
+        }
+
+        class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+
+            public string Info { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19561.cs
+++ b/test/SlowTests/Issues/RavenDB-19561.cs
@@ -75,13 +75,10 @@ namespace SlowTests.Issues
             var externalList = await SetupReplicationAsync(store1, store2);
 
             // wait for replication from store1 to store2/3
-            var waitForReplicationTasks = new List<Task>();
             foreach (var doc in docs)
             {
-                waitForReplicationTasks.Add(WaitAndAssertDocReplicationAsync<User>(store2, doc.Id));
+                await WaitAndAssertDocReplicationAsync<User>(store2, doc.Id);
             }
-            Task.WaitAll(waitForReplicationTasks.ToArray());
-
         }
 
         private async Task WaitAndAssertDocReplicationAsync<T>(DocumentStore store, string id, int timeout = 15_000) where T : class

--- a/test/SlowTests/Issues/RavenDB-19561.cs
+++ b/test/SlowTests/Issues/RavenDB-19561.cs
@@ -84,22 +84,7 @@ namespace SlowTests.Issues
 
         }
 
-        private string GenRandomString(int size)
-        {
-            var sb = new StringBuilder(size);
-            var ran = new Random();
-            var firstCharAsInt = Convert.ToInt32('a');
-            var lastCharAsInt = Convert.ToInt32('z');
-            for (int i = 0; i < size; i++)
-            {
-                sb.Append(Convert.ToChar(ran.Next(firstCharAsInt, lastCharAsInt + 1)));
-            }
-
-            return sb.ToString();
-        }
-
-
-        private async Task WaitAndAssertDocReplicationAsync<T>(DocumentStore store, string id, int timeout = 15_000_000) where T : class
+        private async Task WaitAndAssertDocReplicationAsync<T>(DocumentStore store, string id, int timeout = 15_000) where T : class
         {
             var result = await WaitForDocumentToReplicateAsync<User>(store, id, timeout);
             Assert.True(result!=null, $"doc \"{id}\" didn't replicated.");

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
@@ -791,6 +792,25 @@ namespace FastTests
             tcpListener.Stop();
 
             return port;
+        }
+
+        public static string GenRandomString(int size)
+        {
+            return GenRandomString(new Random(), size);
+        }
+
+        public static string GenRandomString(Random random, int size)
+        {
+            var sb = new StringBuilder(size);
+            // var ran = new Random();
+            var firstCharAsInt = Convert.ToInt32('a');
+            var lastCharAsInt = Convert.ToInt32('z');
+            for (int i = 0; i < size; i++)
+            {
+                sb.Append(Convert.ToChar(random.Next(firstCharAsInt, lastCharAsInt + 1)));
+            }
+
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
…y few minutes

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19561

### Additional description

Replication memory issues leading to OOM restart every few minutes.
Node need to replicate a big amount of data to another node and it load all from storage to memory..
When the DB is encrypted, the data is loaded to memory and sitting in memory in its decrypted form.
When there's almost OOM, part of the data is transferred to the swap file in the disk (by the OS).
When we have decrypted data loaded to memory, we lock the memory and by that prevent it from being transferred to swap file for security, and when we have a big amount of data to load it can cause OOM.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
