### PR TITLE
RavenDB-19606 - Improve the performance of deleting a document

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1796,8 +1796,11 @@ namespace Raven.Server.Documents
                 if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
                     AttachmentsStorage.DeleteAttachmentsOfDocument(context, lowerId, changeVector, modifiedTicks);
 
-                CountersStorage.DeleteCountersForDocument(context, id, collectionName);
-                TimeSeriesStorage.DeleteAllTimeSeriesForDocument(context, id, collectionName);
+                if ((flags & DocumentFlags.HasCounters) == DocumentFlags.HasCounters)
+                    CountersStorage.DeleteCountersForDocument(context, id, collectionName);
+
+                if ((flags & DocumentFlags.HasTimeSeries) == DocumentFlags.HasTimeSeries)
+                    TimeSeriesStorage.DeleteAllTimeSeriesForDocument(context, id, collectionName);
 
                 context.Transaction.AddAfterCommitNotification(new DocumentChange
                 {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1793,13 +1793,13 @@ namespace Raven.Server.Documents
 
                 table.Delete(doc.StorageId);
 
-                if ((flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
+                if (flags.Contain(DocumentFlags.HasAttachments))
                     AttachmentsStorage.DeleteAttachmentsOfDocument(context, lowerId, changeVector, modifiedTicks);
 
-                if ((flags & DocumentFlags.HasCounters) == DocumentFlags.HasCounters)
+                if (flags.Contain(DocumentFlags.HasCounters))
                     CountersStorage.DeleteCountersForDocument(context, id, collectionName);
 
-                if ((flags & DocumentFlags.HasTimeSeries) == DocumentFlags.HasTimeSeries)
+                if (flags.Contain(DocumentFlags.HasTimeSeries))
                     TimeSeriesStorage.DeleteAllTimeSeriesForDocument(context, id, collectionName);
 
                 context.Transaction.AddAfterCommitNotification(new DocumentChange

--- a/src/Voron/Data/RawData/RawDataSection.cs
+++ b/src/Voron/Data/RawData/RawDataSection.cs
@@ -308,7 +308,7 @@ namespace Voron.Data.RawData
             _llt.FreePage(_sectionHeader->PageNumber);
         }
 
-        public double Free(long id)
+        public RawDataSection Free(long id)
         {
             if (_llt.Flags == TransactionFlags.Read)
                 ThrowReadOnlyTransaction(id);
@@ -352,7 +352,7 @@ namespace Voron.Data.RawData
             _sectionHeader->AllocatedSize -= sizeFreed;
             AvailableSpace[pageHeader->PageNumberInSection] += (ushort)sizeFreed;
 
-            return Density;
+            return this;
         }
 
         public event DataMovedDelegate DataMoved;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -509,8 +509,12 @@ namespace Voron.Data.Tables
             if (largeValue)
                 return;
 
-            var density = ActiveDataSmallSection.Free(id);
-            if (ActiveDataSmallSection.Contains(id) || density > 0.5)
+            var rawDataSection = ActiveDataSmallSection.Free(id);
+            if (ActiveDataSmallSection.Contains(id))
+                return;
+
+            var density = rawDataSection.Density;
+            if (density > 0.5)
                 return;
 
             var sectionPageNumber = RawDataSection.GetSectionPageNumber(_tx.LowLevelTransaction, id);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19606/Improve-the-performance-of-deleting-a-document

### Additional description

- delete the counters and time-series only if they exist in the document
- get the `Density` only if it's really needed

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- It has been verified by manual testing