### PR TITLE
RavenDB-19616 Fixing high unmanaged memory usage when filtering out docs during ETL 

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -317,15 +317,21 @@ namespace Raven.Server.Documents.ETL
                 transformer.Initialize(debugMode: _testMode != null);
 
                 var batchSize = 0;
+                var extractedItemsSize = 0;
 
                 var batchStopped = false;
 
                 foreach (var item in items)
                 {
+                    extractedItemsSize++;
+
                     if (item.Filtered)
                     {
                         stats.RecordChangeVector(item.ChangeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
+
+                        item.Dispose();
+
                         continue;
                     }
 
@@ -338,6 +344,17 @@ namespace Raven.Server.Documents.ETL
                         stats.RecordChangeVector(item.ChangeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
 
+                        item.Dispose();
+
+                        if (extractedItemsSize % (Database.Configuration.Etl.MaxNumberOfExtractedItems ?? 8192) == 0)
+                        {
+                            if (CanContinueBatch(stats, item, extractedItemsSize, context) == false)
+                            {
+                                batchStopped = true;
+                                break;
+                            }
+                        }
+
                         continue;
                     }
 
@@ -348,6 +365,8 @@ namespace Raven.Server.Documents.ETL
                     {
                         stats.RecordChangeVector(item.ChangeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
+
+                        item.Dispose();
 
                         continue;
                     }

--- a/src/Raven.Server/Documents/ETL/ExtractedItem.cs
+++ b/src/Raven.Server/Documents/ETL/ExtractedItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using Raven.Client;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
@@ -6,7 +7,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.ETL
 {
-    public abstract class ExtractedItem
+    public abstract class ExtractedItem : IDisposable
     {
         public bool Filtered;
 
@@ -68,5 +69,22 @@ namespace Raven.Server.Documents.ETL
         public TimeSeriesDeletedRangeItem TimeSeriesDeletedRangeItem { get; protected set; }
         
         public LazyStringValue CounterTombstoneId { get; protected set; }
+
+        public void Dispose()
+        {
+            Document?.Dispose();
+
+            if (DocumentId != null && DocumentId.IsDisposed == false)
+                DocumentId.Dispose();
+
+            if (CollectionFromMetadata != null && CollectionFromMetadata.IsDisposed == false)
+                CollectionFromMetadata.Dispose();
+
+            if (CounterTombstoneId != null && CounterTombstoneId.IsDisposed)
+                CounterTombstoneId?.Dispose();
+
+            CounterGroupDocument?.Dispose();
+            TimeSeriesDeletedRangeItem?.Dispose();
+        }
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19616/High-unmanaged-memory-usage-when-filtering-out-docs-during-ETL

### Additional description

 In order to avoid high memory usage let's dispose an extracted item which is filtered out. Additionally when items are already processed by another node (meaning that task was moved here) then let's check periodically if we can continue the batch.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 


- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
