### PR TITLE
RavenDB-19237: Add the ability to import just one collection

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerExportOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerExportOptions.cs
@@ -1,19 +1,10 @@
-﻿using System.Collections.Generic;
-
-namespace Raven.Client.Documents.Smuggler
+﻿namespace Raven.Client.Documents.Smuggler
 {
     public class DatabaseSmugglerExportOptions : DatabaseSmugglerOptions, IDatabaseSmugglerExportOptions
     {
-        public DatabaseSmugglerExportOptions()
-        {
-            Collections = new List<string>();
-        }
-
-        public List<string> Collections { get; set; }
     }
 
     internal interface IDatabaseSmugglerExportOptions : IDatabaseSmugglerOptions
     {
-        List<string> Collections { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerImportOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerImportOptions.cs
@@ -6,7 +6,6 @@ namespace Raven.Client.Documents.Smuggler
     {
         public DatabaseSmugglerImportOptions()
         {
-            Collections = new List<string>();
         }
 
         public DatabaseSmugglerImportOptions(DatabaseSmugglerOptions options)
@@ -20,12 +19,10 @@ namespace Raven.Client.Documents.Smuggler
         }
 
         public bool SkipRevisionCreation { get; set; }
-        public List<string> Collections { get; set; }
     }
 
     internal interface IDatabaseSmugglerImportOptions : IDatabaseSmugglerOptions
     {
         bool SkipRevisionCreation { get; set; }
-        public List<string> Collections { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerImportOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerImportOptions.cs
@@ -1,9 +1,12 @@
-﻿namespace Raven.Client.Documents.Smuggler
+﻿using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Smuggler
 {
     public class DatabaseSmugglerImportOptions : DatabaseSmugglerOptions, IDatabaseSmugglerImportOptions
     {
         public DatabaseSmugglerImportOptions()
         {
+            Collections = new List<string>();
         }
 
         public DatabaseSmugglerImportOptions(DatabaseSmugglerOptions options)
@@ -17,10 +20,12 @@
         }
 
         public bool SkipRevisionCreation { get; set; }
+        public List<string> Collections { get; set; }
     }
 
     internal interface IDatabaseSmugglerImportOptions : IDatabaseSmugglerOptions
     {
         bool SkipRevisionCreation { get; set; }
+        public List<string> Collections { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -78,6 +78,6 @@ namespace Raven.Client.Documents.Smuggler
         bool RemoveAnalyzers { get; set; }
         string TransformScript { get; set; }
         int MaxStepsForTransformScript { get; set; }
-        public List<string> Collections { get; set; }
+        List<string> Collections { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Raven.Client.Documents.Smuggler
+﻿using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Smuggler
 {
     public class DatabaseSmugglerOptions : IDatabaseSmugglerOptions
     {
@@ -45,6 +47,7 @@
             MaxStepsForTransformScript = DefaultMaxStepsForTransformScript;
             IncludeExpired = true;
             IncludeArtificial = false;
+            Collections = new List<string>();
         }
 
         public DatabaseItemType OperateOnTypes { get; set; }
@@ -62,6 +65,8 @@
         public int MaxStepsForTransformScript { get; set; }
 
         public string EncryptionKey { get; set; }
+
+        public List<string> Collections { get; set; }
     }
 
     internal interface IDatabaseSmugglerOptions
@@ -73,5 +78,6 @@
         bool RemoveAnalyzers { get; set; }
         string TransformScript { get; set; }
         int MaxStepsForTransformScript { get; set; }
+        public List<string> Collections { get; set; }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -8,16 +8,9 @@ namespace Raven.Server.Smuggler.Documents.Data
 {
     public class DatabaseSmugglerOptionsServerSide : DatabaseSmugglerOptions, IDatabaseSmugglerImportOptions, IDatabaseSmugglerExportOptions
     {
-        public DatabaseSmugglerOptionsServerSide()
-        {
-            Collections = new List<string>();
-        }
-
         public bool ReadLegacyEtag { get; set; }
 
         public string FileName { get; set; }
-
-        public List<string> Collections { get; set; }
 
         public AuthorizationStatus AuthorizationStatus { get; set; } = AuthorizationStatus.ValidUser;
 

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -643,13 +643,13 @@ namespace Raven.Server.Smuggler.Documents
                     if (reader.TryGet(Constants.Documents.Blob.Document, out BlittableJsonReaderObject blobMetadata) == false ||
                         blobMetadata.TryGet(nameof(TimeSeriesItem.Collection), out string collection) == false)
                     {
-                        await SkipEntry(reader, size, skipDueToReadError: true);
+                        await SkipEntryAsync(reader, size, skipDueToReadError: true);
                         continue;
                     }
 
                     if (collectionsHashSet.Count > 0 && collectionsHashSet.Contains(collection) == false)
                     {
-                        await SkipEntry(reader, size, skipDueToReadError: false);
+                        await SkipEntryAsync(reader, size, skipDueToReadError: false);
                         continue;
                     }
 
@@ -658,7 +658,7 @@ namespace Raven.Server.Smuggler.Documents
                         blobMetadata.TryGet(nameof(TimeSeriesItem.ChangeVector), out string cv) == false ||
                         blobMetadata.TryGet(nameof(TimeSeriesItem.Baseline), out DateTime baseline) == false)
                     {
-                        await SkipEntry(reader, size, skipDueToReadError: true);
+                        await SkipEntryAsync(reader, size, skipDueToReadError: true);
                         continue;
                     }
 
@@ -675,7 +675,7 @@ namespace Raven.Server.Smuggler.Documents
                 }
             }
             
-            async Task SkipEntry(BlittableJsonReaderObject reader, int size, bool skipDueToReadError)
+            async Task SkipEntryAsync(BlittableJsonReaderObject reader, int size, bool skipDueToReadError)
             {
                 if (skipDueToReadError)
                 {
@@ -1484,6 +1484,7 @@ namespace Raven.Server.Smuggler.Documents
                     else
                     {
                         SkipEntry(data);
+                        continue;
                     }
 
                     if (data.TryGet("Key", out tombstone.LowerId) &&
@@ -1592,6 +1593,7 @@ namespace Raven.Server.Smuggler.Documents
                     else
                     {
                         SkipEntry(data);
+                        continue;
                     }
 
                     var conflict = new DocumentConflict();

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -512,7 +512,7 @@ namespace FastTests.Server.Replication
             }
         }
 
-        private class GetReplicationTombstonesCommand : RavenCommand<List<string>>
+        protected internal class GetReplicationTombstonesCommand : RavenCommand<List<string>>
         {
             public override bool IsReadRequest => true;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19237/Add-the-ability-to-import-just-one-collection

### Additional description

New feature: now you can specify which collections we want to import.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing 

- Tests have been added that prove the feature works;

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio;