### PR TITLE
RavenDB-19613 Use modern JavaScript syntax in Jint integration

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3261,7 +3261,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 JavascriptConversionExtensions.NullableSupport.Instance,
                 JavascriptConversionExtensions.NewSupport.Instance,
                 JavascriptConversionExtensions.ListInitSupport.Instance,
-                MemberInitAsJson.ForAllTypes,
+                CustomMemberInitAsJson.ForAllTypes,
                 new JavascriptConversionExtensions.TimeSeriesSupport<T>(this),
 #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
                 JavascriptConversionExtensions.DateOnlySupport.Instance
@@ -3279,7 +3279,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 extensions[newSize - 1] = new JavascriptConversionExtensions.IdentityPropertySupport(DocumentQuery.Conventions, _typedParameterSupport?.Name);
             }
 
-            return expression.CompileToJavascript(new JavascriptCompilationOptions(extensions)
+            return expression.CompileToJavascript(new JavascriptCompilationOptions(ScriptVersion.ECMAScript2017, extensions)
             {
                 CustomMetadataProvider = new PropertyNameConventionJSMetadataProvider(_conventions)
             });

--- a/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
@@ -97,27 +97,31 @@ namespace Raven.Server.Documents.Patch
                         case "concat":
                             value = new ClrFunctionInstance(engine, name, static (_, arguments) => arguments.At(0));
                             return true;
-                        case "some":
                         case "includes":
+                        case "some":
                             value = new ClrFunctionInstance(engine, name, static (_, _) => JsBoolean.False);
                             return true;
                         case "every":
                             value = new ClrFunctionInstance(engine, name, static (_, _) => JsBoolean.True);
                             return true;
-                        case "indexOf":
-                        case "lastIndexOf":
                         case "findIndex":
                         case "findLastIndex":
+                        case "indexOf":
+                        case "lastIndexOf":
                             value = new ClrFunctionInstance(engine, name, static (_, _) => _numberNegativeOne);
                             return true;
                         case "filter":
-                        case "flatMap":
                         case "flat":
+                        case "flatMap":
                         case "map":
                         case "reverse":
                         case "slice":
                         case "sort":
                         case "splice":
+                        case "toReversed":
+                        case "toSorted":
+                        case "toSpliced":
+                        case "with":
                             value = new ClrFunctionInstance(engine, name, (_, _) => new JsArray(engine));
                             return true;
                     }

--- a/test/SlowTests/Client/Queries/RavenDB-17041.cs
+++ b/test/SlowTests/Client/Queries/RavenDB-17041.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Client.Queries
                     const string expectedQuery = "from index 'UserIndex' as u " +
                                                  "select { FirstName : u.FirstName, " +
                                                  "LastName : u.LastName, " +
-                                                 "Roles : u.Roles.map(function(r){return {Role:r.Role};}) } " +
+                                                 "Roles : u.Roles.map(r=>({Role:r.Role})) } " +
                                                  "include 'u.Roles[].Role'";
 
                     Assert.Equal(expectedQuery, actualQuery);

--- a/test/SlowTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/SlowTests/Client/QueriesWithCustomFunctions.cs
@@ -311,7 +311,7 @@ namespace SlowTests.Client
                     var query = session.Query<User>()
                         .Select(u => new { Roles = u.Roles.Select(r => new { RoleName = r + "!" }) });
 
-                    Assert.Equal("from 'Users' as u select { Roles : u.Roles.map(function(r){return {RoleName:r+\"!\"};}) }", query.ToString());
+                    Assert.Equal("from 'Users' as u select { Roles : u.Roles.map(r=>({RoleName:r+\"!\"})) }", query.ToString());
 
                     var queryResult = query.ToList();
 
@@ -343,7 +343,7 @@ namespace SlowTests.Client
                     var query = session.Query<User>()
                         .Select(u => new { Roles = u.Roles.Select(r => new { RoleName = r + "!" }) });
 
-                    Assert.Equal("from 'Users' as u select { Roles : u.Roles.map(function(r){return {RoleName:r+\"!\"};}) }", query.ToString());
+                    Assert.Equal("from 'Users' as u select { Roles : u.Roles.map(r=>({RoleName:r+\"!\"})) }", query.ToString());
 
                     var queryResult = await query.ToListAsync();
 
@@ -449,7 +449,7 @@ from 'Users' as u select output(u)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(p){return p.Name+"" ""+p.LastName;};
+	var format = p=>p.Name+"" ""+p.LastName;
 	return { FullName : format(u) };
 }
 from 'Users' as u select output(u)", query.ToString());
@@ -484,7 +484,7 @@ from 'Users' as u select output(u)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(p){return p.Name+"" ""+p.LastName;};
+	var format = p=>p.Name+"" ""+p.LastName;
 	return { FullName : format(u) };
 }
 from 'Users' as u select output(u)", query.ToString());
@@ -523,7 +523,7 @@ from 'Users' as u select output(u)", query.ToString());
                         @"declare function output(u) {
 	var space = "" "";
 	var last = u.LastName;
