### PR TITLE
RavenDB-19583 Fixed MessageBuilder.Buffer size verification and resizing

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/Messages/MessageBuilder.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Messages/MessageBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
+using Sparrow.Binary;
 
 namespace Raven.Server.Integrations.PostgreSQL.Messages
 {
@@ -378,7 +379,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Messages
             {
                 using (var oldOwner = _bufferOwner)
                 {
-                    _bufferOwner = MemoryPool<byte>.Shared.Rent(oldOwner.Memory.Length * 2);
+                    _bufferOwner = MemoryPool<byte>.Shared.Rent(Bits.PowerOf2(pos + addedSize));
                     oldOwner.Memory.CopyTo(_bufferOwner.Memory);
                 }
             }

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -124,7 +124,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 var processedString = (prop.Token & BlittableJsonReaderBase.TypesMask) switch
                 {
-                    BlittableJsonToken.CompressedString => (string)prop.Value,
+                    BlittableJsonToken.CompressedString => (string)(LazyCompressedStringValue)prop.Value,
                     BlittableJsonToken.String => (LazyStringValue)prop.Value,
                     _ => null
                 };

--- a/test/SlowTests/Issues/RavenDB-19583.cs
+++ b/test/SlowTests/Issues/RavenDB-19583.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL
+{
+    public class RavenDB_19583 : PostgreSqlIntegrationTestBase
+    {
+        public RavenDB_19583(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Order
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string OrderLines { get; set; }
+        }
+
+        [Fact]
+        public async Task CaResizeBufferCorrectlyWhenMassiveColumnsAreNextToLightweightColumns()
+        {
+            string query = $"from Orders";
+
+            DoNotReuseServer(EnablePostgresSqlSettings);
+
+            using (var store = GetDocumentStore())
+            {
+                var order = new Order
+                {
+                    Id = "orders/1",
+                    Name = "OrderOne",
+                    OrderLines = string.Join(" ", Enumerable.Range(0, 300_000).Select(i => "a"))
+                };
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(order);
+                    session.SaveChanges();
+                }
+
+                var result = await Act(store, query, Server);
+                Assert.Equal(result.Rows[0]["OrderLines"], order.OrderLines);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19583/Documents-with-a-massive-column-content-arent-properly-written-to-the-MessageBuilder.Buffer

### Additional description

Loading a collection with massive documents caused an error. After investigation, it came out that we store the document fields (columns) in the `MessageBuilder.Buffer` that resizes itself every time it is too small to keep the data.
Its' size was then multiplied by two and we proceeded to retry storing the data in the buffer one more time, regardless it is still too small anyway.

I've changed the MessageBuilder.Buffer (Memory) resizing. Now, we multiply the size of the buffer by two, but **until** it is too small, not **if**.

That fixes the issue with huge column content.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
