### PR TITLE
RavenDB-17312 Fixing problems with PropertyAccessor.GetPropertiesInOrder() not preserving the order 

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -150,10 +150,12 @@ namespace Raven.Server.Documents.Indexes
             public const long ProperlyParseThreeDigitsMillisecondsDates = 52_002; // RavenDB-17711
 
             public const long EngineTypeStored = 54_000; // introducing Corax, added engine type to the index storage
+
+            public const long GuaranteedOrderOfPropertiesInJsMapReduceIndexes = 54_001; // RavenDB-17312
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = EngineTypeStored;
+            public const long CurrentVersion = GuaranteedOrderOfPropertiesInJsMapReduceIndexes;
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -151,11 +151,11 @@ namespace Raven.Server.Documents.Indexes
 
             public const long EngineTypeStored = 54_000; // introducing Corax, added engine type to the index storage
 
-            public const long GuaranteedOrderOfPropertiesInJsMapReduceIndexes = 54_001; // RavenDB-17312
+            public const long GuaranteedOrderOfPropertiesInMapReduceIndexes = 54_001; // RavenDB-17312
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = GuaranteedOrderOfPropertiesInJsMapReduceIndexes;
+            public const long CurrentVersion = GuaranteedOrderOfPropertiesInMapReduceIndexes;
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -485,7 +485,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                 _indexContext = indexContext;
                 _groupByFields = index.Definition.GroupByFields;
 
-                if (index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.GuaranteedOrderOfPropertiesInJsMapReduceIndexes)
+                if (index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.GuaranteedOrderOfPropertiesInMapReduceIndexes)
                 {
                     _orderedMapFields = index.Definition.MapFields.Values.OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
                 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -487,7 +487,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
                 if (index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.GuaranteedOrderOfPropertiesInMapReduceIndexes)
                 {
-                    _orderedMapFields = index.Definition.MapFields.Values.OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
+                    if (index.Definition.MapFields.Count > 0) // sometimes in JS indexes we're not able to extract field names
+                    {
+                        _orderedMapFields = index.Definition.MapFields.Values.OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
+                    }
                 }
 
                 _isMultiMap = index.IsMultiMap;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/DictionaryAccessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/DictionaryAccessor.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         private readonly List<KeyValuePair<string, DictionaryValueAccessor>> _propertiesInOrder =
             new List<KeyValuePair<string, DictionaryValueAccessor>>();
 
-        private DictionaryAccessor(Dictionary<string, object> instance, Dictionary<string, CompiledIndexField> groupByFields = null)
+        private DictionaryAccessor(Dictionary<string, object> instance, List<IndexFieldBase> orderedMapFields = null, Dictionary<string, CompiledIndexField> groupByFields = null)
         {
             if (instance == null)
                 throw new NotSupportedException("Indexed dictionary must be of type: Dictionary<string, object>");
@@ -33,13 +33,23 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 }
 
                 _properties.Add(key, getMethod);
-                _propertiesInOrder.Add(new KeyValuePair<string, DictionaryValueAccessor>(key, getMethod));
+
+                if (orderedMapFields == null)
+                    _propertiesInOrder.Add(new KeyValuePair<string, DictionaryValueAccessor>(key, getMethod));
+            }
+
+            if (orderedMapFields != null)
+            {
+                foreach (var field in orderedMapFields)
+                {
+                    _propertiesInOrder.Add(new KeyValuePair<string, DictionaryValueAccessor>(field.Name, _properties[field.Name]));
+                }
             }
         }
 
-        internal static DictionaryAccessor Create(Dictionary<string, object> instance, Dictionary<string, CompiledIndexField> groupByFields = null)
+        internal static DictionaryAccessor Create(Dictionary<string, object> instance, List<IndexFieldBase> orderedMapFields = null, Dictionary<string, CompiledIndexField> groupByFields = null)
         {
-            return new DictionaryAccessor(instance, groupByFields);
+            return new DictionaryAccessor(instance, orderedMapFields, groupByFields);
         }
 
         public IEnumerable<(string Key, object Value, CompiledIndexField GroupByField, bool IsGroupByField)> GetPropertiesInOrder(object target)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/PropertyAccessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/PropertyAccessor.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         public static IPropertyAccessor Create(Type type, object instance)
         {
             if (type == typeof(ObjectInstance))
-                return new JintPropertyAccessor(null);
+                return new JintPropertyAccessor(null, null);
 
             if (instance is Dictionary<string, object> dict)
                 return DictionaryAccessor.Create(dict);
@@ -149,10 +149,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
             public CompiledIndexField GroupByField;
         }
 
-        internal static IPropertyAccessor CreateMapReduceOutputAccessor(Type type, object instance, Dictionary<string, CompiledIndexField> groupByFields, bool isObjectInstance = false)
+        internal static IPropertyAccessor CreateMapReduceOutputAccessor(Type type, object instance, List<IndexFieldBase> orderedMapFields, Dictionary<string, CompiledIndexField> groupByFields, bool isObjectInstance = false)
         {
             if (isObjectInstance || type == typeof(ObjectInstance) || type.IsSubclassOf(typeof(ObjectInstance)))
-                return new JintPropertyAccessor(groupByFields);
+                return new JintPropertyAccessor(orderedMapFields, groupByFields);
 
             if (instance is Dictionary<string, object> dict)
                 return DictionaryAccessor.Create(dict, groupByFields);
@@ -163,10 +163,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
     internal class JintPropertyAccessor : IPropertyAccessor
     {
+        private readonly List<IndexFieldBase> _orderedMapFields;
         private readonly Dictionary<string, CompiledIndexField> _groupByFields;
 
-        public JintPropertyAccessor(Dictionary<string, CompiledIndexField> groupByFields)
+        public JintPropertyAccessor(List<IndexFieldBase> orderedMapFields, Dictionary<string, CompiledIndexField> groupByFields)
         {
+            _orderedMapFields = orderedMapFields;
             _groupByFields = groupByFields;
         }
 
@@ -174,14 +176,34 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         {
             if (!(target is ObjectInstance oi))
                 throw new ArgumentException($"JintPropertyAccessor.GetPropertiesInOrder is expecting a target of type ObjectInstance but got one of type {target.GetType().Name}.");
-            foreach (var property in oi.GetOwnProperties())
+
+            if (_orderedMapFields != null)
             {
-                var propertyAsString = property.Key.AsString();
+                foreach (var outputField in _orderedMapFields)
+                {
+                    var property = oi.GetProperty(outputField.Name);
 
-                CompiledIndexField field = null;
-                var isGroupByField = _groupByFields?.TryGetValue(propertyAsString, out field) ?? false;
+                    var propertyAsString = outputField.Name;
 
-                yield return (propertyAsString, GetValue(property.Value.Value), field, isGroupByField);
+                    CompiledIndexField field = null;
+                    var isGroupByField = _groupByFields?.TryGetValue(propertyAsString, out field) ?? false;
+
+                    yield return (propertyAsString, GetValue(property.Value), field, isGroupByField);
+                }
+            }
+            else
+            {
+                // legacy mode - it does not guarantee the order of properties
+
+                foreach (var property in oi.GetOwnProperties())
+                {
+                    var propertyAsString = property.Key.AsString();
+
+                    CompiledIndexField field = null;
+                    var isGroupByField = _groupByFields?.TryGetValue(propertyAsString, out field) ?? false;
+
+                    yield return (propertyAsString, GetValue(property.Value.Value), field, isGroupByField);
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -230,7 +230,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 return false;
             foreach (var p in oe.Properties)
             {
-                var key = p.GetKey(_engine);
+                var key = p is Property prop ? prop.GetKey(_engine) : p.GetKey(_engine);
                 var keyAsString = key.AsString();
                 if (Fields.Contains(keyAsString) == false)
                     return false;

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -710,17 +710,17 @@ namespace Raven.Server.Utils
             return PropertyAccessorCache.GetOrAdd(type, x => PropertyAccessor.Create(type, value));
         }
 
-        public static IPropertyAccessor GetPropertyAccessorForMapReduceOutput(object value, Dictionary<string, CompiledIndexField> groupByFields)
+        public static IPropertyAccessor GetPropertyAccessorForMapReduceOutput(object value, List<IndexFieldBase> orderedMapFields, Dictionary<string, CompiledIndexField> groupByFields)
         {
             var type = value.GetType();
 
             if (type == typeof(ObjectInstance)) // We don't cache JS types
-                return PropertyAccessor.CreateMapReduceOutputAccessor(type, value, groupByFields, true);
+                return PropertyAccessor.CreateMapReduceOutputAccessor(type, value, orderedMapFields, groupByFields, true);
 
             if (value is Dictionary<string, object>) // don't use cache when using dictionaries
                 return PropertyAccessor.Create(type, value);
 
-            return PropertyAccessorForMapReduceOutputCache.GetOrAdd(type, x => PropertyAccessor.CreateMapReduceOutputAccessor(type, value, groupByFields));
+            return PropertyAccessorForMapReduceOutputCache.GetOrAdd(type, x => PropertyAccessor.CreateMapReduceOutputAccessor(type, value, orderedMapFields, groupByFields));
         }
 
 

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -718,7 +718,7 @@ namespace Raven.Server.Utils
                 return PropertyAccessor.CreateMapReduceOutputAccessor(type, value, orderedMapFields, groupByFields, true);
 
             if (value is Dictionary<string, object>) // don't use cache when using dictionaries
-                return PropertyAccessor.Create(type, value);
+                return PropertyAccessor.CreateMapReduceOutputAccessor(type, value, orderedMapFields, groupByFields);
 
             return PropertyAccessorForMapReduceOutputCache.GetOrAdd(type, x => PropertyAccessor.CreateMapReduceOutputAccessor(type, value, orderedMapFields, groupByFields));
         }

--- a/test/SlowTests/Issues/RavenDB_17312.cs
+++ b/test/SlowTests/Issues/RavenDB_17312.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17312 : RavenTestBase
+{
+    public RavenDB_17312(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+    public void JintPropertyAccessorMustGuaranteeTheOrderOfProperties()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.ExecuteIndex(new UsersReducedByNameAndLastName());
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Joe", LastName = "Doe", Age = 33 });
+                session.Store(new User { Name = "Joe", LastName = "Doe", Age = 34});
+                
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
+                
+                var results = session.Query<User>("UsersReducedByNameAndLastName").OfType<ReduceResults>().ToList();
+                
+                Assert.Equal(1, results.Count);
+
+                Assert.Equal(2, results[0].Count);
+                Assert.Equal("Joe", results[0].Name);
+                Assert.Equal("Doe", results[0].LastName);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+    public void JintPropertyAccessorMustGuaranteeTheOrderOfPropertiesMultiMapIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.ExecuteIndex(new UsersAndEmployeesReducedByNameAndLastName());
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Joe", LastName = "Doe", Age = 33 });
+                session.Store(new User { Name = "Joe", LastName = "Doe", Age = 34 });
+
+                session.Store(new Employee { FirstName = "Joe", LastName = "Doe", ReportsTo = null });
+                session.Store(new Employee { FirstName = "Joe", LastName = "Doe", ReportsTo = "employees/1-A" });
+
+                session.SaveChanges();
+
+                Indexes.WaitForIndexing(store);
+
+                var results = session.Query<User>("UsersAndEmployeesReducedByNameAndLastName").OfType<ReduceResults>().ToList();
+
+                Assert.Equal(1, results.Count);
+
+                Assert.Equal(4, results[0].Count);
+                Assert.Equal("Joe", results[0].Name);
+                Assert.Equal("Doe", results[0].LastName);
+            }
+        }
+    }
+
+    private class ReduceResults
+    {
+        public string Name { get; set; }
+
+        public string LastName { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    private class UsersReducedByNameAndLastName : AbstractJavaScriptIndexCreationTask
+    {
+        public UsersReducedByNameAndLastName()
+        {
+            Maps = new HashSet<string>
+            {
+                // we're forcing here different order of fields of returned results based on Age property
+
+                @"map('Users', function (u){ 
+                    
+                    if (u.Age % 2 == 0)
+                    {
+                        return { Count: 1, Name: u.Name, LastName: u.LastName };
+                    }
+
+                    return {  LastName: u.LastName, Name: u.Name, Count: 1};
+                })",
+
+            };
+            Reduce = @"groupBy(x => { return { Name: x.Name, LastName: x.LastName } })
+                                .aggregate(g => {return {
+                                    Name: g.key.Name,
+                                    LastName: g.key.LastName,
+                                    Count: g.values.reduce((total, val) => val.Count + total,0)
+                               };})";
+
+        }
+    }
+
+    private class UsersAndEmployeesReducedByNameAndLastName : AbstractJavaScriptIndexCreationTask
+    {
+        public UsersAndEmployeesReducedByNameAndLastName()
+        {
+            Maps = new HashSet<string>
+            {
+                // we're forcing here different order of fields of returned results based on Age property
+
+                @"map('Users', function (u){ 
+                    
+                    if (u.Age % 2 == 0)
+                    {
+                        return { Count: 1, Name: u.Name, LastName: u.LastName };
+                    }
+
+                    return {  LastName: u.LastName, Name: u.Name, Count: 1};
+                })",
+
+                // we're forcing here different order of fields of returned results based on ReportsTo property
+
+                @"map('Employees', function (e){ 
+                    
+                    if (e.ReportsTo == null)
+                    {
+                        return { Count: 1, Name: e.FirstName, LastName: e.LastName };
+                    }
+
+                    return {  LastName: e.LastName, Name: e.FirstName, Count: 1};
+                })",
+            };
+            Reduce = @"groupBy(x => { return { Name: x.Name, LastName: x.LastName } })
+                                .aggregate(g => {return {
+                                    Name: g.key.Name,
+                                    LastName: g.key.LastName,
+                                    Count: g.values.reduce((total, val) => val.Count + total,0)
+                               };})";
+
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_18331.cs
+++ b/test/SlowTests/Issues/RavenDB_18331.cs
@@ -69,7 +69,7 @@ select new
                     List<IndexingError> indexingErrors = stats.Errors;
 
                     Assert.Equal(1, indexingErrors.Count);
-                    Assert.Contains(@"current item to reduce: {""Product"":""Milk"",""FakeValue"":0}", indexingErrors.First().Error);
+                    Assert.Contains(@"current item to reduce: {""FakeValue"":0,""Product"":""Milk""}", indexingErrors.First().Error);
                     Assert.Equal(@"Reduce key: { 'Product' : Milk }", indexingErrors.First().Document);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_19546.cs
+++ b/test/SlowTests/Issues/RavenDB_19546.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Claims;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19546 : RavenTestBase
+    {
+        public RavenDB_19546(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ShouldWork()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = x =>
+                {
+                    x.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                    {
+                        CustomizeJsonDeserializer = s =>
+                        {
+                            s.Converters.Add(new IntIdConverter<UserAuth>((o, id) => o.Id = id));
+                            s.Converters.Add(new IntIdConverter<UserAuthDetails>((o, id) => o.Id = id));
+                        }
+                    };
+                    x.Conventions.FindIdentityProperty = conventionsFindIdentityProperty;
+                }
+            }))
+            {
+                new UserAndUserAuthDetails_Index().Execute(store);
+                new UserAndUserAuthDetails_JavascriptIndex().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Id = "users/1",
+                        FullName = "User with no claims",
+                        ManuallyAttributedRoleIds = new List<string>() { "roles/1" }
+                    }, "users/1");
+                    session.Store(new User
+                    {
+                        Id = "users/2",
+                        FullName = "User with one claim",
+                        ManuallyAttributedRoleIds = new List<string>() { "roles/1" }
+                    }, "users/2");
+                    session.Store(new User
+                    {
+                        Id = "users/3",
+                        FullName = "User with two claims",
+                        ManuallyAttributedRoleIds = new List<string>() { "roles/1" }
+                    }, "users/3");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    CreateAuthUser(session, 1);
+                    CreateAuthUser(session, 2, new Claim("type", "value"));
+                    CreateAuthUser(session, 3, new Claim("type", "value"), new Claim("unrelated", "value"));
+                    session.SaveChanges();
+                }
+                var userAuthDetailsForUserIndexName = new UserAndUserAuthDetails_Index().IndexName;
+                store.Maintenance.Send(new ResetIndexOperation(userAuthDetailsForUserIndexName));
+                var userAuthDetailsForUserJavascriptIndexName = new UserAndUserAuthDetails_JavascriptIndex().IndexName;
+                store.Maintenance.Send(new ResetIndexOperation(userAuthDetailsForUserJavascriptIndexName));
+                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromSeconds(10));
+
+                WaitForUserToContinueTheTest(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var c = session.Query<UserClaims>().ToList().Count;
+                    Assert.Equal(3, c);
+
+
+                }
+            }
+        }
+        private class UserClaims
+        {
+            public string Id { get; set; }
+            public string UserId { get; set; }
+            public IDictionary<string, SerializedClaim[]> ClaimsPerProvider { get; set; }
+        }
+        private class SerializedClaim
+        {
+            public string Type { get; set; }
+            public string Value { get; set; }
+            public string ValueType { get; set; }
+            public string Issuer { get; set; }
+            public string OriginalIssuer { get; set; }
+        }
+        private Func<MemberInfo, bool> conventionsFindIdentityProperty = prop =>
+        {
+            if (prop.Name != "Id")
+                return false;
+
+            if (prop.DeclaringType?.IsAssignableFrom(typeof(UserAuth)) == true)
+                return false;
+            if (prop.DeclaringType?.IsAssignableFrom(typeof(UserAuthDetails)) == true)
+                return false;
+
+            return true;
+        };
+        private static void CreateAuthUser(IDocumentSession session, int id, params Claim[] claims)
+        {
+            session.Store(new UserAuth { Id = id, RefIdStr = $"users/{id}" }, $"UserAuth/{id}");
+            session.Store(
+                new UserAuthDetails
+                {
+                    UserAuthId = id,
+                    Provider = "idsrv",
+                    Items = new Dictionary<string, string>()
+                    {
+                        {
+                            "Claims",
+                            FastTests.Blittable.StringExtensions.ToJsonString(claims.Select(x => new SerializedClaim()
+                            {
+                                Type = x.Type,
+                                Value = x.Value,
+                                ValueType = x.ValueType,
+                                Issuer = x.Issuer,
+                                OriginalIssuer = x.OriginalIssuer
+                            }))
+                        }
+                    }
+                }, $"UserAuthDetails/{id}");
+        }
+
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Language { get; set; }
+            public string Email { get; set; }
+
+            public string FullName { get; set; }
+            public IList<string> ManuallyAttributedRoleIds { get; set; }
+        }
+
+        private class UserAuthDetails
+        {
+            public int UserAuthId { get; set; }
+            public int Id { get; set; }
+
+            public virtual string Provider { get; set; }
+            public virtual Dictionary<string, string> Items { get; set; } = new Dictionary<string, string>();
+            public virtual DateTime ModifiedDate { get; set; }
+
+        }
+
+        private class UserAuth
+        {
+            public int Id { get; set; }
+            public string RefIdStr { get; set; }
+        }
+
+        private class UserAndUserAuthDetails_Index : AbstractMultiMapIndexCreationTask<UserAndUserAuthDetails_Index.Result>
+        {
+            public class Result
+            {
+                public string UserId { get; set; }
+                public string[] UserAuthDetailIds { get; set; }
+            }
+
+            public UserAndUserAuthDetails_Index()
+            {
+                AddMap<User>(users => from user in users
+                                      select new Result
+                                      {
+                                          UserId = user.Id,
+                                          UserAuthDetailIds = new string[] { }
+                                      });
+                AddMap<UserAuthDetails>(details => from userAuthDetails in details
+                                                   let userAuth = LoadDocument<UserAuth>("UserAuths/" + userAuthDetails.UserAuthId)
+                                                   select new Result
+                                                   {
+                                                       UserId = userAuth.RefIdStr,
+                                                       UserAuthDetailIds = new[] { userAuthDetails.Id.ToString() }
+                                                   });
+
+                Reduce = results => from result in results
+                                    group result by result.UserId
+                    into g
+                                    select new Result
+                                    {
+                                        UserId = g.Key,
+                                        UserAuthDetailIds = g.SelectMany(r => r.UserAuthDetailIds).ToArray()
+                                    };
+
+                OutputReduceToCollection = "UserAndUserAuthDetails";
+            }
+        }
+
+        private class UserAndUserAuthDetails_JavascriptIndex : AbstractJavaScriptIndexCreationTask
+        {
+            public UserAndUserAuthDetails_JavascriptIndex()
+            {
+                Maps = new HashSet<string>()
+            {
+                @"map('UserAndUserAuthDetails', function(auth){
+var entity = load(auth.UserId, 'Users');
+if (entity === null) return;
+
+var claimsPerProvider = {};
+var claimsModifiedDatePerProvider = {};
+
+for (var i = 0; i < auth.UserAuthDetailIds.length; i++) {
+	var id = auth.UserAuthDetailIds[i];
+	var userAuthDetails = load('UserAuthDetails/' + id, 'UserAuthDetails');
+	if (!userAuthDetails.Items.Claims) return;
+
+	// which will cause the mappings for roles to use stale data
+	if (claimsModifiedDatePerProvider[userAuthDetails.Provider] &&
+		claimsModifiedDatePerProvider[userAuthDetails.Provider] > userAuthDetails.ModifiedDate)
+		return;
+
+	claimsPerProvider[userAuthDetails.Provider] = [];
+	claimsModifiedDatePerProvider[userAuthDetails.Provider] = userAuthDetails.ModifiedDate;
+
+	var claims = JSON.parse(userAuthDetails.Items.Claims);
+	for (var j = 0; j < claims.length; j++) {
+		var c = claims[j];
+		claimsPerProvider[userAuthDetails.Provider].push(c);
+	}
+}
+                    var userClaim = {};
+                    userClaim.UserId = auth.UserId;
+                    userClaim.ClaimsPerProvider = claimsPerProvider;
+                    return userClaim;
+                })"
+            };
+
+                Reduce = @"groupBy(x => ({UserId: x.UserId, ClaimsPerProvider: x.ClaimsPerProvider}))
+            .aggregate(g => {
+            return {
+                UserId: g.key.UserId,
+                ClaimsPerProvider: g.key.ClaimsPerProvider
+            }
+        })";
+
+                OutputReduceToCollection = "UserClaims";
+            }
+        }
+
+
+
+        private class IntIdConverter<T> : JsonConverter where T : new()
+        {
+            private readonly Action<T, int> _idSetter;
+
+            public IntIdConverter(Action<T, int> idSetter) => _idSetter = idSetter;
+
+            public override bool CanConvert(Type objectType) => objectType == typeof(T);
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var item = JObject.Load(reader);
+                var entity = new T();
+                serializer.Populate(item.CreateReader(), entity);
+                var id = item[Constants.Documents.Metadata.Key]?[Constants.Documents.Metadata.Id]?.ToString();
+                _idSetter(entity, ToIntId(id));
+                return entity;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanWrite => false;
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        public static int ToIntId(string id)
+        {
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+            if (!id.Contains("/"))
+                throw new InvalidOperationException($"'{id}' does not look like a RavenDB ID, missing a /");
+            return int.Parse(id.Split('/')[1]);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17312/PropertyAccessor.GetPropertiesInOrder-does-not-preserve-order

### Additional description

Initially it comes from JS indexes and faulty implementation of `JintPropertyAccessor.GetPropertiesInOrder()`. Full details are in the issue. 

Although during the investigation it appeared that also C# multi map-reduce indexes could generate invalid map-reduce results if the order of properties in returned objects from map functions was not the same.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. Please explain how has it been implemented? 

Only new indexes will use this new approach.


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
