### PR TITLE
RavenDB-19626 removed CloneToJsonContext method used by reply transaction because it does not clone properly

### DIFF
--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents
             return Processed;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             throw new NotSupportedException($"ToDto() of {nameof(ExecuteRateLimitedOperations<T>)} Should not be called");
         }

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.Expiration
                 return DeletionCount;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
 
                 var keyValuePairs = new KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[_expired.Count];

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new DeleteRevisionsCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedPutAttachmentCommandDto
                 {
@@ -427,7 +427,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedDeleteAttachmentCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -775,7 +775,7 @@ namespace Raven.Server.Documents.Handlers
                 return Database.DocumentsStorage.ExtractCollectionName(context, conflicts[0].Collection);
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new ClusterTransactionMergedCommandDto
                 {
@@ -819,7 +819,7 @@ namespace Raven.Server.Documents.Handlers
                 return sb.ToString();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedBatchCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -461,7 +461,7 @@ namespace Raven.Server.Documents.Handlers
                 return NumberOfCommands;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedInsertBulkCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Handlers
                 countersToRemove.Clear();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new ExecuteCounterBatchCommandDto
                 {
@@ -577,7 +577,7 @@ namespace Raven.Server.Documents.Handlers
                 _result.Counters.ErroredCount += ErrorCount;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new SmugglerCounterBatchCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -794,7 +794,7 @@ namespace Raven.Server.Documents.Handlers
             _document?.Dispose();
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             return new MergedPutCommandDto()
             {

--- a/src/Raven.Server/Documents/Handlers/HiLoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/HiLoHandler.cs
@@ -153,7 +153,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedNextHiLoCommandDto
                 {
@@ -220,7 +220,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedHiLoReturnCommandDto
                 {

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -974,7 +974,7 @@ namespace Raven.Server.Documents.Handlers
                                                     "Cannot put TimeSeries on artificial documents.");
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 throw new System.NotImplementedException();
             }
@@ -1039,7 +1039,7 @@ namespace Raven.Server.Documents.Handlers
                 return newItem;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 throw new System.NotImplementedException();
             }

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -243,7 +243,7 @@ namespace Raven.Server.Documents.Handlers
             return ExecuteDirectly(context);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             return null;
         }
@@ -269,7 +269,7 @@ namespace Raven.Server.Documents.Handlers
             return ExecuteDirectly(context);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             return null;
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             }
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             return new DeleteReduceOutputDocumentsCommandDto
             {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
@@ -373,7 +373,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             }
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             var dto = new OutputReduceToCollectionCommandDto
             {

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -418,7 +418,7 @@ namespace Raven.Server.Documents.Patch
             return null;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             var dto = new BatchPatchDocumentCommandDto();
             FillDto(dto);
@@ -474,7 +474,7 @@ namespace Raven.Server.Documents.Patch
             return HandleReply(_id, PatchResult, reply, modifiedCollections);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             var dto = new PatchDocumentCommandDto();
             FillDto(dto);

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -261,7 +261,7 @@ namespace Raven.Server.Documents.Queries
                 }
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 throw new NotSupportedException($"ToDto() of {nameof(BulkOperationCommand<T>)} Should not be called");
             }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1045,7 +1045,7 @@ namespace Raven.Server.Documents.Replication
                 return operationsCount;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedUpdateDatabaseChangeVectorCommandDto
                 {
@@ -1564,7 +1564,7 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 var replicatedAttachmentStreams = _replicationInfo.ReplicatedAttachmentStreams?
                     .Select(kv => KeyValuePair.Create(kv.Key.ToString(), kv.Value.Stream))
@@ -1575,7 +1575,7 @@ namespace Raven.Server.Documents.Replication
                     Mode = _mode,
                     LastEtag = _lastEtag,
                     SupportedFeatures = _replicationInfo.SupportedFeatures,
-                    ReplicatedItemDtos = _replicationInfo.ReplicatedItems.Select(i => i.Clone(context)).ToArray(),
+                    ReplicatedItemDtos = _replicationInfo.ReplicatedItems.Select(i => i.Clone(context, context.Allocator)).ToArray(),
                     SourceDatabaseId = _replicationInfo.SourceDatabaseId,
                     ReplicatedAttachmentStreams = replicatedAttachmentStreams
                 };
@@ -1613,7 +1613,7 @@ namespace Raven.Server.Documents.Replication
             var replicationItems = new ReplicationBatchItem[replicatedItemsCount];
             for (var i = 0; i < replicatedItemsCount; i++)
             {
-                replicationItems[i] = ReplicatedItemDtos[i].Clone(context);
+                replicationItems[i] = ReplicatedItemDtos[i].Clone(context, context.Allocator);
             }
 
             Dictionary<Slice, AttachmentReplicationItem> replicatedAttachmentStreams = null;

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -940,7 +940,7 @@ namespace Raven.Server.Documents.Replication
                 return result.IsValid ? 1 : 0;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new UpdateSiblingCurrentEtagDto
                 {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
@@ -109,7 +109,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             }
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             MemoryStream stream = null;
             if (Stream != null)
