### PR TITLE
RavenDB-19597: Contention sources for ArrayPool<T>

### DIFF
--- a/src/Corax/Analyzers/Analyzer.cs
+++ b/src/Corax/Analyzers/Analyzer.cs
@@ -6,13 +6,15 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Corax.Pipeline;
+using Sparrow.Server;
 
 namespace Corax
 {
     public unsafe class Analyzer : IDisposable
     {
-        public static Analyzer DefaultAnalyzer = Create(default(KeywordTokenizer), default(ExactTransformer));
-        public static Analyzer DefaultLowercaseAnalyzer = Create(default(KeywordTokenizer), default(LowerCaseTransformer));
+        public static Analyzer CreateDefaultAnalyzer(ByteStringContext context) => Create(context, default(KeywordTokenizer), default(ExactTransformer));
+        public static Analyzer CreateLowercaseAnalyzer(ByteStringContext context) => Create(context, default(KeywordTokenizer), default(LowerCaseTransformer));
+
         public static readonly ArrayPool<byte> BufferPool = ArrayPool<byte>.Create();
         public static readonly ArrayPool<Token> TokensPool = ArrayPool<Token>.Create();
         public readonly int DefaultOutputSize;
@@ -301,7 +303,8 @@ namespace Corax
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Analyzer Create<TTokenizer, TTransform1, TTransform2, TTransform3>(in TTokenizer tokenizer = default(TTokenizer), 
+        public static Analyzer Create<TTokenizer, TTransform1, TTransform2, TTransform3>(ByteStringContext context, 
+                            in TTokenizer tokenizer = default(TTokenizer), 
                             in TTransform1 transform1 = default(TTransform1),
                             in TTransform2 transform2 = default(TTransform2), 
                             in TTransform3 transform3 = default(TTransform3))
@@ -419,23 +422,25 @@ namespace Corax
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Analyzer Create<TTokenizer, TTransform1>(in TTokenizer tokenizer = default(TTokenizer),
+        public static Analyzer Create<TTokenizer, TTransform1>(ByteStringContext context, 
+                            in TTokenizer tokenizer = default(TTokenizer),
                             in TTransform1 transform1 = default(TTransform1))
             where TTokenizer : ITokenizer
             where TTransform1 : ITransformer
         {
-            return Create<TTokenizer, TTransform1, NullTransformer, NullTransformer>(tokenizer, transform1);
+            return Create<TTokenizer, TTransform1, NullTransformer, NullTransformer>(context, tokenizer, transform1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Analyzer Create<TTokenizer, TTransform1, TTransform2>(in TTokenizer tokenizer = default(TTokenizer),
+        public static Analyzer Create<TTokenizer, TTransform1, TTransform2>(ByteStringContext context,
+                            in TTokenizer tokenizer = default(TTokenizer),
                             in TTransform1 transform1 = default(TTransform1),
                             in TTransform2 transform2 = default(TTransform2))
             where TTokenizer : ITokenizer
             where TTransform1 : ITransformer
             where TTransform2 : ITransformer
         {
-            return Create<TTokenizer, TTransform1, TTransform2, NullTransformer>(tokenizer, transform1, transform2);
+            return Create<TTokenizer, TTransform1, TTransform2, NullTransformer>(context, tokenizer, transform1, transform2);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Analyzers/AnalyzerScope.cs
+++ b/src/Corax/Analyzers/AnalyzerScope.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Corax.Mappings;
+using Corax.Pipeline;
+using Sparrow.Server;
+using Voron;
+
+namespace Corax.Analyzers
+{
+    internal unsafe class AnalyzerScope : IDisposable
+    {
+        private readonly IndexSearcher _indexSearcher;
+        private readonly Analyzer _analyzer;
+
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope _tempBufferScope;
+        private int _tempOutputBufferSize;
+        private byte* _tempOutputBuffer;
+        private int _tempOutputTokenSize;
+        private Token* _tempTokenBuffer;
+
+        public AnalyzerScope(IndexSearcher indexSearcher, Analyzer analyzer)
+        {
+            _indexSearcher = indexSearcher;
+            _analyzer = analyzer;
+
+            InitializeTemporaryBuffers(indexSearcher.Allocator);
+        }
+
+        public AnalyzerScope(string fieldName, IndexSearcher indexSearcher, IndexFieldsMapping fieldsMapping, bool hasDynamics)
+        {
+            _indexSearcher = indexSearcher;
+
+            if (fieldsMapping.TryGetByFieldName(indexSearcher.Allocator, fieldName, out var binding))
+            {
+                _analyzer = binding.Analyzer;
+            }
+            else
+            {
+                if (hasDynamics is false)
+                    ThrowWhenDynamicFieldNotFound(fieldName);
+
+                using var _ = Slice.From(indexSearcher.Allocator, fieldName, out var fieldNameSlice);
+                var mode = _indexSearcher.GetFieldIndexingModeForDynamic(fieldNameSlice);
+
+                _analyzer = mode switch
+                {
+                    FieldIndexingMode.Normal => fieldsMapping!.DefaultAnalyzer,
+                    FieldIndexingMode.Search => fieldsMapping!.SearchAnalyzer(fieldName.ToString()),
+                    FieldIndexingMode.No => Analyzer.CreateDefaultAnalyzer(_indexSearcher.Allocator),
+                    FieldIndexingMode.Exact => fieldsMapping!.ExactAnalyzer(fieldName.ToString()),
+                    _ => ThrowWhenAnalyzerModeNotFound(mode)
+                };
+            }
+
+            InitializeTemporaryBuffers(indexSearcher.Allocator);
+        }
+
+        private void InitializeTemporaryBuffers(ByteStringContext allocator)
+        {
+            _tempOutputBufferSize = Constants.Analyzers.DefaultBufferForAnalyzers;
+            _tempOutputTokenSize = Constants.Analyzers.DefaultBufferForAnalyzers;
+
+            _tempBufferScope = allocator.AllocateDirect(_tempOutputBufferSize + _tempOutputTokenSize * Unsafe.SizeOf<Token>(), out var tempBuffer);
+            _tempOutputBuffer = tempBuffer.Ptr;
+            _tempTokenBuffer = (Token*)(tempBuffer.Ptr + _tempOutputBufferSize);
+        }
+
+        private void UnlikelyGrowBuffers(int outputSize, int tokenSize)
+        {
+            _tempBufferScope.Dispose();
+
+            _tempOutputBufferSize = outputSize;
+            _tempOutputTokenSize = tokenSize;
+
+            _tempBufferScope = _indexSearcher.Allocator.AllocateDirect(_tempOutputBufferSize + _tempOutputTokenSize * Unsafe.SizeOf<Token>(), out var tempBuffer);
+            _tempOutputBuffer = tempBuffer.Ptr;
+            _tempTokenBuffer = (Token*)(tempBuffer.Ptr + _tempOutputBufferSize);
+        }
+
+        public ByteStringContext<ByteStringMemoryCache>.InternalScope Execute(ReadOnlySpan<byte> source, out Span<byte> buffer, out Span<Token> tokens)
+        {
+            _analyzer.GetOutputBuffersSize(source.Length, out var outputSize, out var tokensSize);
+
+            if (outputSize > _tempOutputBufferSize || tokensSize > _tempOutputTokenSize)
+                UnlikelyGrowBuffers(outputSize, tokensSize);
+
+            var tokenSpace = new Span<Token>(_tempTokenBuffer, _tempOutputTokenSize);
+            var wordSpace = new Span<byte>(_tempOutputBuffer, _tempOutputBufferSize);
+            _analyzer.Execute(source, ref wordSpace, ref tokenSpace);
+
+            var scope = _indexSearcher.Allocator.AllocateDirect(tokenSpace.Length * sizeof(Token) + wordSpace.Length, out var outputMemory);
+
+            var outputBuffer = new Span<byte>(outputMemory.Ptr, wordSpace.Length);
+            var outputTokens = new Span<Token>(outputMemory.Ptr + outputBuffer.Length, tokenSpace.Length);
+
+            wordSpace.CopyTo(outputBuffer);
+            tokenSpace.CopyTo(outputTokens);
+
+            buffer = outputBuffer;
+            tokens = outputTokens;
+
+            return scope;
+        }
+
+        private static Analyzer ThrowWhenAnalyzerModeNotFound(FieldIndexingMode mode)
+        {
+            throw new ArgumentOutOfRangeException($"{mode} is not implemented in {nameof(AnalyzerScope)}");
+        }
+
+        private static void ThrowWhenDynamicFieldNotFound(string fieldName)
+        {
+            throw new InvalidDataException(
+                $"Cannot find field {fieldName} inside known binding and also index doesn't contain dynamic fields. The field you try to read is not inside index.");
+        }
+
+        public void Dispose()
+        {
+            _tempBufferScope.Dispose();
+        }
+    }
+}

--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -102,7 +102,7 @@ namespace Corax
 
         public static class Analyzers
         {
-            internal const int DefaultBufferForAnalyzers = 4 * Sparrow.Global.Constants.Size.Kilobyte;
+            public const int DefaultBufferForAnalyzers = 4 * Sparrow.Global.Constants.Size.Kilobyte;
         }
         
         public static class Suggestions

--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -43,7 +43,7 @@ public partial class IndexSearcher
             ? _fieldMapping.SearchAnalyzer(field.FieldName.ToString()) 
             : field.Analyzer;
         
-        var wildcardAnalyzer = Analyzer.Create<WhitespaceTokenizer, ExactTransformer>();
+        var wildcardAnalyzer = Analyzer.Create<WhitespaceTokenizer, ExactTransformer>(this.Allocator);
 
         searchAnalyzer.GetOutputBuffersSize(term.Length, out var outputSize, out var tokenSize);
         wildcardAnalyzer.GetOutputBuffersSize(term.Length, out var wildcardSize, out var wildcardTokenSize);

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -41,7 +41,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     public long NumberOfEntries => _numberOfEntries ??= _metadataTree?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
 
-    internal ByteStringContext Allocator => _transaction.Allocator;
+    public ByteStringContext Allocator => _transaction.Allocator;
 
     internal Transaction Transaction => _transaction;
 
@@ -208,7 +208,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
 
         analyzer ??= binding.FieldIndexingMode is FieldIndexingMode.Search
-            ? Analyzer.DefaultLowercaseAnalyzer // lowercase only when search is used in non-full-text-search match 
+            ? Analyzer.CreateLowercaseAnalyzer(this.Allocator) // lowercase only when search is used in non-full-text-search match 
             : binding.Analyzer!;
 
         return AnalyzeTerm(analyzer, originalTerm, out value);

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -306,7 +306,6 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         if (readResult == null)
             return FieldIndexingMode.Normal;
 
-
         var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
         return mode;
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
@@ -87,7 +87,7 @@ internal class AnalyzersScope : IDisposable
             {
                 FieldIndexingMode.Normal => _knownFields!.DefaultAnalyzer,
                 FieldIndexingMode.Search => _knownFields!.SearchAnalyzer(fieldName.ToString()),
-                FieldIndexingMode.No => Analyzer.DefaultAnalyzer,
+                FieldIndexingMode.No => Analyzer.CreateDefaultAnalyzer( _indexSearcher.Allocator),
                 FieldIndexingMode.Exact => _knownFields!.ExactAnalyzer(fieldName.ToString()),
                 _ => ThrowWhenAnalyzerModeNotFound(mode)
             };

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
@@ -5,66 +5,108 @@ using System.Runtime.CompilerServices;
 using Corax;
 using Corax.Mappings;
 using Corax.Pipeline;
+using Microsoft.CodeAnalysis;
+using Sparrow.Server;
 using Voron;
+using static Raven.Server.Documents.Indexes.MapReduce.ReduceKeyProcessor;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
-internal class AnalyzersScope : IDisposable
+internal unsafe class AnalyzersScope : IDisposable
 {
     private readonly IndexFieldsMapping _knownFields;
     private readonly bool _hasDynamics;
-    private Token[] _tokensBuffer;
-    private byte[] _outputBuffer;
     private readonly IndexSearcher _indexSearcher;
     private readonly Dictionary<Slice, Analyzer> _analyzersCache;
-    
+
+    private ByteStringContext<ByteStringMemoryCache>.InternalScope _tempBufferScope;
+    private int _tempOutputBufferSize;
+    private byte* _tempOutputBuffer;
+    private int _tempOutputTokenSize;
+    private Token* _tempTokenBuffer;
+
     public AnalyzersScope(IndexSearcher indexSearcher, IndexFieldsMapping fieldsMapping, bool hasDynamics)
     {
         _indexSearcher = indexSearcher;
         _knownFields = fieldsMapping;
         _hasDynamics = hasDynamics;
         _analyzersCache = new(SliceComparer.Instance);
-        UnlikelyGrowBuffer(128, 128);
+        InitializeTemporaryBuffers(indexSearcher.Allocator);
+    }
+
+    private void InitializeTemporaryBuffers(ByteStringContext allocator)
+    {
+        _tempOutputBufferSize = Constants.Analyzers.DefaultBufferForAnalyzers;
+        _tempOutputTokenSize = Constants.Analyzers.DefaultBufferForAnalyzers;
+
+        _tempBufferScope = allocator.AllocateDirect(_tempOutputBufferSize + _tempOutputTokenSize * Unsafe.SizeOf<Token>(), out var tempBuffer);
+        _tempOutputBuffer = tempBuffer.Ptr;
+        _tempTokenBuffer = (Token*)(tempBuffer.Ptr + _tempOutputBufferSize);
+    }
+
+    private void UnlikelyGrowBuffers(int outputSize, int tokenSize)
+    {
+        _tempBufferScope.Dispose();
+
+        _tempOutputBufferSize = outputSize;
+        _tempOutputTokenSize = tokenSize;
+
+        _tempBufferScope = _indexSearcher.Allocator.AllocateDirect(_tempOutputBufferSize + _tempOutputTokenSize * Unsafe.SizeOf<Token>(), out var tempBuffer);
+        _tempOutputBuffer = tempBuffer.Ptr;
+        _tempTokenBuffer = (Token*)(tempBuffer.Ptr + _tempOutputBufferSize);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Execute(Slice fieldName, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope Execute(Slice fieldName, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
     {
         Analyzer analyzer = GetAnalyzer(fieldName);
-        ExecuteAnalyze(analyzer, source, out buffer, out tokens);
+        return ExecuteAnalyze(analyzer, source, out buffer, out tokens);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Execute(FieldMetadata field, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens, bool exact)
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope Execute(FieldMetadata field, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens, bool exact)
     {
-        
         if (field.Mode == FieldIndexingMode.Exact || field.Analyzer == null || exact)
         {
-            buffer = source;
-            _tokensBuffer[0] = new Token() {Length = (uint)source.Length, Offset = 0, Type = TokenType.Term};
-            tokens = _tokensBuffer.AsSpan(0, 1);
-            return;
+            var scope = _indexSearcher.Allocator.AllocateDirect(1 * sizeof(Token) + source.Length, out var outputMemory);
+
+            var outputBuffer = new Span<byte>(outputMemory.Ptr, source.Length);
+            var outputTokens = new Span<Token>(outputMemory.Ptr + outputBuffer.Length, 1);
+
+            source.CopyTo(outputBuffer);
+            outputTokens[0] = new Token() {Length = (uint)source.Length, Offset = 0, Type = TokenType.Term};
+
+            buffer = outputBuffer;
+            tokens = outputTokens;
+            return scope;
         }
 
         var analyzer = field.Analyzer;
-        
-        ExecuteAnalyze(analyzer, source, out buffer, out tokens);
+        return ExecuteAnalyze(analyzer, source, out buffer, out tokens);
     }
     
-    private void ExecuteAnalyze(Analyzer analyzer, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
+    private ByteStringContext<ByteStringMemoryCache>.InternalScope ExecuteAnalyze(Analyzer analyzer, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
     {
         analyzer.GetOutputBuffersSize(source.Length, out var outputSize, out var tokensSize);
+        if (outputSize > _tempOutputBufferSize || tokensSize > _tempOutputTokenSize)
+            UnlikelyGrowBuffers(outputSize, tokensSize);
 
-        if ((_tokensBuffer?.Length ?? 0) < tokensSize && (_outputBuffer?.Length ?? 0 ) < outputSize)
-            UnlikelyGrowBuffer(outputSize, tokensSize);
+        var tokenSpace = new Span<Token>(_tempTokenBuffer, _tempOutputTokenSize);
+        var wordSpace = new Span<byte>(_tempOutputBuffer, _tempOutputBufferSize);
+        analyzer.Execute(source, ref wordSpace, ref tokenSpace);
 
-        var bufferOutput = _outputBuffer.AsSpan();
-        var tokenOutput = _tokensBuffer.AsSpan();
-        analyzer.Execute(source, ref bufferOutput, ref tokenOutput);
+        var scope = _indexSearcher.Allocator.AllocateDirect(tokenSpace.Length * sizeof(Token) + wordSpace.Length, out var outputMemory);
 
+        var outputBuffer = new Span<byte>(outputMemory.Ptr, wordSpace.Length);
+        var outputTokens = new Span<Token>(outputMemory.Ptr + outputBuffer.Length, tokenSpace.Length);
 
-        buffer = bufferOutput;
-        tokens = tokenOutput;
+        wordSpace.CopyTo(outputBuffer);
+        tokenSpace.CopyTo(outputTokens);
+
+        buffer = outputBuffer;
+        tokens = outputTokens;
+
+        return scope;
     }
 
     private Analyzer GetAnalyzer(Slice fieldName, FieldMetadata field = default)
@@ -109,31 +151,8 @@ internal class AnalyzersScope : IDisposable
             $"Cannot find field {fieldName.ToString()} inside known binding and also index doesn't contain dynamic fields. The field you try to read is not inside index.");
     }
 
-    private void UnlikelyGrowBuffer(int outputSize, int tokensSize)
-    {
-        ReturnBuffers();
-
-        _outputBuffer = Analyzer.BufferPool.Rent(outputSize);
-        _tokensBuffer = Analyzer.TokensPool.Rent(tokensSize);
-    }
-
-    private void ReturnBuffers()
-    {
-        if (_tokensBuffer != null)
-        {
-            Analyzer.TokensPool.Return(_tokensBuffer);
-            _tokensBuffer = null;
-        }
-
-        if (_outputBuffer != null)
-        {
-            Analyzer.BufferPool.Return(_outputBuffer);
-            _outputBuffer = null;
-        }
-    }
-
     public void Dispose()
     {
-        ReturnBuffers();
+        _tempBufferScope.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
@@ -10,8 +10,6 @@ using Sparrow.Server;
 using Voron;
 using static Raven.Server.Documents.Indexes.MapReduce.ReduceKeyProcessor;
 
-namespace Raven.Server.Documents.Indexes.Persistence.Corax;
-
 internal unsafe class AnalyzersScope : IDisposable
 {
     private readonly IndexFieldsMapping _knownFields;
@@ -124,6 +122,7 @@ internal unsafe class AnalyzersScope : IDisposable
         {
             if (_hasDynamics is false)
                 ThrowWhenDynamicFieldNotFound(fieldName);
+
             var mode = _indexSearcher.GetFieldIndexingModeForDynamic(fieldName);
             
             analyzer = mode switch

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
@@ -59,7 +59,7 @@ internal unsafe class AnalyzersScope : IDisposable
     public ByteStringContext<ByteStringMemoryCache>.InternalScope Execute(Slice fieldName, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
     {
         Analyzer analyzer = GetAnalyzer(fieldName);
-        return ExecuteAnalyze(analyzer, source, out buffer, out tokens);
+        return Execute(analyzer, source, out buffer, out tokens);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -81,10 +81,10 @@ internal unsafe class AnalyzersScope : IDisposable
         }
 
         var analyzer = field.Analyzer;
-        return ExecuteAnalyze(analyzer, source, out buffer, out tokens);
+        return Execute(analyzer, source, out buffer, out tokens);
     }
     
-    private ByteStringContext<ByteStringMemoryCache>.InternalScope ExecuteAnalyze(Analyzer analyzer, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
+    public ByteStringContext<ByteStringMemoryCache>.InternalScope Execute(Analyzer analyzer, ReadOnlySpan<byte> source, out ReadOnlySpan<byte> buffer, out ReadOnlySpan<Token> tokens)
     {
         analyzer.GetOutputBuffersSize(source.Length, out var outputSize, out var tokensSize);
         if (outputSize > _tempOutputBufferSize || tokensSize > _tempOutputTokenSize)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnalyzersScope.cs
@@ -31,6 +31,7 @@ internal unsafe class AnalyzersScope : IDisposable
         _knownFields = fieldsMapping;
         _hasDynamics = hasDynamics;
         _analyzersCache = new(SliceComparer.Instance);
+
         InitializeTemporaryBuffers(indexSearcher.Allocator);
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -49,12 +49,13 @@ public class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         Dictionary<string, Dictionary<string, FacetValues>> facetsByName = new();
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
 
-        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories,
-            _fieldMappings, null, null, -1, null);
+        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1, null);
         var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out var isBinary);
         var coraxPageSize = CoraxGetPageSize(_indexSearcher, facetQuery.Query.PageSize, query, isBinary);
         var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);
+
         using var analyzersScope = new AnalyzersScope(_indexSearcher, _fieldMappings, _index.Definition.HasDynamicFields);
+
         int read = 0;
         while ((read = baseQuery.Fill(ids)) != 0)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
@@ -66,8 +66,7 @@ public static class CoraxIndexingHelpers
                 switch (value.Indexing)
                 {
                     case FieldIndexing.Exact:
-                        defaultAnalyzerToUse = GetOrCreateAnalyzer(Constants.Documents.Indexing.Fields.AllFields, index.Configuration.DefaultExactAnalyzerType.Value.Type,
-                            CreateKeywordAnalyzer);
+                        defaultAnalyzerToUse = GetOrCreateAnalyzer(Constants.Documents.Indexing.Fields.AllFields, index.Configuration.DefaultExactAnalyzerType.Value.Type, CreateKeywordAnalyzer);
                         break;
 
                     case FieldIndexing.Search:
@@ -162,11 +161,11 @@ public static class CoraxIndexingHelpers
         
         return mappingBuilder.Build();
 
-        CoraxAnalyzer GetOrCreateAnalyzer(string fieldName, Type analyzerType, Func<string, Type, CoraxAnalyzer> createAnalyzer)
+        CoraxAnalyzer GetOrCreateAnalyzer(string fieldName, Type analyzerType, Func<ByteStringContext, string, Type, CoraxAnalyzer> createAnalyzer)
         {
             if (analyzers.TryGetValue(analyzerType, out var analyzer) == false)
             {
-                analyzers[analyzerType] = analyzer = createAnalyzer(fieldName, analyzerType);
+                analyzers[analyzerType] = analyzer = createAnalyzer(context, fieldName, analyzerType);
             }
 
             return analyzer;
@@ -175,7 +174,7 @@ public static class CoraxIndexingHelpers
         CoraxAnalyzer CreateDefaultAnalyzer(string fieldName, Type analyzerType)
         {
             if (analyzerType == typeof(LowerCaseKeywordAnalyzer))
-                return CoraxAnalyzer.Create(default(KeywordTokenizer), default(LowerCaseTransformer));
+                return CoraxAnalyzer.Create(context, default(KeywordTokenizer), default(LowerCaseTransformer));
 
             if (analyzerType.IsSubclassOf(typeof(LuceneAnalyzer)))
                 return LuceneAnalyzerAdapter.Create(LuceneIndexingExtensions.CreateAnalyzerInstance(fieldName, analyzerType));
@@ -183,10 +182,10 @@ public static class CoraxIndexingHelpers
             return CoraxIndexingExtensions.CreateAnalyzerInstance(fieldName, analyzerType);
         }
 
-        CoraxAnalyzer CreateKeywordAnalyzer(string fieldName, Type analyzerType)
+        CoraxAnalyzer CreateKeywordAnalyzer(ByteStringContext context, string fieldName, Type analyzerType)
         {
             if (analyzerType == typeof(KeywordAnalyzer))
-                return CoraxAnalyzer.Create(default(KeywordTokenizer), default(ExactTransformer));
+                return CoraxAnalyzer.Create(context, default(KeywordTokenizer), default(ExactTransformer));
 
             if (analyzerType.IsSubclassOf(typeof(LuceneAnalyzer)))
                 return LuceneAnalyzerAdapter.Create(LuceneIndexingExtensions.CreateAnalyzerInstance(fieldName, analyzerType));
@@ -194,7 +193,7 @@ public static class CoraxIndexingHelpers
             return CoraxIndexingExtensions.CreateAnalyzerInstance(fieldName, analyzerType);
         }
 
-        CoraxAnalyzer CreateStandardAnalyzer(string fieldName, Type analyzerType)
+        CoraxAnalyzer CreateStandardAnalyzer(ByteStringContext context, string fieldName, Type analyzerType)
         {
             if (analyzerType == typeof(RavenStandardAnalyzer))
                 return LuceneAnalyzerAdapter.Create(new RavenStandardAnalyzer(Version.LUCENE_29));    

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
@@ -111,7 +111,7 @@ internal class RavenMoreLikeThis : MoreLikeThisBase, IDisposable
         var termOriginal = Encoding.UTF8.GetBytes(r.ReadToEnd());
 
         using var _ = Slice.From(this._builderParameters.Allocator, fieldName, ByteStringType.Immutable, out var fieldNameSlice);
-        using var __ = _analyzersScope.Execute(fieldNameSlice, termOriginal, out var outputBuffer, out var outputTokens);
+        using var __ = _analyzersScope.Execute(_analyzer, termOriginal, out var outputBuffer, out var outputTokens);
 
         var tokenCount = 0;
         foreach (var token in outputTokens)

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
@@ -253,7 +253,7 @@ internal class RavenMoreLikeThis : MoreLikeThisBase, IDisposable
         
         void InsertTerm(ReadOnlySpan<byte> termToAdd, bool exactInsert = false)
         {
-            _analyzersScope.Execute(field, termToAdd, out var bufferSpan, out var tokensSpan, exactInsert);
+            using var _ = _analyzersScope.Execute(field, termToAdd, out var bufferSpan, out var tokensSpan, exactInsert);
             for (int index = 0; index < tokensSpan.Length; index++)
             {
                 Token token = tokensSpan[index];

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
@@ -44,7 +44,7 @@ internal class RavenMoreLikeThis : MoreLikeThisBase, IDisposable
 
     public RavenMoreLikeThis(CoraxQueryBuilder.Parameters builderParameters, Analyzer analyzer = null)
     {
-        _analyzer = analyzer ?? Analyzer.DefaultAnalyzer;
+        _analyzer = analyzer ?? Analyzer.CreateDefaultAnalyzer(builderParameters.Allocator);
         _builderParameters = builderParameters;
         _analyzersScope = new(builderParameters.IndexSearcher, builderParameters.IndexFieldsMapping, builderParameters.HasDynamics);
     }

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1401,7 +1401,7 @@ namespace FastTests.Corax
             Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
             Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
 
-            var analyzer = Analyzer.Create<KeywordTokenizer, LowerCaseTransformer>();
+            var analyzer = Analyzer.Create<KeywordTokenizer, LowerCaseTransformer>(ctx);
 
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             IndexEntries(bsc, entriesToIndex, CreateKnownFields(bsc, analyzer));
@@ -1478,7 +1478,7 @@ namespace FastTests.Corax
             Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
             Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
 
-            var analyzer = Analyzer.Create<WhitespaceTokenizer, LowerCaseTransformer>();
+            var analyzer = Analyzer.Create<WhitespaceTokenizer, LowerCaseTransformer>(ctx);
             using var builder = IndexFieldsMappingBuilder.CreateForWriter(false)
                 .AddBinding(IdIndex, idSlice, analyzer)
                 .AddBinding(ContentIndex, contentSlice, analyzer);
@@ -1536,7 +1536,7 @@ namespace FastTests.Corax
             Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
             Slice.From(ctx, "Content", ByteStringType.Immutable, out Slice contentSlice);
 
-            var analyzer = Analyzer.Create<WhitespaceTokenizer, LowerCaseTransformer>();
+            var analyzer = Analyzer.Create<WhitespaceTokenizer, LowerCaseTransformer>(ctx);
             using var builder = IndexFieldsMappingBuilder.CreateForWriter(false)
                 .AddBinding(IdIndex, idSlice, analyzer)
                 .AddBinding(ContentIndex, contentSlice, analyzer);

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -160,7 +160,7 @@ public class RawCoraxFlag : StorageTest
 
         using var builder = (analyzers
             ? IndexFieldsMappingBuilder.CreateForWriter(false)
-                .AddBinding(IndexId, idSlice, Analyzer.DefaultAnalyzer)
+                .AddBinding(IndexId, idSlice, Analyzer.CreateDefaultAnalyzer(ctx))
                 .AddBinding(ContentId, contentSlice, LuceneAnalyzerAdapter.Create(new RavenStandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30)))
             : IndexFieldsMappingBuilder.CreateForWriter(false)
                 .AddBinding(IndexId, idSlice)

--- a/test/FastTests/Corax/SimplePipeline.cs
+++ b/test/FastTests/Corax/SimplePipeline.cs
@@ -130,7 +130,7 @@ namespace FastTests.Corax
         {
             Span<byte> source = Encoding.UTF8.GetBytes("This is a SiMple tEsT");
 
-            var analyzer = Analyzer.Create(default(WhitespaceTokenizer), default(LowerCaseTransformer));
+            var analyzer = Analyzer.Create(this.Allocator, default(WhitespaceTokenizer), default(LowerCaseTransformer));
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);
 
             Span<byte> buffer = new byte[bufferSize];
@@ -159,7 +159,7 @@ namespace FastTests.Corax
             Span<byte> source = Encoding.UTF8.GetBytes(input);
             ReadOnlySpan<byte> sourceLowerCased = Encoding.UTF8.GetBytes(input.ToLower());
 
-            var analyzer = Analyzer.Create(default(KeywordTokenizer), default(LowerCaseTransformer));
+            var analyzer = Analyzer.Create(this.Allocator, default(KeywordTokenizer), default(LowerCaseTransformer));
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);
 
             Span<byte> buffer = new byte[bufferSize];
@@ -179,7 +179,7 @@ namespace FastTests.Corax
         {
             Span<byte> source = Encoding.UTF8.GetBytes(input);
 
-            var analyzer = Analyzer.Create(default(KeywordTokenizer), default(LowerCaseTransformer));
+            var analyzer = Analyzer.Create(this.Allocator, default(KeywordTokenizer), default(LowerCaseTransformer));
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);
 
             Span<byte> buffer = new byte[bufferSize];
@@ -205,7 +205,7 @@ namespace FastTests.Corax
             Span<byte> source = Encoding.UTF8.GetBytes(input);
 
 
-            var analyzer = Analyzer.Create(default(WhitespaceTokenizer), default(LowerCaseTransformer));
+            var analyzer = Analyzer.Create(this.Allocator, default(WhitespaceTokenizer), default(LowerCaseTransformer));
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);
 
             Span<byte> buffer = new byte[bufferSize];
@@ -258,7 +258,7 @@ namespace FastTests.Corax
         {
             Span<byte> source = Encoding.UTF8.GetBytes("This is a SiMple stop stop tEsT");
 
-            var analyzer = Analyzer.Create(default(WhitespaceTokenizer), default(LowerCaseTransformer))
+            var analyzer = Analyzer.Create(this.Allocator, default(WhitespaceTokenizer), default(LowerCaseTransformer))
                                    .With(default(FilterTransformer<BasicLowercaseFilter>));     
             
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);
@@ -283,7 +283,7 @@ namespace FastTests.Corax
         {
             ReadOnlySpan<char> source = "This is a SiMple stop stop tEsT".AsSpan();
 
-            var analyzer = Analyzer.Create(default(WhitespaceTokenizer), default(LowerCaseTransformer))
+            var analyzer = Analyzer.Create(this.Allocator, default(WhitespaceTokenizer), default(LowerCaseTransformer))
                                    .With(default(FilterTransformer<BasicLowercaseFilter>));
 
             analyzer.GetOutputBuffersSize(source.Length, out int bufferSize, out int tokenSize);

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -134,7 +134,7 @@ namespace FastTests.Corax
 
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
 
-            using var mapping = CreateKnownFields(bsc, Analyzer.DefaultAnalyzer);
+            using var mapping = CreateKnownFields(bsc, Analyzer.CreateDefaultAnalyzer(bsc));
             mapping.TryGetByFieldId(1, out var contentField);
 
             IndexEntries(bsc, new[] { entry1, entry2, entry3, entry4, entry5 }, mapping);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19597

### Additional description

The ArrayPool<T> locking mechanism creates contention under high requests environments.

There are 2 ways to avoid this contention, one is to avoid using it altogether and the other one is separating the pools from the actual executing thread. 
While the correct approach would be to amp-up the usage of shared buffers (which would make) the complexity it introduces is much greater than what it make sense to be done at the moment. Therefore, we did go that route for the locations where the changes would be isolated from the rest of the Analyzers infrastructure and defer the rest to use per thread Array Pools just to avoid the locking convoys. 

### Type of change
- Optimization

### How risky is the change?
- Low 