### PR TITLE
RavenDB-19630 updated base docker images to dotnet/runtime-deps:6.0

### DIFF
--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal-arm32v7
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-focal-arm32v7
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal-arm64v8
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-focal-arm64v8
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-focal
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19630 

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