@@ -127,15 +127,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 Name = Name.Clone(context), 
                 Stream = stream
             };
-            
-            var baseMem = Base64Hash.CloneToJsonContext(context, out item.Base64Hash);
-            var keyMem = Key.CloneToJsonContext(context, out item.Key);
+
+            item.Base64Hash = Base64Hash.Clone(allocator);
+            item.Key = Key.Clone(allocator);
             
 
             item.ToDispose(new DisposableAction(() =>
             {
-                context.ReturnMemory(baseMem);
-                context.ReturnMemory(keyMem);
+                item.Base64Hash.Release(allocator);
+                item.Key.Release(allocator);
             }));
 
             return item;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
@@ -62,14 +62,14 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             }
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             var item = new AttachmentTombstoneReplicationItem();
-            var keyMem = Key.CloneToJsonContext(context, out item.Key);
+            item.Key = Key.Clone(allocator);
 
             item.ToDispose(new DisposableAction(() =>
             {
-                context.ReturnMemory(keyMem);
+                item.Key.Release(allocator);
             }));
 
             return item;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Server;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.ReplicationItems
@@ -80,7 +81,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 stats.RecordCountersRead(counters.Count);
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             return new CounterReplicationItem
             {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Server;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.ReplicationItems
@@ -176,7 +177,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             }
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             return new DocumentReplicationItem
             {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -7,6 +7,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Server;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.ReplicationItems
@@ -31,11 +32,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public abstract void Read(DocumentsOperationContext context, IncomingReplicationStatsScope stats);
 
-        protected abstract ReplicationBatchItem CloneInternal(JsonOperationContext context);
+        protected abstract ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator);
 
-        public ReplicationBatchItem Clone(JsonOperationContext context)
+        public ReplicationBatchItem Clone(JsonOperationContext context, ByteStringContext allocator)
         {
-            var item = CloneInternal(context);
+            var item = CloneInternal(context, allocator);
 
             item.Type = Type;
             item.ChangeVector = ChangeVector;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Server;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.ReplicationItems
@@ -67,7 +68,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             }
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             return new RevisionTombstoneReplicationItem
             {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             Debug.Assert(Collection != null);
         }
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             return new TimeSeriesDeletedRangeItem
             {
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         }
 
 
-        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context)
+        protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             var item = new TimeSeriesReplicationItem
             {
@@ -188,11 +188,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             };
 
             var mem = Segment.Clone(context, out item.Segment);
-            var keyMem = Key.CloneToJsonContext(context, out item.Key);
+            item.Key = Key.Clone(allocator);
 
             item.ToDispose(new DisposableAction(() =>
             {
-                context.ReturnMemory(keyMem);
+                item.Key.Release(allocator);
                 context.ReturnMemory(mem);
             }));
             

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -10,6 +10,7 @@ using Raven.Client.Util;
 using Raven.Server.Documents.Patch;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Utils;
@@ -208,7 +209,7 @@ namespace Raven.Server.Documents.Replication
                 return count;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 // The LowerId created as in memory LazyStringValue that doesn't have escape characters
                 // so EscapePositions set to empty to avoid reference to escape bytes (after string bytes) while serializing

--- a/src/Raven.Server/Documents/Revisions/RevisionsOperations.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsOperations.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Revisions
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new DeleteRevisionsBeforeCommandDto
                 {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1419,7 +1419,7 @@ namespace Raven.Server.Documents.Revisions
                 return _ids.Count;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new EnforceRevisionConfigurationCommandDto(_revisionsStorage, _ids);
             }
@@ -1659,7 +1659,7 @@ namespace Raven.Server.Documents.Revisions
                 return collectionName;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new RevertDocumentsCommandDto(_list);
             }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents.TimeSeries
                 return retained;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new TimeSeriesRetentionCommandDto(_keys, _collection, _to);
             }
@@ -354,7 +354,7 @@ namespace Raven.Server.Documents.TimeSeries
                 return Marked;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new AddedNewRollupPoliciesCommandDto(_collection, _from, _to, _skip);
             }
