### PR TITLE
RavenDB-14798

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -488,11 +488,20 @@ namespace Raven.Server.Documents
             }
 
             var mergedCommands = new BatchHandler.ClusterTransactionMergedCommand(this, batch);
+
+            ForTestingPurposes?.BeforeExecutingClusterTransactions?.Invoke();
+
             try
             {
                 //If we get a database shutdown while we process a cluster tx command this
                 //will cause us to stop running and disposing the context while its memory is still been used by the merger execution
                 await TxMerger.Enqueue(mergedCommands);
+            }
+            catch (ObjectDisposedException) when (_databaseShutdown.IsCancellationRequested)
+            {
+                HandleDatabaseShutdown(batch);
+
+                return batch;
             }
             catch (Exception e)
             {
@@ -528,6 +537,11 @@ namespace Raven.Server.Documents
 
                     _clusterTransactionDelayOnFailure = 1000;
                 }
+                catch (ObjectDisposedException) when (_databaseShutdown.IsCancellationRequested)
+                {
+                    HandleDatabaseShutdown(singleCommand);
+                    // not returning here on purpose, we need to set the exception for the rest of the commands
+                }
                 catch (Exception e)
                 {
                     OnClusterTransactionCompletion(command, mergedCommand, exception: e);
@@ -547,6 +561,15 @@ namespace Raven.Server.Documents
 
                     return;
                 }
+            }
+        }
+
+        private void HandleDatabaseShutdown(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch)
+        {
+            var exception = CreateDatabaseShutdownException();
+            foreach (var command in batch)
+            {
+                ClusterTransactionWaiter.SetException(command.Options.TaskId, command.Index, exception);
             }
         }
 
@@ -710,6 +733,8 @@ namespace Raven.Server.Documents
                 TxMerger?.Dispose();
             });
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposed TxMerger");
+
+            ForTestingPurposes?.AfterTxMergerDispose?.Invoke();
 
             // must acquire the lock in order to prevent concurrent access to index files
             if (lockTaken == false)
@@ -1804,6 +1829,10 @@ namespace Raven.Server.Documents
             internal Action CollectionRunnerBeforeOpenReadTransaction;
 
             internal Action CompactionAfterDatabaseUnload;
+
+            internal Action AfterTxMergerDispose;
+
+            internal Action BeforeExecutingClusterTransactions;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -512,6 +512,8 @@ namespace Raven.Server.ServerWide.Commands
             public long PreviousCount;
             public string Database;
 
+            public bool Processed;
+
             public DynamicJsonValue ToJson()
             {
                 return new DynamicJsonValue

--- a/test/SlowTests/Issues/RavenDB-14798.cs
+++ b/test/SlowTests/Issues/RavenDB-14798.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Database;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_14798 : RavenTestBase
+    {
+        public RavenDB_14798(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_throw_correct_exception_when_database_disposed_during_cluster_transaction()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                       {
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    await session.StoreAsync(new User());
+
+                    Task unloadTask = null;
+                    var database = await GetDatabase(store.Database);
+                    var testingStuff = database.ForTestingPurposesOnly();
+
+                    var afterTxMergerDispose = new ManualResetEvent(false);
+
+                    testingStuff.AfterTxMergerDispose = () => afterTxMergerDispose.Set();
+                    testingStuff.BeforeExecutingClusterTransactions = () =>
+                    {
+                        unloadTask = Task.Run(() => Server.ServerStore.DatabasesLandlord.UnloadDirectly(database.Name));
+                        afterTxMergerDispose.WaitOne();
+                    };
+
+                    var exception = await Assert.ThrowsAsync<DatabaseDisabledException>(async () => await session.SaveChangesAsync());
+                    Assert.Contains("is shutting down", exception.Message);
+                    await unloadTask;
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-14798.cs
+++ b/test/SlowTests/Issues/RavenDB-14798.cs
@@ -36,6 +36,7 @@ namespace SlowTests.Issues
                     testingStuff.AfterTxMergerDispose = () => afterTxMergerDispose.Set();
                     testingStuff.BeforeExecutingClusterTransactions = () =>
                     {
+                        // doing it async because we cannot dispose the database until we are finished with the cluster transactions task
                         unloadTask = Task.Run(() => Server.ServerStore.DatabasesLandlord.UnloadDirectly(database.Name));
                         afterTxMergerDispose.WaitOne();
                     };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14798/System.ObjectDisposedException-Cannot-access-a-disposed-object

### Additional description

- set the correct exception when database is being shutdown
- wait for the cluster transaction to complete before disposing the `DocumentDatabase`.
Otherwise, we get `ObjectDisposed` when trying to access the `DatabaseShutdown` cancellation token in multiple places.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works