### PR TITLE
RavenDB-19083 Added test for case where no results is returned during reduce on the orchestrator

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -70,10 +70,7 @@ public class ShardedMapReduceQueryResultsMerger
         }
 
         if (propertyAccessor == null)
-        {
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-19083 add a test for this");
-            return new List<BlittableJsonReaderObject>();
-        }
+            return new List<BlittableJsonReaderObject>(0);
 
         var objects = new ShardedAggregatedAnonymousObjects(results, propertyAccessor, _context);
         return objects.GetOutputsToStore().ToList();

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -34,8 +34,6 @@ public class ShardedMapReduceQueryResultsMerger
 
     public List<BlittableJsonReaderObject> Merge()
     {
-        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-19083 Make sure that we have the auto map index in the orchestrator");
-
         var index = _indexesContext.GetIndex(_indexName);
         if (index == null)
             IndexDoesNotExistException.ThrowFor(_indexName);

--- a/test/SlowTests/Issues/RavenDB_19083.cs
+++ b/test/SlowTests/Issues/RavenDB_19083.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using FastTests.Client;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19083 : RavenTestBase
+{
+    public RavenDB_19083(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+    public void No_results_after_reduce_on_orchestrator()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var index = new Orders_ByCompany();
+
+            store.ExecuteIndex(index);
+
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    session.Store(new Query.Order()
+                    {
+                        Company = "companies/1",
+                        Lines = new List<OrderLine>
+                        {
+                            new OrderLine(){ Quantity = 1, PricePerUnit = 10}
+                        }
+                    });
+                }
+
+                session.SaveChanges();
+
+                var results = session.Query<Orders_ByCompany.Result, Orders_ByCompany>().Customize(x => x.WaitForNonStaleResults()).ToList();
+
+                Assert.Equal(0, results.Count);
+            }
+        }
+    }
+
+    private class Orders_ByCompany : AbstractIndexCreationTask<Query.Order, Orders_ByCompany.Result>
+    {
+        public class Result
+        {
+            public string Company { get; set; }
+            public int Count { get; set; }
+            public decimal Total { get; set; }
+        }
+
+        public Orders_ByCompany()
+        {
+            Map = orders => from order in orders
+                            select new Result { Company = order.Company, Count = 1, Total = order.Lines.Sum(l => (l.Quantity * l.PricePerUnit) * (1 - l.Discount)) };
+
+            Reduce = results => from result in results
+                                group result by result.Company
+                                into g
+                                let total = g.Sum(x => x.Total)
+                                where total < 100
+                                select new { Company = g.Key, Count = g.Sum(x => x.Count), Total =  total };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19083/Sharding-Queries-MapReduce

### Additional description

1. First TODO fixed in https://github.com/ravendb/ravendb/pull/14112
2. Added passing test

### Type of change

- Test

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
