### PR TITLE
RavenDB-19708: Execute complex query before boosting

### DIFF
--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -322,7 +322,7 @@ namespace Corax.Queries
                         if (result == false)
                             break;
 
-                        Debug.Assert(read < BlockSize);
+                        Debug.Assert(read <= BlockSize);
 
                         if (read == 0)
                             continue;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
@@ -118,14 +118,14 @@ public class CoraxOrQueries : CoraxBooleanQueryBase
                 AddToQueryTree(IndexSearcher.InQuery(field, terms));
         }
 
-        if (ScoreFunction is not NullScoreFunction && ScoreFunction != null)
-            baseQuery = IndexSearcher.Boost(baseQuery, ScoreFunction);
-        
         if (_complexMatches != null)
         {
             foreach (var complex in _complexMatches ?? Enumerable.Empty<IQueryMatch>())
                 AddToQueryTree(complex);
         }
+
+        if (ScoreFunction is not NullScoreFunction && ScoreFunction != null)
+            baseQuery = IndexSearcher.Boost(baseQuery, ScoreFunction);
 
         return baseQuery;
         

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
@@ -120,9 +120,6 @@ public abstract class IndexOperationBase : IDisposable
     {
         var numberOfEntries = searcher.NumberOfEntries;
         
-        if (numberOfEntries == 0)
-            return 16;
-        
         //If we have a binary operation, we need to pass a buffer large enough to hold all the individual results.
         //We need to do this to get correct results and since we don't know how much results subqueries will have  we must create a buffer big enough to get all items from index
         if (query.Metadata.OrderBy is not null || query.Metadata.IsDistinct || isBoolean)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19708

### Additional description
The boosting was applied before the complex query was evaluated as a base query and therefore causing a NRE. 

### Type of change
Bug fix

### How risky is the change?
Low 