### PR TITLE
RavenDB-19478 Expose Optimize index option in the Studio

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -106,6 +106,8 @@ class editIndex extends viewModelBase {
 
     inheritSearchEngineText: KnockoutComputed<string>;
     effectiveSearchEngineText: KnockoutComputed<string>;
+    
+    canOptimizeIndex = ko.observable<boolean>(false);
 
     static readonly searchEngineConfigurationLabel = configurationConstants.indexing.staticIndexingEngineType;
 
@@ -309,6 +311,8 @@ class editIndex extends viewModelBase {
                 this.defaultSearchEngine(indexDefaults.StaticIndexingEngineType === "None" ? "Lucene" : indexDefaults.StaticIndexingEngineType);
                 
                 this.extractSearchEngineFromConfig();
+                
+                this.canOptimizeIndex((this.searchEngineConfiguration() || this.defaultSearchEngine()) === "Lucene");
 
                 this.editedIndex().registerCustomAnalyzers(analyzersList);
                 

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -33,7 +33,7 @@
                                         <span>Dump</span>
                                     </a>
                                 </li>
-                                <li title="Optimize Lucene index files">
+                                <li title="Optimize Lucene index files" data-bind="visible: canOptimizeIndex">
                                     <a href="#" data-bind="click: openOptimizeDialog">
                                         <i class="icon-compact"></i>
                                         <span>Optimize</span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19478

### Additional description

Do NOT allow lucene optimize for corax indexes.

### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change
