### PR TITLE
RavenDB-13122 - Fix NRE on Revert Revisions Per Collection

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1553,6 +1553,15 @@ namespace Raven.Server.Documents.Revisions
                     }
                     var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                     var revisions = readCtx.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
+                    if (revisions == null)
+                    {
+                        var msg = $"collection {collection} doesn't have revisions";
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info(msg);
+                        result.WarnAboutFailedCollection(msg);
+                        return false;
+                    }
+
                     tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag);
                 }
                 else

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1555,7 +1555,7 @@ namespace Raven.Server.Documents.Revisions
                     var revisions = readCtx.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
                     if (revisions == null)
                     {
-                        var msg = $"collection {collection} doesn't have revisions";
+                        var msg = $"Collection '{collection}' doesn't have any revisions.";
                         if (_logger.IsInfoEnabled)
                             _logger.Info(msg);
                         result.WarnAboutFailedCollection(msg);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13122

### Additional description

Fix NRE when trying to revert revisions for a collection that doesn't have revisions.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
