### PR TITLE
RavenDB-19655: Array was smaller than what it should have been asked for.

### DIFF
--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -198,8 +198,8 @@ namespace Corax.Queries
             }
 
             // Allocate the new buffer based on the size the original buffer had in bytes.
-            var newBufferHandler = _context.Allocate(sizeInBytes, out var newBuffer);
-            
+            var newBufferHandler = _context.Allocate(sizeInBytes * sizeof(long), out var newBuffer);
+
             // Ensure we copy the content and then switch the buffers. 
             new Span<long>(buffer.Ptr, currentlyUsed).CopyTo(new Span<long>(newBuffer.Ptr, newBuffer.Length));
 

--- a/src/Corax/Queries/MultiTermBoostingMatch.cs
+++ b/src/Corax/Queries/MultiTermBoostingMatch.cs
@@ -164,7 +164,7 @@ namespace Corax.Queries
             }
 
             // Allocate the new buffer
-            var bufferHandler = _context.Allocate(2 * size, out var buffer);
+            var bufferHandler = _context.Allocate(2 * size * sizeof(long), out var buffer);
 
             // Ensure we copy the content and then switch the buffers. 
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19655

### Additional description
Allocated memory was missing the type size, so we were effectively allocating less memory than we would use in the worst case scenario for 2 primitives.

### Type of change
Bug fix

### How risky is the change?
Low 