### PR TITLE
RavenDB-17976 - Support adding new shard

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/Sharding/ShardRestoreSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/Sharding/ShardRestoreSettings.cs
@@ -1,18 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Client.ServerWide.Sharding;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups.Sharding
 {
     public class ShardedRestoreSettings : IDynamicJson
     {
+        public List<ShardBucketRange> BucketRanges;
         public Dictionary<int, SingleShardRestoreSetting> Shards { get; set; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
+                [nameof(BucketRanges)] = new DynamicJsonArray(BucketRanges),
                 [nameof(Shards)] = Shards != null ? DynamicJsonValue.Convert(Shards)
                     : null
             };
@@ -27,6 +30,7 @@ namespace Raven.Client.Documents.Operations.Backups.Sharding
             if (other == null)
                 throw new ArgumentException(nameof(other));
 
+            BucketRanges = other.BucketRanges;
             Shards = new Dictionary<int, SingleShardRestoreSetting>(other.Shards.Count);
             foreach (var shardToSetting in other.Shards)
             {

--- a/src/Raven.Client/Documents/Operations/Backups/Sharding/ShardRestoreSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/Sharding/ShardRestoreSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Sparrow.Json.Parsing;
 
@@ -6,13 +7,13 @@ namespace Raven.Client.Documents.Operations.Backups.Sharding
 {
     public class ShardedRestoreSettings : IDynamicJson
     {
-        public SingleShardRestoreSetting[] Shards { get; set; }
+        public Dictionary<int, SingleShardRestoreSetting> Shards { get; set; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                [nameof(Shards)] = Shards != null ? new DynamicJsonArray(Shards.Select(x => x.ToJson()))
+                [nameof(Shards)] = Shards != null ? DynamicJsonValue.Convert(Shards)
                     : null
             };
         }
@@ -26,10 +27,10 @@ namespace Raven.Client.Documents.Operations.Backups.Sharding
             if (other == null)
                 throw new ArgumentException(nameof(other));
 
-            Shards = new SingleShardRestoreSetting[other.Shards.Length];
-            for (int i = 0; i < other.Shards.Length; i++)
+            Shards = new Dictionary<int, SingleShardRestoreSetting>(other.Shards.Count);
+            foreach (var shardToSetting in other.Shards)
             {
-                Shards[i] = new SingleShardRestoreSetting(other.Shards[i]);
+                Shards[shardToSetting.Key] = new SingleShardRestoreSetting(shardToSetting.Value);
             }
         }
     }

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -109,6 +109,7 @@ namespace Raven.Client.Json.Serialization
         public static readonly Func<BlittableJsonReaderObject, ModifySolverResult> ModifySolverResult = GenerateJsonDeserializationRoutine<ModifySolverResult>();
 
         public static readonly Func<BlittableJsonReaderObject, ModifyOrchestratorTopologyResult> ModifyOrchestratorTopologyResult = GenerateJsonDeserializationRoutine<ModifyOrchestratorTopologyResult>();
+        public static readonly Func<BlittableJsonReaderObject, CreateShardResult> CreateShardResult = GenerateJsonDeserializationRoutine<CreateShardResult>();
 
         public static readonly Func<BlittableJsonReaderObject, DisableDatabaseToggleResult> DisableResourceToggleResult = GenerateJsonDeserializationRoutine<DisableDatabaseToggleResult>();
 

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -109,7 +109,7 @@ namespace Raven.Client.Json.Serialization
         public static readonly Func<BlittableJsonReaderObject, ModifySolverResult> ModifySolverResult = GenerateJsonDeserializationRoutine<ModifySolverResult>();
 
         public static readonly Func<BlittableJsonReaderObject, ModifyOrchestratorTopologyResult> ModifyOrchestratorTopologyResult = GenerateJsonDeserializationRoutine<ModifyOrchestratorTopologyResult>();
-        public static readonly Func<BlittableJsonReaderObject, CreateShardResult> CreateShardResult = GenerateJsonDeserializationRoutine<CreateShardResult>();
+        public static readonly Func<BlittableJsonReaderObject, AddDatabaseShardResult> CreateShardResult = GenerateJsonDeserializationRoutine<AddDatabaseShardResult>();
 
         public static readonly Func<BlittableJsonReaderObject, DisableDatabaseToggleResult> DisableResourceToggleResult = GenerateJsonDeserializationRoutine<DisableDatabaseToggleResult>();
 

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -155,7 +155,7 @@ namespace Raven.Client.ServerWide
         }
     }
 
-    public class DatabaseTopology
+    public class DatabaseTopology : IDynamicJson
     {
         public List<string> Members = new List<string>();
         public List<string> Promotables = new List<string>();

--- a/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/AddDatabaseNodeOperation.cs
@@ -20,9 +20,9 @@ namespace Raven.Client.ServerWide.Operations
             _node = node;
         }
 
-        internal AddDatabaseNodeOperation(string databaseName, int shard, string node = null) : this(databaseName, node)
+        internal AddDatabaseNodeOperation(string databaseName, int shardNumber, string node = null) : this(databaseName, node)
         {
-            _databaseName = ClientShardHelper.ToShardName(databaseName, shard);
+            _databaseName = ClientShardHelper.ToShardName(databaseName, shardNumber);
         }
 
         public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
