### PR TITLE
RavenDB-19519 Add schema upgrades progress to the init log

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -83,6 +83,7 @@ namespace Raven.Server.Documents
             internal Action<(DocumentDatabase Database, string caller)> AfterDatabaseCreation;
             internal Action<CancellationToken> DelayIncomingReplication;
             internal int? HoldDocumentDatabaseCreation = null;
+            internal Action AfterDatabaseInitialize;
             internal bool PreventedRehabOfIdleDatabase = false;
             internal ManualResetEvent DeleteDatabaseWhileItBeingDeleted = null;
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
@@ -801,6 +802,8 @@ namespace Raven.Server.Documents
                 ForTestingPurposes?.OnBeforeDocumentDatabaseInitialization?.Invoke(documentDatabase);
 
                 documentDatabase.Initialize(InitializeOptions.None, wakeup);
+
+                ForTestingPurposes?.AfterDatabaseInitialize?.Invoke();
 
                 AddToInitLog("Finish database initialization");
                 DeleteDatabaseCachedInfo(documentDatabase.Name, throwOnError: false);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -76,6 +76,8 @@ namespace Raven.Server.Documents
 
         private readonly object _clusterLocker = new object();
 
+        public Action<string> AddToInitLog => _addToInitLog;
+
         /// <summary>
         /// The current lock, used to make sure indexes have a unique names
         /// </summary>

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -112,16 +112,9 @@ namespace Raven.Server.Storage.Schema
 
                 if (shouldAddToInitLog)
                 {
-                    if (result)
-                    {
-                        var msg = $"Finished Schema Upgrade from version #{updater.From} to version #{updater.To}";
-                        _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
-                    }
-                    else
-                    {
-                        var msg = $"Failed to Schema Upgrade from version #{updater.From} to version #{updater.To}";
-                        _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
-                    }
+
+                    var msg = $"{(result ? "Finished" : "Failed to")}  Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
                 }
 
                 return result;

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -100,7 +100,7 @@ namespace Raven.Server.Storage.Schema
 
                 if (shouldAddToInitLog)
                 {
-                    var msg = $"Started Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                    var msg = $"Started schema upgrade from version #{updater.From} to version #{updater.To}";
                     _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
                 }
 
@@ -113,7 +113,7 @@ namespace Raven.Server.Storage.Schema
                 if (shouldAddToInitLog)
                 {
 
-                    var msg = $"{(result ? "Finished" : "Failed to")}  Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                    var msg = $"{(result ? "Finished" : "Failed to")} schema upgrade from version #{updater.From} to version #{updater.To}";
                     _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
                 }
 

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Storage.Schema
             internal bool Upgrade(SchemaUpgradeTransactions transactions, int currentVersion, out int versionAfterUpgrade)
             {
                 currentVersion = FixCurrentVersion(_storageType, currentVersion);
-
+                bool shouldAddToInitLog = false;
                 switch (_storageType)
                 {
                     case StorageType.Server:
@@ -80,8 +80,10 @@ namespace Raven.Server.Storage.Schema
                     case StorageType.Configuration:
                         break;
                     case StorageType.Documents:
+                        shouldAddToInitLog = true;
                         if (SkippedDocumentsVersion.Contains(currentVersion))
-                            throw new NotSupportedException($"Documents schema upgrade from version {currentVersion} is not supported, use the recovery tool to dump the data and then import it into a new database");
+                            throw new NotSupportedException(
+                                $"Documents schema upgrade from version {currentVersion} is not supported, use the recovery tool to dump the data and then import it into a new database");
                         break;
                     case StorageType.Index:
                         break;
@@ -96,11 +98,33 @@ namespace Raven.Server.Storage.Schema
 
                 versionAfterUpgrade = updater.To;
 
-                return updater.Update(new UpdateStep(transactions)
+                if (shouldAddToInitLog)
+                {
+                    var msg = $"Started Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                }
+
+                bool result =  updater.Update(new UpdateStep(transactions)
                 {
                     ConfigurationStorage = _configurationStorage,
                     DocumentsStorage = _documentsStorage,
                 });
+
+                if (shouldAddToInitLog)
+                {
+                    if (result)
+                    {
+                        var msg = $"Finished Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                        _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    }
+                    else
+                    {
+                        var msg = $"Failed to Schema Upgrade from version #{updater.From} to version #{updater.To}";
+                        _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    }
+                }
+
+                return result;
             }
 
             private static int FixCurrentVersion(StorageType storageType, int currentVersion)

--- a/test/SlowTests/Issues/RavenDB-19519.cs
+++ b/test/SlowTests/Issues/RavenDB-19519.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions.Database;
+using Raven.Server.Config.Settings;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19519 : RavenTestBase
+    {
+        public RavenDB_19519(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public void SchemaUpgradeAddedToInitLog()
+        {
+            var folder = NewDataPath(forceCreateDir: true);
+            DoNotReuseServer();
+
+            var zipPath = new PathSetting("SchemaUpgrade/Issues/SystemVersion/Identities_CompareExchange_RavenData_from12.zip");
+            Assert.True(File.Exists(zipPath.FullPath));
+
+            ZipFile.ExtractToDirectory(zipPath.FullPath, folder);
+            using (var server = GetNewServer(new ServerCreationOptions
+                   {
+                       DeletePrevious = false,
+                       RunInMemory = false,
+                       DataDirectory = folder,
+                       RegisterForDisposal = false,
+                   }))
+            {
+                server.Configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad = new TimeSetting(100, TimeUnit.Milliseconds);
+
+                var sm = new SemaphoreSlim(initialCount: 0);
+
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseInitialize = () =>
+                {
+                    sm.Wait();
+                };
+
+                try
+                {
+                    using (var store = new DocumentStore
+                           {
+                               Urls = new[] { server.WebUrl },
+                               Database = "a"
+                           })
+                    {
+                        store.Initialize();
+
+                        using (var session = store.OpenSession())
+                        {
+                            var exception = Assert.Throws<DatabaseLoadTimeoutException>(() => session.Store(new User { Name = "Foo" }));
+                            Assert.True(exception.Message.Contains("Schema Upgrade"));
+                        }
+                    }
+                }
+                finally
+                {
+                    sm.Release(2); // we have 2 databases
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19519.cs
+++ b/test/SlowTests/Issues/RavenDB-19519.cs
@@ -19,6 +19,7 @@ namespace SlowTests.Issues
         {
         }
 
+        [Fact]
         public void SchemaUpgradeAddedToInitLog()
         {
             var folder = NewDataPath(forceCreateDir: true);
@@ -58,7 +59,7 @@ namespace SlowTests.Issues
                         using (var session = store.OpenSession())
                         {
                             var exception = Assert.Throws<DatabaseLoadTimeoutException>(() => session.Store(new User { Name = "Foo" }));
-                            Assert.True(exception.Message.Contains("Schema Upgrade"));
+                            Assert.True(exception.Message.Contains("schema upgrade"));
                         }
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19519/Add-schema-upgrades-progress-to-the-init-log

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
