### PR TITLE
RavenDB-19570 - Failing test RevertByMultipleCollections_ShouldRemove…

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -20,6 +20,7 @@ using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -41,7 +42,7 @@ namespace Raven.Server.Documents.Revisions
         private static readonly Slice RevisionsTombstonesSlice;
         private static readonly Slice RevisionsPrefix;
         public static Slice ResolvedFlagByEtagSlice;
-        public long SizeLimit = 32 * 1_024 * 1_024;
+        public long SizeLimitInBytes = (new Size(PlatformDetails.Is32Bits == false ? 32 : 2, SizeUnit.Megabytes)).GetValue(SizeUnit.Bytes);
 
         public static readonly string RevisionsTombstones = "Revisions.Tombstones";
 
@@ -1325,7 +1326,7 @@ namespace Raven.Server.Documents.Revisions
                 if (elapsed > MaxEnforceConfigurationSingleBatchTime)
                     return false;
 
-                if (context.AllocatedMemory > SizeLimit)
+                if (context.AllocatedMemory > SizeLimitInBytes)
                     return false;
 
                 return true;
@@ -1572,7 +1573,7 @@ namespace Raven.Server.Documents.Revisions
 
                     RestoreRevision(readCtx, writeCtx, parameters, id, result, list);
 
-                    if (readCtx.AllocatedMemory + writeCtx.AllocatedMemory > SizeLimit)
+                    if (readCtx.AllocatedMemory + writeCtx.AllocatedMemory > SizeLimitInBytes)
                     {
                         return true;
                     }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -41,6 +41,7 @@ namespace Raven.Server.Documents.Revisions
         private static readonly Slice RevisionsTombstonesSlice;
         private static readonly Slice RevisionsPrefix;
         public static Slice ResolvedFlagByEtagSlice;
+        public long SizeLimit = 32 * 1_024 * 1_024;
 
         public static readonly string RevisionsTombstones = "Revisions.Tombstones";
 
@@ -1443,8 +1444,6 @@ namespace Raven.Server.Documents.Revisions
                 }
             }
         }
-
-        private const long SizeLimit = 32 * 1_024 * 1_024;
 
         private class Parameters
         {

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -37,19 +37,17 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByMultipleCollections_ShouldRemoveDocWhichCreatedAfterTheMinDate()
         {
-            var batchSizeLimit = 32 * 1_024;
+            var batchSizeLimitInBytes = 32 * 1_024; //32kb
             var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "companies", "users" };
-            var names = new[] { GenerateRandomString(batchSizeLimit / 2), GenerateRandomString(batchSizeLimit / 2 + 1), GenerateRandomString(batchSizeLimit / 2), };
-            var server = GetNewServer();
+            var names = new[] { GenerateRandomString(batchSizeLimitInBytes / 2), GenerateRandomString(batchSizeLimitInBytes / 2 + 1), GenerateRandomString(batchSizeLimitInBytes / 2), };
             using var store = GetDocumentStore(new Options
             {
-                Server = server,
                 ReplicationFactor = 1
             });
 
-            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            database.DocumentsStorage.RevisionsStorage.SizeLimit = batchSizeLimit;
-            await RevisionsHelper.SetupRevisions(store, server.ServerStore);
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = batchSizeLimitInBytes;
+            await RevisionsHelper.SetupRevisions(store, Server.ServerStore);
             
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -37,109 +37,91 @@ namespace SlowTests.Server.Documents.Revisions
         [Fact]
         public async Task RevertByMultipleCollections_ShouldRemoveDocWhichCreatedAfterTheMinDate()
         {
-            var defaultBatchSize = 32 * 1_024 * 1_024;
+            var batchSizeLimit = 32 * 1_024;
             var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "companies", "users" };
-            var names = new []
+            var names = new[] { GenerateRandomString(batchSizeLimit / 2), GenerateRandomString(batchSizeLimit / 2 + 1), GenerateRandomString(batchSizeLimit / 2), };
+            var server = GetNewServer();
+            using var store = GetDocumentStore(new Options
             {
-                GenerateRandomString(defaultBatchSize / 2), 
-                GenerateRandomString(defaultBatchSize / 2 + 1), 
-                GenerateRandomString(defaultBatchSize / 2),
-            };
-            using (var store = GetDocumentStore())
+                Server = server,
+                ReplicationFactor = 1
+            });
+
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.RevisionsStorage.SizeLimit = batchSizeLimit;
+            await RevisionsHelper.SetupRevisions(store, server.ServerStore);
+            
+            using (var session = store.OpenAsyncSession())
             {
-                await RevisionsHelper.SetupRevisions(store, Server.ServerStore);
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new Company
-                    {
-                        Name = names[0]
-                    }, "companies/1");
+                await session.StoreAsync(new Company { Name = names[0] }, "companies/1");
 
-                    await session.StoreAsync(new Company
-                    {
-                        Name = names[1]
-                    }, "companies/2");
+                await session.StoreAsync(new Company { Name = names[1] }, "companies/2");
 
-                    await session.StoreAsync(new User
-                    {
-                        Name = names[2]
-                    }, "users/1");
+                await session.StoreAsync(new User { Name = names[2] }, "users/1");
 
