### PR TITLE
RavenDB-19633 Close connection if got empty message

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2892,6 +2892,11 @@ namespace Raven.Server
                     while (true)
                     {
                         var read = await s.ReceiveAsync(buffer, SocketFlags.None);
+                        if (read == 0)
+                        {
+                            Logger.Info($"Received 0 bytes. Close the connection. RemoteEndPoint:{s.RemoteEndPoint} SocketHashCode{s.GetHashCode()}");
+                            return;
+                        }
                         await s.SendAsync(buffer.Slice(0, read), SocketFlags.None);
                     }
                 }
@@ -2929,6 +2934,11 @@ namespace Raven.Server
                     while (true)
                     {
                         var read = s.Receive(buffer);
+                        if (read == 0)
+                        {
+                            Logger.Info($"Received 0 bytes. Close the connection. RemoteEndPoint:{s.RemoteEndPoint} SocketHashCode{s.GetHashCode()}");
+                            return;
+                        }
                         s.Send(buffer, 0, read, SocketFlags.None);
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19633

### Additional description

Close connection on empty message.

### Type of change

- Bug fix
- Regression bug fix
- Optimization
- New feature

### How risky is the change?

- Low 
- Moderate 
- High
- Not relevant

### Backward compatibility

- Non breaking change
- Ensured. Please explain how has it been implemented?
- Breaking change
- Not relevant

### Is it platform specific issue?

- Yes. Please list the affected platforms.
- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- It requires further work in the Studio
- No UI work is needed
