### PR TITLE
RavenDB-19663: Snapshot backup without indexes does not calculate in lack of indexes for the space required for backup

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -681,12 +681,11 @@ namespace Raven.Server.Documents.PeriodicBackup
             long totalUsedSpace = 0;
             foreach (var mountPointUsage in _database.GetMountPointsUsage(includeTempBuffers: false))
             {
-                if(mountPointUsage.Type == "Index" && excludeIndexes) continue;
+                if(mountPointUsage.Type == "Index" && excludeIndexes)
+                    continue;
 
                 totalUsedSpace += mountPointUsage.UsedSpace;
             }
-
-            if (_forTestingPurposes != null) _forTestingPurposes.RequiredFreeSpaceOnSnapshot = totalUsedSpace;
 
             var directoryPath = Path.GetDirectoryName(filePath);
 

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1432,6 +1432,21 @@ namespace Raven.Server.Web.System
                 }
             }
         }
+
+        internal TestingStuff _forTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (_forTestingPurposes != null)
+                return _forTestingPurposes;
+
+            return _forTestingPurposes = new TestingStuff();
+        }
+
+        public class TestingStuff
+        {
+            internal long RequiredFreeSpaceOnSnapshot;
+        }
     }
 
     public class OngoingTasksResult : IDynamicJson

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1432,21 +1432,6 @@ namespace Raven.Server.Web.System
                 }
             }
         }
-
-        internal TestingStuff _forTestingPurposes;
-
-        internal TestingStuff ForTestingPurposesOnly()
-        {
-            if (_forTestingPurposes != null)
-                return _forTestingPurposes;
-
-            return _forTestingPurposes = new TestingStuff();
-        }
-
-        public class TestingStuff
-        {
-            internal long RequiredFreeSpaceOnSnapshot;
-        }
     }
 
     public class OngoingTasksResult : IDynamicJson


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19663/Snapshot-backup-without-indexes-does-not-calculate-in-lack-of-indexes-for-the-space-required-for-backup

### Additional description

We should take into account excluded indexes when calculating the required space for backup in the case of `Snapshot`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed