### PR TITLE
RavenDB-19503 - Avoid cloning attachments on the orchestrator

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -226,42 +226,6 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
         }
 
-        public class DataForReplicationCommand : IDisposable
-        {
-            internal string SourceDatabaseId { get; set; }
-
-            internal ReplicationBatchItem[] ReplicatedItems { get; set; }
-
-            internal Dictionary<Slice, AttachmentReplicationItem> ReplicatedAttachmentStreams { get; set; }
-
-            public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
-
-            public Logger Logger { get; set; }
-
-            public void Dispose()
-            {
-                if (ReplicatedAttachmentStreams != null)
-                {
-                    foreach (var item in ReplicatedAttachmentStreams.Values)
-                    {
-                        item?.Dispose();
-                    }
-
-                    ReplicatedAttachmentStreams?.Clear();
-                }
-
-                if (ReplicatedItems != null)
-                {
-                    foreach (var item in ReplicatedItems)
-                    {
-                        item?.Dispose();
-                    }
-                }
-
-                ReplicatedItems = null;
-            }
-        }
-
         public override LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
         {
             return ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -49,8 +49,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
         public StreamsTempFile GetTempFile()
         {
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "figure out if the sharded db is encrypted ('encrypted' parameter for 'StreamsTempFile')");
-
             var name = $"attachment.{Guid.NewGuid():N}.shardedReplication";
             var tempPath = _parent.Context.ServerStore._env.Options.DataPager.Options.TempPath.Combine(name);
             return new StreamsTempFile(tempPath.FullPath, _parent.Context.Encrypted);
@@ -198,7 +196,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 foreach (var attachment in dataForReplicationCommand.ReplicatedAttachmentStreams)
                 {
                     if (attachment.Value.Stream is StreamsTempFile.InnerStream innerStream == false)
-                        throw new NotSupportedException("Cannot understand how to read stream: " + attachment.Value.Stream);
+                        throw new NotSupportedException($"Cannot understand how to read stream of type '{attachment.Value.Stream.GetType().Name}'. Should not happen!");
 
                     for (var shard = 0; shard < _parent.Context.ShardCount; shard++)
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             }
             catch (Exception e)
             {
-                batch?.BatchSent.TrySetException(e);
+                batch?.BatchSent?.TrySetException(e);
                 try
                 {
                     _tcpConnectionOptions.Dispose();

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -155,6 +155,7 @@ namespace Raven.Server.Documents.Sharding
             }
 
             Items.Clear();
+            BatchSent?.TrySetCanceled();
             BatchSent = null;
         }
     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -141,6 +141,8 @@ namespace Raven.Server.Documents.Sharding
 
         public void Dispose()
         {
+            BatchSent?.TrySetCanceled();
+
             if (AttachmentStreams != null)
             {
                 foreach (var attachment in AttachmentStreams)
@@ -155,7 +157,6 @@ namespace Raven.Server.Documents.Sharding
             }
 
             Items.Clear();
-            BatchSent?.TrySetCanceled();
             BatchSent = null;
         }
     }

--- a/src/Raven.Server/Documents/StreamsTempFile.cs
+++ b/src/Raven.Server/Documents/StreamsTempFile.cs
@@ -167,9 +167,13 @@ namespace Raven.Server.Documents
 
             public IDisposable CreateReaderStream(out LimitedStream limitedStream)
             {
-                var safeFileHandle = new SafeFileHandle(_parent._file.InnerStream.SafeFileHandle.DangerousGetHandle(), false);
-                var stream = new FileStream(safeFileHandle, FileAccess.Read);
+                var safeFileHandle = new SafeFileHandle(_parent._file.InnerStream.SafeFileHandle.DangerousGetHandle(), ownsHandle: false);
+                Stream stream = new FileStream(safeFileHandle, FileAccess.Read);
                 stream.Seek(_startPosition, SeekOrigin.Begin);
+                if (_stream is TempCryptoStream tcs)
+                {
+                    stream = new TempCryptoStream(stream, tcs);
+                }
                 limitedStream = new LimitedStream(stream, Length, _startPosition, _startPosition);
 
                 return new DisposableAction(() =>

--- a/src/Raven.Server/Documents/StreamsTempFile.cs
+++ b/src/Raven.Server/Documents/StreamsTempFile.cs
@@ -178,8 +178,11 @@ namespace Raven.Server.Documents
 
                 return new DisposableAction(() =>
                 {
-                    stream.Dispose();
-                    safeFileHandle.Dispose();
+                    using (safeFileHandle)
+                    using (stream)
+                    {
+                        // disposing
+                    }
                 });
             }
         }

