### PR TITLE
RavenDB-17679 - Cannot clone document with a rollup time series

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1075,7 +1075,8 @@ namespace Raven.Server.Documents.Handlers
                                     cmd.DestinationId,
                                     docCollection,
                                     cmd.DestinationName,
-                                    reader.AllValues()
+                                    reader.AllValues(),
+                                    verifyName: false
                                 );
 
                             Reply.Add(new DynamicJsonValue

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_14386.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_14386.cs
@@ -5,6 +5,9 @@ using Xunit;
 using Xunit.Abstractions;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions.Documents;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.TimeSeries;
 
 namespace SlowTests.Client.TimeSeries.Issues
 {
@@ -121,6 +124,76 @@ namespace SlowTests.Client.TimeSeries.Issues
                     }
 
                     Assert.Throws<DocumentDoesNotExistException>(() =>session.SaveChanges());
+                }
+            }
+        }
+
+        // RavenDB-17679
+        [Fact]
+        public async Task TimeSeriesCopyShouldNotThrowForRollupTimeSeries()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var raw = new RawTimeSeriesPolicy();
+
+                var p1 = new TimeSeriesPolicy("BySecond", TimeSpan.FromSeconds(1));
+
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            RawPolicy = raw,
+                            Policies = new List<TimeSeriesPolicy> { p1 }
+                        }
+                    },
+                    PolicyCheckFrequency = TimeSpan.FromSeconds(1)
+                };
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+
+                var id = "users/1-A";
+                var id2 = "users/2-A";
+                var tag = "Heartrate";
+                var baseline = RavenTestHelper.UtcToday;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), id);
+                    var tsf = session.TimeSeriesFor(id, "Heartrate");
+                    for (int i = 0; i <= 20; i++)
+                    {
+                        tsf.Append(baseline.AddMinutes(i), new[] { (double)i }, "watches/apple");
+                    }
+
+                    session.Store(new User(), id2);
+                    session.SaveChanges();
+                }
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                await database.TimeSeriesPolicyRunner.RunRollups();
+
+                using (var session = store.OpenSession())
+                {
+                    var user2 = session.Load<User>("users/2-A");
+                    var user = session.Load<User>("users/1-A");
+
+                    foreach (var singleResult in session.Advanced.GetTimeSeriesFor(user))
+                    {
+                        session.Advanced.Defer(new CopyTimeSeriesCommandData(id,
+                            singleResult,
+                            id2,
+                            singleResult));
+                    }
+
+                    session.SaveChanges();
+
+                    var ts = session.TimeSeriesFor(user2, tag);
+                    var res = ts.Get();
+                    Assert.NotNull(res);
+                    ts = session.TimeSeriesFor(user2, p1.GetTimeSeriesName(tag));
+                    res = ts.Get();
+                    Assert.NotNull(res);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17679/Cannot-clone-document-with-a-rollup-time-series

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
