### PR TITLE
RavenDB-19690 - Slow document writes when getting a ConcurrenyException in the merged transaction

### DIFF
--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -1098,7 +1098,8 @@ namespace Raven.Server.Documents
                                     SlowWriteNotification.Notify(stats, _parent);
                                 }
                             }
-                            DoCommandNotification(op);
+
+                            NotifyOnThreadPool(op);
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19690/Slow-document-writes-when-getting-a-ConcurrenyException-in-the-merged-transaction

### Additional description

Notifying task completion must be in a different thread than the Transaction Merger Thread.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- It has been verified by manual testing