### PR TITLE
RavenDB-19659 - use the new id from the server node that it came from

### DIFF
--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Identity
             _range = new RangeValue(1, 0, null);
         }
 
-        [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextId) overload")]
+        [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextId) overload.")]
         protected virtual string GetDocumentIdFromId(long nextId)
         {
             return $"{Prefix}{nextId}-{ServerTag}";
@@ -60,7 +60,7 @@ namespace Raven.Client.Documents.Identity
             public long Current;
             public string ServerTag;
 
-            [Obsolete("Will be removed in next major version of the product. Use RangeValue(min, max, serverTag) instead")]
+            [Obsolete("Will be removed in next major version of the product. Use RangeValue(min, max, serverTag) instead.")]
             public RangeValue(long min, long max) : this(min, max, null)
             {
             }
@@ -76,7 +76,7 @@ namespace Raven.Client.Documents.Identity
 
         private Lazy<Task> _nextRangeTask = new Lazy<Task>(() => Task.CompletedTask);
 
-        [Obsolete("Use field Range.ServerTag")]
+        [Obsolete("Will be removed in next major version of the product. Use field Range.ServerTag instead.")]
         protected string ServerTag;
 
         /// <summary>
@@ -86,8 +86,10 @@ namespace Raven.Client.Documents.Identity
         /// <returns></returns>
         public virtual async Task<string> GenerateDocumentIdAsync(object entity)
         {
-            var result = await NextIdAsync().ConfigureAwait(false);
-            return GetDocumentIdFromId(result);
+            var result = await GetNextIdAsync().ConfigureAwait(false);
+#pragma warning disable CS0618
+            return GetDocumentIdFromId(result.Id);
+#pragma warning restore CS0618
         }
 
         public async Task<NextId> GetNextIdAsync()
@@ -160,7 +162,9 @@ namespace Raven.Client.Documents.Identity
             }
 
             Prefix = hiloCommand.Result.Prefix;
+#pragma warning disable CS0618
             ServerTag = hiloCommand.Result.ServerTag;
+#pragma warning restore CS0618
             _lastRangeDate = hiloCommand.Result.LastRangeAt;
             _lastBatchSize = hiloCommand.Result.LastSize;
             Range = new RangeValue(hiloCommand.Result.Low, hiloCommand.Result.High, hiloCommand.Result.ServerTag);

--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Identity
             _range = new RangeValue(1, 0, null);
         }
 
-        [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextIdResult) overload")]
+        [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextId) overload")]
         protected virtual string GetDocumentIdFromId(long nextId)
         {
             return $"{Prefix}{nextId}-{ServerTag}";
@@ -66,11 +66,8 @@ namespace Raven.Client.Documents.Identity
             public string ServerTag;
 
             [Obsolete("Will be removed in next major version of the product. Use RangeValue(min, max, serverTag) instead")]
-            public RangeValue(long min, long max)
+            public RangeValue(long min, long max) : this(min, max, null)
             {
-                Min = min;
-                Max = max;
-                Current = min - 1;
             }
 
             public RangeValue(long min, long max, string serverTag)
@@ -94,9 +91,9 @@ namespace Raven.Client.Documents.Identity
         /// <returns></returns>
         public async Task<string> GenerateDocumentIdAsync(object entity)
         {
-            var nextIdResult = await GetNextIdAsync().ConfigureAwait(false);
+            var result = await GetNextIdAsync().ConfigureAwait(false);
             _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();
-            return GetDocumentIdFromId(nextIdResult);
+            return GetDocumentIdFromId(result);
         }
 
         public async Task<NextId> GetNextIdAsync()
@@ -202,7 +199,7 @@ namespace Raven.Client.Documents.Identity
             internal Action BeforeGeneratingDocumentId;
         }
 
