### PR TITLE
RavenDB-18916 - ResolveToLatestInClusterOnTheFly fails with "Could not dispose test"

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -910,6 +910,7 @@ namespace Raven.Server.Documents.Replication
 
         public void Dispose()
         {
+            _disposeOnce.Dispose();
             if (_incomingWork != PoolOfThreads.LongRunningWork.Current)
             {
                 try
@@ -922,7 +923,6 @@ namespace Raven.Server.Documents.Replication
                 }
             }
             _incomingWork = null;
-            _disposeOnce.Dispose();
         }
 
         private void DisposeInternal()

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1806,8 +1806,12 @@ namespace Raven.Server.Documents.Replication
                 if (_log.IsInfoEnabled)
                     _log.Info("Closing and disposing document replication connections.");
 
+                ForTestingPurposes?.BeforeDisposingIncomingReplicationHandlers?.Invoke();
                 foreach (var incoming in _incoming)
+                {
+                    incoming.Value.IncomingWork?.Join(Int32.MaxValue);
                     ea.Execute(incoming.Value.Dispose);
+                }
 
                 foreach (var outgoing in _outgoing)
                     ea.Execute(outgoing.Dispose);
@@ -2067,6 +2071,8 @@ namespace Raven.Server.Documents.Replication
         {
             public Action<OutgoingReplicationHandler> OnOutgoingReplicationStart;
             public Action<Exception> OnIncomingReplicationHandlerFailure;
+            public Action OnIncomingReplicationHandlerStart;
+            public Action BeforeDisposingIncomingReplicationHandlers;
         }
     }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1809,7 +1809,6 @@ namespace Raven.Server.Documents.Replication
                 ForTestingPurposes?.BeforeDisposingIncomingReplicationHandlers?.Invoke();
                 foreach (var incoming in _incoming)
                 {
-                    incoming.Value.IncomingWork?.Join(Int32.MaxValue);
                     ea.Execute(incoming.Value.Dispose);
                 }
 

--- a/test/SlowTests/Issues/RavenDB-18916.cs
+++ b/test/SlowTests/Issues/RavenDB-18916.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Replication;
+using Raven.Client.Exceptions.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
+using Raven.Server.NotificationCenter;
+using Raven.Server.Utils;
+using Xunit;
+using Constants = Raven.Client.Constants;
+using Raven.Server.Documents.Replication;
+using Raven.Server.ServerWide.Context;
+using Xunit.Abstractions;
+using System.Threading;
+using Amazon.Runtime;
+using System.Security.Cryptography;
+using Nito.AsyncEx;
+using static Raven.Server.Documents.Replication.ReplicationOperation;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18916 : ReplicationTestBase
+    {
+        public RavenDB_18916(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task DeadLockTest()
+        {
+            var server = GetNewServer();
+
+            using var store1 = GetDocumentStore(new Options { Server = server, ReplicationFactor = 1 });
+            using var store2 = GetDocumentStore(new Options { Server = server, ReplicationFactor = 1 });
+
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+            var replicationLoader = database.ReplicationLoader;
+
+            var handlersMre = new ManualResetEvent(false);
+            replicationLoader.ForTestingPurposesOnly().OnIncomingReplicationHandlerStart = () =>
+            {
+                throw new EndOfStreamException("Shahar");
+            };
+            replicationLoader.ForTestingPurposesOnly().OnIncomingReplicationHandlerFailure = (e) =>
+            {
+                handlersMre.WaitOne();
+            };
+            replicationLoader.ForTestingPurposesOnly().BeforeDisposingIncomingReplicationHandlers = () =>
+            {
+                handlersMre.Set();
+            };
+
+            await SetupReplicationAsync(store1, store2);
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/2-A", Name = "Shahar" });
+                await session.SaveChangesAsync();
+            }
+
+            await DisposeServerAsync(server, 20_000); // Shouldnt throw "System.InvalidOperationException: Could not dispose server with URL.."
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -1302,12 +1302,10 @@ namespace SlowTests.Server.Replication
 
                 await EnsureReplicatingAsync(store2, store1);
 
-                var database = Servers.Single(s => s.WebUrl == store1.Urls[0]).ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database).Result;
-                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (context.OpenReadTransaction())
+                using (var session = store1.OpenAsyncSession())
                 {
-                    var count = database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context);
-                    Assert.Equal(3, count);
+                    var reivisions = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
+                    Assert.Equal(3, reivisions.Count);
                 }
 
             }


### PR DESCRIPTION
 ### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18916/SlowTests.Server.Replication.ReplicationConflictsTests.ResolveToLatestInClusterOnTheFly

### Additional description

ResolveToLatestInClusterOnTheFly fails with "Could not dispose test".
The ```ReplicationLoader``` thread tries to dispose the ```IncomingReplicationHandler``` and the ```IncomingReplicationHandler``` thread tries to dispose itself at the same time.
They are waiting for each other, which eventually causes a deadlock.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