-	var format = function(p){return p.Name+space+last;};
+	var format = p=>p.Name+space+last;
 	return { FullName : format(u) };
 }
 from 'Users' as u select output(u)", query.ToString());
@@ -562,7 +562,7 @@ from 'Users' as u select output(u)", query.ToString());
                         @"declare function output(u) {
 	var space = "" "";
 	var last = u.LastName;
-	var format = function(p){return p.Name+space+last;};
+	var format = p=>p.Name+space+last;
 	return { FullName : format(u) };
 }
 from 'Users' as u select output(u)", query.ToString());
@@ -727,7 +727,7 @@ from 'Users' as u select output(u)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(user){return user.Name+"" ""+user.LastName;};
+	var format = user=>user.Name+"" ""+user.LastName;
 	var detail = load(u.DetailId);
 	var friend = load(u.FriendId);
 	return { FullName : format(u), Friend : format(friend), Detail : detail.Number };
@@ -777,7 +777,7 @@ from 'Users' as u where u.Name != $p0 select output(u) include timings()",
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(user){return user.Name+"" ""+user.LastName;};
+	var format = user=>user.Name+"" ""+user.LastName;
 	var detail = load(u.DetailId);
 	var friend = load(u.FriendId);
 	return { FullName : format(u), Friend : format(friend), Detail : detail.Number };
@@ -824,7 +824,7 @@ from 'Users' as u where u.Name != $p0 select output(u) include timings()",
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(user){return user.Name+"" ""+u.LastName;};
+	var format = user=>user.Name+"" ""+u.LastName;
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
@@ -868,7 +868,7 @@ from 'Users' as u select output(u)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
-	var format = function(user){return user.Name+"" ""+u.LastName;};
+	var format = user=>user.Name+"" ""+u.LastName;
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
@@ -1085,7 +1085,7 @@ from 'Users' as u select output(u)", query.ToString());
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
 	var last = u.LastName;
-	var format = function(user){return user.Name+"" ""+last;};
+	var format = user=>user.Name+"" ""+last;
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
@@ -1130,7 +1130,7 @@ from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by LastName 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u) {
 	var last = u.LastName;
-	var format = function(user){return user.Name+"" ""+last;};
+	var format = user=>user.Name+"" ""+last;
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
@@ -1228,7 +1228,7 @@ from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by LastName 
                         @"declare function output(user) {
 	var first = user.Name;
 	var last = user.LastName;
-	var format = function(){return first+"" ""+last;};
+	var format = ()=>first+"" ""+last;
 	return { FullName : format() };
 }
 from 'Users' as user select output(user)", query.ToString());
@@ -1397,7 +1397,7 @@ from 'Users' as u select output(u)", query.ToString());
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(u, _doc_0) {
 	var friend = _doc_0.Name;
-	var details = load(u.DetailIds).map(function(x){return x.Number;});
+	var details = load(u.DetailIds).map(x=>x.Number);
 	return { FullName : u.Name+"" ""+u.LastName, Friend : friend, Details : details };
 }
 from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToString());
@@ -1471,8 +1471,8 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
                     var query = from u in session.Query<User>()
                                 select new { RolesList = u.Roles.Select(a => new { Id = a }).ToList(), RolesArray = u.Roles.Select(a => new { Id = a }).ToArray() };
 
-                    Assert.Equal("from 'Users' as u select { RolesList : u.Roles.map(function(a){return {Id:a};}), " +
-                                 "RolesArray : u.Roles.map(function(a){return {Id:a};}) }", query.ToString());
+                    Assert.Equal("from 'Users' as u select { RolesList : u.Roles.map(a=>({Id:a})), " +
+                                 "RolesArray : u.Roles.map(a=>({Id:a})) }", query.ToString());
 
                     var queryResult = query.ToList();
 
