### PR TITLE
RavenDB-19694 create indexes when creating sharded db for existing folder

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1123,7 +1123,7 @@ namespace Raven.Server.Documents
                 databaseIsBeenDeleted == false)
                 throw new DatabaseNotRelevantException(databaseName + " is not relevant for " + _serverStore.NodeTag);
 
-            return CreateDatabaseConfiguration(_serverStore, databaseRecord.DatabaseName, databaseRecord.Settings);
+            return CreateDatabaseConfiguration(_serverStore, databaseName.Value, databaseRecord.Settings);
         }
 
         private static bool TryGetDeletionInProgress(Dictionary<string, DeletionInProgressStatus> deletionInProgress, string databaseName, string nodeTag, out DeletionInProgressStatus status)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19694

### Additional description

Search local node for shards and create indexes from there

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
