### PR TITLE
RavenDB-19627 Invalid permissions for Get Revision Attachment and Get Multiple Attachments

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -58,13 +58,13 @@ namespace Raven.Server.Documents.Handlers
             return GetAttachment(true);
         }
 
-        [RavenAction("/databases/*/attachments", "POST", AuthorizationStatus.ValidUser, EndpointType.Write)]
+        [RavenAction("/databases/*/attachments", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public Task GetPost()
         {
             return GetAttachment(false);
         }
 
-        [RavenAction("/databases/*/attachments/bulk", "POST", AuthorizationStatus.ValidUser, EndpointType.Write)]
+        [RavenAction("/databases/*/attachments/bulk", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetAttachments()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19627

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