@@ -1509,7 +1509,7 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
                                 select new { FirstName = u.Name, LastName = u.LastName ?? "Has no last name" };
 
                     Assert.Equal("from 'Users' as u select { FirstName : u.Name, " +
-                                 "LastName : (u.LastName!=null?u.LastName:\"Has no last name\") }"
+                                 "LastName : (u.LastName??\"Has no last name\") }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -1694,7 +1694,7 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
                                  "Trim : u.Name.trim(), " +
                                  "ToUpper : u.Name.toUpperCase(), " +
                                  "ToLower : u.Name.toLowerCase(), " +
-                                 "Contains : u.Name.indexOf(\"e\") !== -1, " +
+                                 "Contains : u.Name.includes(\"e\"), " +
                                  "Format : \"Name: \"+u.Name+\", LastName : \"+u.LastName, " +
                                  "Split : u.Name.split(new RegExp(\"r\", \"g\")), " +
                                  "SplitLimit : u.Name.split(new RegExp(\"r\", \"g\")), " +
@@ -1789,8 +1789,8 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
 
                     Assert.Equal("from 'UserGroups' as u select { " +
                                  "Name : u.Name, " +
-                                 "UsersByName : u.Users.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = _cur;return _obj;}, {}), " +
-                                 "UsersByNameLastName : u.Users.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.LastName;})(_cur);return _obj;}, {}) }",
+                                 "UsersByName : u.Users.reduce((_obj, _cur) => { _obj[(a=>a.Name)(_cur)] = _cur; return _obj; }, {}), " +
+                                 "UsersByNameLastName : u.Users.reduce((_obj, _cur) => { _obj[(a=>a.Name)(_cur)] = (a=>a.LastName)(_cur); return _obj; }, {}) }",
                         query.ToString());
 
                     var queryResult = query.ToList();
@@ -1842,9 +1842,9 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
 
                     Assert.Equal("from 'Users' as u load u.DetailIds as details[] " +
                                  "select { Name : u.Name, " +
-                                 "First : details.find(function(x){return x.Number>1;}).Number, " +
+                                 "First : details.find(x=>x.Number>1).Number, " +
                                  "FirstOrDefault : details[0], " +
-                                 "FirstOrDefaultWithPredicate : details.find(function(x){return x.Number<3;}) }"
+                                 "FirstOrDefaultWithPredicate : details.find(x=>x.Number<3) }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -1894,8 +1894,8 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
                                 };
 
                     Assert.Equal("from 'Users' as u select { Name : u.Name, " +
-                                 "DetailNumbers : u.DetailIds.map(function(detailId){return {detailId:detailId,detail:load(detailId)};})" +
-                                 ".map(function(__rvn0){return {Number:__rvn0.detail.Number};}) }"
+                                 "DetailNumbers : u.DetailIds.map(detailId=>({detailId:detailId,detail:load(detailId)}))" +
+                                 ".map(__rvn0=>({Number:__rvn0.detail.Number})) }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -2562,7 +2562,7 @@ from 'Users' as u load u.FriendId as _doc_0 select output(u, _doc_0)", query.ToS
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(o) {
-	var TotalSpentOnOrder = function(order){return order.Lines.map(function(l){return l.PricePerUnit*l.Quantity-l.Discount;}).reduce(function(a, b) { return a + b; }, 0);};
+	var TotalSpentOnOrder = order=>order.Lines.map(l=>l.PricePerUnit*l.Quantity-l.Discount).reduce((a, b) => a + b, 0);
 	return { Id : id(o), TotalMoneySpent : TotalSpentOnOrder(o) };
 }
 from 'Orders' as o select output(o)", complexLinqQuery.ToString());
@@ -2645,7 +2645,7 @@ from 'Orders' as o load o.Employee as employee select output(o, employee)", quer
                                 select new { Total = order.Lines.Sum(l => l.PricePerUnit * l.Quantity * (1 - l.Discount)) };
 
                     Assert.Equal("from 'Orders' as 'order' " +
-                                 "select { Total : order.Lines.map(function(l){return l.PricePerUnit*l.Quantity*(1-l.Discount);}).reduce(function(a, b) { return a + b; }, 0) }"
+                                 "select { Total : order.Lines.map(l=>l.PricePerUnit*l.Quantity*(1-l.Discount)).reduce((a, b) => a + b, 0) }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -2730,19 +2730,19 @@ from 'Orders' as o load o.Employee as employee select output(o, employee)", quer
                         });
 
                     Assert.Equal("from 'Users' as u select { " +
-                                 "LastOrDefault : u.Roles.slice(-1)[0], " +
-                                 "LastOrDefaultWithPredicate : u.Roles.slice().reverse().find(function(x){return x!==\"4\";}), " +
+                                 "LastOrDefault : u.Roles.at(-1), " +
+                                 "LastOrDefaultWithPredicate : u.Roles.findLast(x=>x!==\"4\"), " +
                                  "Take : u.Roles.slice(0, 2), " +
                                  "Skip : u.Roles.slice(2, u.Roles.length), " +
-                                 "Max : u.Roles.reduce(function(a, b) { return Raven_Max(a, b);}), " +
-                                 "MaxWithSelector : u.Details.map(function(d){return d.Number;}).reduce(function(a, b) { return Raven_Max(a, b);}), " +
-                                 "Min : u.Roles.reduce(function(a, b) { return Raven_Min(a, b);}), " +
-                                 "MinWithSelector : u.Details.map(function(d){return d.Number;}).reduce(function(a, b) { return Raven_Min(a, b);}), " +
-                                 "Reverse : u.Roles.slice().reverse(), " +
+                                 "Max : u.Roles.reduce((a, b) => Raven_Max(a, b)), " +
+                                 "MaxWithSelector : u.Details.map(d=>d.Number).reduce((a, b) => Raven_Max(a, b)), " +
+                                 "Min : u.Roles.reduce((a, b) => Raven_Min(a, b)), " +
+                                 "MinWithSelector : u.Details.map(d=>d.Number).reduce((a, b) => Raven_Min(a, b)), " +
+                                 "Reverse : u.Roles.toReversed(), " +
                                  "IndexOf : u.Roles.indexOf(\"3\"), " +
                                  "Concat : u.Roles.concat($p0), " +
                                  "Distinct : Array.from(new Set(u.Roles)), " +
-                                 "ElementAt : u.Details.map(function(x){return x.Number;})[2] }"
+                                 "ElementAt : u.Details.map(x=>x.Number)[2] }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -2949,7 +2949,7 @@ from 'Users' as u where u.LastName = $p0 select output(u)", query.ToString());
                     var query = session.Query<Node>().Select(node => new { Grandchildren = node.Children.SelectMany(x => x.Children).ToList() });
 
                     Assert.Equal("from 'Nodes' as node select " +
-                                 "{ Grandchildren : node.Children.reduce(function(a, b) { return a.concat((function(x){return x.Children;})(b)); }, []) }"
+                                 "{ Grandchildren : node.Children.flatMap(x=>x.Children) }"
                         , query.ToString());
 
                     var queryResult = query.ToList();
@@ -3000,11 +3000,11 @@ from 'Users' as u where u.LastName = $p0 select output(u)", query.ToString());
                     Assert.Equal("from 'TestableDTOs' as item select { " +
                                  "Id : id(item), " +
                                  "data : item.Data, " +
-                                 "values : (function(arr){return arr.length > 0 ? arr : [null]})" +
+                                 "values : (arr => arr.length > 0 ? arr : [null])" +
                                  "(Object.getOwnPropertyNames(item.Data)" +
-                                 ".map(function(k){return item.Data[k]})" +
-                                 ".reduce(function(a, b) { return a.concat(b);},[])" +
-                                 ".map((function(n){return n;}))) }"
+                                 ".map(k=>item.Data[k])" +
+                                 ".flat()" +
+                                 ".map((n=>n))) }"
                         , query.ToString());
 
                     var first = await query.FirstAsync();
@@ -3411,7 +3411,7 @@ from 'Orders' as o load o.Company as company select output(o, company)", query.T
 
                         Assert.Equal("from 'Documents' as d where (id() in ($p0)) and (d.Deleted = $p1) " +
                                      "select { Id : id(d), Deleted : d.Deleted, " +
-                                     "Values : d.SubDocuments.filter(function(x){return $p2.length===0||$p3.indexOf(x.TargetId)>=0;}).map(function(x){return {TargetId:x.TargetId,TargetValue:x.TargetValue};}) }"
+                                     "Values : d.SubDocuments.filter(x=>$p2.length===0||$p3.includes(x.TargetId)).map(x=>({TargetId:x.TargetId,TargetValue:x.TargetValue})) }"
                             , projection.ToString());
 
                         var result = projection.ToList();
@@ -3459,7 +3459,7 @@ from 'Orders' as o load o.Company as company select output(o, company)", query.T
 
                         Assert.Equal("from 'Documents' as d where (id() in ($p0)) and (d.Deleted = $p1) " +
                                      "select { Id : id(d), Deleted : d.Deleted, " +
-                                     "Values : d.SubDocuments.filter(function(x){return $p2.length===0||$p3.indexOf(x.TargetId)>=0;}).map(function(x){return {TargetId:x.TargetId,TargetValue:x.TargetValue};}) }"
+                                     "Values : d.SubDocuments.filter(x=>$p2.length===0||$p3.includes(x.TargetId)).map(x=>({TargetId:x.TargetId,TargetValue:x.TargetValue})) }"
                             , projection.ToString());
 
                         var result = projection.ToList();
@@ -3506,7 +3506,7 @@ from 'Orders' as o load o.Company as company select output(o, company)", query.T
 
                         Assert.Equal("from 'Documents' as d where (id() in ($p0)) and (d.Deleted = $p1) " +
                                      "select { Id : id(d), Deleted : d.Deleted, " +
-                                     "Values : d.SubDocuments.filter(function(x){return $p2==null||x.TargetId===$p3;}).map(function(x){return {TargetId:x.TargetId,TargetValue:x.TargetValue};}) }"
+                                     "Values : d.SubDocuments.filter(x=>$p2==null||x.TargetId===$p3).map(x=>({TargetId:x.TargetId,TargetValue:x.TargetValue})) }"
                             , projection.ToString());
 
                         var result = projection.ToList();

--- a/test/SlowTests/Issues/RavenDB-10046.cs
+++ b/test/SlowTests/Issues/RavenDB-10046.cs
@@ -123,8 +123,8 @@ namespace SlowTests.Issues
                                 };
 
                     Assert.Equal("from 'Orders' as o select { " +
-                                 "Any : o.Lines.some(function(x){return x.ProductName===$p0;}), " +
-                                 "NestedQuery : o.Lines.filter(function(x){return x.PricePerUnit<$p1;}).map(function(y){return y.ProductName;}) }",
+                                 "Any : o.Lines.some(x=>x.ProductName===$p0), " +
+                                 "NestedQuery : o.Lines.filter(x=>x.PricePerUnit<$p1).map(y=>y.ProductName) }",
                                  query.ToString());
 
                     var result = query.ToList();
