### PR TITLE
RavenDB-19563 - Fix for TimeSeriesCopy

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -1072,15 +1072,17 @@ namespace Raven.Server.Documents.Handlers
 
                             var reader = Database.DocumentsStorage.TimeSeriesStorage.GetReader(context, cmd.Id, cmd.Name, cmd.From ?? DateTime.MinValue, cmd.To ?? DateTime.MaxValue);
 
-                            var docCollection = TimeSeriesHandler.ExecuteTimeSeriesBatchCommand.GetDocumentCollection(Database, context, cmd.DestinationId, fromEtl: false);
+                            var destinationDocCollection = TimeSeriesHandler.ExecuteTimeSeriesBatchCommand.GetDocumentCollection(Database, context, cmd.DestinationId, fromEtl: false);
 
                             var cv = Database.DocumentsStorage.TimeSeriesStorage.AppendTimestamp(context,
                                     cmd.DestinationId,
-                                    docCollection,
+                                    destinationDocCollection,
                                     cmd.DestinationName,
                                     reader.AllValues(),
                                     verifyName: false
                                 );
+
+                            LastChangeVector = cv;
 
                             Reply.Add(new DynamicJsonValue
                             {
@@ -1088,6 +1090,9 @@ namespace Raven.Server.Documents.Handlers
                                 [nameof(BatchRequestParser.CommandData.ChangeVector)] = cv,
                                 [nameof(BatchRequestParser.CommandData.Type)] = nameof(CommandType.TimeSeriesCopy),
                             });
+
+                            ModifiedCollections?.Add(destinationDocCollection);
+
                             break;
 
                         case CommandType.Counters:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19563

### Additional description

- Update the last database change vector after `TimeSeriesCopy`
- Updated the ModifiedCollections if needed

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works