### PR TITLE
RavenDB-17575 - Requests carrying timeseries are not visible on studio dashboards

### DIFF
--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -144,12 +144,12 @@ namespace Raven.Server.Dashboard
                         var trafficWatchItem = new TrafficWatchItem
                         {
                             Database = database.Name,
-                            RequestsPerSecond = (int)database.Metrics.Requests.RequestsPerSec.GetRate(rate),
+                            RequestsPerSecond = (int)Math.Round(database.Metrics.Requests.RequestsPerSec.GetRate(rate)), // show 1 instead of 0 in case of 0.98...
                             AverageRequestDuration = database.Metrics.Requests.AverageDuration.GetRate(),
-                            DocumentWritesPerSecond = (int)database.Metrics.Docs.PutsPerSec.GetRate(rate),
-                            AttachmentWritesPerSecond = (int)database.Metrics.Attachments.PutsPerSec.GetRate(rate),
-                            CounterWritesPerSecond = (int)database.Metrics.Counters.PutsPerSec.GetRate(rate),
-                            TimeSeriesWritesPerSecond = (int)database.Metrics.TimeSeries.PutsPerSec.GetRate(rate),
+                            DocumentWritesPerSecond = (int)Math.Round(database.Metrics.Docs.PutsPerSec.GetRate(rate)),
+                            AttachmentWritesPerSecond = (int)Math.Round(database.Metrics.Attachments.PutsPerSec.GetRate(rate)),
+                            CounterWritesPerSecond = (int)Math.Round(database.Metrics.Counters.PutsPerSec.GetRate(rate)),
+                            TimeSeriesWritesPerSecond = (int)Math.Round(database.Metrics.TimeSeries.PutsPerSec.GetRate(rate)),
                             DocumentsWriteBytesPerSecond = database.Metrics.Docs.BytesPutsPerSec.GetRate(rate),
                             AttachmentsWriteBytesPerSecond = database.Metrics.Attachments.BytesPutsPerSec.GetRate(rate),
                             CountersWriteBytesPerSecond = database.Metrics.Counters.BytesPutsPerSec.GetRate(rate),

--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -144,12 +144,12 @@ namespace Raven.Server.Dashboard
                         var trafficWatchItem = new TrafficWatchItem
                         {
                             Database = database.Name,
-                            RequestsPerSecond = (int)Math.Round(database.Metrics.Requests.RequestsPerSec.GetRate(rate)), // show 1 instead of 0 in case of 0.98...
+                            RequestsPerSecond = (int)Math.Ceiling(database.Metrics.Requests.RequestsPerSec.GetRate(rate)),
                             AverageRequestDuration = database.Metrics.Requests.AverageDuration.GetRate(),
-                            DocumentWritesPerSecond = (int)Math.Round(database.Metrics.Docs.PutsPerSec.GetRate(rate)),
-                            AttachmentWritesPerSecond = (int)Math.Round(database.Metrics.Attachments.PutsPerSec.GetRate(rate)),
-                            CounterWritesPerSecond = (int)Math.Round(database.Metrics.Counters.PutsPerSec.GetRate(rate)),
-                            TimeSeriesWritesPerSecond = (int)Math.Round(database.Metrics.TimeSeries.PutsPerSec.GetRate(rate)),
+                            DocumentWritesPerSecond = (int)Math.Ceiling(database.Metrics.Docs.PutsPerSec.GetRate(rate)),
+                            AttachmentWritesPerSecond = (int)Math.Ceiling(database.Metrics.Attachments.PutsPerSec.GetRate(rate)),
+                            CounterWritesPerSecond = (int)Math.Ceiling(database.Metrics.Counters.PutsPerSec.GetRate(rate)),
+                            TimeSeriesWritesPerSecond = (int)Math.Ceiling(database.Metrics.TimeSeries.PutsPerSec.GetRate(rate)),
                             DocumentsWriteBytesPerSecond = database.Metrics.Docs.BytesPutsPerSec.GetRate(rate),
                             AttachmentsWriteBytesPerSecond = database.Metrics.Attachments.BytesPutsPerSec.GetRate(rate),
                             CountersWriteBytesPerSecond = database.Metrics.Counters.BytesPutsPerSec.GetRate(rate),


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17575/Requests-carrying-timeseries-are-not-visible-on-studio-dashboards

### Additional description

Requests carrying timeseries are not visible on studio dashboards.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