-                    await session.SaveChangesAsync();
-                }
-
-                await Task.Delay(100);
-                DateTime last = DateTime.UtcNow;
-                await Task.Delay(100);
-
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new Company
-                    {
-                        Name = "abc"
-                    }, "companies/1");
-
-                    await session.StoreAsync(new Company
-                    {
-                        Name = "abc"
-                    }, "companies/2");
-
-                    await session.StoreAsync(new User
-                    {
-                        Name = "abc"
-                    }, "users/1");
-
-                    await session.StoreAsync(new User
-                    {
-                        Name = "abc"
-                    }, "users/2");
-
-                    await session.SaveChangesAsync();
-                }
-
-                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
-
-                RevertResult result;
-                using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                {
-                    result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
-                        token: token, collections: collections);
-                }
-                
-                using (var session = store.OpenAsyncSession())
-                {
-                    var o1 = await session.LoadAsync<Company>("companies/1");
-                    var o2 = await session.LoadAsync<Company>("companies/2");
-                    var o3 = await session.LoadAsync<User>("users/1");
-                    var o4 = await session.LoadAsync<User>("users/2");
-                    Assert.NotNull(o1);
-                    Assert.NotNull(o2);
-                    Assert.NotNull(o3);
-                    Assert.Null(o4);
-
-                    var revisions_c1 = await session.Advanced.Revisions.GetForAsync<Company>("companies/1");
-                    Assert.Equal(3, revisions_c1.Count);
-                    Assert.Equal(names[0], revisions_c1[0].Name);
-                    Assert.Equal("abc", revisions_c1[1].Name);
-                    Assert.Equal(names[0], revisions_c1[2].Name);
-
-                    var revisions_c2 = await session.Advanced.Revisions.GetForAsync<Company>("companies/2");
-                    Assert.Equal(3, revisions_c2.Count);
-                    Assert.Equal(names[1], revisions_c2[0].Name);
-                    Assert.Equal("abc", revisions_c2[1].Name);
-                    Assert.Equal(names[1], revisions_c2[2].Name);
-
-                    var revisions_u1 = await session.Advanced.Revisions.GetForAsync<User>("users/1");
-                    Assert.Equal(3, revisions_u1.Count);
-                    Assert.Equal(names[2], revisions_u1[0].Name);
-                    Assert.Equal("abc", revisions_u1[1].Name);
-                    Assert.Equal(names[2], revisions_u1[2].Name);
-
-                    var revisions_u2 = await session.Advanced.Revisions.GetForAsync<User>("users/2");
-                    Assert.Null(revisions_u2[0].Name);
-                    Assert.Equal("abc", revisions_u2[1].Name);
-                }
+                await session.SaveChangesAsync();
             }
+
+            await Task.Delay(100);
+            DateTime last = DateTime.UtcNow;
+            await Task.Delay(100);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Company { Name = "abc" }, "companies/1");
+
+                await session.StoreAsync(new Company { Name = "abc" }, "companies/2");
+
+                await session.StoreAsync(new User { Name = "abc" }, "users/1");
+
+                await session.StoreAsync(new User { Name = "abc" }, "users/2");
+
+                await session.SaveChangesAsync();
+            }
+
+            var db = database;//await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            RevertResult result;
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            {
+                result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                    token: token, collections: collections);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var o1 = await session.LoadAsync<Company>("companies/1");
+                var o2 = await session.LoadAsync<Company>("companies/2");
+                var o3 = await session.LoadAsync<User>("users/1");
+                var o4 = await session.LoadAsync<User>("users/2");
+                Assert.NotNull(o1);
+                Assert.NotNull(o2);
+                Assert.NotNull(o3);
+                Assert.Null(o4);
+
+                var revisions_c1 = await session.Advanced.Revisions.GetForAsync<Company>("companies/1");
+                Assert.Equal(3, revisions_c1.Count);
+                Assert.Equal(names[0], revisions_c1[0].Name);
+                Assert.Equal("abc", revisions_c1[1].Name);
+                Assert.Equal(names[0], revisions_c1[2].Name);
+
+                var revisions_c2 = await session.Advanced.Revisions.GetForAsync<Company>("companies/2");
+                Assert.Equal(3, revisions_c2.Count);
+                Assert.Equal(names[1], revisions_c2[0].Name);
+                Assert.Equal("abc", revisions_c2[1].Name);
+                Assert.Equal(names[1], revisions_c2[2].Name);
+
+                var revisions_u1 = await session.Advanced.Revisions.GetForAsync<User>("users/1");
+                Assert.Equal(3, revisions_u1.Count);
+                Assert.Equal(names[2], revisions_u1[0].Name);
+                Assert.Equal("abc", revisions_u1[1].Name);
+                Assert.Equal(names[2], revisions_u1[2].Name);
+
+                var revisions_u2 = await session.Advanced.Revisions.GetForAsync<User>("users/2");
+                Assert.Null(revisions_u2[0].Name);
+                Assert.Equal("abc", revisions_u2[1].Name);
+            }
+
         }
 
         private string GenerateRandomString(int size)
@@ -572,7 +554,7 @@ namespace SlowTests.Server.Documents.Revisions
             }
         }
 
-        [Fact] //--
+        [Fact]
         public async Task RevertByWrongCollection_EndPointCheck()
         {
             var collections = new string[]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19570

### Additional description

Failing test RevertByMultipleCollections_ShouldRemoveDocWhichCreatedAfterTheMinDate (with OutOfMemoryException on win32).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
