### PR TITLE
RavenDB-18767 Sharding - Queries - Spatial 

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
@@ -35,6 +35,9 @@ public partial class LuceneIndexReadOperation
                 case OrderByFieldType.Random:
                     // we order by random when merging results from shards
                     break;
+                case OrderByFieldType.Distance:
+                    documentWithOrderByFields.AddDoubleOrderByField(d.Distance.Value.Distance);
+                    break;
                 default:
                     documentWithOrderByFields.AddStringOrderByField(_searcher.IndexReader.GetStringValueFor(field.OrderByName, doc, _state));
                     break;

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -335,7 +335,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return true;
         }
 
-        public SpatialField GetOrCreateSpatialField(string name)
+        public virtual SpatialField GetOrCreateSpatialField(string name)
         {
             return _getSpatialField(name);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
@@ -1,0 +1,15 @@
+﻿using Raven.Server.Documents.Indexes.Static.Spatial;
+
+namespace Raven.Server.Documents.Indexes.Static.Sharding;
+
+public class OrchestratorIndexingScope : CurrentIndexingScope
+{
+    public OrchestratorIndexingScope() : base(null, null, null, null, null, null, null)
+    {
+    }
+
+    public override SpatialField GetOrCreateSpatialField(string name)
+    {
+        return null;
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -11,6 +11,7 @@ using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
+using Raven.Server.Documents.Indexes.Static.Sharding;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Json;
@@ -644,7 +645,10 @@ namespace Raven.Server.Documents.Indexes.Static
         {
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
-            
+
+            if (CurrentIndexingScope.Current is OrchestratorIndexingScope)
+                return Enumerable.Empty<object>();
+
             if (lng == null || double.IsNaN(lng.Value))
                 return Enumerable.Empty<AbstractField>();
             if (lat == null || double.IsNaN(lat.Value))
@@ -660,7 +664,10 @@ namespace Raven.Server.Documents.Indexes.Static
         {
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
-            
+
+            if (CurrentIndexingScope.Current is OrchestratorIndexingScope)
+                return Enumerable.Empty<object>();
+
             return CurrentIndexingScope.Current.Index.SearchEngineType is SearchEngineType.Lucene
                 ? spatialField.LuceneCreateIndexableFields(shapeWkt)
                 : Enumerable.Cast<object>(spatialField.CoraxCreateIndexableFields(shapeWkt));

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Queries;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Server.Documents.Includes.Sharding;
+using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Sharding;
 using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Sharding.Commands;
@@ -21,14 +22,16 @@ namespace Raven.Server.Documents.Sharding.Operations;
 
 public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQueryResult>
 {
+    private readonly IndexQueryServerSide _query;
     private readonly TransactionOperationContext _context;
     private readonly ShardedDatabaseRequestHandler _requestHandler;
     private readonly Dictionary<int, ShardedQueryCommand> _queryCommands;
     private readonly ShardedDocumentsComparer _sortingComparer;
     private long _combinedResultEtag;
 
-    public ShardedQueryOperation(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, Dictionary<int, ShardedQueryCommand> queryCommands, ShardedDocumentsComparer sortingComparer, string expectedEtag)
+    public ShardedQueryOperation(IndexQueryServerSide query, TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, Dictionary<int, ShardedQueryCommand> queryCommands, ShardedDocumentsComparer sortingComparer, string expectedEtag)
     {
+        _query = query;
         _context = context;
         _requestHandler = requestHandler;
         _queryCommands = queryCommands;
@@ -188,6 +191,8 @@ public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQ
                 }
             }
         }
+
+        result.RegisterSpatialProperties(_query);
 
         return result;
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedDocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedDocumentsComparer.cs
@@ -58,6 +58,7 @@ public class ShardedDocumentsComparer : IComparer<BlittableJsonReaderObject>
                     return xLng.CompareTo(yLng);
                 }
             case OrderByFieldType.Double:
+            case OrderByFieldType.Distance:
                 {
                     var hasX = TryGetDoubleValue(x, order.Name, index, out double xDbl);
                     var hasY = TryGetDoubleValue(y, order.Name, index, out double yDbl);
@@ -87,12 +88,9 @@ public class ShardedDocumentsComparer : IComparer<BlittableJsonReaderObject>
             case OrderByFieldType.Custom:
                 throw new NotSupportedInShardingException("Custom sorting is not supported in sharding as of yet");
             case OrderByFieldType.Score:
-            case OrderByFieldType.Distance:
             default:
                 throw new ArgumentException("Unknown OrderingType: " + order.OrderingType);
         }
-
-
     }
 
     private string GetString(BlittableJsonReaderObject blittable, string fieldName, int index)

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -22,7 +22,6 @@ using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
-using static Raven.Server.Smuggler.Documents.CounterItem;
 
 namespace Raven.Server.Documents.Sharding.Queries;
 
@@ -87,7 +86,7 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
             var timeSeriesKeys = _query.Metadata.TimeSeriesIncludes.TimeSeries.Keys;
         }
 
-        var operation = new ShardedQueryOperation(_context, _requestHandler, _commands, documentsComparer, _existingResultEtag?.ToString());
+        var operation = new ShardedQueryOperation(_query, _context, _requestHandler, _commands, documentsComparer, _existingResultEtag?.ToString());
 
         var shardedReadResult = await _requestHandler.ShardExecutor.ExecuteParallelForShardsAsync(_commands.Keys.ToArray(), operation, _token);
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -46,10 +46,7 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
         CancellationToken token) : base(context, requestHandler, query, metadataOnly, indexEntriesOnly, token)
     {
         _existingResultEtag = existingResultEtag;
-
         _raftUniqueRequestId = _requestHandler.GetRaftRequestIdFromQuery() ?? RaftIdGenerator.NewId();
-
-        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-19084 Etag handling");
 
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-19084 Add an option to select the shards for query in the client");
         

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Indexes.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Indexes.cs
@@ -98,13 +98,15 @@ public partial class ShardedDatabaseContext
                 switch (definition.Type)
                 {
                     case IndexType.Map:
+                    case IndexType.JavaScriptMap:
                         indexInformationHolder = MapIndex.CreateIndexInformationHolder(definition, _context.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, out _);
                         break;
                     case IndexType.MapReduce:
+                    case IndexType.JavaScriptMapReduce:
                         indexInformationHolder = MapReduceIndex.CreateIndexInformationHolder(definition, _context.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, out _);
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(definition.Type));
+                        throw new ArgumentOutOfRangeException(nameof(definition.Type), definition.Type, "Unknown index type");
                 }
 
                 return indexInformationHolder;

