### PR TITLE
RavenDB-19579 for studio include the shard number in the metadata

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -266,6 +266,8 @@ namespace Raven.Client
                 public const string Etag = "@etag";
 
                 internal const string OrderByFields = "@order-by-fields";
+
+                internal const string ShardNumber = "@shard-number";
             }
 
             public class Collections

--- a/src/Raven.Client/Extensions/BlittableJsonExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Extensions
 {
@@ -70,6 +71,23 @@ namespace Raven.Client.Extensions
 
             changeVector = changeVectorAsObject as string;
             return true;
+        }
+
+        internal static BlittableJsonReaderObject AddToMetadata<T>(this BlittableJsonReaderObject item, JsonOperationContext context, string key, T value)
+        {
+            item.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata);
+            metadata.Modifications = new DynamicJsonValue(metadata)
+            {
+                [key] = value
+            };
+            item.Modifications = new DynamicJsonValue(item)
+            {
+                [Constants.Documents.Metadata.Key] = metadata
+            };
+            using (var old = item)
+            {
+                return context.ReadObject(item, "add-to-metadata");
+            }
         }
 
         private static void InvalidMissingChangeVector()

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -14,6 +14,7 @@ using Raven.Server.Documents.Handlers.Processors.Documents;
 using Raven.Server.Documents.Queries.Revisions;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Streaming;
 using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Documents.Sharding.Streaming;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -139,19 +140,19 @@ internal class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
         Disposables.Add(streams);
 
-        IAsyncEnumerable<Document> documents;
+        IAsyncEnumerable<ShardStreamItem<Document>> documents;
         if (startsWith != null)
         {
-            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token).Select(x => x.Item);
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token);
         }
         else
         {
-            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token).Select(x => x.Item);
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token);
         }
 
         return new DocumentsResult
         {
-            DocumentsAsync = documents,
+            DocumentsAsync = ShardedDatabaseContext.ShardedStreaming.UnwrapDocuments(documents),
             ContinuationToken = token,
             Etag = results.CombinedEtag
         };

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -142,11 +142,11 @@ internal class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         IAsyncEnumerable<Document> documents;
         if (startsWith != null)
         {
-            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token);
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token).Select(x => x.Item);
         }
         else
         {
-            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token);
+            documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(streams, token).Select(x => x.Item);
         }
 
         return new DocumentsResult

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedQueryOperation.cs
@@ -44,7 +44,7 @@ public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQ
 
     public HttpRequest HttpRequest { get => _requestHandler.HttpContext.Request; }
 
-    public bool Debug => HttpRequest.IsFromStudio();
+    public bool FromStudio => HttpRequest.IsFromStudio();
 
     RavenCommand<QueryResult> IShardedOperation<QueryResult, ShardedReadResult<ShardedQueryResult>>.CreateCommandForShard(int shardNumber) => _queryCommands[shardNumber];
 
