### PR TITLE
HRINT-3122 Remove number of test ordered to run alphabetically from logs

### DIFF
--- a/test/Tests.Infrastructure/AlphabeticTestsOrderer.cs
+++ b/test/Tests.Infrastructure/AlphabeticTestsOrderer.cs
@@ -19,12 +19,6 @@ namespace Tests.Infrastructure
         {
             var orderedTestCases = testCases.OrderBy(x => x.DisplayName).ToList();
 
-            if (_diagnosticMessageSink != null) //just in case
-            {
-                var message = new DiagnosticMessage("Alphabetically ordered {0} test cases", orderedTestCases.Count);
-                _diagnosticMessageSink.OnMessage(message);
-            }
-
             return orderedTestCases;
         }
 

--- a/test/Tests.Infrastructure/AlphabeticTestsOrderer.cs
+++ b/test/Tests.Infrastructure/AlphabeticTestsOrderer.cs
@@ -1,28 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using DiagnosticMessage = Xunit.Sdk.DiagnosticMessage;
 
 namespace Tests.Infrastructure
 {
-    
+
     public class AlphabeticTestsOrderer : ITestCaseOrderer, ITestCollectionOrderer
     {
-        private readonly IMessageSink _diagnosticMessageSink;
-
-        public AlphabeticTestsOrderer(IMessageSink diagnosticMessageSink) => 
-            _diagnosticMessageSink = diagnosticMessageSink;
-
-        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        public AlphabeticTestsOrderer(IMessageSink diagnosticMessageSink)
         {
-            var orderedTestCases = testCases.OrderBy(x => x.DisplayName).ToList();
-
-            return orderedTestCases;
         }
 
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+            => testCases.OrderBy(x => x.DisplayName, StringComparer.Ordinal);
+
         public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
-            => testCollections.OrderBy(x => x.DisplayName);
+            => testCollections.OrderBy(x => x.DisplayName, StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-3122

### Additional description

Removed logging number of test ordered to run alphabetically.