### PR TITLE
RavenDB-18253 Making sure that we use the same RaftId when sending a query to shards. This way if an auto index needs to be created it's guaranteed that the put index command will be processed just once.

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Queries;
@@ -10,16 +11,18 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Commands;
 
-public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObject, QueryResult>
+public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObject, QueryResult>, IRaftCommand
 {
     private readonly BlittableJsonReaderObject _query;
     private readonly string _indexName;
 
-    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName, bool canReadFromCache) : base(indexQuery, true, metadataOnly, indexEntriesOnly)
+    public ShardedQueryCommand(BlittableJsonReaderObject query, IndexQueryServerSide indexQuery, bool metadataOnly, bool indexEntriesOnly, string indexName,
+        bool canReadFromCache, string raftUniqueRequestId) : base(indexQuery, true, metadataOnly, indexEntriesOnly)
     {
         _query = query;
         _indexName = indexName;
         CanReadFromCache = canReadFromCache;
+        RaftUniqueRequestId = raftUniqueRequestId;
     }
 
     protected override ulong GetQueryHash(JsonOperationContext ctx)
@@ -52,4 +55,6 @@ public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObjec
 
         Result = JsonDeserializationClient.QueryResult(response);
     }
+
+    public string RaftUniqueRequestId { get; }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18253/Sharding-Queries-Auto-index-generation

### Additional description

Guaranteed that an auto index put command will be processed just once since each shard will use the same RaftId

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
