### PR TITLE
RavenDB-19599 Elasticsearch ETL: Allow to enable compatibility mode

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -59,6 +59,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         {
             DynamicJsonValue json = base.ToJson();
             json[nameof(Nodes)] = new DynamicJsonArray(Nodes);
+            json[nameof(EnableCompatibilityMode)] = EnableCompatibilityMode;
             json[nameof(Authentication)] = Authentication == null ? null : new DynamicJsonValue()
             {
                 [nameof(Authentication.Basic)] = Authentication.Basic == null ? null : new DynamicJsonValue()

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -13,6 +13,8 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
 
         public override ConnectionStringType Type => ConnectionStringType.ElasticSearch;
 
+        public bool EnableCompatibilityMode { get; set; }
+
         protected override void ValidateImpl(ref List<string> errors)
         {
             if (Nodes == null || Nodes.Length == 0)

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -422,7 +422,7 @@ namespace Raven.Server.Documents.ETL
                 }
                 catch (Exception e)
                 {
-                    if (CancellationToken.IsCancellationRequested == false)
+                    if (CancellationToken.IsCancellationRequested == false) 
                     {
                         string msg = $"Failed to load transformed data for '{Name}'";
 

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
@@ -16,6 +16,9 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             StaticConnectionPool pool = new StaticConnectionPool(nodesUrls);
             ConnectionSettings settings = new ConnectionSettings(pool);
 
+            if (connectionString.EnableCompatibilityMode)
+                settings.EnableApiVersioningHeader();
+
             if (requestTimeout != null)
                 settings.RequestTimeout(requestTimeout.Value);
 

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
@@ -281,7 +281,7 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
             Name: "",
             Nodes: [],
             Authentication: authenticationInfo.empty().toDto(),
-            EnableCompatibilityMode: true
+            EnableCompatibilityMode: false
         } as Raven.Client.Documents.Operations.ETL.ElasticSearch.ElasticSearchConnectionString, true, []);
     }
 

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringElasticSearchEtlModel.ts
@@ -210,6 +210,7 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
     selectedUrlToTest = ko.observable<string>();
     
     authentication = ko.observable<authenticationInfo>();
+    enableCompatibilityMode = ko.observable<boolean>();
 
     validationGroup: KnockoutValidationGroup;
 
@@ -230,6 +231,7 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
         this.nodesUrls(dto.Nodes.map((x) => new discoveryUrl(x)));
 
         this.authentication(new authenticationInfo(dto.Authentication));
+        this.enableCompatibilityMode(dto.EnableCompatibilityMode);
     }
 
     initValidation(): void {
@@ -268,7 +270,8 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
             this.connectionStringName,
             urlsCount,
             urlsAreDirty,
-            this.authentication().dirtyFlag().isDirty
+            this.authentication().dirtyFlag().isDirty,
+            this.enableCompatibilityMode
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -277,7 +280,8 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
             Type: "ElasticSearch",
             Name: "",
             Nodes: [],
-            Authentication: authenticationInfo.empty().toDto()
+            Authentication: authenticationInfo.empty().toDto(),
+            EnableCompatibilityMode: true
         } as Raven.Client.Documents.Operations.ETL.ElasticSearch.ElasticSearchConnectionString, true, []);
     }
 
@@ -286,7 +290,8 @@ class connectionStringElasticSearchEtlModel extends connectionStringModel {
             Type: "ElasticSearch",
             Name: this.connectionStringName(),
             Nodes: this.nodesUrls().map((x) => x.discoveryUrlName()),
-            Authentication: this.authentication().toDto()
+            Authentication: this.authentication().toDto(),
+            EnableCompatibilityMode: this.enableCompatibilityMode()
         };
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
@@ -140,8 +140,8 @@
 <div class="form-group">
     <label class="control-label">&nbsp;</label>
     <div class="toggle">
-        <input id="toggle-mode" type="checkbox" data-bind="checked: enableCompatibilityMode">
-        <label for="toggle-mode">Enable compatibility mode</label>
+        <input id="toggle-elastic-compatibility-mode" type="checkbox" data-bind="checked: enableCompatibilityMode">
+        <label for="toggle-elastic-compatibility-mode">Enable compatibility mode</label>
     </div>
 </div>
 <div data-bind="if: !nodesUrls.isValid()">

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
@@ -49,7 +49,7 @@
             </ul>
         </div>
     </div>
-    <div data-bind="visible: authMethodUsed() === 'basic'">
+    <div data-bind="collapse: authMethodUsed() === 'basic'">
         <div class="form-group" data-bind="validationElement: username">
             <label class="control-label">Username <i class="required"></i></label>
             <div class="flex-grow">
@@ -63,7 +63,7 @@
             </div>
         </div>
     </div>
