### PR TITLE
RavenDB-19281 Add threshold to start flush and sync when performing replacement of side-by-side index.

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -449,6 +449,14 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex { get; protected set; }
+
+        [Description("Minimum total size of journals to run flush and sync when replacing side by side index.")]
+        [DefaultValue(512)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
+            ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public Size MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex { get; set; }
         
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1812,8 +1812,13 @@ namespace Raven.Server.Documents.Indexes
 
                     if (batchCompleted)
                     {
+                        Size totalSizeOfJournals = Size.Zero;
+                        foreach (var journalSize in _environment.Journal.Files.Select(i => i.JournalSize))
+                            totalSizeOfJournals += journalSize;
                         
-                        FlushAndSync(_environment, (int)Configuration.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex.AsTimeSpan.TotalMilliseconds, tryCleanupRecycledJournals: true);
+                        
+                        if (totalSizeOfJournals >= Configuration.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex)
+                            FlushAndSync(_environment, (int)Configuration.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex.AsTimeSpan.TotalMilliseconds, tryCleanupRecycledJournals: true);
 
                         // this side-by-side index will be replaced in a second, notify about indexing success
                         // so we know that indexing batch is no longer in progress

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -34,7 +34,8 @@ class configurationItem {
         "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
         "Indexing.Lucene.UseCompoundFileInMerging",
         "Indexing.Lucene.IndexInputType",
-        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec"
+        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
+        "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -59,6 +59,8 @@ namespace Voron.Impl.Journal
 
         public long Available4Kbs => _journalWriter?.NumberOfAllocated4Kb - _writePosIn4Kb ?? 0;
 
+        public Size JournalSize => new Size(_journalWriter?.NumberOfAllocated4Kb * 4 ?? 0, SizeUnit.Kilobytes); 
+        
         internal IJournalWriter JournalWriter => _journalWriter;
 
         public PageTable PageTranslationTable => _pageTranslationTable;

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -77,7 +77,8 @@ namespace FastTests.Issues
                 "Indexing.Lucene.UseCompoundFileInMerging",
                 "Indexing.Lucene.IndexInputType",
                 "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
-                
+                "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
+
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",
@@ -87,7 +88,7 @@ namespace FastTests.Issues
                 "Indexing.MaxTimeForMergesToKeepRunningInSec",
                 "Indexing.MergeFactor",
                 "Indexing.NumberOfLargeSegmentsToMergeInSingleBatch",
-                "Indexing.UseCompoundFileInMerging"
+                "Indexing.UseCompoundFileInMerging",
             };
 
             var sortedStudioList = propertiesDeclaredInStudio.OrderBy(x => x).ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19281

### Additional description

There is no need to run it for small journals. 

### Type of change

- Optimization

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
