### PR TITLE
RavenDB-18925 - PreventDeletionOnHubSinkCompromised fails

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -291,6 +291,11 @@ namespace Raven.Server.Documents.Replication
                     if (_log.IsInfoEnabled)
                         _log.Info($"Connection error {FromToString}: an exception was thrown during receiving incoming document replication batch.", e);
 
+
+                    _parent.ForTestingPurposes?.OnIncomingReplicationHandlerFailure?.Invoke(e);
+
+
+
                     OnFailed(e, this);
                 }
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2066,6 +2066,7 @@ namespace Raven.Server.Documents.Replication
         internal class TestingStuff
         {
             public Action<OutgoingReplicationHandler> OnOutgoingReplicationStart;
+            public Action<Exception> OnIncomingReplicationHandlerFailure;
         }
     }
 

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -118,7 +118,7 @@ namespace SlowTests.Server.Replication
             var incomingStr = string.Join(",", incomingHandlers.Select(x => x.GetType()));
             Assert.True(incomingHandlers.Length == 1, $"hub should have 1 incoming handler but has {incomingHandlers.Length}, {incomingStr}");
 
-            incomingHandlers[0].Failed += (handler, exception) =>
+            hubDatabaseInstance.ReplicationLoader.ForTestingPurposesOnly().OnIncomingReplicationHandlerFailure += (exception) =>
             {
                 if (exception.Message.Contains("This hub does not allow for tombstone replication via pull replication"))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18925/SlowTests.Server.Replication.PullReplicationPreventDeletionsTests.PreventDeletionOnHubSinkCompromised

### Additional description

PreventDeletionOnHubSinkCompromised fails.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
