### PR TITLE
RavenDB-16075 - LeaderCanCecedeFromClusterAndNewLeaderWillBeElected failed

### DIFF
--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Http
@@ -180,6 +181,9 @@ namespace Raven.Client.Http
         public Dictionary<string, string> Members { get; protected set; }
         public Dictionary<string, string> Promotables { get; protected set; }
         public Dictionary<string, string> Watchers { get; protected set; }
+
+        [JsonIgnore]
+        public int Count => Members.Count + Promotables.Count + Watchers.Count;
     }
 
     public class NodeStatus : IDynamicJson

--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -183,7 +183,7 @@ namespace Raven.Client.Http
         public Dictionary<string, string> Watchers { get; protected set; }
 
         [JsonIgnore]
-        public int Count => Members.Count + Promotables.Count + Watchers.Count;
+        internal int Count => Members.Count + Promotables.Count + Watchers.Count;
     }
 
     public class NodeStatus : IDynamicJson

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -385,15 +385,7 @@ namespace Raven.Server.Rachis
 
                 try
                 {
-                    ClusterTopology clusterTopology = null;
-                    using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-                    using (var ctx = context.OpenReadTransaction())
-                    {
-                        clusterTopology = _engine.GetTopology(context);
-                    }
-
-                    if(clusterTopology!=null && clusterTopology.AllNodes.Count>1)
-                        _engine.SwitchToCandidateState("An error occurred during our leadership." + Environment.NewLine + e);
+                    _engine.SwitchToCandidateState("An error occurred during our leadership." + Environment.NewLine + e);
                 }
                 catch (Exception e2)
                 {

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -385,7 +385,15 @@ namespace Raven.Server.Rachis
 
                 try
                 {
-                    _engine.SwitchToCandidateState("An error occurred during our leadership." + Environment.NewLine + e);
+                    ClusterTopology clusterTopology = null;
+                    using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                    using (var ctx = context.OpenReadTransaction())
+                    {
+                        clusterTopology = _engine.GetTopology(context);
+                    }
+
+                    if(clusterTopology!=null && clusterTopology.AllNodes.Count>1)
+                        _engine.SwitchToCandidateState("An error occurred during our leadership." + Environment.NewLine + e);
                 }
                 catch (Exception e2)
                 {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -2086,34 +2086,48 @@ namespace Raven.Server.Rachis
 
         public string HardResetToNewCluster(string nodeTag = "A")
         {
-            using (ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
-            using (var tx = ctx.OpenWriteTransaction())
+            var topologyId = Guid.NewGuid().ToString();
+            bool committed = false;
+            try
             {
-                var topologyId = Guid.NewGuid().ToString();
-                var topology = new ClusterTopology(
-                    topologyId,
-                    new Dictionary<string, string>
-                    {
-                        [nodeTag] = Url
-                    },
-                    new Dictionary<string, string>(),
-                    new Dictionary<string, string>(),
-                    _tag,
-                    GetLastEntryIndex(ctx) + 1
-                );
+                using (ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (var tx = ctx.OpenWriteTransaction())
+                {
 
-                UpdateNodeTag(ctx, nodeTag);
+                    var topology = new ClusterTopology(
+                        topologyId,
+                        new Dictionary<string, string>
+                        {
+                            [nodeTag] = Url
+                        },
+                        new Dictionary<string, string>(),
+                        new Dictionary<string, string>(),
+                        _tag,
+                        GetLastEntryIndex(ctx) + 1
+                    );
 
-                SetTopology(this, ctx, topology);
+                    UpdateNodeTag(ctx, nodeTag);
 
-                SetSnapshotRequest(ctx, false);
+                    SetTopology(this, ctx, topology);
 
-                SwitchToSingleLeader(ctx);
+                    SetSnapshotRequest(ctx, false);
 
-                tx.Commit();
+                    SwitchToSingleLeader(ctx);
 
-                return topologyId;
+                    tx.Commit();
+
+                    if(ctx.Transaction.InnerTransaction.LowLevelTransaction.Committed)
+                        committed = true;
+                }
             }
+            catch(ConcurrencyException) when(committed)
+            {
+                // Thrown in tx OnDispose (which is set in SwitchToSingleLeader)
+                // Happens when old Leader.Run->SwitchToCandidateState->SwitchToSingleLeader runs
+                // And then HardResetToNewCluster->SwitchToSingleLeader runs in parallel.
+                // In the second call of the SwitchToSingleLeader the 'leader.Run()' throws because it's term isn't updated.
+            }
+            return topologyId;
         }
 
         public void HardResetToPassive(string topologyId = null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16075/RachisTests.EmergencyOperations.LeaderCanCecedeFromClusterAndNewLeaderWillBeElected

### Additional description

LeaderCanCecedeFromClusterAndNewLeaderWillBeElected failed, because there's some follower which is still 'Promotable'
so the new candidate have no voters (one has topology mismatch and the other promotable) so it turn itself into 'Passive' mode in here:
https://github.com/ravendb/ravendb/blob/ae57440d5857c158453039d05f2e27e121e0d213/src/Raven.Server/Rachis/Candidate.cs#L140

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