@@ -197,8 +197,8 @@ namespace SlowTests.Issues
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
 @"declare function output(o, $p0, $p1, $p2, $p3) {
-	var totalSpentOnOrder = function(order){return order.Lines.map(function(x){return x.PricePerUnit*x.Quantity*(1-$p0);}).reduce(function(a, b) { return a + b; }, 0);};
-	return { Sum : totalSpentOnOrder(o), Any : o.Lines.some(function(x){return x.ProductName===$p1;}), NestedQuery : o.Lines.filter(function(x){return x.PricePerUnit<$p2;}).map(function(y){return y.ProductName;}), Company : load($p3).Name };
+	var totalSpentOnOrder = order=>order.Lines.map(x=>x.PricePerUnit*x.Quantity*(1-$p0)).reduce((a, b) => a + b, 0);
+	return { Sum : totalSpentOnOrder(o), Any : o.Lines.some(x=>x.ProductName===$p1), NestedQuery : o.Lines.filter(x=>x.PricePerUnit<$p2).map(y=>y.ProductName), Company : load($p3).Name };
 }
 from 'Orders' as o select output(o, $p0, $p1, $p2, $p3)", query.ToString());
 

--- a/test/SlowTests/Issues/RavenDB-10457.cs
+++ b/test/SlowTests/Issues/RavenDB-10457.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Issues
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(item) {
-	var prices = Object.map(item.PriceConfig, function(v, k){ return {Price:v.Item1,Quantity:v.Item2};});
+	var prices = Object.map(item.PriceConfig, (v, k) => ({Price:v.Item1,Quantity:v.Item2}));
 	return { Name : item.Name, Prices : prices };
 }
 from index 'TestDocumentByName' as item select output(item)", query.ToString());