--- a/src/Raven.Server/Documents/StreamsTempFile.cs
+++ b/src/Raven.Server/Documents/StreamsTempFile.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents
         internal bool _reading;
         private InnerStream _previousInstance;
 
-        public StreamsTempFile(string tempFile, StorageEnvironment environment) : this (tempFile, environment.Options.Encryption.IsEnabled)
+        public StreamsTempFile(string tempFile, StorageEnvironment environment) : this(tempFile, environment.Options.Encryption.IsEnabled)
         {
         }
 
@@ -179,7 +179,7 @@ namespace Raven.Server.Documents
                 return new DisposableAction(() =>
                 {
                     stream.Dispose();
-                   safeFileHandle.Dispose();
+                    safeFileHandle.Dispose();
                 });
             }
         }

--- a/src/Raven.Server/ServerWide/TempCryptoStream.cs
+++ b/src/Raven.Server/ServerWide/TempCryptoStream.cs
@@ -9,8 +9,8 @@ namespace Raven.Server.ServerWide
     {
         private bool _ignoreSetLength;
         private readonly Stream _stream;
-        private readonly MemoryStream _authenticationTags = new MemoryStream();
-        private readonly MemoryStream _nonces = new MemoryStream();
+        private readonly MemoryStream _authenticationTags;
+        private readonly MemoryStream _nonces;
         private readonly long _startPosition;
 
         public Stream InnerStream => _stream;
@@ -49,10 +49,24 @@ namespace Raven.Server.ServerWide
             return this;
         }
 
+        public TempCryptoStream(Stream stream, TempCryptoStream other)
+        {
+            _stream = stream;
+            _startPosition = other._startPosition;
+            _nonces = other._nonces;
+            _authenticationTags = other._authenticationTags;
+            _internalBuffer = new byte[4096];
+            _key = other._key;
+            _maxLength = other._maxLength;
+            _blockNumber = -1; // so next read will inc to 0
+        }
+
         public TempCryptoStream(Stream stream)
         {
             _stream = stream;
             _startPosition = stream.Position;
+            _nonces = new MemoryStream();
+            _authenticationTags = new MemoryStream();
             _internalBuffer = new byte[4096];
 
             _key = new byte[(int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes()];

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -824,8 +824,8 @@ namespace SlowTests.Server.Replication
         public async Task ReplicationShouldSendMissingAttachmentsFromNonShardedToShardedDatabase_LargeAttachments_Encrypted()
         {
            
-            var databaseName = Encryption.SetupEncryptedDatabase(out var cert, out var masterKey);
-            var databaseName2 = Encryption.SetupEncryptedDatabase(out var cert2, out var masterKey2);
+            var databaseName = Encryption.SetupEncryptedDatabase(out var cert, out _);
+            var databaseName2 = Encryption.SetupEncryptedDatabase(out var cert2, out _);
 
             using (var source = GetDocumentStore(new Options
             {
@@ -915,21 +915,20 @@ namespace SlowTests.Server.Replication
                         var attachments = session.Advanced.Attachments.GetNames(user);
                         Assert.Equal(2, attachments.Length);
 
-                        //TODO: make it work
-                        //foreach (var name in attachments)
-                        //{
-                        //    using (var attachment = await session.Advanced.Attachments.GetAsync(user, name.Name))
-                        //    {
-                        //        Assert.NotNull(attachment);
-                        //        Assert.Equal(3, await attachment.Stream.ReadAsync(buffer, 0, 3));
-                        //        if (attachment.Details.Name == "foo.png")
-                        //        {
-                        //            Assert.Equal(0, buffer[0]);
-                        //            Assert.Equal(1, buffer[1]);
-                        //            Assert.Equal(2, buffer[2]);
-                        //        }
-                        //    }
-                        //}
+                        foreach (var name in attachments)
+                        {
+                            using (var attachment = await session.Advanced.Attachments.GetAsync(user, name.Name))
+                            {
+                                Assert.NotNull(attachment);
+                                Assert.Equal(3, await attachment.Stream.ReadAsync(buffer, 0, 3));
+                                if (attachment.Details.Name == "foo.png")
+                                {
+                                    Assert.Equal(0, buffer[0]);
+                                    Assert.Equal(1, buffer[1]);
+                                    Assert.Equal(2, buffer[2]);
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19503/Sharding-External-Replication-Avoid-cloning-attachments-on-the-orchestrator

### Additional description

Need to handle encrypted database case 

### Type of change

- Optimization


### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
