### PR TITLE
RavenDB-19525 `DateOnly` and `TimeOnly` can be made from `object` when they're wrapped `As(Date|Time)Only()`

### DIFF
--- a/test/SlowTests/Issues/RavenDB_19525.cs
+++ b/test/SlowTests/Issues/RavenDB_19525.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19525 : RavenTestBase
+{
+    public RavenDB_19525(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task DateOnly_TimeOnly_Support_In_Indexing()
+    {
+        using var store = GetDocumentStore();
+        await store.ExecuteIndexAsync(new DateOnlyIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new TestDocument
+            {
+                Values = new Dictionary<string, object>
+                {
+                    {"DateOnly", new DateOnly(2022, 8, 11)}, {"TimeOnly", new TimeOnly(13, 55, 30)}, {"TimeSpan", new TimeSpan(13, 55, 30)}
+                }
+            });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+        var indexes = await store.Maintenance.SendAsync(new GetIndexErrorsOperation());
+        Assert.Empty(indexes.Where(idx => idx.Errors.Any()));
+    }
+
+    private class DateOnlyIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public DateOnlyIndex()
+        {
+            Map = entities => from entity in entities
+                select new
+                {
+                    DateOnly = AsDateOnly(entity.Values["DateOnly"]),
+                    TimeOnly = AsTimeOnly(entity.Values["TimeOnly"]), 
+                    TimeSpan = (TimeSpan)entity.Values["TimeSpan"]
+                };
+        }
+    }
+
+    private class TestDocument
+    {
+        public Dictionary<string, object> Values { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19525

### Additional description

Adding a test for a feature to ensure it works just fine.

### Type of change

- Test

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