@@ -76,7 +76,7 @@ from index 'TestDocumentByName' as item select output(item)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(item) {
-	var total = Object.map(item.MusicCollection, function(v, k){ return v.map(function(x){return x.Quantity*x.Price;}).reduce(function(a, b) { return a + b; }, 0);});
+	var total = Object.map(item.MusicCollection, (v, k) => v.map((x=>x.Quantity*x.Price)).reduce((a, b) => a + b, 0));
 	return { Total : total };
 }
 from index 'TestDocumentByName' as item select output(item)", query.ToString());
@@ -112,7 +112,7 @@ from index 'TestDocumentByName' as item select output(item)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(item) {
-	var georgeAlbums = Object.keys(item.MusicCollection).map(function(a){return{Key: a,Value:item.MusicCollection[a]};}).filter(function(x){return x.Key.startsWith(""G"");}).map(function(s){return s.Value.map(function(x){return {Title:x.Title,ReleaseDate:x.ReleaseDate};});});
+	var georgeAlbums = Object.keys(item.MusicCollection).map(a=>({Key: a,Value:item.MusicCollection[a]})).filter(x=>x.Key.startsWith(""G"")).map(s=>s.Value.map(x=>({Title:x.Title,ReleaseDate:x.ReleaseDate})));
 	return { Name : item.Name, GeorgeAlbums : georgeAlbums };
 }
 from index 'TestDocumentByName' as item select output(item)", query.ToString());
@@ -147,7 +147,7 @@ from index 'TestDocumentByName' as item select output(item)", query.ToString());
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         @"declare function output(item) {
-	var artists = Object.map(item.MusicCollection, function(v, k){ return v.map(function(x){return {Title:x.Title,ReleaseDate:x.ReleaseDate};});});
+	var artists = Object.map(item.MusicCollection, (v, k) => v.map((x=>({Title:x.Title,ReleaseDate:x.ReleaseDate}))));
 	return { Name : item.Name, AlbumsByArtists : artists };
 }
 from index 'TestDocumentByName' as item select output(item)", query.ToString());

--- a/test/SlowTests/Issues/RavenDB-10543.cs
+++ b/test/SlowTests/Issues/RavenDB-10543.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Issues
                                     Average3 = x.Properties.Average(a => a)     //4.5
                                 };
 
-                    Assert.Equal($"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ Average1 : x.Properties.reduce(function(a, b) {{ return a + b; }}, 0)/(x.Properties.length||1), Average2 : x.Items.map(function(a){{return a.Value;}}).reduce(function(a, b) {{ return a + b; }}, 0)/(x.Items.length||1), Average3 : x.Properties.map(function(a){{return a;}}).reduce(function(a, b) {{ return a + b; }}, 0)/(x.Properties.length||1) }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)", query.ToString());
+                    Assert.Equal($"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ Average1 : x.Properties.reduce((a, b) => a + b, 0)/(x.Properties.length||1), Average2 : x.Items.map(a=>a.Value).reduce((a, b) => a + b, 0)/(x.Items.length||1), Average3 : x.Properties.map(a=>a).reduce((a, b) => a + b, 0)/(x.Properties.length||1) }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)", query.ToString());
 
                     var result = query.ToList();
 

--- a/test/SlowTests/Issues/RavenDB-10625.cs
+++ b/test/SlowTests/Issues/RavenDB-10625.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
                                     CheckGroup5 = x.Quantity != null ? x.Quantity : 0,
                                 };
 
