### PR TITLE
RavenDB-19495: BackupDatabaseOnce doesn't use Backup.TempPath (Unit-test)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -17,6 +17,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
+using Raven.Server.Config.Settings;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.Handlers;
@@ -1810,6 +1811,8 @@ namespace Raven.Server.Documents
             internal Action<string, string> DisposeLog;
 
             internal bool ForceSendTombstones = false;
+
+            internal Action<PathSetting> ActionToCallOnGetTempPath;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -100,6 +100,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     throw new Exception(nameof(_forTestingPurposes.SimulateFailedBackup));
                 if (_forTestingPurposes != null && _forTestingPurposes.OnBackupTaskRunHoldBackupExecution != null)
                     _forTestingPurposes.OnBackupTaskRunHoldBackupExecution.Task.Wait();
+                if (_database.ForTestingPurposes != null && _database.ForTestingPurposes.ActionToCallOnGetTempPath != null)
+                    _database.ForTestingPurposes.ActionToCallOnGetTempPath.Invoke(_tempBackupPath);
 
                 if (runningBackupStatus.LocalBackup == null)
                     runningBackupStatus.LocalBackup = new LocalBackup();

--- a/test/SlowTests/Server/Documents/ETL/Olap/BackupTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/BackupTests.cs
@@ -209,12 +209,7 @@ loadToOrders(partitionBy(key),
             {
                 var databaseRecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
                 var coreDataDirectoryPath = new PathSetting(databaseRecord.Settings[RavenConfiguration.GetKey(x => x.Core.DataDirectory)]);
-
-                using (var session = store.OpenAsyncSession())
-                {
-                    await Backup.FillDatabaseWithRandomDataAsync(databaseSizeInMb: 10, session);
-                }
-
+                
                 PathSetting tempPath = null;
                 var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 documentDatabase.ForTestingPurposesOnly().ActionToCallOnGetTempPath = pathSetting =>
@@ -232,7 +227,6 @@ loadToOrders(partitionBy(key),
 
                 if ((assignBackupTempPath && assignStorageTempPath) || assignBackupTempPath)
                 {
-                    
                     Assert.Equal(backupTempPath.Combine(subDirName), tempPath);
                 }
                 else if (assignStorageTempPath)

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -2,13 +2,11 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using FastTests.Graph;
+using Org.BouncyCastle.Math.EC;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
@@ -469,27 +467,6 @@ namespace FastTests
                             PrintBackupStatus(pb.BackupStatus) + Environment.NewLine + "BackupResult Messages:" + Environment.NewLine +
                             PrintBackupResultMessagesStatus(result));
                     }
-                }
-            }
-
-            public async Task FillDatabaseWithRandomDataAsync(int databaseSizeInMb, IAsyncDocumentSession session, int? timeout = default)
-            {
-                var random = new Random();
-                const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-                var timeoutTimeSpan = TimeSpan.FromMilliseconds(timeout ?? _reasonableTimeout);
-
-                using (var cts = new CancellationTokenSource(timeoutTimeSpan))
-                {
-                    for (int i = 0; i < databaseSizeInMb; i++)
-                    {
-                        var entry = new User
-                        {
-                            Name = new string(Enumerable.Repeat(chars, 1024 * 1024)
-                                .Select(s => s[random.Next(s.Length)]).ToArray())
-                        };
-                        await session.StoreAsync(entry, cts.Token);
-                    }
-                    await session.SaveChangesAsync(cts.Token);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19495/BackupDatabaseOnce-doesnt-use-Backup.TempPath

### Additional description

Only unit-test coverage of previously written code.

### Type of change

- Unit-test implementation

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed