### PR TITLE
RavenDB-19688 Additional check when trying to write an `EntriesModifications`.

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -63,7 +63,7 @@ namespace Corax
         // private readonly ConcurrentDictionary<Slice, Dictionary<Slice, ConcurrentQueue<long>>> _bufferConcurrent =
         //     new ConcurrentDictionary<Slice, ConcurrentDictionary<Slice, ConcurrentQueue<long>>>(SliceComparer.Instance);
 
-        private unsafe struct EntriesModifications : IDisposable
+        internal unsafe struct EntriesModifications : IDisposable
         {
             private readonly ByteStringContext _context;
             private ByteStringContext<ByteStringMemoryCache>.InternalScope _disposable;
@@ -74,8 +74,15 @@ namespace Corax
             private int _removals;
             private bool _sortingNeeded;
 
-            public bool HasChanges =>  _removals != 0 || _additions != 0;
-            
+            public bool HasChanges
+            {
+                get
+                {
+                    SortAndRemoveDuplicates();
+                    return _removals != 0 || _additions != 0;
+                }
+            }
+
             public int TotalAdditions => _additions;
             public int TotalRemovals => _removals;
 
@@ -161,22 +168,70 @@ namespace Corax
                 _disposable = scope;
             }
 
-            public void Sort()
+            // There is an case we found in RavenDB-19688
+            // Sometimes term can be added and removed for the same in the same batch and there can be multiple other docs between this two operations.
+            // This requires us to ensure we don't have duplicates here.
+            public void SortAndRemoveDuplicates()
             {
                 if (_removals + _additions <= 1)
                     _sortingNeeded = false;
 
+                var additions = new Span<long>(_start, _additions);
+                var removals = new Span<long>(_end - _removals + 1, _removals);
+                
                 if (_sortingNeeded)
                 {
-                    MemoryExtensions.Sort(new Span<long>(_start, _additions));
-                    MemoryExtensions.Sort(new Span<long>(_end - _removals + 1, _removals));
+                    MemoryExtensions.Sort(additions);
+                    MemoryExtensions.Sort(removals);
                     _sortingNeeded = false;
                 }
+
+                int duplicatesFound = 0;
+                for (int add = 0, rem = 0; add < additions.Length && rem < removals.Length; ++add)
+                {
+                    Start:
+                    ref var currAdd = ref additions[add];
+                    ref var currRem = ref removals[rem];
+
+                    if (currAdd == currRem)
+                    {
+                        currRem = -1;
+                        currAdd = -1;
+                        duplicatesFound++;
+                        rem++;
+                        continue;
+                    }
+                    
+                    if (currAdd < currRem)
+                        continue;
+
+                    if (currAdd > currRem)
+                    {
+                        rem++;
+                        while (rem < removals.Length)
+                        {
+                            if (currAdd <= removals[rem])
+                                goto Start;
+                            rem++;
+                        }
+                    }
+                }
+
+                if (duplicatesFound == 0)
+                    return;
+
+                // rare case
+                MemoryExtensions.Sort(additions);
+                MemoryExtensions.Sort(removals);
+                _additions -= duplicatesFound;
+                _removals -= duplicatesFound;
                 
+                additions.Slice(duplicatesFound).CopyTo(additions);
+                removals.Slice(duplicatesFound).CopyTo(new Span<long>(_end - _removals + 1, _removals));
                 ValidateNoDuplicateEntries();
             }
-
-            [Conditional("DEBUG")]
+            
+         //   [Conditional("DEBUG")]
             private void ValidateNoDuplicateEntries()
             {
                 var removals = Removals;
@@ -187,10 +242,10 @@ namespace Corax
                         throw new InvalidOperationException("Found duplicate addition & removal item during indexing: " + add);
                 }
 
-                foreach (var reomval in removals)
+                foreach (var removal in removals)
                 {
-                    if (additions.BinarySearch(reomval) >= 0)
-                        throw new InvalidOperationException("Found duplicate addition & removal item during indexing: " + reomval);
+                    if (additions.BinarySearch(removal) >= 0)
+                        throw new InvalidOperationException("Found duplicate addition & removal item during indexing: " + removal);
                 }
             }
 
@@ -1412,7 +1467,7 @@ namespace Corax
             var smallSet = Container.GetMutable(llt, id);
             Debug.Assert(entries.Removals.ToArray().Distinct().Count() == entries.TotalRemovals, $"Removals list is not distinct.");
             
-            entries.Sort();
+            entries.SortAndRemoveDuplicates();
           
             int removalIndex = 0;
             
@@ -1463,7 +1518,7 @@ namespace Corax
                 return AddEntriesToTermResult.RemoveTermId;
             }
 
