### PR TITLE
RavenDB-19690 - Improve the performance when we have a lot of ConcurrencyExceptions

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -624,10 +624,8 @@ namespace Voron.Impl.Journal
 
             public void OnTransactionCompleted()
             {
-                if (_waitForJournalStateUpdateUnderTx.IsSet == false)
-                {
-                    _onWriteTransactionCompleted.Set();
-                }
+                // no-op if there no waiters
+                _onWriteTransactionCompleted.Set();
             }
 
             public long LastFlushedTransactionId => _lastFlushed.TransactionId;
@@ -902,6 +900,7 @@ namespace Voron.Impl.Journal
                                 case 1:
                                 case WaitHandle.WaitTimeout:
                                     // _onWriteTransactionCompleted or timeout
+                                    _onWriteTransactionCompleted.Reset();
                                     continue;
 
                                 default:

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -624,7 +624,7 @@ namespace Voron.Impl.Journal
 
             public void OnTransactionCompleted()
             {
-                // no-op if there no waiters
+                // no-op if there are no waiters
                 _onWriteTransactionCompleted.Set();
             }
 
@@ -898,9 +898,13 @@ namespace Voron.Impl.Journal
                                     return;
 
                                 case 1:
-                                case WaitHandle.WaitTimeout:
-                                    // _onWriteTransactionCompleted or timeout
+                                    // once we get a signal (_onWriteTransactionCompleted), we should be able to acquire the write tx lock since we prevent new write transactions.
+                                    // this is just a precaution in order to prevent a loop here if the implementation will change in the future.
                                     _onWriteTransactionCompleted.Reset();
+                                    continue;
+
+                                case WaitHandle.WaitTimeout:
+                                    // timeout
                                     continue;
 
                                 default:

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -880,7 +880,7 @@ namespace Voron.Impl.Journal
                                 _flushLockTaskResponsible.RunTaskIfNotAlreadyRan();
 
                                 // 2 options here:
-                                // - we got a notification after the transaction was commited, in which case 
+                                // - we got a notification after the transaction was committed, in which case 
                                 //   _updateJournalStateAfterFlush was set to null while it was holding the write tx lock
                                 //   and we'll exit (from the while)
                                 // - we got a notification that the transaction is over (for any reason)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -954,6 +954,8 @@ namespace Voron
                 _writeTransactionRunning.Reset();
                 _transactionWriter.Release();
 
+                Journal.Applicator.OnTransactionCompleted();
+
                 if (tx.FlushInProgressLockTaken)
                     FlushInProgressLock.ExitReadLock();
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19690/Slow-document-writes-when-getting-a-ConcurrenyException-in-the-merged-transaction

### Additional description

When we try to apply the journal state after flush we need to run its state update under the write transaction lock.
We don't actually have to do that in our own transaction, we can use an already running write transaction.
However, when we have a lot of concurrency exceptions, we cannot use the write transaction and have to do it by ourselves and acquire the write transaction lock. If we fail we are waiting for a signal from a committed transaction in order to continue. (for 250ms).

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- It has been verified by manual testing