-                    Assert.Equal($"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ CheckGroup : (((x.Quantity!=null?x.Quantity:0))!==0?2:3)===2?1:0, CheckGroup1 : (x.Quantity==null?1:2)===1?1:2, CheckGroup2 : (x.Quantity!=null?x.Quantity:0), CheckGroup3 : (x.Quantity!=null?x.Quantity:0), CheckGroup4 : ((x.Quantity!=null?x.Quantity:0))!==0?2:3, CheckGroup5 : x.Quantity!=null?x.Quantity:0 }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)", query.ToString());
+                    Assert.Equal($"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ CheckGroup : ((x.Quantity??0)!==0?2:3)===2?1:0, CheckGroup1 : (x.Quantity==null?1:2)===1?1:2, CheckGroup2 : (x.Quantity??0), CheckGroup3 : (x.Quantity??0), CheckGroup4 : (x.Quantity??0)!==0?2:3, CheckGroup5 : x.Quantity!=null?x.Quantity:0 }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)", query.ToString());
 
                     var result = query.ToList();
 

--- a/test/SlowTests/Issues/RavenDB-11089.cs
+++ b/test/SlowTests/Issues/RavenDB-11089.cs
@@ -436,7 +436,7 @@ namespace SlowTests.Issues
                         @"declare function output(user) {
 	var first = user.name;
 	var last = user.lastName;
-	var format = function(){return first+"" ""+last;};
+	var format = ()=>first+"" ""+last;
 	return { FullName : format() };
 }
 from 'Users' as user select output(user)", queryAsString);

--- a/test/SlowTests/Issues/RavenDB-11767.cs
+++ b/test/SlowTests/Issues/RavenDB-11767.cs
@@ -62,11 +62,11 @@ namespace SlowTests.Issues
 
                     Assert.Equal("from 'Orders' as o load o.CategoryListId as categoryList " +
                                  "select { Id : id(o), Items : o.OrderItems" +
-                                    ".map(function(i){return {i:i,cat:categoryList.Categories};})" +
-                                    ".map(function(__rvn0){return {__rvn0:__rvn0,id:__rvn0.i.CategoryId};})" +
-                                    ".map(function(__rvn1){return {__rvn1:__rvn1,first:__rvn1.__rvn0.cat.find(function(x){return id(x)===__rvn1.id;})};})" +
-                                    ".map(function(__rvn2){return {__rvn2:__rvn2,name:__rvn2.first.Name};})" +
-                                    ".map(function(__rvn3){return {CategoryName:__rvn3.name};}) }"
+                                    ".map(i=>({i:i,cat:categoryList.Categories}))" +
+                                    ".map(__rvn0=>({__rvn0:__rvn0,id:__rvn0.i.CategoryId}))" +
+                                    ".map(__rvn1=>({__rvn1:__rvn1,first:__rvn1.__rvn0.cat.find(x=>id(x)===__rvn1.id)}))" +
+                                    ".map(__rvn2=>({__rvn2:__rvn2,name:__rvn2.first.Name}))" +
+                                    ".map(__rvn3=>({CategoryName:__rvn3.name})) }"
                                 , queryable.ToString());
 
                     var result = queryable.ToList();

--- a/test/SlowTests/Issues/RavenDB-12369.cs
+++ b/test/SlowTests/Issues/RavenDB-12369.cs
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal("from 'Orders' as x select " +
                                  "{ SortedLines : x.Lines.sort(" +
-                                 "function (a, b){ return a.Quantity - b.Quantity;}) }"
+                                 "(a, b) => a.Quantity - b.Quantity) }"
                         , q.ToString());
 
                     Assert.Equal(10, result.SortedLines[0].Quantity);
@@ -102,9 +102,9 @@ namespace SlowTests.Issues
                     });
 
                     Assert.Equal("from 'Orders' as x select { " +
-                                 "SortedLines : x.Lines.sort(function (a, b){ " +
-                                 "return ((a.ProductName < b.ProductName) " +
-                                 "? -1 : (a.ProductName > b.ProductName)? 1 : 0);}) }"
+                                 "SortedLines : x.Lines.sort((a, b) => " +
+                                 "((a.ProductName < b.ProductName) " +
+                                 "? -1 : (a.ProductName > b.ProductName)? 1 : 0)) }"
                         , q.ToString());
 
                     var result = q.First();
@@ -158,9 +158,9 @@ namespace SlowTests.Issues
                     });
 
                     Assert.Equal("from 'MultiOrders' as x select { " +
-                                 "SortedOrdersByDate : x.Orders.sort(function (a, b){ " +
-                                 "return ((a.OrderedAt < b.OrderedAt) " +
-                                 "? -1 : (a.OrderedAt > b.OrderedAt)? 1 : 0);}) }"
+                                 "SortedOrdersByDate : x.Orders.sort((a, b) => " +
+                                 "((a.OrderedAt < b.OrderedAt) " +
+                                 "? -1 : (a.OrderedAt > b.OrderedAt)? 1 : 0)) }"
                         , q.ToString());
 
                     var result = q.First();
@@ -220,7 +220,7 @@ namespace SlowTests.Issues
                     });
                     Assert.Equal("from 'MultiOrders' as x select { " +
                                  "OrderedBy : x.Info.sort(" +
-                                 "function (a, b){ return a.Address.ZipCode - b.Address.ZipCode;}) }"
+                                 "(a, b) => a.Address.ZipCode - b.Address.ZipCode) }"
                         , q.ToString());
 
                     var result = q.First();
@@ -277,9 +277,9 @@ namespace SlowTests.Issues
                         OrderedBy = x.Info.OrderBy(i => i.Address.City).ToList()
                     });
                     Assert.Equal("from 'MultiOrders' as x select { " +
-                                 "OrderedBy : x.Info.sort(function (a, b){ " +
-                                 "return ((a.Address.City < b.Address.City) " +
-                                 "? -1 : (a.Address.City > b.Address.City)? 1 : 0);}) }"
+                                 "OrderedBy : x.Info.sort((a, b) => " +
+                                 "((a.Address.City < b.Address.City) " +
+                                 "? -1 : (a.Address.City > b.Address.City)? 1 : 0)) }"
                         , q.ToString());
 
                     var result = q.First();
@@ -330,7 +330,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal("from 'Orders' as x select " +
                                  "{ OrderByDescending : x.Lines.sort(" +
-                                 "function (a, b){ return b.Quantity - a.Quantity;}) }"
+                                 "(a, b) => b.Quantity - a.Quantity) }"
                         , q.ToString());
 
                     Assert.Equal(30, result.OrderByDescending[0].Quantity);
@@ -376,9 +376,9 @@ namespace SlowTests.Issues
                     });
 
                     Assert.Equal("from 'Orders' as x select { " +
-                                 "OrderByDescending : x.Lines.sort(function (a, b){ " +
-                                 "return ((a.ProductName < b.ProductName) " +
-                                 "? 1 : (a.ProductName > b.ProductName)? -1 : 0);}) }"
+                                 "OrderByDescending : x.Lines.sort((a, b) => " +
+                                 "((a.ProductName < b.ProductName) " +
+                                 "? 1 : (a.ProductName > b.ProductName)? -1 : 0)) }"
                         , q.ToString());
 
                     var result = q.First();

--- a/test/SlowTests/Issues/RavenDB-13016.cs
+++ b/test/SlowTests/Issues/RavenDB-13016.cs
@@ -59,8 +59,8 @@ namespace SlowTests.Issues
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         "from 'PostComments' as x select { " +
-                            "Comments : x.Comments.map(function(comment){return {comment:comment,owner:load(comment.OwnerId)};})" +
-                                        ".map(function(__rvn0){return {Id:id(__rvn0.comment),Owner:{Id:id(__rvn0.owner)}};}) }"
+                            "Comments : x.Comments.map(comment=>({comment:comment,owner:load(comment.OwnerId)}))" +
+                                        ".map(__rvn0=>({Id:id(__rvn0.comment),Owner:{Id:id(__rvn0.owner)}})) }"
                         , query.ToString());
 
 

--- a/test/SlowTests/Issues/RavenDB-13412.cs
+++ b/test/SlowTests/Issues/RavenDB-13412.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
 
                         let userGroups = RavenQuery
                             .Load<UserGroup>(membership.UserGroups)
-                            .Where(x => x.Organization == organizationId) 
+                            .Where(x => x.Organization == organizationId)
 
                         select new Projection
                         {
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
 
                     Assert.Contains("Id : id(membership)", projectionString);
                     Assert.Contains("Organization : id(organization)", projectionString);
-                    Assert.Contains("UserGroups : userGroups.map(function(x){return id(x);})", projectionString);
+                    Assert.Contains("UserGroups : userGroups.map(x=>id(x))", projectionString);
 
                     var result = projection.First();
 

--- a/test/SlowTests/Issues/RavenDB-13680.cs
+++ b/test/SlowTests/Issues/RavenDB-13680.cs
@@ -84,7 +84,7 @@ namespace SlowTests.Issues
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
 @"declare function output(doc) {
-	var p = doc.Lines.map(function(y){return load(y.Product);});
+	var p = doc.Lines.map(y=>load(y.Product));
 	return { p : p };
 }
 from 'Orders' as doc select output(doc)", q.ToString());

--- a/test/SlowTests/Issues/RavenDB-14281.cs
+++ b/test/SlowTests/Issues/RavenDB-14281.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                 var q1 = query.ToString();
                 var expected =
                     "from 'Users' as customer select { CustomerName : customer.GivenName+\" \"+customer.FamilyName, " +
-                    "Phone : Object.keys(customer.Phones).map(function(a){return{Key: a,Value:customer.Phones[a]};}).filter(function(phone){return phone.Key===\"Work\";}) }";
+                    "Phone : Object.keys(customer.Phones).map(a=>({Key: a,Value:customer.Phones[a]})).filter(phone=>phone.Key===\"Work\") }";
                 Assert.Equal(expected, q1);
 
                 var query2 =
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
                 var q2 = query2.ToString();
                 expected =
                     "from 'Users' as customer select { CustomerName : customer.GivenName+\" \"+customer.FamilyName, " +
