### PR TITLE
RavenDB-19570 - Test Cleanup

### DIFF
--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -60,9 +60,7 @@ namespace SlowTests.Server.Documents.Revisions
                 await session.SaveChangesAsync();
             }
 
-            await Task.Delay(100);
-            DateTime last = DateTime.UtcNow;
-            await Task.Delay(100);
+            var last = DateTime.UtcNow;
 
             using (var session = store.OpenAsyncSession())
             {
@@ -77,12 +75,9 @@ namespace SlowTests.Server.Documents.Revisions
                 await session.SaveChangesAsync();
             }
 
-            var db = database;//await Databases.GetDocumentDatabaseInstanceFor(store);
-
-            RevertResult result;
-            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
             {
-                result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                var result = (RevertResult)await database.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
                     token: token, collections: collections);
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19570/Failing-test-RevertByMultipleCollectionsShouldRemoveDocWhichCreatedAfterTheMinDate

### Additional description

RevertByMultipleCollections_ShouldRemoveDocWhichCreatedAfterTheMinDate Test Cleanup
(Comments in https://github.com/ravendb/ravendb/pull/15353)

### Type of change

- Bug Fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
