### PR TITLE
RavenDB-19549 - Delay Replication on missing attachments loop for sha…

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -1372,7 +1372,7 @@ namespace SlowTests.Server.Replication
                     await session.SaveChangesAsync();
                 }
 
-                var shard = await Sharding.GetShardNumber(source, "FoObAr/0");
+                var shard = await Sharding.GetShardNumberFor(source, "FoObAr/0");
                 var sourceDb = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(ShardHelper.ToShardName(source.Database, shard));
                 sourceDb.Configuration.Replication.RetryMaxTimeout = new TimeSetting((long)TimeSpan.FromMinutes(15).TotalMilliseconds, TimeUnit.Minutes);
                 sourceDb.ReplicationLoader.ForTestingPurposesOnly().OnOutgoingReplicationStart = (o) =>


### PR DESCRIPTION
…rded database

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19549/Delay-Replication-on-missing-attachments-loop-for-sharded-database

### Additional description

Adding tests to ensure delay replication on missing attachment loop is working for sharded database.

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
