### PR TITLE
RavenDB-19610 - Sharding - Handlers - Not Supported

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminTombstoneHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Admin
+{
+    public class ShardedAdminTombstoneHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/admin/tombstones/cleanup", "POST")]
+        public async Task Cleanup()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Tombstone cleanup."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/tombstones/state", "GET")]
+        public async Task State()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Get Tombstone state."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedTransactionsModeHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedTransactionsModeHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Admin
+{
+    public class ShardedTransactionsModeHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/admin/transactions-mode", "GET")]
+        public async Task CommitNonLazyTx()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin transactions-mode operation."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedAllDocumentIdsDebugHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedAllDocumentIdsDebugHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedAllDocumentIdsDebugHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/debug/documents/export-all-ids", "GET")]
+        public async Task ExportAllDocIds()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Documents debug operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedAttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedAttachmentHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Attachments;
 using Raven.Server.Routing;
 
@@ -54,6 +55,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
         public async Task GetPost()
         {
             using (var processor = new ShardedAttachmentHandlerProcessorForGetAttachment(this, isDocument: false))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/attachments/bulk", "POST")]
+        public async Task GetAttachments()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Get Attachments."))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseDebugInfoPackageHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedDatabaseDebugInfoPackageHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/debug/info-package", "GET")]
+        public async Task GetInfoPackage()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentDebugHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedDocumentDebugHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/debug/documents/huge", "GET")]
+        public async Task HugeDocuments()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIndexHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIndexHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents.Handlers.Processors.Indexes;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Indexes;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
@@ -176,6 +177,20 @@ namespace Raven.Server.Documents.Sharding.Handlers
         public async Task SuggestIndexMerge()
         {
             using (var processor = new ShardedIndexHandlerProcessorForSuggestIndexMerge(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/indexes/try", "POST")]
+        public async Task TestJavaScriptIndex()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support JavaScript indexes."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/indexes/finish-rolling", "POST")]
+        public async Task FinishRolling()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support PutRollingIndex command."))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIoMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIoMetricsHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.IoMetrics;
 using Raven.Server.Routing;
 
@@ -10,6 +11,13 @@ public class ShardedIoMetricsHandler : ShardedDatabaseRequestHandler
     public async Task Live()
     {
         using (var processor = new ShardedIoMetricsHandlerProcessorForLive(this))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/debug/io-metrics", "GET")]
+    public async Task Get()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
             await processor.ExecuteAsync();
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedJsonPatchHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedJsonPatchHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedJsonPatchHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/json-patch", "PATCH")]
+        public async Task DocOperations()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support json-patch."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedLegacyReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedLegacyReplicationHandler.cs
@@ -1,0 +1,65 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedLegacyReplicationHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/replication/lastEtag", "GET")]
+        public async Task LastEtag()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/replication/replicateDocs", "POST")]
+        public async Task Documents()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/replication/replicateAttachments", "POST")]
+        public async Task Attachments()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/replication/heartbeat", "POST")]
+        public async Task Heartbeat()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/indexes/last-queried", "POST")]
+        public async Task LastQueried()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/side-by-side-indexes", "PUT")]
+        public async Task SideBySideIndexes()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/transformers/$", "PUT")]
+        public async Task PutTransformer()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/transformers/$", "DELETE")]
+        public async Task DeleteTransformer()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support LegacyReplication."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedPerformanceMetricsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedPerformanceMetricsHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedPerformanceMetricsHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/debug/perf-metrics", "GET")]
+        public async Task IoMetrics()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedScriptRunnersDebugInfoHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedScriptRunnersDebugInfoHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedScriptRunnersDebugInfoHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/debug/script-runners", "GET")]
+        public async Task GetJSDebugInfo()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug script-runners operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents.Handlers.Processors.Smuggler;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Smuggler;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
@@ -35,6 +36,48 @@ namespace Raven.Server.Documents.Sharding.Handlers
         public async Task PostImportDirectory()
         {
             using (var processor = new ShardedSmugglerHandlerProcessorForImportDir(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/smuggler/import", "GET")]
+        public async Task GetImport()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin Smuggler operations."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/smuggler/import-s3-dir", "GET")]
+        public async Task PostImportFromS3Directory()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin Smuggler operations."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/smuggler/migrate/ravendb", "POST")]
+        public async Task MigrateFromRavenDB()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin Smuggler operations."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/migrate/get-migrated-server-urls", "GET")]
+        public async Task GetMigratedServerUrls()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Get migrated server urls operation."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/smuggler/migrate", "POST")]
+        public async Task MigrateFromAnotherDatabase()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support migrate from another database operation."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/smuggler/import/csv", "POST")]
+        public async Task ImportFromCsv()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Smuggler import CSV operation."))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedStorageHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedStorageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Debugging;
 using Raven.Server.Routing;
 
@@ -18,6 +19,48 @@ public class ShardedStorageHandler : ShardedDatabaseRequestHandler
     public async Task GetEnvironmentReport()
     {
         using (var processor = new ShardedStorageHandlerProcessorForGetEnvironmentReport(this))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/admin/storage/manual-flush", "POST")]
+    public async Task ManualFlush()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin manual-flush operation."))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/admin/storage/manual-sync", "POST")]
+    public async Task ManualSync()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin manual-sync operation."))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/debug/storage/trees", "GET")]
+    public async Task Trees()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/debug/storage/btree-structure", "GET")]
+    public async Task BTreeStructure()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/debug/storage/fst-structure", "GET")]
+    public async Task FixedSizeTreeStructure()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenShardedAction("/databases/*/debug/storage/all-environments/report", "GET")]
+    public async Task AllEnvironmentsReport()
+    {
+        using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Debug Information operations."))
             await processor.ExecuteAsync();
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedTransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedTransactionDebugHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedTransactionDebugHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/admin/debug/txinfo", "GET")]
+        public async Task TxInfo()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin debug operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedTransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedTransactionsRecordingHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class ShardedTransactionsRecordingHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/transactions/replay", "POST")]
+        public async Task ReplayRecording()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Transactions replay recording operation."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/transactions/start-recording", "POST")]
+        public async Task StartRecording()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Transactions start recording operation."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/transactions/stop-recording", "POST")]
+        public async Task StopRecording()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Transactions stop recording operation."))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedSqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedSqlMigrationHandler.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.Processors;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Web.Studio.Sharding
+{
+    public class ShardedSqlMigrationHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/smuggler/import/csv", "POST")]
+        public async Task ImportFromCsv()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin sql-migration operations."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/sql-migration/import", "POST")]
+        public async Task ImportSql()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin sql-migration operations."))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/sql-migration/test", "POST")]
+        public async Task TestSql()
+        {
+            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin sql-migration operations."))
+                await processor.ExecuteAsync();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19610/Sharding-Handlers-Not-Supported


### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
