### PR TITLE
RavenDB-18925 - SlowTests.Server.Replication.PullReplicationPreventDe…

### DIFF
--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -113,7 +113,12 @@ namespace SlowTests.Server.Replication
             var hubDatabaseInstance = await Databases.GetDocumentDatabaseInstanceFor(hubStore);
             bool expectedError = false;
             string lastError = null;
-            hubDatabaseInstance.ReplicationLoader.IncomingHandlers.ToArray()[0].Failed += (handler, exception) =>
+            Exception lastException = null;
+            var incomingHandlers = hubDatabaseInstance.ReplicationLoader.IncomingHandlers.ToArray();
+            var incomingStr = string.Join(",", incomingHandlers.Select(x => x.GetType()));
+            Assert.True(incomingHandlers.Length == 1, $"hub should have 1 incoming handler but has {incomingHandlers.Length}, {incomingStr}");
+
+            incomingHandlers[0].Failed += (handler, exception) =>
             {
                 if (exception.Message.Contains("This hub does not allow for tombstone replication via pull replication"))
                 {
@@ -121,6 +126,7 @@ namespace SlowTests.Server.Replication
                 }
 
                 lastError = exception.Message;
+                lastException = exception;
             };
 
             //delete doc from sink
@@ -143,7 +149,11 @@ namespace SlowTests.Server.Replication
 
             //make sure hub threw error
             var result = await WaitForValueAsync(() => Task.FromResult(expectedError), true);
-            Assert.True(result, lastError);
+            if (result == false)
+            {
+                Assert.NotNull(lastException);
+                Assert.True(false, $"The actual exception: {lastException}");
+            }
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18925

### Additional description

SlowTests.Server.Replication.PullReplicationPreventDeletionsTests.PreventDeletionOnHubSinkCompromised fails.
Change the test in a way that will expose the reason for its failure.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