@@ -619,7 +619,7 @@ namespace Raven.Server.Documents.TimeSeries
                 }
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new RollupTimeSeriesCommandDto(_configuration, _now, _states, _isFirstInTopology);
             }

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -342,7 +342,7 @@ namespace Raven.Server.Documents
                 return NumberOfTombstonesDeleted;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new DeleteTombstonesCommandDto
                 {

--- a/src/Raven.Server/Documents/TransactionCommands/DeleteDocumentCommand.cs
+++ b/src/Raven.Server/Documents/TransactionCommands/DeleteDocumentCommand.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.TransactionCommands
             return 1;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
         {
             return new DeleteDocumentCommandDto()
             {

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents
 
         public interface IRecordableCommand
         {
-            IReplayableCommandDto<MergedTransactionCommand> ToDto(JsonOperationContext context);
+            IReplayableCommandDto<MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) where TTransaction : RavenTransaction;
         }
 
         public interface IReplayableCommandDto<out T> where T : MergedTransactionCommand
@@ -104,7 +104,7 @@ namespace Raven.Server.Documents
                 return ExecuteCmd(context);
             }
 
-            public abstract IReplayableCommandDto<MergedTransactionCommand> ToDto(JsonOperationContext context);
+            public abstract IReplayableCommandDto<MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) where TTransaction : RavenTransaction;
 
             [JsonIgnore]
             public readonly TaskCompletionSource<object> TaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1650,7 +1650,7 @@ namespace Raven.Server.Smuggler.Documents
 
             private const int SchemaSize = 2 * 1024 * 1024;
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedBatchPutCommandDto
                 {
@@ -1807,7 +1807,7 @@ namespace Raven.Server.Smuggler.Documents
                 _returnContext.Dispose();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedBatchFixDocumentMetadataCommandDto
                 {
@@ -1889,7 +1889,7 @@ namespace Raven.Server.Smuggler.Documents
                 _returnContext.Dispose();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context)
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
                 return new MergedBatchDeleteRevisionCommandDto
                 {

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -54,14 +54,6 @@ namespace Voron
             }
         }
 
-        public AllocatedMemoryData CloneToJsonContext(JsonOperationContext context, out Slice slice)
-        {
-            var mem = context.GetMemory(Size);
-            Memory.Copy(mem.Address, Content._pointer, Size);
-            slice = new Slice(new ByteString((ByteStringStorage*)mem.Address));
-            return mem;
-        }
-
         public Slice Clone(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
             return new Slice(context.Clone(this.Content, type));

--- a/test/FastTests/Issues/RavenDB_19626.cs
+++ b/test/FastTests/Issues/RavenDB_19626.cs
@@ -1,0 +1,29 @@
+﻿using Sparrow.Json;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_19626 : NoDisposalNeeded
+{
+    public RavenDB_19626(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void Should_Be_Able_To_Clone_Slice_Properly()
+    {
+        using (var allocator = new ByteStringContext(new SharedMultipleUseFlag()))
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        using (Slice.From(allocator, "clone_me", out var input))
+        {
+            // previously we were using here Slice.CloneToJsonContext
+            var clone = input.Clone(allocator);
+
+            Assert.Equal(0, SliceComparer.Compare(input, clone));
+        }
+    }
+}

--- a/test/FastTests/RavenDB_14520.cs
+++ b/test/FastTests/RavenDB_14520.cs
@@ -3,6 +3,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Util;
+using Sparrow.Json;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/FastTests/RavenDB_14520.cs
+++ b/test/FastTests/RavenDB_14520.cs
@@ -3,10 +3,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Util;
-using Sparrow.Json;
-using Sparrow.Server;
-using Sparrow.Threading;
-using Voron;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
+++ b/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
@@ -16,6 +16,7 @@ using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.TransactionCommands;
 using Raven.Server.Json.Converters;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Processors;
@@ -34,7 +35,7 @@ namespace SlowTests.Blittable
         [Fact]
         public async Task SerializeAndDeserialize_PutResolvedConflictsCommand()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var database = CreateDocumentDatabase())
             {
                 //Arrange
@@ -82,7 +83,7 @@ namespace SlowTests.Blittable
         [Fact]
         public async Task SerializeAndDeserialize_MergedDeleteAttachmentCommand()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 //Arrange
                 var changeVector = context.GetLazyString("Some Lazy String");
@@ -118,14 +119,14 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<AttachmentHandler.MergedDeleteAttachmentCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<AttachmentHandler.MergedDeleteAttachmentCommand, RavenTransaction>(context));
             }
         }
 
         [Fact]
         public async Task SerializeAndDeserialize_MergedPutAttachmentCommand()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var database = CreateDocumentDatabase())
             {
                 //Arrange
@@ -174,7 +175,7 @@ namespace SlowTests.Blittable
 
                 //Assert
                 Assert.Equal(expected, actual,
-                    new CustomComparer<AttachmentHandler.MergedPutAttachmentCommand>(context, new[] { typeof(Stream) }));
+                    new CustomComparer<AttachmentHandler.MergedPutAttachmentCommand, RavenTransaction>(context, new[] { typeof(Stream) }));
 
                 stream.Seek(0, SeekOrigin.Begin);
                 var expectedStream = expected.Stream.ReadData();
