### PR TITLE
RavenDB-17650 - Test subscription retry/failover upon `DatabaseDisabl…

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -827,7 +827,6 @@ namespace Raven.Client.Documents.Subscriptions
                 case AllTopologyNodesDownException:
                 {
                     AssertLastConnectionFailure();
-                    _redirectNode = null;
                     return true;
                 }
                 case NodeIsPassiveException e:

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -825,6 +825,11 @@ namespace Raven.Client.Documents.Subscriptions
 
                 case DatabaseDisabledException:
                 case AllTopologyNodesDownException:
+                {
+                    AssertLastConnectionFailure();
+                    _redirectNode = null;
+                    return true;
+                }
                 case NodeIsPassiveException e:
                     {
                         // if we failed to talk to a node, we'll forget about it and let the topology to

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -823,6 +823,8 @@ namespace Raven.Client.Documents.Subscriptions
 
                     return true;
 
+                case DatabaseDisabledException:
+                case AllTopologyNodesDownException:
                 case NodeIsPassiveException e:
                     {
                         // if we failed to talk to a node, we'll forget about it and let the topology to
@@ -848,7 +850,6 @@ namespace Raven.Client.Documents.Subscriptions
                 case SubscriptionInvalidStateException _:
                 case DatabaseDoesNotExistException _:
                 case AuthorizationException _:
-                case AllTopologyNodesDownException _:
                 case SubscriberErrorException _:
                     _processingCts.Cancel();
                     return false;

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3.Model;
+using FastTests;
+using Microsoft.Azure.Documents.Spatial;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using SlowTests.MailingList;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17650 : ClusterTestBase
+    {
+        public RavenDB_17650(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_Retry_When_DatabaseDisabledException_Was_Thrown()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, shouldRunInMemory: false/*, watcherCluster: true*/);
+            using var store = GetDocumentStore(new Options()
+            {
+                ReplicationFactor = 3,
+                Server = leader,
+                RunInMemory = false
+            });
+            string id = "User/33-A";
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = id, Name = "1" });
+                await session.StoreAsync(new User { Name = "2" });
+                await session.SaveChangesAsync();
+            }
+            WaitForUserToContinueTheTest(store);
+
+            await store.Subscriptions
+                .CreateAsync(new SubscriptionCreationOptions<User>
+                {
+                    Name = "BackgroundSubscriptionWorker"
+                });
+            
+            using var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("BackgroundSubscriptionWorker"));
+            // disable database
+            var disableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
+            Assert.True(disableSucceeded.Success);
+            Assert.True(disableSucceeded.Disabled);
+
+            var cts = new CancellationTokenSource();
+            var mre = new ManualResetEvent(false);
+            var t = worker.Run(async batch =>
+            {
+                User user = null;
+                using (var session = batch.OpenAsyncSession())
+                {
+                    user = await session.LoadAsync<User>(id);
+                }
+                
+                if (user != null)
+                {
+                    mre.Set();
+                }
+            }, cts.Token);
+
+            //enable database
+            await Task.Delay(2000);
+            var enableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, false));
+            Assert.False(enableSucceeded.Disabled);
+            Assert.True(enableSucceeded.Success);
+            WaitForUserToContinueTheTest(store);
+            Assert.True(mre.WaitOne(TimeSpan.FromSeconds(15)), "User didn't loaded.");
+        }
+
+        [Fact]
+        public async Task Should_Retry_When_AllNodesTopologyDownException_Was_Thrown()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, shouldRunInMemory: false/*, watcherCluster: true*/);
+            using var store = GetDocumentStore(new Options()
+            {
+                ReplicationFactor = 3,
+                Server = leader,
+                RunInMemory = false
+            });
+            string id = "User/33-A";
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = id, Name = "1" });
+                await session.StoreAsync(new User { Name = "2" });
+                await session.SaveChangesAsync();
+            }
+            WaitForUserToContinueTheTest(store);
+
+            await store.Subscriptions
+                .CreateAsync(new SubscriptionCreationOptions<User>
+                {
+                    Name = "BackgroundSubscriptionWorker"
+                });
+
+            using var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("BackgroundSubscriptionWorker"));
+
+            // dispose nodes
+            var results = new List<(string DataDirectory, string Url, string NodeTag)>();
+            foreach (var node in nodes)
+            {
+                var result = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
+                results.Add(result);
+            }
+
+            var cts = new CancellationTokenSource();
+            var mre = new ManualResetEvent(false);
+            var t = worker.Run(async batch =>
+            {
+                User user = null;
+                using (var session = batch.OpenAsyncSession())
+                {
+                    user = await session.LoadAsync<User>(id);
+                }
+
+                if (user != null)
+                {
+                    mre.Set();
+                }
+            }, cts.Token);
+
+            //revive nodes
+            await Task.Delay(2000);
+            foreach (var result in results)
+            {
+                var cs = new Dictionary<string, string>(DefaultClusterSettings);
+                cs[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
+                var revivedServer = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = result.DataDirectory,
+                    CustomSettings = cs
+                });
+            }
+            
+            Assert.True(mre.WaitOne(TimeSpan.FromSeconds(15)), "User didn't loaded.");
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -55,7 +55,7 @@ namespace SlowTests.Issues
 
             var cts = new CancellationTokenSource();
             var mre = new ManualResetEvent(false);
-            var t = worker.Run(async batch =>
+            var _ = worker.Run( batch =>
             {
                 mre.Set();
             }, cts.Token);
@@ -100,7 +100,7 @@ namespace SlowTests.Issues
 
             var cts = new CancellationTokenSource();
             var mre = new ManualResetEvent(false);
-            var t = worker.Run(async batch =>
+            var _ = worker.Run( batch =>
             {
                 mre.Set();
             }, cts.Token);

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -145,7 +145,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task Should_Throw_SubscriptionInvalidStateException_When_DatabaseDisabledException_Was_Thrown_And_MaxErroneousPeriod_Was_Passed()
+        public async Task Should_Throw_DatabaseDisabledException_When_MaxErroneousPeriod_Was_Passed()
         {
             using var store = GetDocumentStore(new Options()
             {
@@ -200,7 +200,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task Should_Throw_SubscriptionInvalidStateException_When_AllTopologyNodesDownException_Was_Thrown_And_MaxErroneousPeriod_Was_Passed()
+        public async Task Should_Throw_AllTopologyNodesDownException_When_MaxErroneousPeriod_Was_Passed()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, shouldRunInMemory: false);
             using var store = GetDocumentStore(new Options()

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -26,13 +26,12 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Should_Retry_When_DatabaseDisabledException_Was_Thrown()
         {
-            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, shouldRunInMemory: false/*, watcherCluster: true*/);
             using var store = GetDocumentStore(new Options()
             {
-                ReplicationFactor = 3,
-                Server = leader,
+                ReplicationFactor = 1,
                 RunInMemory = false
             });
+            
             string id = "User/33-A";
             using (var session = store.OpenAsyncSession())
             {
@@ -40,7 +39,6 @@ namespace SlowTests.Issues
                 await session.StoreAsync(new User { Name = "2" });
                 await session.SaveChangesAsync();
             }
-            WaitForUserToContinueTheTest(store);
 
             await store.Subscriptions
                 .CreateAsync(new SubscriptionCreationOptions<User>
@@ -49,6 +47,7 @@ namespace SlowTests.Issues
                 });
             
             using var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("BackgroundSubscriptionWorker"));
+
             // disable database
             var disableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
             Assert.True(disableSucceeded.Success);
@@ -58,35 +57,24 @@ namespace SlowTests.Issues
             var mre = new ManualResetEvent(false);
             var t = worker.Run(async batch =>
             {
-                User user = null;
-                using (var session = batch.OpenAsyncSession())
-                {
-                    user = await session.LoadAsync<User>(id);
-                }
-                
-                if (user != null)
-                {
-                    mre.Set();
-                }
+                mre.Set();
             }, cts.Token);
 
             //enable database
-            await Task.Delay(2000);
+            await Task.Delay(500);
             var enableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, false));
             Assert.False(enableSucceeded.Disabled);
             Assert.True(enableSucceeded.Success);
-            WaitForUserToContinueTheTest(store);
             Assert.True(mre.WaitOne(TimeSpan.FromSeconds(15)), "User didn't loaded.");
         }
 
         [Fact]
         public async Task Should_Retry_When_AllNodesTopologyDownException_Was_Thrown()
         {
-            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, shouldRunInMemory: false/*, watcherCluster: true*/);
+            var node = GetNewServer(new ServerCreationOptions { RunInMemory = false });
             using var store = GetDocumentStore(new Options()
             {
-                ReplicationFactor = 3,
-                Server = leader,
+                ReplicationFactor = 1,
                 RunInMemory = false
             });
             string id = "User/33-A";
@@ -107,44 +95,27 @@ namespace SlowTests.Issues
             using var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("BackgroundSubscriptionWorker"));
 
             // dispose nodes
-            var results = new List<(string DataDirectory, string Url, string NodeTag)>();
-            foreach (var node in nodes)
-            {
-                var result = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
-                results.Add(result);
-            }
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
+
 
             var cts = new CancellationTokenSource();
             var mre = new ManualResetEvent(false);
             var t = worker.Run(async batch =>
             {
-                User user = null;
-                using (var session = batch.OpenAsyncSession())
-                {
-                    user = await session.LoadAsync<User>(id);
-                }
-
-                if (user != null)
-                {
-                    mre.Set();
-                }
+                mre.Set();
             }, cts.Token);
 
-            //revive nodes
-            await Task.Delay(2000);
-            foreach (var result in results)
+            //revive node
+            await Task.Delay(500);
+            var cs = new Dictionary<string, string>(DefaultClusterSettings);
+            cs[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
+            var revivedServer = GetNewServer(new ServerCreationOptions
             {
-                var cs = new Dictionary<string, string>(DefaultClusterSettings);
-                cs[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
-                var revivedServer = GetNewServer(new ServerCreationOptions
-                {
-                    DeletePrevious = false,
-                    RunInMemory = false,
-                    DataDirectory = result.DataDirectory,
-                    CustomSettings = cs
-                });
-            }
-            
+                DeletePrevious = false,
+                RunInMemory = false,
+                DataDirectory = result.DataDirectory,
+                CustomSettings = cs
+            });
             Assert.True(mre.WaitOne(TimeSpan.FromSeconds(15)), "User didn't loaded.");
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17650

### Additional description

Test subscription retry/failover upon `DatabaseDisabledException` & `AllNodesTopologyDownException`.
The expected behavior is:
1. upon `DatabaseDisabledException` ~~stop and kill the worker~~  continue retry
2. upon `AllNodesTopologyDownException` continue retry

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