-            entries.Sort();
+            entries.SortAndRemoveDuplicates();
 
             if (TryDeltaEncodingToBuffer(entries.Additions, tmpBuf, out var encoded) == false)
             {
@@ -1522,7 +1577,7 @@ namespace Corax
         {
             var llt = Transaction.LowLevelTransaction;
 
-            entries.Sort();
+            entries.SortAndRemoveDuplicates();
 
             var setSpace = Container.GetMutable(llt, id);
             ref var setState = ref MemoryMarshal.AsRef<SetState>(setSpace);
@@ -1660,7 +1715,7 @@ namespace Corax
 
             // Because the sorting would not change the struct itself, it is safe to use an 'in' modifier to avoid the copying. 
             if(sortingNeeded)
-                entries.Sort();
+                entries.SortAndRemoveDuplicates();
 
             if (TryDeltaEncodingToBuffer(additions, tmpBuf, out var encoded) == false)
             {

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -74,6 +74,8 @@ namespace Corax
             private int _removals;
             private bool _sortingNeeded;
 
+            public bool HasChanges =>  _removals != 0 || _additions != 0;
+            
             public int TotalAdditions => _additions;
             public int TotalRemovals => _removals;
 
@@ -1338,7 +1340,9 @@ namespace Corax
 
                 ref var entries = ref CollectionsMarshal.GetValueRefOrNullRef(currentFieldTerms, term);
                 Debug.Assert(Unsafe.IsNullRef(ref entries) == false);
-
+                if (entries.HasChanges == false)
+                    continue;
+                
                 long termId;
                 ReadOnlySpan<byte> termsSpan = term.AsSpan();
                 
@@ -1550,7 +1554,9 @@ namespace Corax
                 // Therefore, we can copy and we dont need to get a reference to the entry in the dictionary.
                 // IMPORTANT: No modification to the dictionary can happen from this point onwards. 
                 var localEntry = entries;
-
+                if (localEntry.HasChanges == false)
+                    continue;
+                
                 long termId;
                 using var _ = fieldTree.Read(term, out var result);
                 if (localEntry.TotalAdditions > 0 && result.HasValue == false)
@@ -1584,6 +1590,9 @@ namespace Corax
                 // Therefore, we can copy and we dont need to get a reference to the entry in the dictionary.
                 // IMPORTANT: No modification to the dictionary can happen from this point onwards. 
                 var localEntry = entries;
+                if (localEntry.HasChanges == false)
+                    continue;
+                
                 using var _ = fieldTree.Read(term, out var result);
 
                 long termId;

--- a/test/FastTests/Corax/EntriesModificationsTests.cs
+++ b/test/FastTests/Corax/EntriesModificationsTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Corax;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class EntriesModificationsTests
+{
+    [Fact]
+    public void EntriesModificationsWillEraseOddDuplicates()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        var entries = new IndexWriter.EntriesModifications(bsc);
+        
+        entries.Addition(2);
+        entries.Removal(1);
+        entries.Addition(3);
+        entries.Removal(2);
+        entries.SortAndRemoveDuplicates();
+
+        AssertEntriesCase(ref entries);
+    }
+    private static void AssertEntriesCase(ref IndexWriter.EntriesModifications entries)
+    {
+        var additions = entries.Additions;
+        var removals = entries.Removals;
+
+        foreach (var add in additions)
+            Assert.True(0 > removals.BinarySearch(add));
+
+        foreach (var removal in removals)
+            Assert.True(0 > additions.BinarySearch(removal));
+    }
+}

--- a/test/SlowTests/Server/Documents/Indexing/CollisionsOfReduceKeyHashes_StressTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/CollisionsOfReduceKeyHashes_StressTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
 using SlowTests.Server.Documents.Indexing.Static;
 using Tests.Infrastructure;
 using Xunit;
@@ -12,23 +14,28 @@ namespace SlowTests.Server.Documents.Indexing
         {
         }
 
-        [Theory]
-        [InlineData(50000, new[] { "Canada", "France" })] // reduce key tree with depth 3
-        public async Task Auto_index_should_produce_multiple_outputs(int numberOfUsers, string[] locations)
+        private static IEnumerable<object[]> Data() => new[]
+        {
+            new[] { new CollisionsOfReduceKeyHashes.TestData() {NumberOfUsers = 50000, Locations = new[] {"Canada", "France"}, SearchEngineType = SearchEngineType.Lucene}},
+            new[] { new CollisionsOfReduceKeyHashes.TestData() {NumberOfUsers = 50000, Locations = new[] {"Canada", "France"}, SearchEngineType = SearchEngineType.Corax}}
+        };
+        
+        [Theory] 
+        [MemberData(nameof(Data))]// reduce key tree with depth 3
+        public async Task Auto_index_should_produce_multiple_outputs(CollisionsOfReduceKeyHashes.TestData data)
         {
             using (var test = new CollisionsOfReduceKeyHashes(Output))
             {
-                await test.Auto_index_should_produce_multiple_outputs(numberOfUsers, locations);
+                await test.Auto_index_should_produce_multiple_outputs(data);
             }
         }
-
-        [Theory]
-        [InlineData(50000, new[] { "Canada", "France" })] // reduce key tree with depth 3
-        public async Task Static_index_should_produce_multiple_outputs(int numberOfUsers, string[] locations)
+        [Theory] 
+        [MemberData(nameof(Data))]// reduce key tree with depth 3
+        public async Task Static_index_should_produce_multiple_outputs(CollisionsOfReduceKeyHashes.TestData data)
         {
             using (var test = new CollisionsOfReduceKeyHashes(Output))
             {
-                await test.Static_index_should_produce_multiple_outputs(numberOfUsers, locations);
+                await test.Static_index_should_produce_multiple_outputs(data);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
+++ b/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Server.Documents.Indexing
         }
 
         [Theory]
-        [RavenExplicitData]
+        [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task CanUseExactInAutoIndex(RavenTestParameters config)
         {            
             using (var store = GetDocumentStore(new Options
@@ -158,7 +158,7 @@ namespace SlowTests.Server.Documents.Indexing
         }
 
         [Theory]
-        [RavenExplicitData]
+        [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldExtendMappingOfTheSameField(RavenTestParameters config)
         {
             using (var store = GetDocumentStore(new Options
@@ -215,7 +215,7 @@ namespace SlowTests.Server.Documents.Indexing
         }
 
         [Theory]
-        [RavenExplicitData]
+        [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task CanUseExactAndSearchTogetherInAutoMapReduceIndex(RavenTestParameters config)
         {
             using (var store = GetDocumentStore(new Options


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19688

### Additional description

There is a case when the same doc is modified twice during one batch:
https://github.com/ravendb/ravendb/commit/edaf2594a104c1320c3e99761066a8e5ced1710c

We had an assumption that a single doc will be processed only once in a batch.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
