### PR TITLE
RavenDB-19660 Reduce contention on the AllocHGlobal

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedQueryCommand.cs
@@ -1,13 +1,13 @@
-﻿using System.Diagnostics;
-using System.Net.Http;
+﻿using System.Net.Http;
+using System.Text;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Http;
-using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Queries;
 using Sparrow.Json;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Commands;
 
@@ -37,9 +37,8 @@ public class ShardedQueryCommand : AbstractQueryCommand<BlittableJsonReaderObjec
 
     protected override HttpContent GetContent(JsonOperationContext ctx)
     {
-        var queryToSend = _query.Clone(ctx);
-
-        return new BlittableJsonContent(async stream => await queryToSend.WriteJsonToAsync(stream));
+        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "let's create a server-side query class here and use same code as for QueryCommand");
+        return new StringContent(_query.ToString(), Encoding.UTF8, "application/json");
     }
 
     public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)

--- a/test/FastTests/Sharding/Queries/BasicShardedQueryTests.cs
+++ b/test/FastTests/Sharding/Queries/BasicShardedQueryTests.cs
@@ -918,10 +918,10 @@ select project(o)")
                     Assert.Equal(3, queryResult3.Count);
                     Assert.Equal(2, queryResult3[0].Age);
                     Assert.Equal("Adam", queryResult3[0].Name);
-                    Assert.Equal(3, queryResult3[1].Age);
-                    Assert.Equal("Carlos", queryResult3[1].Name);
-                    Assert.Equal(1, queryResult3[2].Age);
-                    Assert.Equal("Grisha", queryResult3[2].Name);
+                    Assert.Equal(3, queryResult3[2].Age);
+                    Assert.Equal("Carlos", queryResult3[2].Name);
+                    Assert.Equal(1, queryResult3[1].Age);
+                    Assert.Equal("Grisha", queryResult3[1].Name);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19660

### Additional description

From profiling by stressing queries for sharded database we saw a contention on a native memory allocation.

Creating the query for the shards was expensive & and combining the results used to clone each item in the return array.

So now we clone the entire array only once, and avoid native allocation when creating the query for the shards.

Bonus: unify the sharded query code path for sorted & non-sorted queries

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
