### PR TITLE
RavenDB-7070 Marking the test as non disposable so SlowTests.Tests.NoNonDisposableTests.ShouldExist won't be failing

### DIFF
--- a/test/FastTests/Corax/EntriesModificationsTests.cs
+++ b/test/FastTests/Corax/EntriesModificationsTests.cs
@@ -3,11 +3,16 @@ using Corax;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace FastTests.Corax;
 
-public class EntriesModificationsTests
+public class EntriesModificationsTests : NoDisposalNeeded
 {
+    public EntriesModificationsTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
     [Fact]
     public void EntriesModificationsWillEraseOddDuplicates()
     {


### PR DESCRIPTION
### Additional description

Fixing test ensuring we have `NoDisposalNeeded` applied when needed

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Existing tests will verify that

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