-                    "Phone : Object.keys(customer.Phones2).map(function(a){return{Key: a,Value:customer.Phones2[a]};}).filter(function(phone){return phone.Key===\"Work\";}) }";
+                    "Phone : Object.keys(customer.Phones2).map(a=>({Key: a,Value:customer.Phones2[a]})).filter(phone=>phone.Key===\"Work\") }";
                 Assert.Equal(expected, q2);
 
                 var res1 = await query.ToArrayAsync();

--- a/test/SlowTests/Issues/RavenDB-9624.cs
+++ b/test/SlowTests/Issues/RavenDB-9624.cs
@@ -186,7 +186,7 @@ namespace SlowTests.Issues
                     RavenTestHelper.AssertEqualRespectingNewLines(
 @"declare function output(__alias0) {
 	var order = __alias0;
-	var sum = order.Lines.map(function(l){return l.PricePerUnit*l.Quantity;}).reduce(function(a, b) { return a + b; }, 0);
+	var sum = order.Lines.map(l=>l.PricePerUnit*l.Quantity).reduce((a, b) => a + b, 0);
 	return { Sum : sum };
 }
 from 'Orders' as __alias0 where __alias0.Company = $p0 select output(__alias0)", query.ToString());
@@ -266,8 +266,8 @@ from 'Orders' as __alias0 where __alias0.Company = $p0 select output(__alias0)",
 	var include = order.Company;
 	var _load = load(include);
 	var update = load(_load.EmployeesIds);
-	var sum = order.Lines.map(function(l){return l.PricePerUnit*l.Quantity*_load.AccountsReceivable;}).reduce(function(a, b) { return a + b; }, 0);
-	return { Comapny : _load, Sum : sum, Employees : update.map(function(e){return e.FirstName;}) };
+	var sum = order.Lines.map(l=>l.PricePerUnit*l.Quantity*_load.AccountsReceivable).reduce((a, b) => a + b, 0);
+	return { Comapny : _load, Sum : sum, Employees : update.map(e=>e.FirstName) };
 }
 from 'Orders' as __alias0 select output(__alias0)", query.ToString());
 
@@ -427,7 +427,7 @@ from 'Orders' as o load o.Company as __alias0 select output(o, __alias0)"
 @"declare function output(o, __alias0) {
 	var update = __alias0;
 	var employees = load(update.EmployeesIds);
-	return { Company : update.Name, Employees : employees.map(function(e){return e.FirstName;}) };
+	return { Company : update.Name, Employees : employees.map(e=>e.FirstName) };
 }
 from 'Orders' as o load o.Company as __alias0 select output(o, __alias0)", query.ToString());
 
@@ -481,7 +481,7 @@ from 'Orders' as o load o.Company as __alias0 select output(o, __alias0)", query
 
                     RavenTestHelper.AssertEqualRespectingNewLines(
 @"declare function output(o) {
-	var _function = o.Lines.map(function(l){return l.PricePerUnit*l.Quantity;}).reduce(function(a, b) { return a + b; }, 0);
+	var _function = o.Lines.map(l=>l.PricePerUnit*l.Quantity).reduce((a, b) => a + b, 0);
 	return { Sum : _function };
 }
 from 'Orders' as o select output(o)", query.ToString());
@@ -541,7 +541,7 @@ from 'Orders' as o select output(o)", query.ToString());
 @"declare function output(o, _function) {
 	var _super = _function.AccountsReceivable;
 	var _var = load(_function.EmployeesIds);
-	return { Company : _function, Number : _super, Employees : _var.map(function(e){return e.FirstName;}) };
+	return { Company : _function, Number : _super, Employees : _var.map(e=>e.FirstName) };
 }
 from 'Orders' as o load o.Company as _function select output(o, _function)", query.ToString());
 

--- a/test/SlowTests/Issues/RavenDB_14269.cs
+++ b/test/SlowTests/Issues/RavenDB_14269.cs
@@ -94,7 +94,7 @@ namespace SlowTests.Issues
                         }
                 };
 
-            Assert.Equal("from 'Users' as customer select { CustomerName : customer.Name, Phones : Object.map(customer.Phones, function(v, k){ return {Label:k,Prefix:v.CountryPrefix,Phone:v.Value};}) }", query.ToString());
+            Assert.Equal("from 'Users' as customer select { CustomerName : customer.Name, Phones : Object.map(customer.Phones, (v, k) => ({Label:k,Prefix:v.CountryPrefix,Phone:v.Value})) }", query.ToString());
 
             var res = await query.ToListAsync();
             Assert.Equal(5, res.Count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19613

### Additional description

* Using lambdas instead full-blown function signatures (no need for arguments and callee in calls)
* Using new Array functions like `at()`, `findLast()`, `flat()`, `flatMap()`, `includes()`, `toReversed()` which reduce interpretation and copying and lead to native CLR function usage


### Type of change

- Optimization
- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

Client will start to issue JS syntax / functions which cannot be handled by 5.x server.

### Is it platform specific issue?

- No

### Documentation update

Not sure?

### Testing 

- Current tests should cover the expected generated syntax and behavior

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
