### PR TITLE
RavenDB-14780: Warn when ignoring `Revisions`, `TimeSeries` and other configs on import because it already exists

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDatabaseRecordActions : IAsyncDisposable
     {
-        ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerProgressBase progress, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
+        ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerResult result, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
     }
 
     public interface ITimeSeriesActions : IAsyncDisposable

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDatabaseRecordActions : IAsyncDisposable
     {
-        ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerProgressBase.DatabaseRecordProgress progress, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
+        ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerProgressBase progress, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
     }
 
     public interface ITimeSeriesActions : IAsyncDisposable

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -923,16 +923,9 @@ namespace Raven.Server.Smuggler.Documents
                             }
                             else
                             {
-                                var sb = new StringBuilder();
-                                sb.Append("Conflict solver configuration of collection '");
-                                sb.Append(collection.Key);
-                                sb.Append("' already exist on the destination Database Record. Configuring this conflict solver from smuggler was skipped, ");
-                                sb.Append(collectionConfiguration.Equals(collection.Value)
-                                    ? "but the configuration was the same as "
-                                    : "even though the configuration differed from ");
-                                sb.Append("the configuration in the target database record");
-
-                                result.AddWarning(sb.ToString());
+                                if (collectionConfiguration.Equals(collection.Value) == false)
+                                    result.AddWarning($"Conflict solver configuration of collection '{collection.Key}' already exist on the destination Database Record. " +
+                                                  "Configuring this conflict solver from smuggler was skipped, even though the configuration differed from the configuration in the target database record");
                             }
                         }
                     }
@@ -1122,16 +1115,9 @@ namespace Raven.Server.Smuggler.Documents
                             }
                             else
                             {
-                                var sb = new StringBuilder();
-                                sb.Append("Time-series configuration of collection '");
-                                sb.Append(collection.Key);
-                                sb.Append("' already exist on the destination Database Record. Configuring this time-series from smuggler was skipped, ");
-                                sb.Append(collectionConfiguration.Equals(collection.Value)
-                                    ? "but the configuration was the same as "
-                                    : "even though the configuration differed from ");
-                                sb.Append("the configuration in the target database record");
-
-                                result.AddWarning(sb.ToString());
+                                if (collectionConfiguration.Equals(collection.Value) == false)
+                                    result.AddWarning($"Time-series configuration of collection '{collection.Key}' already exist on the destination Database Record. " +
+                                                      "Configuring this time-series from smuggler was skipped, even though the configuration differed from the configuration in the target database record");
                             }
                         }
                     }
@@ -1183,16 +1169,9 @@ namespace Raven.Server.Smuggler.Documents
                             }
                             else
                             {
-                                var sb = new StringBuilder();
-                                sb.Append("Revisions configuration of collection '");
-                                sb.Append(collection.Key);
-                                sb.Append("' already exist on the destination Database Record. Configuring this revisions from smuggler was skipped, ");
-                                sb.Append(collectionConfiguration.Equals(collection.Value)
-                                    ? "but the configuration was the same as "
-                                    : "even though the configuration differed from ");
-                                sb.Append("the configuration in the target database record");
-
-                                result.AddWarning(sb.ToString());
+                                if (collectionConfiguration.Equals(collection.Value) == false)
+                                    result.AddWarning($"Revisions configuration of collection '{collection.Key}' already exist on the destination Database Record. " +
+                                                      "Configuring this revisions from smuggler was skipped, even though the configuration differed from the configuration in the target database record");
                             }
                         }
                     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -626,7 +626,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 try
                 {
-                    await actions.WriteDatabaseRecordAsync(databaseRecord, result.DatabaseRecord, _options.AuthorizationStatus, _options.OperateOnDatabaseRecordTypes);
+                    await actions.WriteDatabaseRecordAsync(databaseRecord, result, _options.AuthorizationStatus, _options.OperateOnDatabaseRecordTypes);
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -212,7 +212,7 @@ namespace Raven.Server.Smuggler.Documents
                 _writer.WriteStartObject();
             }
 
-            public async ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerProgressBase.DatabaseRecordProgress progress, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType)
+            public async ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerResult result, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType)
             {
                 _writer.WritePropertyName(nameof(databaseRecord.DatabaseName));
                 _writer.WriteString(databaseRecord.DatabaseName);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14780/Warn-when-ignoring-revisions-timeseries-config-on-import-because-it-already-exists

### Additional description

On import, when the target `DatabaseRecord` already had configurations for collection, it skipped importing them without any user notice.
Added alerts for:
- ConflictSolverConfig
- TimeSeries
- Revisions

All information is displayed in `SmugglerResult`

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed