### PR TITLE
RavenDB-18515 - Creating replication from SINK to HUB results NRE

### DIFF
--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Utils
                         {
                             // thread has exited
                         }
-                        catch (Win32Exception e) when (e.HResult == 0x5)
+                        catch (Win32Exception e) when (e.NativeErrorCode == 0x5)
                         {
                             // thread has exited
                         }

--- a/test/SlowTests/Issues/RavenDB-18515.cs
+++ b/test/SlowTests/Issues/RavenDB-18515.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Server.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18515 : ReplicationTestBase
+    {
+        public RavenDB_18515(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Can_Set_Pin_To_Node_Pull_Replication_As_Sink()
+        {
+            var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
+
+            var notLeaderNodes = nodes.Where(s => s.ServerStore.NodeTag != leader.ServerStore.NodeTag).ToList();
+
+            var hubDatabaseName = GetDatabaseName();
+            var sinkDatabaseName = GetDatabaseName();
+
+            var hubMentorNode = notLeaderNodes[0];
+            var sinkMentorNode = notLeaderNodes[1];
+            using var hubStore = GetDocumentStore(new Options
+            {
+                Server = hubMentorNode,
+                ReplicationFactor = 1,
+                ModifyDatabaseName = (name) => hubDatabaseName,
+                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificate.Value,
+            });
+
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ModifyDatabaseName = (name) => sinkDatabaseName,
+                ReplicationFactor = 3,
+                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificate.Value,
+            });
+
+            var saveResult = await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "HUB",
+                Mode = PullReplicationMode.SinkToHub
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("HUB",
+                new ReplicationHubAccess
+                {
+                    Name = hubStore.Database,
+                    CertificateBase64 = Convert.ToBase64String(certificates.ClientCertificate1.Value.Export(X509ContentType.Cert)),
+                }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = "SINK",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = "SINK",
+                PinToMentorNode = true,
+                CertificateWithPrivateKey = Convert.ToBase64String(certificates.ClientCertificate1.Value.Export(X509ContentType.Pfx)),
+                // TaskId = saveResult.TaskId,
+                MentorNode = sinkMentorNode.ServerStore.NodeTag,
+                Mode = PullReplicationMode.SinkToHub,
+                HubName = "HUB",
+            }));
+
+            using (var sinkSession = sinkStore.OpenSession())
+            {
+                sinkSession.Store(new User { Id = "users/1", Name = "Arava", });
+                sinkSession.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument<User>(hubStore, "users/1", u => u.Name == "Arava", 10_000));
+            var disposedServer = await DisposeServerAndWaitForFinishOfDisposalAsync(sinkMentorNode);
+            using (var sinkSession = sinkStore.OpenSession())
+            {
+                sinkSession.Store(new User { Id = "users/2", Name = "Arava2", });
+                sinkSession.SaveChanges();
+            }
+            
+            Assert.False(WaitForDocument<User>(hubStore, "users/2", u => u.Name == "Arava2", 10_000));
+            var revivedServer = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    { RavenConfiguration.GetKey(x => x.Core.ServerUrls), disposedServer.Url },
+                    { RavenConfiguration.GetKey(x => x.Security.CertificatePath), certificates.ServerCertificatePath }
+                },
+                RunInMemory = true,
+                DataDirectory = disposedServer.DataDirectory,
+                DeletePrevious = false
+            });
+            Assert.True(WaitForDocument<User>(sinkStore, "users/2", u => u.Name == "Arava2", 10_000));
+            Assert.Equal(1, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 1));
+            Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
+
+        }
+
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18515/Creating-replication-from-SINK-to-HUB-results-NRE

### Additional description

Creating replication from SINK to HUB results NRE.
Couldn't reproduce the NRE.
Add a test.
Fixed the wrong exception handling of reusing threads.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed