### PR TITLE
RavenDB-19452 - remove the MountPointsUsage from the response when the request comes from the studio

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -24,6 +24,7 @@ using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Dynamic;
+using Raven.Server.Extensions;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
@@ -390,6 +391,8 @@ namespace Raven.Server.Documents.Handlers
             using (var context = QueryOperationContext.Allocate(Database, needsServerContext: true))
             await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
             {
+                var notFromStudio = HttpContext.Request.IsFromStudio() == false;
+
                 IndexStats[] indexStats;
                 using (context.OpenReadTransaction())
                 {
@@ -402,7 +405,7 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 try
                                 {
-                                    return x.GetStats(calculateLag: true, calculateStaleness: true, calculateMemoryStats: true, queryContext: context);
+                                    return x.GetStats(calculateLag: true, calculateStaleness: true, calculateMemoryStats: notFromStudio, calculateLastBatchStats: notFromStudio, queryContext: context);
                                 }
                                 catch (OperationCanceledException)
                                 {
@@ -474,7 +477,7 @@ namespace Raven.Server.Documents.Handlers
                             return;
                         }
 
-                        indexStats = new[] { index.GetStats(calculateLag: true, calculateStaleness: true, calculateMemoryStats: true, queryContext: context) };
+                        indexStats = new[] { index.GetStats(calculateLag: true, calculateStaleness: true, calculateMemoryStats: notFromStudio, calculateLastBatchStats: notFromStudio, queryContext: context) };
                     }
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -107,7 +107,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             };
         }
 
-        public override IndexStats GetStats(bool calculateLag = false, bool calculateStaleness = false, bool calculateMemoryStats = false, QueryOperationContext queryContext = null)
+        public override IndexStats GetStats(bool calculateLag = false, bool calculateStaleness = false, bool calculateMemoryStats = false, bool calculateLastBatchStats = false, QueryOperationContext queryContext = null)
         {
             return new IndexStats
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2856,7 +2856,8 @@ namespace Raven.Server.Documents.Indexes
             return (lastDocumentEtag, lastTombstoneEtag);
         }
 
-        public virtual IndexStats GetStats(bool calculateLag = false, bool calculateStaleness = false, bool calculateMemoryStats = false,
+        public virtual IndexStats GetStats(bool calculateLag = false, bool calculateStaleness = false,
+            bool calculateMemoryStats = false, bool calculateLastBatchStats = false,
             QueryOperationContext queryContext = null)
         {
             using (CurrentlyInUse(out var valid))
@@ -2895,7 +2896,9 @@ namespace Raven.Server.Documents.Indexes
                     stats.MappedPerSecondRate = MapsPerSec?.OneMinuteRate ?? 0;
                     stats.ReducedPerSecondRate = ReducesPerSec?.OneMinuteRate ?? 0;
 
-                    stats.LastBatchStats = _lastStats?.ToIndexingPerformanceLiveStats();
+                    if (calculateLastBatchStats)
+                        stats.LastBatchStats = _lastStats?.ToIndexingPerformanceLiveStats();
+                    
                     stats.LastQueryingTime = _lastQueryingTime;
 
                     if (Type == IndexType.MapReduce || Type == IndexType.JavaScriptMapReduce)

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -517,6 +517,13 @@ namespace Raven.Server.Web.System
                                 })
                         };
 
+                        if (HttpContext.Request.IsFromStudio())
+                        {
+                            // remove this as this isn't needed for the studio
+                            // cannot remove this entirely since this is used by the client API
+                            databaseInfoJson.Modifications.Remove(nameof(DatabaseInfo.MountPointsUsage));
+                        }
+
                         context.Write(writer, databaseInfoJson);
                     }))
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19452/Large-response-size-of-the-databases-endpoint

### Additional description

Remove the MountPointsUsage from the response when the request comes from the studio

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- It has been verified by manual testing

### UI work

- No UI work is needed
