### PR TITLE
RavenDB-19727 - add before and after memory stats after running the GC operation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminMemoryHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminMemoryHandler.cs
@@ -2,23 +2,54 @@
 using System.Runtime;
 using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.LowMemory;
 
 namespace Raven.Server.Documents.Handlers.Admin
 {
     public class AdminMemoryHandler : RequestHandler
     {
         [RavenAction("/admin/memory/gc", "GET", AuthorizationStatus.Operator)]
-        public Task CollectGarbage()
+        public async Task CollectGarbage()
         {
             var loh = GetBoolValueQueryString("loh", required: false) ?? false;
 
             if (loh)
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
 
+            var memoryBefore = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+            var startTime = DateTime.UtcNow;
+
             GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
 
-            return Task.CompletedTask;
+            var actionTime = DateTime.UtcNow - startTime;
+            var memoryAfter = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName("BeforeGC");
+                writer.WriteString(new Size(memoryBefore, SizeUnit.Bytes).ToString());
+                writer.WriteComma();
+
+                writer.WritePropertyName("AfterGC");
+                writer.WriteString(new Size(memoryAfter, SizeUnit.Bytes).ToString());
+                writer.WriteComma();
+
+                writer.WritePropertyName("Freed");
+                writer.WriteString(new Size(memoryBefore - memoryAfter, SizeUnit.Bytes).ToString());
+                writer.WriteComma();
+
+                writer.WritePropertyName("OperationTimeInSeconds");
+                writer.WriteDouble(actionTime.TotalSeconds);
+
+                writer.WriteEndObject();
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19727/Add-info-regarding-the-GC-operation

### Additional description

Add before and after memory stats after running the GC operation

### How risky is the change?

- Low 

### Testing 

- It has been verified by manual testing