@@ -186,7 +187,7 @@ namespace SlowTests.Blittable
         [Fact]
         public async Task SerializeAndDeserialize_MergedPutCommandTest()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 //Arrange
                 var data = new { ParentProperty = new { NestedProperty = "Some Value" } };
@@ -217,7 +218,7 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<MergedPutCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<MergedPutCommand, RavenTransaction>(context));
             }
         }
 
@@ -265,14 +266,14 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<PatchDocumentCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<PatchDocumentCommand, DocumentsTransaction>(context));
             }
         }
 
         [Fact]
         public async Task SerializeAndDeserialize_DeleteDocumentCommandTest()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 //Arrange
                 var expected = new DeleteDocumentCommand("Some Id", "Some Change Vector", null);
@@ -300,14 +301,14 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<DeleteDocumentCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<DeleteDocumentCommand, RavenTransaction>(context));
             }
         }
 
         [Fact]
         public async Task SerializeAndDeserialize_MergedBatchCommandCommandTest()
         {
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 //Arrange
                 var data = new { ParentProperty = new { NestedProperty = "Some Value" } };
@@ -349,7 +350,7 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<BatchHandler.MergedBatchCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<BatchHandler.MergedBatchCommand, RavenTransaction>(context));
             }
         }
 
@@ -453,7 +454,7 @@ namespace SlowTests.Blittable
                 }
 
                 //Assert
-                Assert.Equal(expected, actual, new CustomComparer<BulkInsertHandler.MergedInsertBulkCommand>(context));
+                Assert.Equal(expected, actual, new CustomComparer<BulkInsertHandler.MergedInsertBulkCommand, DocumentsTransaction>(context));
             }
         }
 
@@ -466,16 +467,18 @@ namespace SlowTests.Blittable
             return jsonSerializer;
         }
 
-        private class CustomComparer<T> : IEqualityComparer<T> where T : TransactionOperationsMerger.IRecordableCommand
+        private class CustomComparer<T, TTransaction> : IEqualityComparer<T> 
+            where T : TransactionOperationsMerger.IRecordableCommand
+            where TTransaction : RavenTransaction
         {
             private readonly IEnumerable<Type> _notCheckTypes;
-            private readonly JsonOperationContext _context;
+            private readonly TransactionOperationContext<TTransaction> _context;
 
-            public CustomComparer(JsonOperationContext context) : this(context, Array.Empty<Type>())
+            public CustomComparer(TransactionOperationContext<TTransaction> context) : this(context, Array.Empty<Type>())
             {
             }
 
-            public CustomComparer(JsonOperationContext context, IEnumerable<Type> notCheckTypes)
+            public CustomComparer(TransactionOperationContext<TTransaction> context, IEnumerable<Type> notCheckTypes)
             {
                 _context = context;
                 _notCheckTypes = notCheckTypes;

--- a/test/SlowTests/Client/Attachments/AttachmentsSession.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSession.cs
@@ -594,7 +594,7 @@ namespace SlowTests.Client.Attachments
         private class ThrowCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
             protected override long ExecuteCmd(DocumentsOperationContext context) => throw new Exception();
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context) 
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) 
                 => throw new NotImplementedException();
             
         }

--- a/test/SlowTests/Issues/RavenDB_15538.cs
+++ b/test/SlowTests/Issues/RavenDB_15538.cs
@@ -144,7 +144,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, false).Select(item => item.Clone(ctx)));
+                            }, false).Select(item => item.Clone(ctx, ctx.Allocator)));
                             etag = firstReplicationOrder.Select(x => x.Etag).Max();
                         }
                         // Replication from source to firstDestination
@@ -166,7 +166,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, false).Select(item => item.Clone(ctx)));
+                            }, false).Select(item => item.Clone(ctx, ctx.Allocator)));
                         }
 
                         var database2 = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(firstDestination.Database);
@@ -180,7 +180,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, false).Select(item => item.Clone(ctx)));
+                            }, false).Select(item => item.Clone(ctx, ctx.Allocator)));
                         }
 
                         // remove the 1st doc sent, because of its change in the middle of the 1st replication, so it was sent twice

--- a/test/SlowTests/Server/TransactionMergerTests.cs
+++ b/test/SlowTests/Server/TransactionMergerTests.cs
@@ -177,7 +177,7 @@ from TestObjs as o where o.Prop = null update
         {
             protected override long ExecuteCmd(DocumentsOperationContext context) => throw new TestException();
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto(JsonOperationContext context) =>
+            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) =>
                 throw new NotImplementedException();
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19626

### Type of change

- Bug fix

### How risky is the change?

- Low  (used by reply tx)

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