@@ -10,14 +10,14 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Sharding
 {
-    internal class CreateShardOperation : IServerOperation<CreateShardResult>
+    internal class AddDatabaseShardOperation : IServerOperation<AddDatabaseShardResult>
     {
         private readonly string _databaseName;
         private readonly int? _shardNumber;
         private readonly string[] _nodes;
         private readonly int? _replicationFactor;
 
-        public CreateShardOperation(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
+        public AddDatabaseShardOperation(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
         {
             ResourceNameValidator.AssertValidDatabaseName(databaseName);
             _databaseName = databaseName;
@@ -26,19 +26,19 @@ namespace Raven.Client.ServerWide.Sharding
             _replicationFactor = replicationFactor;
         }
 
-        public RavenCommand<CreateShardResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        public RavenCommand<AddDatabaseShardResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new CreateShardCommand(_databaseName, _shardNumber, _nodes, _replicationFactor);
+            return new AddDatabaseShardCommand(_databaseName, _shardNumber, _nodes, _replicationFactor);
         }
 
-        internal class CreateShardCommand : RavenCommand<CreateShardResult>, IRaftCommand
+        internal class AddDatabaseShardCommand : RavenCommand<AddDatabaseShardResult>, IRaftCommand
         {
             private readonly string _databaseName;
             private readonly int? _shardNumber;
             private readonly string[] _nodes;
             private readonly int? _replicationFactor;
 
-            public CreateShardCommand(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
+            public AddDatabaseShardCommand(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
             {
                 _databaseName = databaseName;
                 _shardNumber = shardNumber;
@@ -86,11 +86,11 @@ namespace Raven.Client.ServerWide.Sharding
         }
     }
 
-    public class CreateShardResult
+    public class AddDatabaseShardResult
     {
         public string DatabaseName { get; set; }
-        public int NewShardNumber { get; set; }
-        public DatabaseTopology NewShardTopology { get; set; }
+        public int ShardNumber { get; set; }
+        public DatabaseTopology ShardTopology { get; set; }
         public long RaftCommandIndex { get; set; }
     }
 }

--- a/src/Raven.Client/ServerWide/Sharding/CreateShardOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/CreateShardOperation.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Net.Http;
+using System.Text;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Sharding
+{
+    internal class CreateShardOperation : IServerOperation<CreateShardResult>
+    {
+        private readonly string _databaseName;
+        private readonly int? _shardNumber;
+        private readonly string[] _nodes;
+        private readonly int? _replicationFactor;
+
+        public CreateShardOperation(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
+        {
+            ResourceNameValidator.AssertValidDatabaseName(databaseName);
+            _databaseName = databaseName;
+            _shardNumber = shardNumber;
+            _nodes = nodes;
+            _replicationFactor = replicationFactor;
+        }
+
+        public RavenCommand<CreateShardResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new CreateShardCommand(_databaseName, _shardNumber, _nodes, _replicationFactor);
+        }
+
+        internal class CreateShardCommand : RavenCommand<CreateShardResult>, IRaftCommand
+        {
+            private readonly string _databaseName;
+            private readonly int? _shardNumber;
+            private readonly string[] _nodes;
+            private readonly int? _replicationFactor;
+
+            public CreateShardCommand(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
+            {
+                _databaseName = databaseName;
+                _shardNumber = shardNumber;
+                _nodes = nodes;
+                _replicationFactor = replicationFactor;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                var sb = new StringBuilder($"{node.Url}/admin/databases/shard?databaseName={Uri.EscapeDataString(_databaseName)}");
+
+                if (_shardNumber.HasValue)
+                    sb = sb.Append($"&shardNumber={_shardNumber}");
+
+                if (_replicationFactor.HasValue)
+                    sb.Append($"&replicationFactor={_replicationFactor}");
+
+                if (_nodes?.Length > 0)
+                {
+                    foreach (var nodeStr in _nodes)
+                    {
+                        sb.Append("&node=").Append(Uri.EscapeDataString(nodeStr));
+                    }
+                }
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Put
+                };
+
+                url = sb.ToString();
+                return request;
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = JsonDeserializationClient.CreateShardResult(response);
+            }
+
+            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+        }
+    }
+
+    public class CreateShardResult
+    {
+        public string DatabaseName { get; set; }
+        public int NewShardNumber { get; set; }
+        public DatabaseTopology NewShardTopology { get; set; }
+        public long RaftCommandIndex { get; set; }
+    }
+}

--- a/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
@@ -6,7 +6,7 @@ public class ShardingConfiguration
 {
     public OrchestratorConfiguration Orchestrator;
 
-    public DatabaseTopology[] Shards;
+    public Dictionary<int, DatabaseTopology> Shards;
 
     public List<ShardBucketRange> BucketRanges = new List<ShardBucketRange>();
 

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -1,16 +1,18 @@
-﻿namespace Raven.Client.Util
+﻿using System;
+using System.Xml.Linq;
+
+namespace Raven.Client.Util
 {
     internal static class ClientShardHelper
     {
         public static string ToShardName(string database, int shardNumber)
         {
-            var name = ToDatabaseName(database);
+            if (IsShardName(database))
+                throw new ArgumentException($"Expected a non shard name but got {database}");
 
-            int shardNumberPosition = name.IndexOf('$');
-            if (shardNumberPosition == -1)
-                return $"{name}${shardNumber}";
-
-            return name;
+            ResourceNameValidator.AssertValidDatabaseName(database);
+            
+            return $"{database}${shardNumber}";
         }
 
         public static string ToDatabaseName(string shardName)
@@ -19,7 +21,34 @@
             if (shardNumberPosition == -1)
                 return shardName;
 
-            return shardName.Substring(0, shardNumberPosition);
+            var databaseName = shardName.Substring(0, shardNumberPosition);
+            ResourceNameValidator.AssertValidDatabaseName(databaseName);
+
+            return databaseName;
+        }
+
+        public static bool TryGetShardNumberAndDatabaseName(string databaseName, out string shardedDatabaseName, out int shardNumber)
+        {
+            var index = databaseName.IndexOf('$');
+            shardNumber = -1;
+
+            if (index != -1)
+            {
+                var slice = databaseName.AsSpan().Slice(index + 1);
+                shardedDatabaseName = databaseName.Substring(0, index);
+                if (int.TryParse(slice.ToString(), out shardNumber) == false)
+                    throw new ArgumentException(nameof(shardedDatabaseName), "Unable to parse sharded database name: " + shardedDatabaseName);
+
+                return true;
+            }
+
+            shardedDatabaseName = databaseName;
+            return false;
+        }
+
+        public static bool IsShardName(string shardName)
+        {
+            return shardName.IndexOf('$') != -1;
         }
     }
 }

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Xml.Linq;
 
 namespace Raven.Client.Util
@@ -8,7 +9,10 @@ namespace Raven.Client.Util
         public static string ToShardName(string database, int shardNumber)
         {
             if (IsShardName(database))
+            {
+                Debug.Assert(false, $"Expected a non shard name but got {database}");
                 throw new ArgumentException($"Expected a non shard name but got {database}");
+            }
 
             ResourceNameValidator.AssertValidDatabaseName(database);
             

--- a/src/Raven.Server/Documents/ComputeHttpEtags.cs
+++ b/src/Raven.Server/Documents/ComputeHttpEtags.cs
@@ -153,9 +153,9 @@ namespace Raven.Server.Documents
             return str;
         }
 
-        public static string CombineEtags<T>(Dictionary<int, AbstractExecutor.ShardExecutionResult<T>> cmds) => CombineEtags(EnumerateEtags(cmds));
+        public static string CombineEtags<T>(Dictionary<int, ShardExecutionResult<T>> cmds) => CombineEtags(EnumerateEtags(cmds));
 
-        public static IEnumerable<string> EnumerateEtags<T>(Dictionary<int, AbstractExecutor.ShardExecutionResult<T>> cmds)
+        public static IEnumerable<string> EnumerateEtags<T>(Dictionary<int, ShardExecutionResult<T>> cmds)
         {
             foreach (var shardInfo in cmds.Values)
             {

--- a/src/Raven.Server/Documents/ComputeHttpEtags.cs
+++ b/src/Raven.Server/Documents/ComputeHttpEtags.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Raven.Client.Http;
 using Raven.Server.Documents.Includes;
+using Raven.Server.Documents.Sharding.Executors;
 using Sparrow.Platform;
 using Sparrow.Server.Utils;
 
@@ -152,13 +153,13 @@ namespace Raven.Server.Documents
             return str;
         }
 
-        public static string CombineEtags<T>(Memory<RavenCommand<T>> cmds) => CombineEtags(EnumerateEtags(cmds));
+        public static string CombineEtags<T>(Dictionary<int, AbstractExecutor.ShardExecutionResult<T>> cmds) => CombineEtags(EnumerateEtags(cmds));
 
-        public static IEnumerable<string> EnumerateEtags<T>(Memory<RavenCommand<T>> cmds)
+        public static IEnumerable<string> EnumerateEtags<T>(Dictionary<int, AbstractExecutor.ShardExecutionResult<T>> cmds)
         {
-            for (var index = 0; index < cmds.Length; index++)
+            foreach (var shardInfo in cmds.Values)
             {
-                var cmd = cmds.Span[index];
+                var cmd = shardInfo.Command;
                 string etag = cmd.Etag;
                 if (etag != null)
                     yield return etag;

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -964,7 +964,7 @@ namespace Raven.Server.Documents
 
         public static DocumentDatabase CreateDocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog)
         {
-            return ShardHelper.IsShardedName(name) ?
+            return ShardHelper.IsShardName(name) ?
                 new ShardedDocumentDatabase(name, configuration, serverStore, addToInitLog) :
                 new DocumentDatabase(name, configuration, serverStore, addToInitLog);
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         public RestoreFromLocal(RestoreBackupConfiguration restoreConfiguration)
         {
-            if (restoreConfiguration.ShardRestoreSettings?.Shards.Length > 0)
+            if (restoreConfiguration.ShardRestoreSettings?.Shards.Count > 0)
                 return;
 
             if (string.IsNullOrWhiteSpace(restoreConfiguration.BackupLocation))

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
@@ -63,10 +63,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public static async Task<AbstractRestoreBackupTask> CreateBackupTaskAsync(ServerStore serverStore, RestoreBackupConfigurationBase configuration,
             IRestoreSource restoreSource, long operationId, OperationCancelToken token)
         {
-            if (configuration.ShardRestoreSettings?.Shards.Length > 0)
+            if (configuration.ShardRestoreSettings?.Shards.Count > 0)
                 return new ShardedRestoreOrchestrationTask(serverStore, configuration, operationId, token);
             
-            var singleShardRestore = ShardHelper.IsShardedName(configuration.DatabaseName);
+            var singleShardRestore = ShardHelper.IsShardName(configuration.DatabaseName);
 
             var filesToRestore = await GetOrderedFilesToRestoreAsync(restoreSource, configuration);
             var firstFile = filesToRestore[0];

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
@@ -99,6 +99,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
 
             databaseRecord.Sharding = new ShardingConfiguration
             {
+                BucketRanges = RestoreConfiguration.ShardRestoreSettings.BucketRanges,
                 Shards = new Dictionary<int, DatabaseTopology>(RestoreConfiguration.ShardRestoreSettings.Shards.Count),
                 Orchestrator = new OrchestratorConfiguration
                 {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
@@ -112,9 +112,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
 
             var clusterTransactionIdBase64 = Guid.NewGuid().ToBase64Unpadded();
             var nodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var (_, shardRestoreSetting) in RestoreConfiguration.ShardRestoreSettings.Shards)
+            foreach (var (shardNumber, shardRestoreSetting) in RestoreConfiguration.ShardRestoreSettings.Shards)
             {
-                var shardNumber = shardRestoreSetting.ShardNumber;
+                Debug.Assert(shardRestoreSetting.ShardNumber == shardNumber);
                 
                 databaseRecord.Sharding.Shards[shardNumber] = new DatabaseTopology
                 {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
@@ -69,7 +70,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
 
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
                 "RavenDB-19202 : consider using the most up-to-date database record");
-            if (_shardNumber > 0)
+
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal,
+                "Should ensure the shard topologies are always sorted. Need this functionality here to check this is always the first element.");
+
+            if (databaseRecord.Sharding.Shards.ElementAtOrDefault(0).Key != _shardNumber)
                 smuggler._options.OperateOnTypes &= ~DatabaseItemType.Subscriptions;
 
             smuggler.OnDatabaseRecordAction += smugglerDatabaseRecord =>

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -808,7 +808,7 @@ namespace Raven.Server.Documents.Replication
 
         private void HandleMigrationReplication(DatabaseRecord newRecord, List<IDisposable> instancesToDispose)
         {
-            if (ShardHelper.TryGetShardNumber(newRecord.DatabaseName, out var myShard) == false)
+            if (ShardHelper.TryGetShardNumberAndDatabaseName(newRecord.DatabaseName, out var shardedDatabaseName, out var myShard) == false)
                 return;
 
             var toRemove = new List<BucketMigrationReplication>();
@@ -871,7 +871,7 @@ namespace Raven.Server.Documents.Replication
                         var destNode = destTopology.WhoseTaskIsIt(RachisState.Follower, process, getLastResponsibleNode: null);
                         var migrationDestination = new BucketMigrationReplication(process, destNode)
                         {
-                            Database = ShardHelper.ToShardName(newRecord.DatabaseName, process.DestinationShard),
+                            Database = ShardHelper.ToShardName(shardedDatabaseName, process.DestinationShard),
                             Url = _clusterTopology.GetUrlFromTag(destNode)
                         };
 

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedImportCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedImportCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -42,7 +41,7 @@ namespace Raven.Server.Documents.Sharding.Commands
 
         public HttpRequest HttpRequest { get; }
 
-        public BlittableJsonReaderObject Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<BlittableJsonReaderObject>> results) => null;
+        public BlittableJsonReaderObject Combine(Dictionary<int, ShardExecutionResult<BlittableJsonReaderObject>> results) => null;
 
         public RavenCommand<BlittableJsonReaderObject> CreateCommandForShard(int shardNumber) => new ShardedImportCommand(_options, _holders[shardNumber].OutStream, _operationId);
 

--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -4,11 +4,20 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 
-namespace Raven.Server.Documents.Sharding.Executors;
+namespace Raven.Server.Documents.Sharding.Executors
+{
+    public class ShardExecutionResult<T>
+    {
+        public int ShardNumber;
+        public T Result;
+        public RavenCommand<T> Command;
+    }
+};
 
 public abstract class AbstractExecutor : IDisposable
 {
@@ -121,13 +130,6 @@ public abstract class AbstractExecutor : IDisposable
         }
 
         return result;
-    }
-
-    public class ShardExecutionResult<T>
-    {
-        public int ShardNumber;
-        public T Result;
-        public RavenCommand<T> Command;
     }
 
     private async Task<int> ExecuteAsync<TExecutionMode, TFailureMode, TResult, TCombinedResult>(

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetHashCount.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetHashCount.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
@@ -7,6 +8,7 @@ using Raven.Server.Documents.Commands.Attachments;
 using Raven.Server.Documents.Handlers.Processors.Attachments;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Attachments;
 
@@ -33,16 +35,16 @@ internal class ShardedAttachmentHandlerProcessorForGetHashCount : AbstractAttach
             HttpRequest = httpRequest ?? throw new ArgumentNullException(nameof(httpRequest));
         }
 
-        public GetAttachmentHashCountCommand.Response Combine(Memory<GetAttachmentHashCountCommand.Response> results)
+        public GetAttachmentHashCountCommand.Response Combine(Dictionary<int, ShardExecutionResult<GetAttachmentHashCountCommand.Response>> results)
         {
             var response = new GetAttachmentHashCountCommand.Response
             {
                 Hash = _hash
             };
 
-            var responses = results.Span;
+            var responses = results.Values;
             foreach (var r in responses)
-                response.Count += r.Count;
+                response.Count += r.Result.Count;
 
             return response;
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetHashCount.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetHashCount.cs
@@ -6,9 +6,9 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Attachments;
 using Raven.Server.Documents.Handlers.Processors.Attachments;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Attachments;
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -13,7 +12,6 @@ using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.Json;
-using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
@@ -94,7 +92,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult { Results = results };
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Session.Operations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Collections;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
@@ -93,7 +94,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Memory<StreamResult> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult { Results = results };
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
@@ -6,10 +6,10 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Collections;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -7,9 +6,9 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Counters;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
@@ -9,6 +9,7 @@ using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Counters;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
 {
@@ -74,14 +75,14 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-        public CountersDetail Combine(Memory<CountersDetail> results)
+        public CountersDetail Combine(Dictionary<int, ShardExecutionResult<CountersDetail>> results)
         {
             var combined = new CountersDetail();
             var counterDetailsResult = new List<CounterDetail>();
 
-            foreach (var countersDetail in results.Span)
+            foreach (var countersDetail in results.Values)
             {
-                counterDetailsResult.AddRange(countersDetail.Counters);
+                counterDetailsResult.AddRange(countersDetail.Result.Counters);
             }
 
             combined.Counters = counterDetailsResult;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForTerms.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForTerms.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Indexes
 
             public string ExpectedEtag { get; }
 
-            public TermsQueryResultServerSide CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<TermsQueryResultServerSide>> results)
+            public TermsQueryResultServerSide CombineResults(Dictionary<int, ShardExecutionResult<TermsQueryResultServerSide>> results)
             {
                 var pageSize = _pageSize;
                 var terms = new SortedSet<string>();
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Indexes
 
             public RavenCommand<TermsQueryResultServerSide> CreateCommandForShard(int shardNumber) => new GetIndexTermsCommand(indexName: _indexName, field: _field, _fromValue, _pageSize);
 
-            public string CombineCommandsEtag(Dictionary<int, AbstractExecutor.ShardExecutionResult<TermsQueryResultServerSide>> commands)
+            public string CombineCommandsEtag(Dictionary<int, ShardExecutionResult<TermsQueryResultServerSide>> commands)
             {
                 var etags = ComputeHttpEtags.EnumerateEtags(commands);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
@@ -7,12 +6,12 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.Http;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.Http;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 {
@@ -56,11 +57,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 
             public HttpRequest HttpRequest => _handler.HttpContext.Request;
 
-            public GetConflictsPreviewResult Combine(Memory<GetConflictsPreviewResult> results)
+            public GetConflictsPreviewResult Combine(Dictionary<int, ShardExecutionResult<GetConflictsPreviewResult>> results)
             {
                 var totalResults = 0L;
-                foreach (var conflictResult in results.Span)
-                    totalResults += conflictResult.TotalResults;
+                foreach (var conflictResult in results.Values)
+                    totalResults += conflictResult.Result.TotalResults;
                 
                 var final = new GetConflictsPreviewResult
                 {
@@ -77,7 +78,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
                     if (pageSize <= 0)
                         break;
 
-                    var shard = res.Shard;
+                    var shard = res.ShardNumber;
                     _token.Pages[shard].Start += (int)res.Item.ScannedResults;
                 }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
@@ -13,6 +13,7 @@ using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 {
@@ -47,7 +48,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
             }
 
             public HttpRequest HttpRequest => _handler.HttpContext.Request;
-            public GetTombstonesPreviewResult Combine(Memory<GetTombstonesPreviewResult> results)
+            public GetTombstonesPreviewResult Combine(Dictionary<int, ShardExecutionResult<GetTombstonesPreviewResult>> results)
             {
                 var final = new GetTombstonesPreviewResult();
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetTombstones.cs
@@ -8,12 +8,12 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents.Handlers.Processors.Revisions;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 {
@@ -52,7 +53,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 
         public HttpRequest HttpRequest => _handler.HttpContext.Request;
 
-        public List<BlittableJsonReaderObject> Combine(Memory<ResolvedRevisions> results)
+        public List<BlittableJsonReaderObject> Combine(Dictionary<int, ShardExecutionResult<ResolvedRevisions>> results)
         {
             var combined = new List<BlittableJsonReaderObject>();
             var taken = 0;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -8,10 +8,10 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Revisions;
 using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsBin.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsBin.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,13 +8,13 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsBin.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsBin.cs
@@ -15,6 +15,7 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 {
@@ -52,7 +53,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
 
             public HttpRequest HttpRequest => _handler.HttpContext.Request;
 
-            public BlittableJsonReaderObject[] Combine(Memory<BlittableArrayResult> results)
+            public BlittableJsonReaderObject[] Combine(Dictionary<int, ShardExecutionResult<BlittableArrayResult>> results)
             {
                 var list = new List<BlittableJsonReaderObject>();
                 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForExport.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForExport.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Smuggler
                 writer.WriteInteger(ServerVersion.Build);
                 
                 // we execute one by one so requests will not timeout since the export can take long
-                for (var shardNumber = 0; shardNumber < RequestHandler.DatabaseContext.ShardCount; shardNumber++)
+                foreach (var shardNumber in RequestHandler.DatabaseContext.ShardsTopology.Keys)
                 {
                     var smuggler = new DatabaseSmuggler(
                         (_, nodeTag) => RequestHandler.DatabaseContext.Operations.GetChanges(new ShardedDatabaseIdentifier(nodeTag, shardNumber)),

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Raven.Server.Documents.Handlers.Processors.Stats;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Stats;
 
@@ -49,19 +51,19 @@ internal class ShardedStatsHandlerProcessorForEssentialStats : AbstractStatsHand
 
         public HttpRequest HttpRequest { get; }
 
-        public EssentialDatabaseStatistics Combine(Memory<EssentialDatabaseStatistics> results)
+        public EssentialDatabaseStatistics Combine(Dictionary<int, ShardExecutionResult<EssentialDatabaseStatistics>> results)
         {
             EssentialDatabaseStatistics result = null;
 
-            foreach (var stats in results.Span)
+            foreach (var stats in results.Values)
             {
                 if (result == null)
                 {
-                    result = stats;
+                    result = stats.Result;
                     continue;
                 }
 
-                MergeBasicDatabaseStatistics(result, stats);
+                MergeBasicDatabaseStatistics(result, stats.Result);
             }
 
             Debug.Assert(result != null, "result != null");

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,9 +8,9 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Stats;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Stats;
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Session.Operations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Handlers.Processors.Streaming;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Collections;
 using Raven.Server.Documents.Sharding.Operations;
@@ -104,7 +105,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Memory<StreamResult> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult { Results = results };
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult { Results = results };
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -28,6 +28,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Utils;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 {
@@ -194,16 +195,16 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
         public string ExpectedEtag { get; }
 
-        public (IEnumerator<BlittableJsonReaderObject>, StreamQueryStatistics) Combine(Memory<StreamResult> results)
+        public (IEnumerator<BlittableJsonReaderObject>, StreamQueryStatistics) Combine(Dictionary<int, ShardExecutionResult<StreamResult>> results)
         {
             var queryStats = new StreamQueryStatistics();
 
             var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
 
-            foreach (var streamResult in results.Span)
+            foreach (var streamResult in results.Values)
             {
                 var qs = new StreamQueryStatistics();
-                var enumerator = new StreamOperation.YieldStreamResults(_allocateJsonContext, streamResult, isQueryStream: true, isTimeSeriesStream: false, isAsync: false, qs, _token);
+                var enumerator = new StreamOperation.YieldStreamResults(_allocateJsonContext, streamResult.Result, isQueryStream: true, isTimeSeriesStream: false, isAsync: false, qs, _token);
                 enumerator.Initialize();
                 queryStats.TotalResults += qs.TotalResults;
                 queryStats.IndexName = qs.IndexName;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -12,7 +11,6 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Operations;
 using Raven.Client.Exceptions.Documents.Indexes;
-using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Streaming;
@@ -20,6 +18,7 @@ using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Handlers.Processors.Streaming;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.NotificationCenter;
@@ -27,8 +26,6 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
-using Sparrow.Utils;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioStatsHandlerProcessorForGetFooterStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioStatsHandlerProcessorForGetFooterStats.cs
@@ -6,10 +6,10 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Studio;
 using Raven.Server.Documents.Handlers.Processors.Studio;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Studio;
 using Raven.Server.ServerWide.Context;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioStatsHandlerProcessorForGetFooterStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioStatsHandlerProcessorForGetFooterStats.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
@@ -8,6 +9,7 @@ using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.Studio;
 using Raven.Server.ServerWide.Context;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
 {
@@ -36,14 +38,12 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
 
             public HttpRequest HttpRequest => _httpContext.Request;
 
-            public FooterStatistics Combine(Memory<FooterStatistics> results)
+            public FooterStatistics Combine(Dictionary<int, ShardExecutionResult<FooterStatistics>> results)
             {
-                var span = results.Span;
-
                 var result = new FooterStatistics();
 
-                foreach (var stats in span)
-                    result.CombineWith(stats);
+                foreach (var stats in results.Values)
+                    result.CombineWith(stats.Result);
 
                 return result;
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -83,13 +83,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
         protected override void HandleHeartbeatMessage(TransactionOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject)
         {
             blittableJsonReaderObject.TryGet(nameof(ReplicationMessageHeader.DatabaseChangeVector), out string changeVector);
-            
+
             using (var replicationBatches = new ReplicationBatches(this))
             {
                 var batches = replicationBatches.Batches;
                 var tasks = new Task[_parent.Context.ShardCount];
-				int i = 0;
-				
+                int i = 0;
+
                 foreach (var (shardNumber, batch) in batches)
                 {
                     batch.LastAcceptedChangeVector = changeVector ?? _lastAcceptedChangeVector;
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "Optimization possibility: instead of iterating over materialized batch, we can do it while reading from the stream");
             var replicationBatches = new ReplicationBatches(this);
             var batches = replicationBatches.Batches;
-            
+
             foreach (var item in dataForReplicationCommand.ReplicatedItems)
             {
                 int shardNumber = GetShardNumberForReplicationItem(context, item);

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             {
                 var subscription = ServerStore.Cluster.Subscriptions.ReadSubscriptionStateByName(context, DatabaseContext.DatabaseName, name);
 
-                foreach (var topology in DatabaseContext.ShardsTopology)
+                foreach (var topology in DatabaseContext.ShardsTopology.Values)
                 {
                     var node = topology.WhoseTaskIsIt(ServerStore.Engine.CurrentState, subscription, null);
                     if (node == null || node == ServerStore.NodeTag)

--- a/src/Raven.Server/Documents/Sharding/NotificationCenter/BackgroundWork/ShardedDatabaseStatsSender.cs
+++ b/src/Raven.Server/Documents/Sharding/NotificationCenter/BackgroundWork/ShardedDatabaseStatsSender.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -9,6 +10,7 @@ using Raven.Server.Json;
 using Raven.Server.NotificationCenter.BackgroundWork;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.NotificationCenter.BackgroundWork;
 
@@ -39,15 +41,13 @@ public class ShardedDatabaseStatsSender : AbstractDatabaseStatsSender
 
         public HttpRequest HttpRequest => null;
 
-        public NotificationCenterDatabaseStats Combine(Memory<NotificationCenterDatabaseStats> results)
+        public NotificationCenterDatabaseStats Combine(Dictionary<int, ShardExecutionResult<NotificationCenterDatabaseStats>> results)
         {
             var result = new NotificationCenterDatabaseStats();
 
-            for (var i = 0; i < results.Length; i++)
+            foreach (var shardStats in results.Values)
             {
-                var stats = results.Span[i];
-
-                result.CombineWith(stats, _context);
+                result.CombineWith(shardStats.Result, _context);
             }
 
             return result;

--- a/src/Raven.Server/Documents/Sharding/NotificationCenter/BackgroundWork/ShardedDatabaseStatsSender.cs
+++ b/src/Raven.Server/Documents/Sharding/NotificationCenter/BackgroundWork/ShardedDatabaseStatsSender.cs
@@ -5,12 +5,12 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.BackgroundWork;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.NotificationCenter.BackgroundWork;
 

--- a/src/Raven.Server/Documents/Sharding/Operations/AbstractShardedMultiOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/AbstractShardedMultiOperation.cs
@@ -20,7 +20,7 @@ public abstract class AbstractShardedMultiOperation
 
     protected readonly Dictionary<ShardedDatabaseIdentifier, Operation> Operations;
 
-    private IOperationProgress[] _progresses;
+    private Dictionary<int, IOperationProgress> _progresses;
 
     protected AbstractShardedMultiOperation(long id, ShardedDatabaseContext shardedDatabaseContext, Action<IOperationProgress> onProgress)
     {
@@ -73,9 +73,8 @@ public abstract class AbstractShardedMultiOperation
     {
         IOperationProgress result = null;
 
-        for (var i = 0; i < _progresses.Length; i++)
+        foreach (var progress in _progresses.Values)
         {
-            var progress = _progresses[i];
             if (progress == null)
                 continue;
 
@@ -99,9 +98,9 @@ public abstract class AbstractShardedMultiOperation
     public async Task<IOperationResult> WaitForCompletionAsync<TOrchestratorResult>(CancellationToken token)
         where TOrchestratorResult : IOperationResult, new()
     {
-        _progresses = new IOperationProgress[Operations.Count];
+        _progresses = new Dictionary<int, IOperationProgress>(Operations.Count);
 
-        var tasks = new Dictionary<ShardedDatabaseIdentifier, Task<IOperationResult>>(_progresses.Length);
+        var tasks = new Dictionary<ShardedDatabaseIdentifier, Task<IOperationResult>>(Operations.Count);
 
         foreach (var operation in Operations)
         {

--- a/src/Raven.Server/Documents/Sharding/Operations/AbstractShardedMultiOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/AbstractShardedMultiOperation.cs
@@ -72,9 +72,13 @@ public abstract class AbstractShardedMultiOperation
     private void MaybeNotifyAboutProgress()
     {
         IOperationProgress result = null;
-
-        foreach (var progress in _progresses.Values)
+        
+        foreach (var shardNumber in ShardedDatabaseContext.ShardsTopology.Keys)
         {
+            if(_progresses.ContainsKey(shardNumber) == false)
+                continue;
+
+            var progress = _progresses[shardNumber];
             if (progress == null)
                 continue;
 

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -55,7 +55,7 @@ internal class ShardedBulkInsertOperation : BulkInsertOperationBase<ShardedBatch
     public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.NoCompression;
 
     public HttpRequest HttpRequest => _requestHandler.HttpContext.Request;
-    public HttpResponseMessage Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<HttpResponseMessage>> results) => null;
+    public HttpResponseMessage Combine(Dictionary<int, ShardExecutionResult<HttpResponseMessage>> results) => null;
 
     public RavenCommand<HttpResponseMessage> CreateCommandForShard(int shardNumber)
     {

--- a/src/Raven.Server/Documents/Sharding/Operations/FetchDocumentsFromShardsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/FetchDocumentsFromShardsOperation.cs
@@ -16,7 +16,6 @@ using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
-using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Operations
 {
@@ -59,7 +58,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public string ExpectedEtag { get; }
 
-        public GetShardedDocumentsResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<GetDocumentsResult>> results)
+        public GetShardedDocumentsResult CombineResults(Dictionary<int, ShardExecutionResult<GetDocumentsResult>> results)
         {
             var docs = new Dictionary<string, BlittableJsonReaderObject>(StringComparer.OrdinalIgnoreCase);
             var includesMap = new Dictionary<string, BlittableJsonReaderObject>(StringComparer.OrdinalIgnoreCase);

--- a/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Smuggler;
 using Raven.Client.Http;
 using Raven.Server.Documents.Sharding.Executors;
 using Sparrow.Utils;
@@ -25,7 +24,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-        public OperationState Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<OperationState>> results)
+        public OperationState Combine(Dictionary<int, ShardExecutionResult<OperationState>> results)
         {
             var combined = new OperationState();
 

--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
@@ -5,10 +5,10 @@ using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Streaming;
 using Sparrow.Json;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding.Operations
 {

--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedReadOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedReadOperation.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using Raven.Client.Http;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
+using Raven.Server.Documents.Sharding.Executors;
 
 namespace Raven.Server.Documents.Sharding.Operations;
 

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedGetCollectionFieldsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedGetCollectionFieldsOperation.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
 		public string ExpectedEtag { get; }
 
-        public Dictionary<LazyStringValue, FieldType> CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<BlittableJsonReaderObject>> results)
+        public Dictionary<LazyStringValue, FieldType> CombineResults(Dictionary<int, ShardExecutionResult<BlittableJsonReaderObject>> results)
         {
             var combined = new Dictionary<LazyStringValue, FieldType>(LazyStringValueComparer.Instance);
             

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedGetCollectionFieldsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedGetCollectionFieldsOperation.cs
@@ -27,12 +27,12 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-		public string ExpectedEtag { get; }
+        public string ExpectedEtag { get; }
 
         public Dictionary<LazyStringValue, FieldType> CombineResults(Dictionary<int, ShardExecutionResult<BlittableJsonReaderObject>> results)
         {
             var combined = new Dictionary<LazyStringValue, FieldType>(LazyStringValueComparer.Instance);
-            
+
             foreach (var collectionFields in results.Values)
             {
                 if (collectionFields.Result == null)
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Sharding.Operations
                 for (int i = 0; i < collectionFields.Result.Count; i++)
                 {
                     collectionFields.Result.GetPropertyByIndex(i, ref propDetails);
-                    if(Enum.TryParse(propDetails.Value.ToString(), out FieldType type))
+                    if (Enum.TryParse(propDetails.Value.ToString(), out FieldType type))
                         combined.TryAdd(propDetails.Name.Clone(_context), type);
                 }
             }

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedGetRevisionsByChangeVectorsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedGetRevisionsByChangeVectorsOperation.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-		public string ExpectedEtag { get; }
+        public string ExpectedEtag { get; }
 
         public BlittableJsonReaderObject[] CombineResults(Dictionary<int, ShardExecutionResult<BlittableArrayResult>> results)
         {

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedGetRevisionsByChangeVectorsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedGetRevisionsByChangeVectorsOperation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Http;
@@ -29,7 +28,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
 		public string ExpectedEtag { get; }
 
-        public BlittableJsonReaderObject[] CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<BlittableArrayResult>> results)
+        public BlittableJsonReaderObject[] CombineResults(Dictionary<int, ShardExecutionResult<BlittableArrayResult>> results)
         {
             int len = 0;
             foreach (var s in results.Values)

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedLastChangeVectorForCollectionOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedLastChangeVectorForCollectionOperation.cs
@@ -26,7 +26,7 @@ public readonly struct ShardedLastChangeVectorForCollectionOperation : IShardedO
 
     public HttpRequest HttpRequest => _shardedSubscriptionsHandler.HttpContext.Request;
 
-    public LastChangeVectorForCollectionCombinedResult Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<LastChangeVectorForCollectionResult>> results)
+    public LastChangeVectorForCollectionCombinedResult Combine(Dictionary<int, ShardExecutionResult<LastChangeVectorForCollectionResult>> results)
     {
         var dic = new Dictionary<string, string>();
         

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
@@ -48,7 +48,7 @@ public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQ
 
     public Dictionary<string, List<TimeSeriesRange>> MissingTimeSeriesIncludes { get; set; }
 
-    public string CombineCommandsEtag(Dictionary<int, AbstractExecutor.ShardExecutionResult<QueryResult>> commands)
+    public string CombineCommandsEtag(Dictionary<int, ShardExecutionResult<QueryResult>> commands)
     {
         _combinedResultEtag = 0;
 
@@ -60,7 +60,7 @@ public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQ
         return CharExtensions.ToInvariantString(_combinedResultEtag);
     }
 
-    public ShardedQueryResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<QueryResult>> results)
+    public ShardedQueryResult CombineResults(Dictionary<int, ShardExecutionResult<QueryResult>> results)
     {
         var result = new ShardedQueryResult
         {

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
@@ -35,7 +35,7 @@ public readonly struct ShardedSubscriptionTryoutOperation : IShardedOperation<Ge
 
     public HttpRequest HttpRequest => _httpContext.Request;
 
-    public GetDocumentsResult Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<GetDocumentsResult>> results)
+    public GetDocumentsResult Combine(Dictionary<int, ShardExecutionResult<GetDocumentsResult>> results)
     {
         var getDocumentsResult = new GetDocumentsResult();
         var objList = new List<BlittableJsonReaderObject>();

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Commands;
@@ -7,6 +8,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -33,14 +35,14 @@ public readonly struct ShardedSubscriptionTryoutOperation : IShardedOperation<Ge
 
     public HttpRequest HttpRequest => _httpContext.Request;
 
-    public GetDocumentsResult Combine(Memory<GetDocumentsResult> results)
+    public GetDocumentsResult Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<GetDocumentsResult>> results)
     {
         var getDocumentsResult = new GetDocumentsResult();
         var objList = new List<BlittableJsonReaderObject>();
 
-        foreach (var res in results.ToArray())
+        foreach (var shardResult in results.Values)
         {
-            foreach (BlittableJsonReaderObject obj in res.Results)
+            foreach (BlittableJsonReaderObject obj in shardResult.Result.Results)
             {
                 objList.Add(obj.Clone(_context));
             }

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedTimeSeriesOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedTimeSeriesOperation.cs
@@ -21,7 +21,7 @@ internal class ShardedTimeSeriesOperation : IShardedOperation<GetMultipleTimeSer
 
     public HttpRequest HttpRequest { get; }
 
-    public GetMultipleTimeSeriesRangesCommand.Response Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<GetMultipleTimeSeriesRangesCommand.Response>> results)
+    public GetMultipleTimeSeriesRangesCommand.Response Combine(Dictionary<int, ShardExecutionResult<GetMultipleTimeSeriesRangesCommand.Response>> results)
     {
         GetMultipleTimeSeriesRangesCommand.Response result = new()
         {

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedTimeSeriesOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedTimeSeriesOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
 
 namespace Raven.Server.Documents.Sharding.Operations;
 
@@ -20,16 +21,16 @@ internal class ShardedTimeSeriesOperation : IShardedOperation<GetMultipleTimeSer
 
     public HttpRequest HttpRequest { get; }
 
-    public GetMultipleTimeSeriesRangesCommand.Response Combine(Memory<GetMultipleTimeSeriesRangesCommand.Response> results)
+    public GetMultipleTimeSeriesRangesCommand.Response Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<GetMultipleTimeSeriesRangesCommand.Response>> results)
     {
         GetMultipleTimeSeriesRangesCommand.Response result = new()
         {
             Results = new List<TimeSeriesDetails>()
         };
 
-        foreach (var cmdResult in results.Span)
+        foreach (var cmdResult in results.Values)
         {
-            result.Results.AddRange(cmdResult.Results);
+            result.Results.AddRange(cmdResult.Result.Results);
         }
 
         return result;

--- a/src/Raven.Server/Documents/Sharding/Operations/SingleNodeShardedBatchOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/SingleNodeShardedBatchOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Sharding.Commands;
+using Raven.Server.Documents.Sharding.Executors;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -26,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-        public DynamicJsonArray Combine(Memory<BlittableJsonReaderObject> results)
+        public DynamicJsonArray Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<BlittableJsonReaderObject>> results)
         {
             var reply = new object[_totalCommands];
             foreach (var c in _commands.Values)

--- a/src/Raven.Server/Documents/Sharding/Operations/SingleNodeShardedBatchOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/SingleNodeShardedBatchOperation.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Operations
 
         public HttpRequest HttpRequest => _httpContext.Request;
 
-        public DynamicJsonArray Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<BlittableJsonReaderObject>> results)
+        public DynamicJsonArray Combine(Dictionary<int, ShardExecutionResult<BlittableJsonReaderObject>> results)
         {
             var reply = new object[_totalCommands];
             foreach (var c in _commands.Values)

--- a/src/Raven.Server/Documents/Sharding/Operations/WaitForIndexNotificationOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/WaitForIndexNotificationOperation.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands;
+using Raven.Server.Documents.Sharding.Executors;
 
 namespace Raven.Server.Documents.Sharding.Operations
 {
@@ -26,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Operations
         }
 
         public HttpRequest HttpRequest => null;
-        public object Combine(Memory<object> results) => throw new NotImplementedException();
+        public object Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<object>> results) => throw new NotImplementedException();
 
         public RavenCommand<object> CreateCommandForShard(int shardNumber) => new WaitForIndexNotificationCommand(_indexes);
     }

--- a/src/Raven.Server/Documents/Sharding/Operations/WaitForIndexNotificationOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/WaitForIndexNotificationOperation.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Operations
         }
 
         public HttpRequest HttpRequest => null;
-        public object Combine(Dictionary<int, AbstractExecutor.ShardExecutionResult<object>> results) => throw new NotImplementedException();
+        public object Combine(Dictionary<int, ShardExecutionResult<object>> results) => throw new NotImplementedException();
 
         public RavenCommand<object> CreateCommandForShard(int shardNumber) => new WaitForIndexNotificationCommand(_indexes);
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -81,9 +81,9 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
 
             queryTemplates = new(_requestHandler.DatabaseContext.ShardCount);
 
-            for (int i = 0; i < _requestHandler.DatabaseContext.ShardCount; i++)
+            foreach (var shardNumber in _requestHandler.DatabaseContext.ShardsTopology.Keys)
             {
-                queryTemplates.Add(i, queryTemplate);
+                queryTemplates.Add(shardNumber, queryTemplate);
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -107,13 +107,15 @@ public partial class ShardedDatabaseContext
             var t = token?.Token ?? default;
 
             var tasks = new Task[_context.ShardCount];
+            int i = 0;
             using (_context.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                for (var shardNumber = 0; shardNumber < tasks.Length; shardNumber++)
+                foreach (var shardNumber in _context.ShardsTopology.Keys)
                 {
                     var command = commandFactory(context, shardNumber);
 
-                    tasks[shardNumber] = ConnectAsync(command, shardNumber);
+                    tasks[i] = ConnectAsync(command, shardNumber);
+                    i++;
                 }
             }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -163,15 +163,15 @@ namespace Raven.Server.Documents.Sharding
 
     public class ShardReplicationNode : ExternalReplication
     {
-        public int Shard;
+        public int ShardNumber;
 
         public ShardReplicationNode()
         {
         }
 
-        public ShardReplicationNode(string database, string connectionStringName, int shard) : base(database, connectionStringName)
+        public ShardReplicationNode(string database, string connectionStringName, int shardNumber) : base(database, connectionStringName)
         {
-            Shard = shard;
+            ShardNumber = shardNumber;
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -3,17 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client;
 using Raven.Client.Documents.Session;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.Documents.Sharding.Streaming.Comparers;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Utils;
-using static Raven.Server.Documents.Sharding.Executors.AbstractExecutor;
 
 namespace Raven.Server.Documents.Sharding
 {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Sharding
         private readonly Logger _logger;
 
         public readonly ShardExecutor ShardExecutor;
-        public readonly AllNodesExecutor AllNodesExecutor;
+        public readonly AllOrchestratorNodesExecutor AllNodesExecutor;
         public DatabaseRecord DatabaseRecord => _record;
 
         public RavenConfiguration Configuration { get; internal set; }
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Sharding
             Indexes = new ShardedIndexesContext(this, serverStore);
 
             ShardExecutor = new ShardExecutor(ServerStore, this);
-            AllNodesExecutor = new AllNodesExecutor(ServerStore, this);
+            AllNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, this);
 
             NotificationCenter = new ShardedDatabaseNotificationCenter(this);
             NotificationCenter.Initialize();
@@ -97,9 +97,9 @@ namespace Raven.Server.Documents.Sharding
 
         public bool Encrypted => _record.Encrypted;
 
-        public int ShardCount => _record.Sharding.Shards.Length;
+        public int ShardCount => _record.Sharding.Shards.Count;
 
-        public DatabaseTopology[] ShardsTopology => _record.Sharding.Shards;
+        public Dictionary<int, DatabaseTopology> ShardsTopology => _record.Sharding.Shards;
 
         public int GetShardNumber(int shardBucket) => ShardHelper.GetShardNumber(_record.Sharding.BucketRanges, shardBucket);
 

--- a/src/Raven.Server/Documents/Sharding/Streaming/CombinedStreamResult.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/CombinedStreamResult.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
+using Raven.Server.Documents.Sharding.Executors;
 
 namespace Raven.Server.Documents.Sharding.Streaming;
 
 public class CombinedStreamResult
 {
-    public Memory<StreamResult> Results;
+    public Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> Results;
 
     public async ValueTask<CombinedReadContinuationState> InitializeAsync(ShardedDatabaseContext databaseContext, CancellationToken token)
     {

--- a/src/Raven.Server/Documents/Sharding/Streaming/CombinedStreamResult.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/CombinedStreamResult.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Sharding.Streaming;
 
 public class CombinedStreamResult
 {
-    public Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> Results;
+    public Dictionary<int, ShardExecutionResult<StreamResult>> Results;
 
     public async ValueTask<CombinedReadContinuationState> InitializeAsync(ShardedDatabaseContext databaseContext, CancellationToken token)
     {

--- a/src/Raven.Server/Documents/Sharding/Streaming/ShardStreamItem.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ShardStreamItem.cs
@@ -3,5 +3,5 @@
 public class ShardStreamItem<T>
 {
     public T Item;
-    public int Shard;
+    public int ShardNumber;
 }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -68,10 +68,10 @@ public class SubscriptionConnectionsStateOrchestrator : SubscriptionConnectionsS
 
     private void StartShardSubscriptionWorkers()
     {
-        for (int i = 0; i < _databaseContext.ShardCount; i++)
+        foreach (var shardNumber in _databaseContext.ShardsTopology.Keys)
         {
-            var re = _databaseContext.ShardExecutor.GetRequestExecutorAt(i);
-            var shard = ShardHelper.ToShardName(_databaseContext.DatabaseName, i);
+            var re = _databaseContext.ShardExecutor.GetRequestExecutorAt(shardNumber);
+            var shard = ShardHelper.ToShardName(_databaseContext.DatabaseName, shardNumber);
             var worker = CreateShardedWorkerHolder(shard, re, lastErrorDateTime: null);
             _shardWorkers.Add(shard, worker);
         }

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -163,7 +163,8 @@ namespace Raven.Server.ServerWide
             [nameof(SourceMigrationSendCompletedCommand)] = 60_000,
             [nameof(DestinationMigrationConfirmCommand)] = 60_000,
             [nameof(SourceMigrationCleanupCommand)] = 60_000,
-            [nameof(PutShardedSubscriptionCommand)] = 60_000
+            [nameof(PutShardedSubscriptionCommand)] = 60_000,
+            [nameof(CreateNewShardCommand)] = 60_000,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1246,7 +1246,7 @@ namespace Raven.Server.ServerWide
                                 continue;
                             }
                         }
-                        //TODO stav: handle removal of cluster node with last shardNumber
+                        
                         if (record.IsSharded == false)
                         {
                             if (record.Topology.RelevantFor(removed))

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -287,7 +287,7 @@ namespace Raven.Server.ServerWide.Commands
         [Conditional("DEBUG")]
         private static void AssertDatabaseName(string databaseName)
         {
-            if (ShardHelper.IsShardedName(databaseName))
+            if (ShardHelper.IsShardName(databaseName))
                 throw new InvalidOperationException($"Cannot use '{nameof(ClusterTransactionCommand)}' with a sharded database ('{databaseName}').");
         }
 

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.ServerWide.Commands
                 throw new ArgumentNullException(nameof(database), "The database argument must have value");
             if (index < 0)
                 throw new InvalidDataException("Index must be a non-negative number");
-            if (ShardHelper.IsShardedName(database))
+            if (ShardHelper.IsShardName(database))
                 throw new ArgumentException($"{GetType()} cannot accept shards as a database. This command use the _shard_ '{database}' which is not allow here.");
 
             Key = key;

--- a/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
@@ -30,8 +30,8 @@ namespace Raven.Server.ServerWide.Commands
             }
             else
             {
-                if (record.Sharding.Shards.Length <= ShardNumber)
-                    throw new RachisApplyException($"The request shard '{ShardNumber}' doesn't exists in '{record.DatabaseName}'");
+                if (record.Sharding.Shards.ContainsKey(ShardNumber.Value) == false)
+                    throw new RachisApplyException($"The requested shard '{ShardNumber.Value}' doesn't exists in '{record.DatabaseName}'");
 
                 topology = record.Sharding.Shards[ShardNumber.Value];
             }

--- a/src/Raven.Server/ServerWide/Commands/Sharding/CreateNewShardCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/CreateNewShardCommand.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Raven.Client.ServerWide;
+using Raven.Server.Rachis;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Sharding
+{
+    public class CreateNewShardCommand : UpdateDatabaseCommand
+    {
+        public DatabaseTopology Topology;
+        public DateTime At;
+        public int Shard;
+
+        public CreateNewShardCommand()
+        {
+            //
+        }
+
+        public CreateNewShardCommand(string databaseName, int shardNumber, DatabaseTopology shardTopology, DateTime at, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        {
+            if (ShardHelper.IsShardName(databaseName))
+                throw new ArgumentException($"The command {nameof(CreateNewShardCommand)} expected a sharded database name but got shard {databaseName} instead.");
+
+            Topology = shardTopology;
+            At = at;
+            Shard = shardNumber;
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            Topology.NodesModifiedAt = At;
+            SetLeaderStampForTopology(Topology, etag);
+
+            if (record.Sharding.Shards.ContainsKey(Shard))
+                throw new RachisApplyException($"Cannot add new shard {Shard} to the database {DatabaseName} because it already exists.");
+
+            record.Sharding.Shards.Add(Shard, Topology);
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Topology)] = Topology.ToJson();
+            json[nameof(RaftCommandIndex)] = RaftCommandIndex;
+            json[nameof(At)] = At;
+            json[nameof(Shard)] = Shard;
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -28,6 +28,12 @@ namespace Raven.Server.ServerWide.Commands
 
         }
 
+        protected static void SetLeaderStampForTopology(DatabaseTopology topology, long etag)
+        {
+            topology.Stamp ??= new LeaderStamp { Term = -1, LeadersTicks = -1, Index = -1 };
+            topology.Stamp.Index = etag;
+        }
+
         public abstract void FillJson(DynamicJsonValue json);
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -43,18 +43,11 @@ namespace Raven.Server.ServerWide.Commands
                 return;
             }
 
-            if (record.Sharding.Shards.Length <= ShardNumber)
-                throw new RachisApplyException($"The request shard '{ShardNumber}' doesn't exists in '{record.DatabaseName}'");
+            if (record.Sharding.Shards.ContainsKey(ShardNumber.Value) == false)
+                throw new RachisApplyException($"The requested shard '{ShardNumber.Value}' doesn't exists in '{record.DatabaseName}'");
 
             record.Sharding.Shards[ShardNumber.Value] = Topology;
         }
-
-        private static void SetLeaderStampForTopology(DatabaseTopology topology, long etag)
-        {
-            topology.Stamp ??= new LeaderStamp {Term = -1, LeadersTicks = -1, Index = -1};
-            topology.Stamp.Index = etag;
-        }
-
 
         public override void FillJson(DynamicJsonValue json)
         {

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -173,6 +173,7 @@ namespace Raven.Server.ServerWide
             [nameof(EditExpirationCommand)] = GenerateJsonDeserializationRoutine<EditExpirationCommand>(),
             [nameof(EditDocumentsCompressionCommand)] = GenerateJsonDeserializationRoutine<EditDocumentsCompressionCommand>(),
             [nameof(EditRefreshCommand)] = GenerateJsonDeserializationRoutine<EditRefreshCommand>(),
+            [nameof(CreateNewShardCommand)] = GenerateJsonDeserializationRoutine<CreateNewShardCommand>(),
             [nameof(DeleteDatabaseCommand)] = GenerateJsonDeserializationRoutine<DeleteDatabaseCommand>(),
             [nameof(IncrementClusterIdentityCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentityCommand>(),
             [nameof(IncrementClusterIdentitiesBatchCommand)] = GenerateJsonDeserializationRoutine<IncrementClusterIdentitiesBatchCommand>(),

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -28,7 +28,6 @@ using Raven.Server.ServerWide.Sharding;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide
 {
@@ -40,7 +39,7 @@ namespace Raven.Server.ServerWide
                 return record.Topology;
 
             var rehabs = new HashSet<string>();
-            foreach (var shardedTopology in record.Sharding.Shards)
+            foreach (var shardedTopology in record.Sharding.Shards.Values)
             {
                 foreach (var rehab in shardedTopology.Rehabs)
                 {
@@ -214,8 +213,8 @@ namespace Raven.Server.ServerWide
                     var sharding = Sharding;
                     if (sharding != null)
                     {
-                        sharding.Raw.TryGet(nameof(DatabaseRecord.Sharding.Shards), out BlittableJsonReaderArray array);
-                        _isSharded = array is { Length: > 0 };
+                        sharding.Raw.TryGet(nameof(DatabaseRecord.Sharding.Shards), out BlittableJsonReaderObject shardTopologies);
+                        _isSharded = shardTopologies is { Count: > 0 };
                     }
                     else
                     {
@@ -229,11 +228,11 @@ namespace Raven.Server.ServerWide
 
         public RawDatabaseRecord GetShardedDatabaseRecord(int shardNumber)
         {
-            Sharding.Raw.TryGet(nameof(ShardingConfiguration.Shards), out BlittableJsonReaderArray array);
-            if(array.Length <= shardNumber)
+            Sharding.Raw.TryGet(nameof(ShardingConfiguration.Shards), out BlittableJsonReaderObject shardTopologies);
+            if (shardTopologies.TryGet(shardNumber.ToString(), out BlittableJsonReaderObject shardedTopology) == false)
+            {
                 throw new ArgumentException($"Can't fetch topology of shard number {shardNumber} from the raw record because it does not exist.");
-
-            var shardedTopology = (BlittableJsonReaderObject)array[shardNumber];
+            }
             var shardName = ShardHelper.ToShardName(DatabaseName, shardNumber);
 
             var settings = new Dictionary<string, string>();
@@ -274,11 +273,19 @@ namespace Raven.Server.ServerWide
             if (IsSharded == false)
                 yield break;
 
-            Sharding.Raw.TryGet(nameof(ShardingConfiguration.Shards), out BlittableJsonReaderArray array);
+            Sharding.Raw.TryGet(nameof(ShardingConfiguration.Shards), out BlittableJsonReaderObject shardTopologies);
 
-            for (var index = 0; index < array.Length; index++)
+            for (int i = 0; i < shardTopologies.Count; i++)
             {
-                yield return GetShardedDatabaseRecord(index);
+                var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
+                shardTopologies.GetPropertyByIndex(i, ref propertyDetails);
+
+                if(propertyDetails.Value == null)
+                    continue;
+
+                var shardNumber = RawShardingConfiguration.GetShardNumberFromPropertyDetails(propertyDetails);
+
+                yield return GetShardedDatabaseRecord(shardNumber);
             }
         }
 
@@ -289,24 +296,20 @@ namespace Raven.Server.ServerWide
                 if (DeletionInProgress.Count == 0)
                     return false;
 
-                if (Sharding.Shards.Sum(x => x.Count) == 0)
+                if (Sharding.Shards.Sum(x => x.Value.Count) == 0)
                     return true;
 
-                int shard = 0;
-                foreach (var shardTopology in Sharding.Shards)
+                foreach (var (shardNumber, shardTopology) in Sharding.Shards)
                 {
                     foreach (var nodeWithShard in shardTopology.AllNodes)
                     {
-                        if (DeletionInProgress.TryGetValue(DatabaseRecord.GetKeyForDeletionInProgress(nodeWithShard, shard), out var deletionStatus) == false || deletionStatus == DeletionInProgressStatus.No)
+                        if (DeletionInProgress.TryGetValue(DatabaseRecord.GetKeyForDeletionInProgress(nodeWithShard, shardNumber), out var deletionStatus) == false || deletionStatus == DeletionInProgressStatus.No)
                         {
                             return false;
                         }
                     }
-
-                    shard++;
                 }
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal,
-                    "Handle case where shard numbers are not consecutive");
+                
                 return true;
             }
             else
@@ -337,8 +340,8 @@ namespace Raven.Server.ServerWide
             if (IsSharded == false)
                 return Topology.ClusterTransactionIdBase64;
 
-            Debug.Assert(Sharding.Shards.All(s => s.ClusterTransactionIdBase64.Equals(Sharding.Shards[0].ClusterTransactionIdBase64)));
-            return Sharding.Shards[0].ClusterTransactionIdBase64;
+            Debug.Assert(Sharding.Shards.All(s => s.Value.ClusterTransactionIdBase64.Equals(Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64)));
+            return Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64;
         }
 
         private DatabaseStateStatus? _databaseState;
@@ -1214,6 +1217,16 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        internal bool IsShardBeingDeletedOnAnyNode(int shardNumber)
+        {
+            foreach (var deletion in DeletionInProgress)
+            {
+                if (deletion.Key.Contains(shardNumber.ToString()))
+                    return true;
+            }
+
+            return true;
+        }
 
         public void Dispose()
         {

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -1225,7 +1225,7 @@ namespace Raven.Server.ServerWide
                     return true;
             }
 
-            return true;
+            return false;
         }
 
         public void Dispose()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -877,12 +877,12 @@ namespace Raven.Server.ServerWide
                         {
                             addDatabase.Record.Sharding.BucketRanges = new List<ShardBucketRange>();
                             var start = 0;
-                            var step = ShardHelper.NumberOfBuckets / addDatabase.Record.Sharding.Shards.Length;
-                            for (int i = 0; i < addDatabase.Record.Sharding.Shards.Length; i++)
+                            var step = ShardHelper.NumberOfBuckets / addDatabase.Record.Sharding.Shards.Count;
+                            foreach (var (shardNumber, shardTopology) in addDatabase.Record.Sharding.Shards)
                             {
                                 addDatabase.Record.Sharding.BucketRanges.Add(new ShardBucketRange
                                 {
-                                    ShardNumber = i,
+                                    ShardNumber = shardNumber,
                                     BucketRangeStart = start
                                 });
                                 start += step;
@@ -899,7 +899,7 @@ namespace Raven.Server.ServerWide
 
                         var index = 0;
                         var keys = pool.Keys.ToList();
-                        foreach (var shardTopology in addDatabase.Record.Sharding.Shards)
+                        foreach (var (shardNumber, shardTopology) in addDatabase.Record.Sharding.Shards)
                         {
                             while (shardTopology.ReplicationFactor > shardTopology.Count)
                             {
@@ -922,7 +922,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private static Dictionary<string, int> GetNodesDistribution(ClusterTopology clusterTopology, DatabaseTopology[] shards)
+        private static Dictionary<string, int> GetNodesDistribution(ClusterTopology clusterTopology, Dictionary<int, DatabaseTopology> shards)
         {
             var total = 0;
             var pool = new Dictionary<string, int>(); // tag, number of occurrences
@@ -932,7 +932,7 @@ namespace Raven.Server.ServerWide
                 pool[node.Key] = 0;
             }
 
-            foreach (var shardTopology in shards)
+            foreach (var (shardNumber, shardTopology) in shards)
             {
                 total += shardTopology.ReplicationFactor;
             }
@@ -2850,7 +2850,7 @@ namespace Raven.Server.ServerWide
             {
                 InitializeTopology(record.Sharding.Orchestrator.Topology);
 
-                foreach (var shardTopology in record.Sharding.Shards)
+                foreach (var (shardNumber, shardTopology) in record.Sharding.Shards)
                 {
                     InitializeTopology(shardTopology);
                 }

--- a/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
+++ b/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Amqp.Framing;
 using JetBrains.Annotations;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;

--- a/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
+++ b/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
@@ -115,10 +115,10 @@ public class RawShardingConfiguration
 
     internal static int GetShardNumberFromPropertyDetails(BlittableJsonReaderObject.PropertyDetails propertyDetails)
     {
-        if (int.TryParse(propertyDetails.Name.ToString(), out int sharNumber) == false)
+        if (int.TryParse(propertyDetails.Name.ToString(), out int shardNumber) == false)
             throw new ArgumentException($"Error while trying to extract the shard number from the raw database record. Expected an int but got a {propertyDetails.Name}");
 
-        return sharNumber;
+        return shardNumber;
     }
 
     private List<ShardBucketRange> _shardBucketRanges;

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -898,7 +898,7 @@ namespace Raven.Server.Smuggler.Documents
                 _writer.WriteStartObject();
 
                 _writer.WritePropertyName(nameof(shardingConfiguration.Shards));
-                _context.Write(_writer, new DynamicJsonArray(shardingConfiguration.Shards.Select(x => x.ToJson())));
+                _context.Write(_writer, DynamicJsonValue.Convert(shardingConfiguration.Shards));
 
                 _writer.WritePropertyName(nameof(shardingConfiguration.BucketRanges));
                 _context.Write(_writer, new DynamicJsonArray(shardingConfiguration.BucketRanges.Select(x => x.ToJson())));

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -12,6 +12,7 @@ using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Sharding.Commands;
+using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Documents.Sharding.Operations;
@@ -174,7 +175,7 @@ public class ShardedStudioCollectionsHandlerProcessorForPreviewCollection : Abst
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Memory<StreamResult> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult {Results = results};
         }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -175,7 +175,7 @@ public class ShardedStudioCollectionsHandlerProcessorForPreviewCollection : Abst
 
         public string ExpectedEtag { get; }
 
-        public CombinedStreamResult CombineResults(Dictionary<int, AbstractExecutor.ShardExecutionResult<StreamResult>> results)
+        public CombinedStreamResult CombineResults(Dictionary<int, ShardExecutionResult<StreamResult>> results)
         {
             return new CombinedStreamResult {Results = results};
         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -438,7 +438,7 @@ namespace Raven.Server.Web.System
                 databaseRecord.Sharding.Orchestrator.Topology ??= new OrchestratorTopology();
                 SetReplicationFactor(databaseRecord.Sharding.Orchestrator.Topology, clusterTopology, replicationFactor);
 
-                foreach (var databaseTopology in databaseRecord.Sharding.Shards)
+                foreach (var (shardNumber, databaseTopology) in databaseRecord.Sharding.Shards)
                     UpdateDatabaseTopology(databaseTopology, clusterTopology, replicationFactor, clusterTransactionId);
             }
             else

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -228,7 +228,7 @@ namespace Raven.Server.Web.System
                         {
                             dbNodes = rawRecord.Sharding.Orchestrator.Topology.Members.Select(x =>
                                 TopologyNodeToJson(x, clusterTopology, name, ServerNode.Role.Member));
-                            stampIndex = rawRecord.Sharding.Shards.Max(x => x.Stamp?.Index ?? -1);
+                            stampIndex = rawRecord.Sharding.Shards.Max(x => x.Value.Stamp?.Index ?? -1);
                         }
                         else
                         {

--- a/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
+++ b/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
@@ -36,9 +36,9 @@ internal class BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus : Abstra
 
             if (dbRecord.IsSharded)
             {
-                for (int i = 0; i < dbRecord.Sharding.Shards.Length; i++)
+                foreach (var shardNumber in dbRecord.Sharding.Shards.Keys)
                 {
-                    var status = ServerStore.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(ShardHelper.ToShardName(name, i), taskId.Value));
+                    var status = ServerStore.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(ShardHelper.ToShardName(name, shardNumber), taskId.Value));
                     statuses.Add(status);
                 }
 

--- a/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
+++ b/src/Raven.Server/Web/System/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForGetOngoingTasks.cs
@@ -288,7 +288,7 @@ internal abstract class AbstractOngoingTasksHandlerProcessorForGetOngoingTasks<T
     {
         if (ResourceNameValidator.IsValidResourceName(RequestHandler.DatabaseName, ServerStore.Configuration.Core.DataDirectory.FullPath, out string errorMessage) == false)
         {
-            bool sharded = ShardHelper.IsShardedName(RequestHandler.DatabaseName);
+            bool sharded = ShardHelper.IsShardName(RequestHandler.DatabaseName);
             if (sharded == false)
                 throw new BadRequestException(errorMessage);
         }

--- a/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
@@ -696,11 +696,11 @@ class databaseCreationModel {
             settings[configuration.core.dataDirectory] = dataDir;
         }
 
-        const shards: Raven.Client.ServerWide.DatabaseTopology[] = [];
+        const shards: Record<string, Raven.Client.ServerWide.DatabaseTopology> = {};
         const numberOfShards = this.sharding.numberOfShards();
         if (numberOfShards && this.getShardingConfigSection().enabled()) {
             for (let i = 0; i < numberOfShards; i++) {
-                shards.push({} as Raven.Client.ServerWide.DatabaseTopology);
+                shards[i.toString()] = {} as Raven.Client.ServerWide.DatabaseTopology;
             }
         }
         

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -66,7 +66,8 @@ namespace FastTests.Client
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand",
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand",
                 "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand",
-                "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand", "GetTcpInfoForReplicationCommand", "GetCollectionFieldsCommand", "PreviewCollectionCommand"
+                "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand", "GetTcpInfoForReplicationCommand", "GetCollectionFieldsCommand", "PreviewCollectionCommand",
+				"CreateShardCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -48,10 +48,10 @@ namespace FastTests.Client
                 "ReorderDatabaseMembersCommand", "ReplaceClusterCertificateCommand", "ResetEtlCommand", "ResetIndexCommand", "SetDatabaseDynamicDistributionCommand",
                 "SetIndexLockCommand", "SetIndexPriorityCommand", "SetLogsConfigurationCommand", "StartIndexCommand", "StartIndexingCommand",
                 "StartTransactionsRecordingCommand", "StopIndexCommand", "StopIndexingCommand", "StopTransactionsRecordingCommand",
-                "UpdateUnusedDatabasesCommand", "WaitForRaftIndexCommand", "ConfigureTimeSeriesCommand", "ConfigureTimeSeriesPolicyCommand", 
+                "UpdateUnusedDatabasesCommand", "WaitForRaftIndexCommand", "ConfigureTimeSeriesCommand", "ConfigureTimeSeriesPolicyCommand",
                 "UpdateSubscriptionCommand", "RemoveTimeSeriesPolicyCommand", "GetTimeSeriesStatisticsCommand", "GetTimeSeriesCommand", "GetMultipleTimeSeriesCommand",
                 "GetAttachmentsCommand", "ConfigureTimeSeriesValueNamesCommand", "DeleteIndexErrorsCommand", "TimeSeriesBatchCommand", "GetRevisionsResultCommand", "SetIndexStateCommand",
-                "BackupCommand", "GetReplicationHubAccessCommand", "GetServerWideExternalReplicationCommand", "GetServerWideExternalReplicationsCommand", 
+                "BackupCommand", "GetReplicationHubAccessCommand", "GetServerWideExternalReplicationCommand", "GetServerWideExternalReplicationsCommand",
                 "PutServerWideBackupConfigurationCommand", "PutServerWideExternalReplicationCommand", "ConditionalGetDocumentsCommand", "GetStudioConfigurationCommand", "GetTimeSeriesConfigurationCommand",
                 "EnforceRevisionsConfigurationCommand",
                 "DeleteServerWideTaskCommand", "RegisterReplicationHubAccessCommand", "ToggleServerWideTaskStateCommand", "UnregisterReplicationHubAccessCommand", "GetRevisionsCountCommand",
@@ -67,7 +67,7 @@ namespace FastTests.Client
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand",
                 "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand",
                 "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand", "GetTcpInfoForReplicationCommand", "GetCollectionFieldsCommand", "PreviewCollectionCommand",
-				"AddDatabaseShardCommand"
+                "AddDatabaseShardCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -67,7 +67,7 @@ namespace FastTests.Client
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand",
                 "GetEssentialStatisticsCommand", "GetMultipleTimeSeriesRangesCommand", "GetShardedPeriodicBackupStatusCommand",
                 "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand", "GetTcpInfoForReplicationCommand", "GetCollectionFieldsCommand", "PreviewCollectionCommand",
-				"CreateShardCommand"
+				"AddDatabaseShardCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1252,10 +1252,10 @@ namespace RachisTests.DatabaseCluster
                 }
 
                 //create new shard
-                var res = store.Maintenance.Server.Send(new CreateShardOperation(store.Database, shardNumber: 4));
-                Assert.Equal(4, res.NewShardNumber);
-                Assert.Equal(2, res.NewShardTopology.ReplicationFactor);
-                Assert.Equal(2, res.NewShardTopology.AllNodes.Count());
+                var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database, shardNumber: 4));
+                Assert.Equal(4, res.ShardNumber);
+                Assert.Equal(2, res.ShardTopology.ReplicationFactor);
+                Assert.Equal(2, res.ShardTopology.AllNodes.Count());
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
 
                 await AssertWaitForValueAsync(async () =>
@@ -1297,11 +1297,11 @@ namespace RachisTests.DatabaseCluster
                 Assert.Equal(2, shardTopology.ReplicationFactor);
                 
                 //create new shard
-                var res = store.Maintenance.Server.Send(new CreateShardOperation(store.Database));
-                var shardNumber = res.NewShardNumber;
+                var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database));
+                var shardNumber = res.ShardNumber;
                 Assert.Equal(2, shardNumber);
-                Assert.Equal(2, res.NewShardTopology.ReplicationFactor);
-                Assert.Equal(2, res.NewShardTopology.AllNodes.Count());
+                Assert.Equal(2, res.ShardTopology.ReplicationFactor);
+                Assert.Equal(2, res.ShardTopology.AllNodes.Count());
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
 
                 await AssertWaitForValueAsync(async () =>
@@ -1342,11 +1342,11 @@ namespace RachisTests.DatabaseCluster
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
                 //create new shard
-                var res = store.Maintenance.Server.Send(new CreateShardOperation(store.Database, nodes: new []{ "A", "C" }));
-                var shardNumber = res.NewShardNumber;
+                var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database, nodes: new []{ "A", "C" }));
+                var shardNumber = res.ShardNumber;
                 Assert.Equal(2, shardNumber);
-                Assert.Equal(2, res.NewShardTopology.ReplicationFactor);
-                Assert.Equal(2, res.NewShardTopology.AllNodes.Count());
+                Assert.Equal(2, res.ShardTopology.ReplicationFactor);
+                Assert.Equal(2, res.ShardTopology.AllNodes.Count());
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
 
                 await AssertWaitForValueAsync(async () =>

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1165,7 +1165,7 @@ namespace RachisTests.DatabaseCluster
                     return shardTopology.Members.Count;
                 }, 1);
                 
-                Assert.Equal(nodeContainingShard0, shardTopology.Members[0]);
+                Assert.DoesNotContain(nodeContainingShard0, shardTopology.Members);
 
                 serverWithNewShard = Servers.Single(x => x.ServerStore.NodeTag == nodeContainingShard0);
                 Assert.False(serverWithNewShard.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(ShardHelper.ToShardName(store.Database, 0), out var _));

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -376,20 +376,20 @@ namespace SlowTests.Cluster
                         }
                     };
 
-                    r.Sharding.Shards = new[]
+                    r.Sharding.Shards = new Dictionary<int, DatabaseTopology>()
                     {
-                        new DatabaseTopology
+                        {0, new DatabaseTopology
                         {
                             Members = members
-                        }, 
-                        new DatabaseTopology
+                        }},
+                        {1, new DatabaseTopology
                         {
                             Members = members
-                        }, 
-                        new DatabaseTopology
+                        }},
+                        {2, new DatabaseTopology
                         {
                             Members = members
-                        }
+                        }},
                     };
                 };
             }

--- a/test/SlowTests/Cluster/ShardedClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ShardedClusterTransactionTests.cs
@@ -35,7 +35,8 @@ namespace SlowTests.Cluster
             options.ModifyDatabaseRecord = r =>
             {
                 r.Sharding ??= new ShardingConfiguration();
-                r.Sharding.Shards = Enumerable.Range(0, numberOfShards).Select(_ => new DatabaseTopology()).ToArray();
+                r.Sharding.Shards = Enumerable.Range(0, numberOfShards)
+                    .Select((shardNumber) => new KeyValuePair<int, DatabaseTopology>(shardNumber, new DatabaseTopology())).ToDictionary(x => x.Key, x => x.Value);
             };
 
             using var store = Sharding.GetDocumentStore(options);

--- a/test/SlowTests/Issues/RavenDB_18762.cs
+++ b/test/SlowTests/Issues/RavenDB_18762.cs
@@ -30,20 +30,20 @@ public class RavenDB_18762 : ClusterTestBase
             {
                 Sharding = new ShardingConfiguration
                 {
-                    Shards = new[]
+                    Shards = new Dictionary<int, DatabaseTopology>()
                     {
-                        new DatabaseTopology
+                        {0, new DatabaseTopology
                         {
                             Members = new List<string> { "A", "B", "C" }
-                        },
-                        new DatabaseTopology
+                        }},
+                        {1, new DatabaseTopology
                         {
                             Members = new List<string> { "A", "B", "C" }
-                        },
-                        new DatabaseTopology
+                        }},
+                        {2, new DatabaseTopology
                         {
                             Members = new List<string> { "A", "B", "C" }
-                        }
+                        }},
                     }
                 }
             }, 3, cluster.Leader.WebUrl);

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -533,7 +533,7 @@ namespace SlowTests.Sharding.Backup
 
                 }
 
-                Assert.Equal(dbRecord.Sharding.Shards.Length, shardNumToDocIds.Count);
+                Assert.Equal(dbRecord.Sharding.Shards.Count, shardNumToDocIds.Count);
             }
 
             await AssertDocsInShardedDb(store, shardNumToDocIds);

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using MySqlX.XDevAPI;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
@@ -88,15 +89,14 @@ namespace SlowTests.Sharding.Backup
                 {
                     var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(newDbName));
                     Assert.Equal(DatabaseStateStatus.Normal, dbRec.DatabaseState);
-                    Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                    Assert.Equal(3, dbRec.Sharding.Shards.Count);
 
                     var shardNodes = new HashSet<string>();
-                    for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                    foreach (var shardToTopology in dbRec.Sharding.Shards)
                     {
-                        var shardTopology = dbRec.Sharding.Shards[index];
-                        Assert.Equal(1, shardTopology.Members.Count);
-                        Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
-                        Assert.True(shardNodes.Add(shardTopology.Members[0]));
+                        Assert.Equal(1, shardToTopology.Value.Members.Count);
+                        Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardToTopology.Value.Members[0]);
+                        Assert.True(shardNodes.Add(shardToTopology.Value.Members[0]));
                     }
 
                     using (var session = store.OpenSession(newDbName))
@@ -145,7 +145,7 @@ namespace SlowTests.Sharding.Backup
                 {
                     var databaseRecord = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
                     Assert.Equal(DatabaseStateStatus.Normal, databaseRecord.DatabaseState);
-                    Assert.Equal(3, databaseRecord.Sharding.Shards.Length);
+                    Assert.Equal(3, databaseRecord.Sharding.Shards.Count);
                     Assert.Equal(1, databaseRecord.PeriodicBackups.Count);
                     Assert.NotNull(databaseRecord.Revisions);
 
@@ -198,16 +198,16 @@ namespace SlowTests.Sharding.Backup
                     {
                         var databaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
 
-                        Assert.Equal(3, databaseRecord.Sharding.Shards.Length);
+                        Assert.Equal(3, databaseRecord.Sharding.Shards.Count);
                         Assert.Equal(1, databaseRecord.PeriodicBackups.Count);
                         Assert.NotNull(databaseRecord.Revisions);
 
                         var shardNodes = new HashSet<string>();
-                        for (var index = 0; index < databaseRecord.Sharding.Shards.Length; index++)
+                        foreach (var shardToTopology in databaseRecord.Sharding.Shards)
                         {
-                            var shardTopology = databaseRecord.Sharding.Shards[index];
+                            var shardTopology = shardToTopology.Value;
                             Assert.Equal(1, shardTopology.Members.Count);
-                            Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                            Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
@@ -264,14 +264,14 @@ namespace SlowTests.Sharding.Backup
                     }, timeout: TimeSpan.FromSeconds(60)))
                     {
                         var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                        Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                        Assert.Equal(3, dbRec.Sharding.Shards.Count);
 
                         var shardNodes = new HashSet<string>();
-                        for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                        foreach (var shardToTopology in dbRec.Sharding.Shards)
                         {
-                            var shardTopology = dbRec.Sharding.Shards[index];
+                            var shardTopology = shardToTopology.Value;
                             Assert.Equal(1, shardTopology.Members.Count);
-                            Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                            Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
@@ -327,14 +327,14 @@ namespace SlowTests.Sharding.Backup
                     }, timeout: TimeSpan.FromSeconds(60)))
                     {
                         var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                        Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                        Assert.Equal(3, dbRec.Sharding.Shards.Count);
 
                         var shardNodes = new HashSet<string>();
-                        for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                        foreach (var shardToTopology in dbRec.Sharding.Shards)
                         {
-                            var shardTopology = dbRec.Sharding.Shards[index];
+                            var shardTopology = shardToTopology.Value;
                             Assert.Equal(1, shardTopology.Members.Count);
-                            Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                            Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
@@ -412,14 +412,14 @@ namespace SlowTests.Sharding.Backup
                 }, timeout: TimeSpan.FromSeconds(60)))
                 {
                     var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                    Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                    Assert.Equal(3, dbRec.Sharding.Shards.Count);
 
                     var shardNodes = new HashSet<string>();
-                    for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                    foreach (var shardToTopology in dbRec.Sharding.Shards)
                     {
-                        var shardTopology = dbRec.Sharding.Shards[index];
+                        var shardTopology = shardToTopology.Value;
                         Assert.Equal(1, shardTopology.Members.Count);
-                        Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                        Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                         Assert.True(shardNodes.Add(shardTopology.Members[0]));
                     }
 
@@ -486,14 +486,14 @@ namespace SlowTests.Sharding.Backup
                 }, timeout: TimeSpan.FromSeconds(60)))
                 {
                     var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                    Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                    Assert.Equal(3, dbRec.Sharding.Shards.Count);
 
                     var shardNodes = new HashSet<string>();
-                    for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                    foreach (var shardToTopology in dbRec.Sharding.Shards)
                     {
-                        var shardTopology = dbRec.Sharding.Shards[index];
+                        var shardTopology = shardToTopology.Value;
                         Assert.Equal(1, shardTopology.Members.Count);
-                        Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                        Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                         Assert.True(shardNodes.Add(shardTopology.Members[0]));
                     }
 
@@ -591,14 +591,14 @@ namespace SlowTests.Sharding.Backup
                     }))
                     {
                         var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                        Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                        Assert.Equal(3, dbRec.Sharding.Shards.Count);
                         Assert.True(dbRec.Encrypted);
 
-                        for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                        foreach (var shardToTopology in dbRec.Sharding.Shards)
                         {
-                            var shardTopology = dbRec.Sharding.Shards[index];
+                            var shardTopology = shardToTopology.Value;
                             Assert.Equal(1, shardTopology.Members.Count);
-                            Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                            Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                         }
 
                         using (var session = store.OpenSession(databaseName))
@@ -684,15 +684,15 @@ namespace SlowTests.Sharding.Backup
                     }))
                     {
                         var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(newDbName));
-                        Assert.Equal(3, dbRec.Sharding.Shards.Length);
+                        Assert.Equal(3, dbRec.Sharding.Shards.Count);
                         Assert.True(dbRec.Encrypted);
 
                         var shardNodes = new HashSet<string>();
-                        for (var index = 0; index < dbRec.Sharding.Shards.Length; index++)
+                        foreach (var shardToTopology in dbRec.Sharding.Shards)
                         {
-                            var shardTopology = dbRec.Sharding.Shards[index];
+                            var shardTopology = shardToTopology.Value;
                             Assert.Equal(1, shardTopology.Members.Count);
-                            Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                            Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
@@ -758,16 +758,16 @@ namespace SlowTests.Sharding.Backup
                     ValidateRestoreResult(result, sharding);
 
                     var databaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
-                    Assert.Equal(3, databaseRecord.Sharding.Shards.Length);
+                    Assert.Equal(3, databaseRecord.Sharding.Shards.Count);
                     Assert.Equal(1, databaseRecord.PeriodicBackups.Count);
                     Assert.NotNull(databaseRecord.Revisions);
 
                     var shardNodes = new HashSet<string>();
-                    for (var index = 0; index < databaseRecord.Sharding.Shards.Length; index++)
+                    foreach (var shardToTopology in databaseRecord.Sharding.Shards)
                     {
-                        var shardTopology = databaseRecord.Sharding.Shards[index];
+                        var shardTopology = shardToTopology.Value;
                         Assert.Equal(1, shardTopology.Members.Count);
-                        Assert.Equal(sharding.Shards[index].Members[0], shardTopology.Members[0]);
+                        Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
                         Assert.True(shardNodes.Add(shardTopology.Members[0]));
                     }
 

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -847,7 +847,7 @@ namespace SlowTests.Sharding.Backup
                 }, timeout: TimeSpan.FromSeconds(60)))
                 {
                     var newDatabaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabaseName));
-                    Assert.Equal(3, newDatabaseRecord.Sharding.Shards.Length);
+                    Assert.Equal(3, newDatabaseRecord.Sharding.Shards.Count);
                     Assert.Equal(100, newDatabaseRecord.Sharding.BucketRanges[1].BucketRangeStart);
 
                     using (var session = store.OpenAsyncSession(database: restoredDatabaseName))

--- a/test/SlowTests/Sharding/BucketMigration/BucketsMigratorTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/BucketsMigratorTests.cs
@@ -55,11 +55,11 @@ namespace SlowTests.Sharding.BucketMigration
             return list;
         }
 
-        private ShardReport[] CreateShardReports(DatabaseRecord record, int? seed = null)
+        private Dictionary<int, ShardReport> CreateShardReports(DatabaseRecord record, int? seed = null)
         {
             var rnd = new Random(seed ?? 357);
 
-            var shards = new ShardReport[record.Sharding.Shards.Length];
+            var shards = new Dictionary<int, ShardReport>(record.Sharding.Shards.Count);
 
             for (int bucket = 0; bucket < ShardHelper.NumberOfBuckets; bucket++)
             {
@@ -87,29 +87,29 @@ namespace SlowTests.Sharding.BucketMigration
             {
                 Sharding = new ShardingConfiguration()
                 {
-                    Shards = new[]
+                    Shards = new Dictionary<int, DatabaseTopology>()
                     {
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
-                        new DatabaseTopology(),
+                        {0, new DatabaseTopology()},
+                        {1, new DatabaseTopology()},
+                        {2, new DatabaseTopology()},
+                        {3, new DatabaseTopology()},
+                        {4, new DatabaseTopology()},
+                        {5, new DatabaseTopology()},
+                        {6, new DatabaseTopology()},
+                        {7, new DatabaseTopology()},
+                        {8, new DatabaseTopology()},
+                        {9, new DatabaseTopology()},
                     },
                     BucketMigrations = new Dictionary<int, ShardBucketMigration>()
                 }
             };
 
             //record.ShardAllocations = PopulateRanges(record.Shards.Length);
-            record.Sharding.BucketRanges = PopulateRangesEvenly(record.Sharding.Shards.Length);
+            record.Sharding.BucketRanges = PopulateRangesEvenly(record.Sharding.Shards.Count);
             var reports = CreateShardReports(record);
             var totalMovedBytes = 0L;
             Console.WriteLine($"Inital:");
-            Console.WriteLine(string.Join(Environment.NewLine, reports.Select(r => $"{r.Shard}:{new Size(r.TotalSize, SizeUnit.Bytes)}")));
+            Console.WriteLine(string.Join(Environment.NewLine, reports.Select(r => $"{r.Value.Shard}:{new Size(r.Value.TotalSize, SizeUnit.Bytes)}")));
 
             var policy = new MigrationPolicy { SizeThreshold = 10 * 1024 * 1024 };
             var moves = 0;
@@ -139,7 +139,7 @@ namespace SlowTests.Sharding.BucketMigration
                     Console.WriteLine($"After {moves} moves");
                     Console.WriteLine($"ranges: {record.Sharding.BucketRanges.Count}");
                     Console.WriteLine($"So far moved: {new Size(totalMovedBytes, SizeUnit.Bytes)}");
-                    Console.WriteLine(string.Join(Environment.NewLine, reports.Select(r => $"{r.Shard}:{new Size(r.TotalSize, SizeUnit.Bytes)}")));
+                    Console.WriteLine(string.Join(Environment.NewLine, reports.Select(r => $"{r.Value.Shard}:{new Size(r.Value.TotalSize, SizeUnit.Bytes)}")));
                 }
 
                 if (moves % 16 == 0)

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -204,14 +204,14 @@ namespace SlowTests.Sharding.Cluster
         {
             using var store = Sharding.GetDocumentStore();
 
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User(), "users/1-A");
+                session.SaveChanges();
+            }
+
             var writes = Task.Run(() =>
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new User(), "users/1-A");
-                    session.SaveChanges();
-                }
-
                 for (int i = 0; i < 100; i++)
                 {
                     using (var session = store.OpenSession())

--- a/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
@@ -2,10 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,7 +36,7 @@ namespace SlowTests.Sharding.Cluster
                 await AssertWaitForValueAsync(async () =>
                 {
                     var shards = await ShardingCluster.GetShards(store);
-                    return shards.Sum(s => s.Rehabs.Count);
+                    return shards.Sum(s => s.Value.Rehabs.Count);
                 }, 3);
 
                 await AssertWaitForValueAsync(async () =>
@@ -68,7 +72,7 @@ namespace SlowTests.Sharding.Cluster
                 await AssertWaitForValueAsync(async () =>
                 {
                     var shards = await ShardingCluster.GetShards(store);
-                    return shards?.Sum(s => s.Members.Count);
+                    return shards?.Sum(s => s.Value.Members.Count);
                 }, 9);
                 
                 await AssertWaitForValueAsync(async () =>
@@ -222,14 +226,14 @@ namespace SlowTests.Sharding.Cluster
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    var add = new AddDatabaseNodeOperation(database, shard: i);
+                    var add = new AddDatabaseNodeOperation(database, shardNumber: i);
                     await store.Maintenance.Server.SendAsync(add);
                 }
 
                 await AssertWaitForValueAsync(async () =>
                 {
                     var shards = await ShardingCluster.GetShards(store);
-                    return shards.Sum(s => s.Members.Count);
+                    return shards.Sum(s => s.Value.Members.Count);
                 }, 6);
             }
         }

--- a/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
@@ -48,10 +48,10 @@ public partial class ClusterTestBase
             return _parent.CreateDatabaseInCluster(record, replicationFactor, tuple.Leader.WebUrl, certificate);
         }
 
-        private static DatabaseTopology[] GetDatabaseTopologyForShards(int replicationFactor, List<string> tags, int shards)
+        private static Dictionary<int, DatabaseTopology> GetDatabaseTopologyForShards(int replicationFactor, List<string> tags, int shards)
         {
             Assert.True(replicationFactor <= tags.Count);
-            var topology = new DatabaseTopology[shards];
+            var topology = new Dictionary<int, DatabaseTopology>(shards);
             for (int i = 0; i < shards; i++)
                 topology[i] = CreateTopology<DatabaseTopology>(replicationFactor, tags, i);
 
@@ -142,7 +142,7 @@ public partial class ClusterTestBase
             }, true, timeout: timeout, interval: 333);
         }
 
-        public async Task<DatabaseTopology[]> GetShards(DocumentStore store)
+        public async Task<Dictionary<int, DatabaseTopology>> GetShards(DocumentStore store)
         {
             var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
             return record.Sharding?.Shards;

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -49,14 +49,14 @@ public partial class RavenTestBase
 
                 if (databaseRecord.IsSharded)
                 {
-                    for (var i = 0; i < databaseRecord.Sharding.Shards.Length; i++)
+                    foreach (var shardToTopology in databaseRecord.Sharding.Shards)
                     {
-                        if (nonStaleShards.Contains(i))
+                        if (nonStaleShards.Contains(shardToTopology.Key))
                             continue;
 
-                        var shardStatus = StaleStatus(shardId: i);
+                        var shardStatus = StaleStatus(shardId: shardToTopology.Key);
                         if (shardStatus == IndexStaleStatus.NonStale)
-                            nonStaleShards.Add(i);
+                            nonStaleShards.Add(shardToTopology.Key);
 
                         staleStatus |= shardStatus;
                     }
@@ -81,9 +81,9 @@ public partial class RavenTestBase
             var files = new List<string>();
             if (databaseRecord.IsSharded)
             {
-                for (var i = 0; i < databaseRecord.Sharding.Shards.Length; i++)
+                foreach (var shardNumber in databaseRecord.Sharding.Shards.Keys)
                 {
-                    files.Add(OutputIndexInfo(i));
+                    files.Add(OutputIndexInfo(shardNumber));
                 }
             }
             else
@@ -136,9 +136,9 @@ public partial class RavenTestBase
 
             if (databaseRecord.IsSharded)
             {
-                for (var i = 0; i < databaseRecord.Sharding.Shards.Length; i++)
+                foreach (var shardNumber in databaseRecord.Sharding.Shards.Keys)
                 {
-                    var statistics = admin.ForShard(i).Send(new GetStatisticsOperation("wait-for-indexing", nodeTag));
+                    var statistics = admin.ForShard(shardNumber).Send(new GetStatisticsOperation("wait-for-indexing", nodeTag));
                     allIndexes.AddRange(statistics.Indexes);
                 }
             }
@@ -207,7 +207,7 @@ public partial class RavenTestBase
             var errors = new List<IndexErrors>();
             if (databaseRecord.IsSharded)
             {
-                List<string> shardNames = ShardHelper.GetShardNames(databaseName, databaseRecord.Sharding.Shards.Length).ToList();
+                List<string> shardNames = ShardHelper.GetShardNames(databaseName, databaseRecord.Sharding.Shards.Keys.AsEnumerable()).ToList();
                 foreach (var name in shardNames)
                 {
                     shardsDict.TryAdd(name, toWait.ToHashSet(StringComparer.OrdinalIgnoreCase));

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -676,7 +676,7 @@ public partial class RavenTestBase
 
                 await server.Sharding.StartBucketMigration(store.Database, bucket, shardNumber, toShard);
                 
-                var exists = _parent.WaitForDocument<dynamic>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, toShard));
+                var exists = _parent.WaitForDocument<dynamic>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, toShard), timeout: 30_000);
                 Assert.True(exists, $"{id} wasn't found at shard {toShard}");
             }
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -734,11 +734,11 @@ namespace FastTests
                             modifyRecord?.Invoke(record);
                             record.Sharding = new ShardingConfiguration
                             {
-                                Shards = new[]
+                                Shards = new Dictionary<int, DatabaseTopology>()
                                 {
-                                    new DatabaseTopology(),
-                                    new DatabaseTopology(),
-                                    new DatabaseTopology(),
+                                    {0, new DatabaseTopology()},
+                                    {1, new DatabaseTopology()},
+                                    {2, new DatabaseTopology()}
                                 }
                             };
                         };

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -139,9 +139,9 @@ namespace FastTests
 
             if (databaseRecord.IsSharded)
             {
-                for (var i = 0; i < databaseRecord.Sharding.Shards.Length; i++)
+                foreach (var shardNumber in databaseRecord.Sharding.Shards.Keys)
                 {
-                    var shardExecutor = executor.ForShard(i);
+                    var shardExecutor = executor.ForShard(shardNumber);
                     AssertNoIndexErrorsInternal(shardExecutor);
                 }
 

--- a/test/Tests.Infrastructure/Utils/MaintenanceOperationExecutorTester.cs
+++ b/test/Tests.Infrastructure/Utils/MaintenanceOperationExecutorTester.cs
@@ -74,14 +74,14 @@ public class MaintenanceOperationExecutorTester<TResult> : IMaintenanceOperation
         _databaseRecord ??= await _executor.Server.SendAsync(new GetDatabaseRecordOperation(_executor._databaseName));
         if (_databaseRecord.IsSharded)
         {
-            for (var i = 0; i < _databaseRecord.Sharding.Shards.Length; i++)
+            foreach (var shardNumber in _databaseRecord.Sharding.Shards.Keys)
             {
-                var shardTopology = _databaseRecord.Sharding.Shards[i];
+                var shardTopology = _databaseRecord.Sharding.Shards[shardNumber];
 
                 foreach (var (nKey, nExecutor) in GetExecutors(shardTopology))
                 {
-                    var shardKey = nKey.ForShard(i);
-                    var shardExecutor = nExecutor.ForShard(i);
+                    var shardKey = nKey.ForShard(shardNumber);
+                    var shardExecutor = nExecutor.ForShard(shardNumber);
 
                     yield return (shardKey, await shardExecutor.SendAsync(_factoryWithResult()));
                 }
@@ -101,14 +101,14 @@ public class MaintenanceOperationExecutorTester<TResult> : IMaintenanceOperation
         _databaseRecord ??= await _executor.Server.SendAsync(new GetDatabaseRecordOperation(_executor._databaseName));
         if (_databaseRecord.IsSharded)
         {
-            for (var i = 0; i < _databaseRecord.Sharding.Shards.Length; i++)
+            foreach (var shardToTopology in _databaseRecord.Sharding.Shards)
             {
-                var shardTopology = _databaseRecord.Sharding.Shards[i];
+                var shardTopology = shardToTopology.Value;
 
                 foreach (var (nKey, nExecutor) in GetExecutors(shardTopology))
                 {
-                    var shardKey = nKey.ForShard(i);
-                    var shardExecutor = nExecutor.ForShard(i);
+                    var shardKey = nKey.ForShard(shardToTopology.Key);
+                    var shardExecutor = nExecutor.ForShard(shardToTopology.Key);
 
                     yield return (shardKey, shardExecutor);
                 }

--- a/test/Tests.Infrastructure/Utils/SessionTester.cs
+++ b/test/Tests.Infrastructure/Utils/SessionTester.cs
@@ -76,15 +76,15 @@ public class SessionTester
 
         if (_databaseRecord.IsSharded)
         {
-            for (var i = 0; i < _databaseRecord.Sharding.Shards.Length; i++)
+            foreach (var shardToTopology in _databaseRecord.Sharding.Shards)
             {
-                var shardTopology = _databaseRecord.Sharding.Shards[i];
+                var shardTopology = shardToTopology.Value;
 
                 foreach (string member in shardTopology.Members)
                 {
-                    var key = new UniqueDatabaseInstanceKey(member).ForShard(i);
+                    var key = new UniqueDatabaseInstanceKey(member).ForShard(shardToTopology.Key);
 
-                    var session = _documentStore.OpenSession(ShardHelper.ToShardName(_documentStore.Database, i));
+                    var session = _documentStore.OpenSession(ShardHelper.ToShardName(_documentStore.Database, shardToTopology.Key));
 
                     yield return (key, session);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17976

### Additional description

Added new command and endpoint for shard creation.
Since shard numbers can be from now on non-consecutive, changed arrays that acted as shard-to-value to dictionary instead.

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No
