### PR TITLE
RavenDB-19667 : fix bug in schema upgrade From50002

### DIFF
--- a/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/60000/From50002.cs
@@ -116,7 +116,9 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     {
                         step.Commit(context);
                         step.RenewTransactions();
-
+                        table = tableName == null
+                            ? new Table(schema, step.WriteTx)
+                            : step.WriteTx.OpenTable(schema, tableName);
                         indexTree = step.WriteTx.ReadTree(indexName, isIndexTree: true);
                         _processedInCurrentTx = 0;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19667

### Additional description

re-open the table after transaction renewal 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
