### PR TITLE
RavenDB-16772: don't log OperationCanceledException in subscription

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -377,7 +377,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
                                 var errorMessage = $"Failed to process subscription {connection.SubscriptionId} / from client {remoteEndPoint}";
                                 connection.AddToStatusDescription($"{errorMessage}. Sending response to client");
-                                if (connection._logger.IsInfoEnabled)
+                                if (connection._logger.IsInfoEnabled && e is not OperationCanceledException)
                                 {
                                     connection._logger.Info(errorMessage, e);
                                 }
@@ -536,11 +536,14 @@ namespace Raven.Server.Documents.TcpHandlers
                 }
                 else
                 {
-                    connection.AddToStatusDescription("Subscription error");
-
-                    if (connection._logger.IsInfoEnabled)
+                    if (ex is not OperationCanceledException)
                     {
-                        connection._logger.Info("Subscription error", ex);
+                        connection.AddToStatusDescription("Subscription error");
+
+                        if (connection._logger.IsInfoEnabled)
+                        {
+                            connection._logger.Info("Subscription error", ex);
+                        }
                     }
                     await connection.WriteJsonAsync(new DynamicJsonValue
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16772

### Additional description

OperationCanceledException is logged even it is expected exception on database shut down or disabling.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?


- No

### UI work

- No UI work is needed