--- a/test/SlowTests/Issues/RavenDB-13682.cs
+++ b/test/SlowTests/Issues/RavenDB-13682.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByRoundedSpatialRanges(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -120,7 +120,7 @@ order by spatial.distance(spatial.point(a.Lat, a.Lng), spatial.point(35.1, -106.
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseDynamicQueryOrderBySpatial_WithAlias(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -145,7 +145,7 @@ limit 1")
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseDynamicQueryOrderBySpatial(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -170,7 +170,7 @@ limit 1")
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanProjectDistanceComputation(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-15794.cs
+++ b/test/SlowTests/Issues/RavenDB-15794.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Issues
 
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CirclesShouldIntersect(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_3222.cs
+++ b/test/SlowTests/Issues/RavenDB_3222.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void TDSQ(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/BoundingBoxIndexTests.cs
+++ b/test/SlowTests/Tests/Spatial/BoundingBoxIndexTests.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void BoundingBoxTest(Options options)
         {
             // X XXX X

--- a/test/SlowTests/Tests/Spatial/BrainV.cs
+++ b/test/SlowTests/Tests/Spatial/BrainV.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformSpatialSearchWithNulls(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -64,7 +64,7 @@ namespace SlowTests.Tests.Spatial
 
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseNullCoalescingOperator(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/CartesianTests.cs
+++ b/test/SlowTests/Tests/Spatial/CartesianTests.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void Points(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/DynamicSpatialQueries.cs
+++ b/test/SlowTests/Tests/Spatial/DynamicSpatialQueries.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifySingleSpatialPropertyInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -59,7 +59,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyMultipleSpatialPropertiesInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -109,7 +109,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifySelectedSpatialPropertiesWithAliasInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -152,7 +152,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifySelectedSpatialPropertiesWithoutAliasInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -195,7 +195,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyNoSpatialPropertiesInResultsWhenSelectingOnlyLatitudeProperty(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -232,7 +232,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyNoSpatialPropertiesInResultsWhenSelectingNonSpatialField(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -269,7 +269,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyPolygonInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -318,7 +318,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyCirclesInResults(Options options)
         {
             var house1 = new GeoDoc(44.75, -93.35);
@@ -390,7 +390,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void VerifyWKTCircleHasDistance(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/GeoUriTests.cs
+++ b/test/SlowTests/Tests/Spatial/GeoUriTests.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void PointTest(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/JamesCrowley.cs
+++ b/test/SlowTests/Tests/Spatial/JamesCrowley.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void GeoSpatialTest(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/Nick.cs
+++ b/test/SlowTests/Tests/Spatial/Nick.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Test(Options options)
         {
             using (IDocumentStore store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SimonBartlett.cs
+++ b/test/SlowTests/Tests/Spatial/SimonBartlett.cs
@@ -92,7 +92,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CirclesShouldNotIntersect(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -125,7 +125,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void GeohashIndexDefaultLevel_LineStringShouldNotThrowException(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -157,7 +157,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void GeohashIndexLevel7_LineStringShouldNotThrowException(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/Spatial.cs
+++ b/test/SlowTests/Tests/Spatial/Spatial.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Tests.Spatial
         }
         
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void WeirdSpatialResults(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -111,7 +111,7 @@ namespace SlowTests.Tests.Spatial
         }
         
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void MatchSpatialResults(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -175,7 +175,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void WeirdSpatialResults2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -211,7 +211,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void SpatialSearchWithSwedishCulture(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialQueries.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialQueries.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanRunSpatialQueriesInMemory(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -54,7 +54,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         //Failing test from http://groups.google.com/group/ravendb/browse_thread/thread/7a93f37036297d48/
         public void CanSuccessfullyDoSpatialQueryOfNearbyLocations(Options options)
         {
@@ -113,7 +113,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanSuccessfullyQueryByMiles(Options options)
         {
             var myHouse = new DummyGeoDoc(44.757767, -93.355322);

--- a/test/SlowTests/Tests/Spatial/SpatialSearch.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialSearch.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_do_spatial_search_with_client_api(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -113,7 +113,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_do_spatial_search_with_client_api2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -139,7 +139,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_do_spatial_search_with_client_api_within_given_capacity(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -207,7 +207,19 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void PolandTestOrderByDistanceLucene(Options options)
+        {
+            PolandTestOrderByDistance(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void PolandTestOrderByDistanceCorax(Options options)
+        {
+            PolandTestOrderByDistance(options);
+        }
+
         public void PolandTestOrderByDistance(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -250,7 +262,19 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_do_spatial_search_with_client_api_addorderLucene(Options options)
+        {
+            Can_do_spatial_search_with_client_api_addorder(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Can_do_spatial_search_with_client_api_addorderCorax(Options options)
+        {
+            Can_do_spatial_search_with_client_api_addorder(options);
+        }
+
         public void Can_do_spatial_search_with_client_api_addorder(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialSorting.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialSorting.cs
@@ -115,7 +115,19 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQueryLucene(Options options)
+        {
+            CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQueryCorax(Options options)
+        {
+            CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(options);
+        }
+
         public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -135,8 +147,20 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-        public void CanSortByDistanceWOFilteringWDocQuery(Options options)
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanSortByDistanceWOFilteringWDocQueryLucene(Options options)
+        {
+            CanSortByDistanceWOFilteringWDocQuery(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanSortByDistanceWOFilteringWDocQueryCorax(Options options)
+        {
+            CanSortByDistanceWOFilteringWDocQuery(options);
+        }
+
+        private void CanSortByDistanceWOFilteringWDocQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
@@ -174,7 +198,19 @@ namespace SlowTests.Tests.Spatial
 
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanSortByDistanceWOFilteringLucene(Options options)
+        {
+            CanSortByDistanceWOFiltering(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanSortByDistanceWOFilteringCorax(Options options)
+        {
+            CanSortByDistanceWOFiltering(options);
+        }
+
         public void CanSortByDistanceWOFiltering(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -193,7 +229,19 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanSortByDistanceWOFilteringBySpecifiedFieldLucene(Options options)
+        {
+            CanSortByDistanceWOFilteringBySpecifiedField(options);
+        }
+
+        [RavenTheory(RavenTestCategory.Spatial)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanSortByDistanceWOFilteringBySpecifiedFieldCorax(Options options)
+        {
+            CanSortByDistanceWOFilteringBySpecifiedField(options);
+        }
+
         public void CanSortByDistanceWOFilteringBySpecifiedField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialTest2.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialTest2.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void WeirdSpatialResults(Options options)
         {
             using (IDocumentStore store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialUnitTests.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialUnitTests.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Test(Options options)
         {
             var myHouse = new DummyGeoDoc(44.757767, -93.355322);

--- a/test/SlowTests/Tests/Spatial/TwoLocations.cs
+++ b/test/SlowTests/Tests/Spatial/TwoLocations.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocations(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -93,7 +93,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocations2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -128,7 +128,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocationsOverHttp(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -159,7 +159,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocationsHttp2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -190,7 +190,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocationsRaw(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -225,7 +225,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryByMultipleLocationsRawOverHttp(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/WktSanitizerTests.cs
+++ b/test/SlowTests/Tests/Spatial/WktSanitizerTests.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void Integration(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18767/Sharding-Queries-Spatial
https://issues.hibernatingrhinos.com/issue/RavenDB-19666/Sharding-Collection-query-and-projection-doesnt-work

### Additional description

1. Set of changes to make spatial queries work in sharded env:

- support for order by distance on the orchestrator side (still doesn't work when using Corax) 
- fixed problem with applying reduce function containing `CreateSpatialField()` on the orchestrator 
- returning additional spatial properties from the orchestrator (it's requested by Studio when running spatial queries)

2. Fixed a problem with collection queries which loads specific documents by ID and do a projection e.g. `from Users as u where id() = 'users/1' select { Age: u.Age, Name: u.Name }` - the part `select ... ` was not sent to the shards by the orchestrator

### Type of change

- Fixes for sharding 

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed