### PR TITLE
RavenDB-19672 Tombstone view doesn't load

### DIFF
--- a/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
@@ -169,7 +169,7 @@ function getSettingsMenuItem(appUrls: computedAppUrls) {
         }),
         new leafMenuItem({
             route: 'databases/advanced/tombstonesState',
-            moduleId: 'viewmodels/database/advanced/tombstonesState',
+            moduleId: require('viewmodels/database/advanced/tombstonesState'),
             title: 'Tombstones',
             nav: true,
             css: 'icon-revisions-bin',


### PR DESCRIPTION
### Issue link672
https://issues.hibernatingrhinos.com/issue/RavenDB-19672

### Additional description
Added the missing 'require' in settings.ts

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