-    <div data-bind="visible: authMethodUsed() === 'apiKey'">
+    <div data-bind="collapse: authMethodUsed() === 'apiKey'">
         <div class="form-group" data-bind="validationElement: apiKeyId">
             <label class="control-label">API Key ID <i class="required"></i></label>
             <div class="flex-grow">
@@ -77,7 +77,7 @@
             </div>
         </div>
     </div>
-    <div data-bind="visible: authMethodUsed() === 'certificate'">
+    <div data-bind="collapse: authMethodUsed() === 'certificate'">
         <div class="input-group file-input">
             <input type="file" id="elasticCertificateFilePicker" data-bind="event: { change: _.partial(uploadElasticCertificate, $element) }" />
         </div>
@@ -123,6 +123,25 @@
                 </div>
             </div>
         </div>
+    </div>
+</div>
+<div class="form-group margin-top-lg margin-bottom-sm">
+    <label class="control-label">&nbsp;</label>
+    <div class="text-warning bg-warning padding padding-sm margin-top flex-horizontal">
+        <div class="flex-start"><small><i class="icon-warning"></i></small></div>
+        <div>
+            <small>
+            In order to use the latest <strong>7.x</strong> Elasticsearch client with an <strong>8.x</strong> Elasticsearch server, you must enable the compatibility mode below.<br />
+            This will set <strong>EnableApiVersioningHeader</strong> on the Elasticsearch connection string.
+            </small>
+        </div>
+    </div>
+</div>
+<div class="form-group">
+    <label class="control-label">&nbsp;</label>
+    <div class="toggle">
+        <input id="toggle-mode" type="checkbox" data-bind="checked: enableCompatibilityMode">
+        <label for="toggle-mode">Enable compatibility mode</label>
     </div>
 </div>
 <div data-bind="if: !nodesUrls.isValid()">

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -61,7 +61,7 @@ loadToOrders" + IndexSuffix + @"(orderData);";
         };
 
         protected ElasticSearchEtlConfiguration SetupElasticEtl(DocumentStore store, string script, IEnumerable<ElasticSearchIndex> indexes, IEnumerable<string> collections, bool applyToAllDocuments = false,
-            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, string configurationName = null, string transformationName = null, string[] nodes = null)
+            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, string configurationName = null, string transformationName = null, string[] nodes = null, bool enableCompatibilityMode = false)
         {
             var connectionStringName = $"{store.Database}@{store.Urls.First()} to ELASTIC";
 
@@ -84,10 +84,17 @@ loadToOrders" + IndexSuffix + @"(orderData);";
                         Script = script,
                         ApplyToAllDocuments = applyToAllDocuments
                     }
-                }
+                },
             };
 
-            AddEtl(store, config, new ElasticSearchConnectionString { Name = connectionStringName, Nodes = nodes ?? ElasticSearchTestNodes.Instance.VerifiedNodes.Value, Authentication = authentication });
+            AddEtl(store, config,
+                new ElasticSearchConnectionString
+                {
+                    Name = connectionStringName,
+                    Nodes = nodes ?? ElasticSearchTestNodes.Instance.VerifiedNodes.Value,
+                    Authentication = authentication,
+                    EnableCompatibilityMode = enableCompatibilityMode
+                });
 
             return config;
         }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -944,6 +944,60 @@ output('test output')"
             }
         }
 
+        [RequiresElasticSearchRetryFact]
+        public void CanEnableCompatibilityMode()
+        {
+            using (var store = GetDocumentStore())
+            using (GetElasticClient(out var client))
+            {
+                var config = SetupElasticEtl(store, DefaultScript, DefaultIndexes, DefaultCollections, enableCompatibilityMode: true);
+                var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        OrderLines = new List<OrderLine>
+                        {
+                            new OrderLine {Cost = 3, Product = "Cheese", Quantity = 3}, new OrderLine {Cost = 4, Product = "Bear", Quantity = 2},
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+                var ordersCount = client.Count<object>(c => c.Index(OrdersIndexName));
+                var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
+
+                Assert.Equal(1, ordersCount.Count);
+                Assert.Equal(2, orderLinesCount.Count);
+
+                etlDone.Reset();
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("orders/1-A");
+
+                    session.SaveChanges();
+                }
+
+                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+                var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrdersIndexName));
+                var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
+
+                Assert.True(ordersCount.IsValid);
+                Assert.True(orderLinesCount.IsValid);
+
+                Assert.Equal(0, ordersCountAfterDelete.Count);
+                Assert.Equal(0, orderLinesCountAfterDelete.Count);
+            }
+        }
+
         private class Order
         {
             public Address Address { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19599/Elasticsearch-ETL-Allow-to-enable-compatibility-mode

### Additional description

It's necessary when using v8 ES server

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio

