### PR TITLE
RavenDB-19639 - add the missing index name to the error

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3744,7 +3744,7 @@ namespace Raven.Server.Documents.Indexes
         {
             foreach (var field in metadata.IndexFieldNames)
             {
-                AssertKnownField(field);
+                AssertKnownField(field, metadata.IndexName);
             }
 
             if (metadata.OrderBy != null)
@@ -3764,24 +3764,24 @@ namespace Raven.Server.Documents.Indexes
                         continue;
 #endif
 
-                    AssertKnownField(f);
+                    AssertKnownField(f, metadata.IndexName);
                 }
             }
         }
 
-        private void AssertKnownField(string f)
+        private void AssertKnownField(string f, string indexName)
         {
             // the catch all field name means that we have dynamic fields names
 
             if (Definition.HasDynamicFields || IndexPersistence.ContainsField(f))
                 return;
 
-            ThrowInvalidField(f);
+            ThrowInvalidField(f, indexName);
         }
 
-        private static void ThrowInvalidField(string f)
+        private static void ThrowInvalidField(string f, string indexName)
         {
-            throw new ArgumentException($"The field '{f}' is not indexed, cannot query/sort on fields that are not indexed");
+            throw new ArgumentException($"The field '{f}' is not indexed for index {indexName}, cannot query/sort on fields that are not indexed");
         }
 
         private void FillFacetedQueryResult(FacetedQueryResult result, bool isStale, long facetSetupEtag, QueryMetadata q,

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3781,7 +3781,7 @@ namespace Raven.Server.Documents.Indexes
 
         private static void ThrowInvalidField(string f, string indexName)
         {
-            throw new ArgumentException($"The field '{f}' is not indexed for index {indexName}, cannot query/sort on fields that are not indexed");
+            throw new ArgumentException($"The field '{f}' is not indexed for index '{indexName}', cannot query/sort on fields that are not indexed");
         }
 
         private void FillFacetedQueryResult(FacetedQueryResult result, bool isStale, long facetSetupEtag, QueryMetadata q,

--- a/test/SlowTests/Issues/RavenDB_2867.cs
+++ b/test/SlowTests/Issues/RavenDB_2867.cs
@@ -52,7 +52,8 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new OldIndex().Execute(store);
+                var index = new OldIndex();
+                index.Execute(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -74,7 +75,7 @@ namespace SlowTests.Issues
                     }
                 });
 
-                Assert.Contains("The field 'LastName' is not indexed, cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                Assert.Contains($"The field 'LastName' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
 
                 store.Maintenance.Send(new StartIndexingOperation());
 

--- a/test/SlowTests/Issues/RavenDB_3232.cs
+++ b/test/SlowTests/Issues/RavenDB_3232.cs
@@ -107,7 +107,7 @@ namespace SlowTests.Issues
                     }
                 });
 
-                Assert.Contains("The field 'LastName' is not indexed, cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                Assert.Contains("The field 'LastName' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
 
                 var mre = new ManualResetEventSlim();
 

--- a/test/SlowTests/Issues/RavenDB_3232.cs
+++ b/test/SlowTests/Issues/RavenDB_3232.cs
@@ -96,7 +96,8 @@ namespace SlowTests.Issues
 
                 store.Maintenance.Send(new StopIndexingOperation());
 
-                new TestIndex().Execute(store);
+                var index  = new TestIndex();
+                index.Execute(store);
 
                 var e = Assert.Throws<RavenException>(() =>
                 {
@@ -107,7 +108,7 @@ namespace SlowTests.Issues
                     }
                 });
 
-                Assert.Contains("The field 'LastName' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                Assert.Contains($"The field 'LastName' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
 
                 var mre = new ManualResetEventSlim();
 

--- a/test/SlowTests/Issues/RavenDB_3232.cs
+++ b/test/SlowTests/Issues/RavenDB_3232.cs
@@ -174,7 +174,7 @@ namespace SlowTests.Issues
                     }
                 });
 
-                Assert.Contains("The field 'LastName' is not indexed, cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                Assert.Contains($"The field 'LastName' is not indexed for index '{oldIndexDef.Name}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
 
                 var mre = new ManualResetEventSlim();
 

--- a/test/SlowTests/MailingList/Class7.cs
+++ b/test/SlowTests/MailingList/Class7.cs
@@ -18,7 +18,8 @@ namespace SlowTests.MailingList
         {
             using (var store = GetDocumentStore())
             {
-                new PersonIndex().Execute(store);
+                var index = new PersonIndex();
+                index.Execute(store);
 
                 Person personA;
                 Person personB;
@@ -47,7 +48,7 @@ namespace SlowTests.MailingList
                             .ToList();
                     });
 
-                    Assert.Contains("The field 'Surname' is not indexed, cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                    Assert.Contains($"The field 'Surname' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
                 }
 
                 using (var session = store.OpenSession())
@@ -60,7 +61,7 @@ namespace SlowTests.MailingList
                            .ToList();
                     });
 
-                    Assert.Contains("The field 'Surname' is not indexed, cannot query/sort on fields that are not indexed", e.InnerException.Message);
+                    Assert.Contains($"The field 'Surname' is not indexed for index '{index.IndexName}', cannot query/sort on fields that are not indexed", e.InnerException.Message);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19639/Missing-index-name-in-error-when-the-field-isnt-index

### Additional description

Add the missing index name to the error

### Type of change

- Bug fix

### How risky is the change?

- Low 