-        public class NextId
+        public struct NextId
         {
             public long Id;
 

--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -14,7 +14,7 @@ using Sparrow.Json;
 namespace Raven.Client.Documents.Identity
 {
     /// <summary>
-    /// Generate hilo numbers against a RavenDB document
+    /// Generate HiLo numbers against a RavenDB document
     /// </summary>
     public class AsyncHiLoIdGenerator
     {

--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -46,11 +46,6 @@ namespace Raven.Client.Documents.Identity
             return $"{Prefix}{nextId}-{ServerTag}";
         }
 
-        protected virtual string GetDocumentIdFromId(NextId result)
-        {
-            return $"{Prefix}{result.Id}-{result.ServerTag}";
-        }
-
         protected RangeValue Range
         {
             get => _range;
@@ -89,10 +84,9 @@ namespace Raven.Client.Documents.Identity
         /// </summary>
         /// <param name="entity">The entity.</param>
         /// <returns></returns>
-        public async Task<string> GenerateDocumentIdAsync(object entity)
+        public virtual async Task<string> GenerateDocumentIdAsync(object entity)
         {
-            var result = await GetNextIdAsync().ConfigureAwait(false);
-            _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();
+            var result = await NextIdAsync().ConfigureAwait(false);
             return GetDocumentIdFromId(result);
         }
 
@@ -182,21 +176,6 @@ namespace Raven.Client.Documents.Identity
             {
                 await re.ExecuteAsync(returnCommand, context, sessionInfo: null, token: CancellationToken.None).ConfigureAwait(false);
             }
-        }
-
-        internal TestingStuff _forTestingPurposes;
-
-        internal TestingStuff ForTestingPurposesOnly()
-        {
-            if (_forTestingPurposes != null)
-                return _forTestingPurposes;
-
-            return _forTestingPurposes = new TestingStuff();
-        }
-
-        internal class TestingStuff
-        {
-            internal Action BeforeGeneratingDocumentId;
         }
 
         public struct NextId

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Documents.Identity
 
         protected virtual AsyncHiLoIdGenerator CreateGeneratorFor(string tag)
         {
-            return new AsyncHiLoIdGenerator(tag, Store, DbName, _identityPartsSeparator);
+            return new DefaultAsyncHiLoIdGenerator(tag, Store, DbName, _identityPartsSeparator);
         }
 
         public async Task ReturnUnusedRange()

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,8 +18,8 @@ namespace Raven.Client.Documents.Identity
     /// </summary>
     public class AsyncMultiTypeHiLoIdGenerator
     {
-        private readonly SemaphoreSlim _generatorLock = new SemaphoreSlim(1, 1);
-        private readonly ConcurrentDictionary<string, AsyncHiLoIdGenerator> _idGeneratorsByTag = new ConcurrentDictionary<string, AsyncHiLoIdGenerator>();
+        private readonly SemaphoreSlim _generatorLock = new(1, 1);
+        private readonly ConcurrentDictionary<string, AsyncHiLoIdGenerator> _idGeneratorsByTag = new();
         protected readonly DocumentStore Store;
         protected readonly string DbName;
         protected readonly DocumentConventions Conventions;
@@ -104,7 +103,7 @@ namespace Raven.Client.Documents.Identity
         {
             if (_idGeneratorsByTag.TryGetValue(collectionName, out var value))
             {
-                return await value.NextIdAsync().ConfigureAwait(false);
+                return (await value.GetNextIdAsync().ConfigureAwait(false)).Id;
             }
 
             await _generatorLock.WaitAsync().ConfigureAwait(false);
@@ -112,7 +111,7 @@ namespace Raven.Client.Documents.Identity
             try
             {
                 if (_idGeneratorsByTag.TryGetValue(collectionName, out value))
-                    return await value.NextIdAsync().ConfigureAwait(false);
+                    return (await value.GetNextIdAsync().ConfigureAwait(false)).Id;
 
                 value = CreateGeneratorFor(collectionName);
                 _idGeneratorsByTag.TryAdd(collectionName, value);
@@ -122,7 +121,7 @@ namespace Raven.Client.Documents.Identity
                 _generatorLock.Release();
             }
 
-            return await value.NextIdAsync().ConfigureAwait(false);
+            return (await value.GetNextIdAsync().ConfigureAwait(false)).Id;
         }
 
         protected virtual AsyncHiLoIdGenerator CreateGeneratorFor(string tag)

--- a/src/Raven.Client/Documents/Identity/DefaultAsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/DefaultAsyncHiLoIdGenerator.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Raven.Client.Documents.Identity;
+
+public class DefaultAsyncHiLoIdGenerator : AsyncHiLoIdGenerator
+{
+    public DefaultAsyncHiLoIdGenerator(string tag, DocumentStore store, string dbName, char identityPartsSeparator) : base(tag, store, dbName, identityPartsSeparator)
+    {
+    }
+
+    protected virtual string GetDocumentIdFromId(NextId result)
+    {
+        return $"{Prefix}{result.Id}-{result.ServerTag}";
+    }
+
+    /// <summary>
+    /// Generates the document ID.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns></returns>
+    public override async Task<string> GenerateDocumentIdAsync(object entity)
+    {
+        var result = await GetNextIdAsync().ConfigureAwait(false);
+        _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();
+        return GetDocumentIdFromId(result);
+    }
+
+    internal TestingStuff _forTestingPurposes;
+
+    internal TestingStuff ForTestingPurposesOnly()
+    {
+        if (_forTestingPurposes != null)
+            return _forTestingPurposes;
+
+        return _forTestingPurposes = new TestingStuff();
+    }
+
+    internal class TestingStuff
+    {
+        internal Action BeforeGeneratingDocumentId;
+    }
+}

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -12,6 +12,7 @@ using Sparrow.Collections;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618
 
 namespace FastTests.Client
 {

--- a/test/SlowTests/Issues/RavenDB-19659.cs
+++ b/test/SlowTests/Issues/RavenDB-19659.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Identity;
+using Raven.Server;
+using Raven.Server.Config;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19659 : ClusterTestBase
+    {
+        public RavenDB_19659(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Unique_document_ids_using_hilo()
+        {
+            var databaseName = GetDatabaseName();
+            ;
+            (List<RavenServer> Nodes, RavenServer Leader) raftCluster = await CreateRaftCluster(2, shouldRunInMemory: false);
+            await CreateDatabaseInCluster(databaseName, 2, raftCluster.Leader.WebUrl);
+
+            using (var store1 = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[]
+                {
+                    raftCluster.Nodes[0].WebUrl,
+                    raftCluster.Nodes[1].WebUrl
+                }
+            })
+            using (var store2 = new DocumentStore
+            {
+                Database = databaseName,
+                Urls = new[]
+                       {
+                           raftCluster.Nodes[0].WebUrl,
+                           raftCluster.Nodes[1].WebUrl
+                       }
+            })
+            {
+                store1.Initialize();
+                store2.Initialize();
+
+                var result0 = await DisposeServerAndWaitForFinishOfDisposalAsync(raftCluster.Nodes[0]);
+                var settings0 = new Dictionary<string, string>
+                {
+                    {RavenConfiguration.GetKey(x => x.Core.ServerUrls), result0.Url}
+                };
+
+                var hiLoKeyGenerator1 = new AsyncHiLoIdGenerator("users", store1, store1.Database, store1.Conventions.IdentityPartsSeparator);
+                var hiLoKeyGenerator2 = new AsyncHiLoIdGenerator("users", store2, store2.Database, store2.Conventions.IdentityPartsSeparator);
+
+                var uniqueIds = new HashSet<string>();
+                for (var i = 0; i < 32; i++)
+                {
+
+                    var id = await hiLoKeyGenerator1.GenerateDocumentIdAsync(new User());
+                    uniqueIds.Add(id);
+                }
+
+                var mre = new ManualResetEvent(false);
+
+                var result1 = await DisposeServerAndWaitForFinishOfDisposalAsync(raftCluster.Nodes[1]);
+                var settings1 = new Dictionary<string, string>
+                {
+                    {RavenConfiguration.GetKey(x => x.Core.ServerUrls), result1.Url}
+                };
+
+                using (GetNewServer(new ServerCreationOptions
+                {
+                    RunInMemory = false,
+                    DeletePrevious = false,
+                    DataDirectory = result0.DataDirectory,
+                    CustomSettings = settings0
+                }))
+                {
+                    for (var i = 0; i < 31; i++)
+                    {
+                        var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User());
+                        uniqueIds.Add(id);
+                    }
+                }
+
+                hiLoKeyGenerator2.ForTestingPurposesOnly().BeforeGeneratingDocumentId = () =>
+                {
+                    // do it only once
+                    hiLoKeyGenerator2.ForTestingPurposesOnly().BeforeGeneratingDocumentId = null;
+                    mre.WaitOne();
+                };
+
+                var generateIdTask = Task.Run(async () => await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User()));
+
+                using (GetNewServer(new ServerCreationOptions
+                {
+                    RunInMemory = false,
+                    DeletePrevious = false,
+                    DataDirectory = result1.DataDirectory,
+                    CustomSettings = settings1
+                }))
+                {
+                    var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User());
+                    uniqueIds.Add(id);
+                    mre.Set();
+                }
+
+                var newId = await generateIdTask;
+                uniqueIds.Add(newId);
+
+                Assert.Contains("users/32-A", uniqueIds);
+                Assert.Equal(65, uniqueIds.Count);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19659.cs
+++ b/test/SlowTests/Issues/RavenDB-19659.cs
@@ -54,8 +54,8 @@ namespace SlowTests.Issues
                     {RavenConfiguration.GetKey(x => x.Core.ServerUrls), result0.Url}
                 };
 
-                var hiLoKeyGenerator1 = new AsyncHiLoIdGenerator("users", store1, store1.Database, store1.Conventions.IdentityPartsSeparator);
-                var hiLoKeyGenerator2 = new AsyncHiLoIdGenerator("users", store2, store2.Database, store2.Conventions.IdentityPartsSeparator);
+                var hiLoKeyGenerator1 = new DefaultAsyncHiLoIdGenerator("users", store1, store1.Database, store1.Conventions.IdentityPartsSeparator);
+                var hiLoKeyGenerator2 = new DefaultAsyncHiLoIdGenerator("users", store2, store2.Database, store2.Conventions.IdentityPartsSeparator);
 
                 var uniqueIds = new HashSet<string>();
                 for (var i = 0; i < 32; i++)

--- a/test/SlowTests/Issues/RavenDB_8959.cs
+++ b/test/SlowTests/Issues/RavenDB_8959.cs
@@ -1,4 +1,5 @@
-﻿using FastTests;
+﻿using System;
+using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Identity;
@@ -43,6 +44,7 @@ namespace SlowTests.Issues
                     {
                     }
 
+                    [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextId) overload.")]
                     protected override string GetDocumentIdFromId(long nextId)
                     {
                         return $"{Prefix}{nextId}";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19659/HiLo-generator-is-getting-the-same-document-twice

### Additional description

Making sure that the HiLo number we got is used with the server node tag it came from. Otherwise, we can get duplicate document ids.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
