### PR TITLE
RavenDB-19466 Can modify metadata using etl transform script

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19466.cs
+++ b/test/SlowTests/Issues/RavenDB-19466.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19466:EtlTestBase 
+{
+    public RavenDB_19466(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanModifyDocumentMetadataUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction()
+    {
+        using (var src = GetDocumentStore())
+        using (var dest = GetDocumentStore())
+        {
+            AddEtl(src, dest, "Users", script: @"function deleteDocumentsBehavior(docId, collection, deleted) {
+                                                                return false; // don't send any deletes to the other side
+                                                            }
+                                                            var metadata = getMetadata(this);
+                                                            metadata[""TestETLMetadataReference""] = ""HelloFromTransformScript"";
+                                                            loadToUsers(this);");
+
+            var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User {Name = "Gracjan"});
+
+                session.SaveChanges();
+            }
+            etlDone.Wait(TimeSpan.FromMinutes(1));
+
+            using (var session = dest.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                Assert.NotNull(user);
+                Assert.Equal("HelloFromTransformScript", session.Advanced.GetMetadataFor(user)["TestETLMetadataReference"]);
+            }
+            
+            using (var session = src.OpenSession())
+            {
+                session.Delete("users/1-A");
+                session.SaveChanges();
+            }
+            
+            etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+            etlDone.Wait(TimeSpan.FromMinutes(1));
+            
+            using (var session = dest.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                Assert.NotNull(user);
+                Assert.Equal("HelloFromTransformScript", session.Advanced.GetMetadataFor(user)["TestETLMetadataReference"]);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19466/Cannot-modify-metadata-in-ETL-script

### Additional description


Firstly, there was an invalid function call inside the script - `getMetadataFrom` instead of `getMetadata`.
Additionally, there was a bug causing the ETL process to fail due to a type error when the `GetMetadata` function was called with a `GlobalObject` object as an argument.

`GetMetadata` has an additional check asserting that the type of the argument is `BlittableObjectInstance`. The test run failed on it and the whole ETL didn't run properly. To fix this issue, I've added an additional check in the `GetMetadata` function to handle this expected behavior during test runs.

Created a test that updates the metadata inside the ETL script in a proper way. 
The script includes both the behavior function and the `getMetadata` method usage. 

We should consider adding an example of updating metadata in the ETL script to our documentation.


### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