@@ -178,7 +178,7 @@ public class ShardedQueryOperation : IShardedReadOperation<QueryResult, ShardedQ
             {
                 foreach (BlittableJsonReaderObject item in array)
                 {
-                    if (Debug == false)
+                    if (FromStudio == false)
                     {
                         yield return item;
                         continue;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -262,6 +262,15 @@ namespace Raven.Server.Documents.Sharding
             public IAsyncEnumerable<ShardStreamItem<Document>> GetDocumentsAsyncById(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results") => 
                 PagedShardedDocumentsById(documents, resultPropertyName, pagingContinuation);
 
+            
+            public static async IAsyncEnumerable<Document> UnwrapDocuments(IAsyncEnumerable<ShardStreamItem<Document>> docs)
+            {
+                await foreach (var doc in docs)
+                {
+                    yield return doc.Item;
+                }
+            }
+
             public IEnumerable<T> PagedShardedItem<T, TInput>(
                 Dictionary<int, ShardExecutionResult<TInput>> results,
                 Func<TInput, IEnumerable<T>> selector,

--- a/src/Raven.Server/Documents/Sharding/Streaming/Comparers/DocumentByLastModifiedDescComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/Comparers/DocumentByLastModifiedDescComparer.cs
@@ -2,16 +2,16 @@
 
 namespace Raven.Server.Documents.Sharding.Streaming.Comparers;
 
-public class DocumentByLastModifiedComparer : Comparer<Document>
+public class DocumentByLastModifiedDescComparer : Comparer<Document>
 {
-    public static DocumentByLastModifiedComparer Instance = new DocumentByLastModifiedComparer();
+    public static DocumentByLastModifiedDescComparer Instance = new DocumentByLastModifiedDescComparer();
         
     public override int Compare(Document x, Document y)
     {
         var diff = x.LastModified.Ticks - y.LastModified.Ticks;
-        if (diff > 0)
-            return 1;
         if (diff < 0)
+            return 1;
+        if (diff > 0)
             return -1;
         return 0;
     }

--- a/src/Raven.Server/Documents/Sharding/Streaming/Comparers/StreamDocumentByLastModifiedComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/Comparers/StreamDocumentByLastModifiedComparer.cs
@@ -8,6 +8,6 @@ public class StreamDocumentByLastModifiedComparer : Comparer<ShardStreamItem<Doc
         
     public override int Compare(ShardStreamItem<Document> x, ShardStreamItem<Document> y)
     {
-        return DocumentByLastModifiedComparer.Instance.Compare(x.Item, y.Item);
+        return DocumentByLastModifiedDescComparer.Instance.Compare(x.Item, y.Item);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
@@ -12,7 +12,8 @@ namespace Raven.Server.Documents.Sharding.Streaming
             return new Document
             {
                 Data = json, 
-                LowerId = metadata.GetIdAsLazyString()
+                LowerId = metadata.GetIdAsLazyString(),
+                LastModified = metadata.GetLastModified()
             };
         }
 

--- a/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -9,7 +9,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.Studio.Processors;
 
-public class StudioCollectionsHandlerProcessorForPreviewCollection : AbstractStudioCollectionsHandlerProcessorForPreviewCollection<DatabaseRequestHandler>
+public class StudioCollectionsHandlerProcessorForPreviewCollection : AbstractStudioCollectionsHandlerProcessorForPreviewCollection<DatabaseRequestHandler, Document>
 {
     private readonly DocumentDatabase _database;
 
@@ -103,6 +103,9 @@ public class StudioCollectionsHandlerProcessorForPreviewCollection : AbstractStu
     {
         return ValueTask.FromResult(ExtractColumnNames(_documents, _context));
     }
+
+    protected override void WriteResult(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, PreviewState state) 
+        => WriteDocument(writer, context, document, state);
 
     public override void Dispose()
     {

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -73,7 +73,7 @@ public class ShardedStudioCollectionsHandlerProcessorForPreviewCollection : Abst
 
     private class ShardedPreviewState : PreviewState
     {
-        private const string ShardNumberKey = "$shard-number";
+        private const string ShardNumberKey = "@shard-number";
         public int ShardNumber;
 
         public override DynamicJsonValue CreateMetadata(BlittableJsonReaderObject current)

--- a/src/Raven.Studio/typescript/commands/database/documents/getDocumentsWithMetadataCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getDocumentsWithMetadataCommand.ts
@@ -15,7 +15,7 @@ class getDocumentsWithMetadataCommand extends commandBase {
         const payload = {
             Ids: this.ids
         };
-        this.post<queryResultDto<documentDto>>(endpoints.databases.document.docs, JSON.stringify(payload), this.db)
+        this.post<queryResultDto<documentDto>>(endpoints.databases.document.docs + "?fromStudio=true", JSON.stringify(payload), this.db)
             .fail((xhr: JQueryXHR) => {
                 if (xhr.status === 404 && this.ids.length === 1) {
                     documentResult.resolve([null]);

--- a/src/Raven.Studio/typescript/commands/database/documents/getDocumentsWithMetadataCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getDocumentsWithMetadataCommand.ts
@@ -15,7 +15,7 @@ class getDocumentsWithMetadataCommand extends commandBase {
         const payload = {
             Ids: this.ids
         };
-        this.post<queryResultDto<documentDto>>(endpoints.databases.document.docs + "?fromStudio=true", JSON.stringify(payload), this.db)
+        this.post<queryResultDto<documentDto>>(endpoints.databases.document.docs, JSON.stringify(payload), this.db)
             .fail((xhr: JQueryXHR) => {
                 if (xhr.status === 404 && this.ids.length === 1) {
                     documentResult.resolve([null]);

--- a/src/Raven.Studio/typescript/models/database/documents/documentMetadata.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/documentMetadata.ts
@@ -43,6 +43,8 @@ class documentMetadata {
     revisionTimeSeries = ko.observableArray<revisionTimeSeries>();
     
     changeVector = ko.observable<string>();
+    
+    shardNumber: number | null;
 
     constructor(dto?: documentMetadataDto) {
         if (dto) {
@@ -52,6 +54,7 @@ class documentMetadata {
             this.nonAuthoritativeInfo = dto['Non-Authoritative-Information'];
             this.id = dto['@id'];
             this.tempIndexScore = dto['Temp-Index-Score'];
+            this.shardNumber = dto['@shard-number'];
 
             const dateFormat = generalUtils.dateFormat;
             this.lastModifiedFullDate = ko.pureComputed(() => {
@@ -123,6 +126,7 @@ class documentMetadata {
                 if (property.toUpperCase() !== '@collection'.toUpperCase() &&
                     property.toUpperCase() !== '@flags'.toUpperCase() &&
                     property.toUpperCase() !== 'Raven-Clr-Type'.toUpperCase() &&
+                    property.toUpperCase() !== '@shard-number'.toUpperCase() &&
                     property.toUpperCase() !== 'Non-Authoritative-Information'.toUpperCase() &&
                     property.toUpperCase() !== '@id'.toUpperCase() &&
                     property.toUpperCase() !== 'Temp-Index-Score'.toUpperCase() &&

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/flagsColumn.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/flagsColumn.ts
@@ -16,7 +16,7 @@ class flagsColumn implements virtualColumn {
         return false;
     }
 
-    width = "70px";
+    width = "140px";
     
     header = `<div style="padding-left: 8px;"><i class="icon-flag"></i></div>`;
 
@@ -28,6 +28,7 @@ class flagsColumn implements virtualColumn {
         const metadata = item.__metadata;
         
         const extraClasses: string[] = [];
+        let shardText: string = "";
         
         if (metadata) {
             const flags = (metadata.flags || "").split(",").map(x => x.trim());
@@ -44,9 +45,11 @@ class flagsColumn implements virtualColumn {
             if (_.includes(flags, "HasTimeSeries")) {
                 extraClasses.push("time-series");
             }
+            
+            shardText = metadata.shardNumber != null ? '<span class="label label-default">SHARD #' + metadata.shardNumber + '</span>' : "";
         }
         
-        return `<div class="cell text-cell flags-cell ${extraClasses.join(" ")}" style="width: ${this.width}"><i title="Attachments" class="icon-attachment"></i><i title="Revisions" class="icon-revisions"></i><i title="Counters" class="icon-new-counter"></i><i title="Time Series" class="icon-new-time-series"></i></div>`;
+        return `<div class="cell text-cell flags-cell ${extraClasses.join(" ")}" style="width: ${this.width}"><i title="Attachments" class="icon-attachment"></i><i title="Revisions" class="icon-revisions"></i><i title="Counters" class="icon-new-counter"></i><i title="Time Series" class="icon-new-time-series"></i>${shardText}</div>`;
     }
 
     toDto(): virtualColumnDto {

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/providers/documentBasedColumnsProvider.ts
@@ -193,7 +193,8 @@ class documentBasedColumnsProvider {
         const docDto = doc.toDto(true);
         
         const text = JSON.stringify(docDto, null, 4);
-        const titleToUse = title ?? doc.getId() ? "Document: " + doc.getId() : "Document Preview";
+        const shardPart = doc.__metadata?.shardNumber != null ? " (shard #" + doc.__metadata.shardNumber + ")" : "";
+        const titleToUse = title ?? doc.getId() ? "Document: " + doc.getId() + shardPart : "Document Preview";
         app.showBootstrapDialog(new showDataDialog(titleToUse, text, "javascript"));
     }
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -90,6 +90,7 @@ interface documentMetadataDto {
     '@flags'?: string;
     '@attachments'?: Array<documentAttachmentDto>;
     '@change-vector'?: string;
+    '@shard-number'?: number;
     '@counters'?: Array<string>;
     '@counters-snapshot'?: dictionary<number>;
     '@timeseries-snapshot'?: dictionary<revisionTimeSeriesDto>;

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -226,6 +226,14 @@
                 <h3 class="margin-none">Properties</h3>
                 <hr class="small" />
                 <dl class="dl-horizontal small" data-bind="with: metadata">
+                    <div data-bind="visible: shardNumber != null">
+                        <dt>Shard:</dt>
+                        <dd>
+                            <span class="label label-default">
+                                # <span data-bind="text: shardNumber"></span>    
+                            </span>
+                        </dd>
+                    </div>
                     <div data-bind="visible: !$root.isCreatingNewDocument()">
                         <dt>Change Vector:</dt>
                         <dd>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19579
https://issues.hibernatingrhinos.com/issue/RavenDB-18807

### Additional description

Allow to include the shard number in the metadata for docs & queries.
Need to pass `fromStudio` on the header.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- It requires further work in the Studio
