### PR TITLE
RavenDB-19628 added Http.KeepAlivePingTimeoutInSec and Http.KeepAlivePingTimeoutInSec configuration options for Kestrel

### DIFF
--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -40,6 +40,18 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Http.MaxRequestLineSizeInKb", ConfigurationEntryScope.ServerWideOnly)]
         public Size MaxRequestLineSize { get; set; }
 
+        [Description("Set Kestrel's HTTP2 keep alive ping timeout")]
+        [DefaultValue(null)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Http.KeepAlivePingTimeoutInSec", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting? KeepAlivePingTimeout { get; set; }
+
+        [Description("Set Kestrel's HTTP2 keep alive ping delay")]
+        [DefaultValue(null)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Http.KeepAlivePingDelayInSec", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting? KeepAlivePingDelay { get; set; }
+
         [Description("Whether Raven's HTTP server should compress its responses")]
         [DefaultValue(true)]
         [ConfigurationEntry("Http.UseResponseCompression", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -43,13 +43,13 @@ namespace Raven.Server.Config.Categories
         [Description("Set Kestrel's HTTP2 keep alive ping timeout")]
         [DefaultValue(null)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Http.KeepAlivePingTimeoutInSec", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Http.Http2.KeepAlivePingTimeoutInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting? KeepAlivePingTimeout { get; set; }
 
         [Description("Set Kestrel's HTTP2 keep alive ping delay")]
         [DefaultValue(null)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Http.KeepAlivePingDelayInSec", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Http.Http2.KeepAlivePingDelayInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting? KeepAlivePingDelay { get; set; }
 
         [Description("Whether Raven's HTTP server should compress its responses")]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -190,6 +190,12 @@ namespace Raven.Server
                     if (Configuration.Http.MaxRequestBufferSize.HasValue)
                         options.Limits.MaxRequestBufferSize = Configuration.Http.MaxRequestBufferSize.Value.GetValue(SizeUnit.Bytes);
 
+                    if (Configuration.Http.KeepAlivePingDelay.HasValue)
+                        options.Limits.Http2.KeepAlivePingDelay = Configuration.Http.KeepAlivePingDelay.Value.AsTimeSpan;
+
+                    if (Configuration.Http.KeepAlivePingTimeout.HasValue)
+                        options.Limits.Http2.KeepAlivePingTimeout = Configuration.Http.KeepAlivePingTimeout.Value.AsTimeSpan;
+
                     options.ConfigureEndpointDefaults(listenOptions => listenOptions.Protocols = Configuration.Http.Protocols);
 
                     if (Certificate.Certificate != null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19628

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
