### PR TITLE
RavenDB-18433 - Show the breakdown of shard size per bucket

### DIFF
--- a/src/Raven.Server/Documents/Sharding/BucketStats.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStats.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Sharding;
 
-public class BucketStats
+public class BucketStats : IDynamicJson
 {
     public int Bucket;
 
@@ -11,4 +12,15 @@ public class BucketStats
     public long NumberOfDocuments;
 
     public DateTime LastModified;
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue()
+        {
+            [nameof(Bucket)] = Bucket,
+            [nameof(Size)] = Size,
+            [nameof(NumberOfDocuments)] = NumberOfDocuments,
+            [nameof(LastModified)] = LastModified,
+        };
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/BucketStats.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStats.cs
@@ -13,7 +13,7 @@ public class BucketStats : IDynamicJson
 
     public DateTime LastModified;
 
-    public DynamicJsonValue ToJson()
+    public virtual DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue()
         {

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -283,6 +283,8 @@ namespace Raven.Server.Json
 
         internal static readonly Func<BlittableJsonReaderObject, BucketsResults> BucketsResults = GenerateJsonDeserializationRoutine<BucketsResults>();
 
+        internal static readonly Func<BlittableJsonReaderObject, BucketInfo> BucketInfo = GenerateJsonDeserializationRoutine<BucketInfo>();
+
         public class Parameters
         {
             private Parameters()

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -59,6 +59,7 @@ using Raven.Server.Smuggler.Migration;
 using Raven.Server.SqlMigration.Model;
 using Raven.Server.Utils;
 using Raven.Server.Web.Studio;
+using Raven.Server.Web.Studio.Processors;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using FacetSetup = Raven.Client.Documents.Queries.Facets.FacetSetup;
@@ -279,6 +280,8 @@ namespace Raven.Server.Json
         internal static readonly Func<BlittableJsonReaderObject, NotificationCenterDatabaseStats> NotificationCenterDatabaseStats = GenerateJsonDeserializationRoutine<NotificationCenterDatabaseStats>();
 
         internal static readonly Func<BlittableJsonReaderObject, DatabasesInfo> DatabasesInfo = GenerateJsonDeserializationRoutine<DatabasesInfo>();
+
+        internal static readonly Func<BlittableJsonReaderObject, BucketsResults> BucketsResults = GenerateJsonDeserializationRoutine<BucketsResults>();
 
         public class Parameters
         {

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBucket.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBucket.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Json;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using BucketStats = Raven.Server.Documents.Sharding.BucketStats;
+
+namespace Raven.Server.Web.Studio.Processors
+{
+    internal abstract class AbstractBucketsHandlerProcessorForGetBucket<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractBucketsHandlerProcessorForGetBucket([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        public int GetBucket()
+        {
+            return RequestHandler.GetIntValueQueryString("bucket", required: true) ?? -1;
+        }
+        
+        protected abstract ValueTask<BucketInfo> GetBucketInfo(TOperationContext context, int bucket);
+
+        public override async ValueTask ExecuteAsync()
+        {
+            using(ContextPool.AllocateOperationContext(out TOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                var bucketInfo = await GetBucketInfo(context, GetBucket());
+                writer.WriteObject(context.ReadObject(bucketInfo.ToJson(), "bucket/results"));
+            }
+        }
+    }
+
+    public class GetBucketInfoCommand : RavenCommand<BucketInfo>
+    {
+        private readonly int _bucket;
+        
+        internal GetBucketInfoCommand(int bucket)
+        {
+            _bucket = bucket;
+        }
+
+        public override bool IsReadRequest => true;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var pathBuilder = new StringBuilder(node.Url);
+            pathBuilder.Append($"/databases/{node.Database}/debug/bucket?");
+            pathBuilder.Append($"&bucket={_bucket}");
+            
+            var request = new HttpRequestMessage {Method = HttpMethod.Get,};
+
+            url = pathBuilder.ToString();
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+            {
+                Result = null;
+                return;
+            }
+
+            Result = JsonDeserializationServer.BucketInfo(response);
+        }
+    }
+
+    public class BucketInfo : BucketStats
+    {
+        public List<string> Documents;
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(Documents)] = new DynamicJsonArray(Documents);
+            return json;
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -1,0 +1,93 @@
+﻿using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Json;
+using Raven.Server.Utils;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio.Processors
+{
+    internal abstract class AbstractBucketsHandlerProcessorForGetBuckets<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractBucketsHandlerProcessorForGetBuckets([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected (int FromBucket, int ToBucket, int Range) GetParameters()
+        {
+            var fromBucket = RequestHandler.GetIntValueQueryString("fromBucket", required: false) ?? 0;
+            var toBucket = RequestHandler.GetIntValueQueryString("toBucket", required: false) ?? int.MaxValue;
+            var range = RequestHandler.GetIntValueQueryString("range", required: false) ?? (32 * 1024);
+            return (fromBucket, toBucket, range);
+        }
+
+        public override async ValueTask ExecuteAsync()
+        {
+            (int fromBucket, int toBucket, int range) = GetParameters();
+            
+            using(ContextPool.AllocateOperationContext(out TOperationContext context))
+            using (var token = RequestHandler.CreateOperationToken())
+            {
+                var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range, token.Token);
+
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+                {
+                    writer.WriteObject(context.ReadObject(bucketsResults.ToJson(), "buckets/results"));
+                }
+            }
+        }
+
+        protected abstract ValueTask<BucketsResults> GetBucketsResults(TOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token);
+    }
+
+    public class GetBucketsCommand : RavenCommand<BucketsResults>
+    {
+        private readonly int _fromBucket;
+        private readonly int _toBucket;
+        private readonly int _range;
+
+        internal GetBucketsCommand(int fromBucket, int toBucket, int range)
+        {
+            _fromBucket = fromBucket;
+            _toBucket = toBucket;
+            _range = range;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var pathBuilder = new StringBuilder(node.Url);
+            pathBuilder.Append($"/databases/{node.Database}/buckets?");
+            pathBuilder.Append($"&fromBucket={_fromBucket}");
+            pathBuilder.Append($"&toBucket={_toBucket}");
+            pathBuilder.Append($"&range={_range}");
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+            };
+
+            url = pathBuilder.ToString();
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+            {
+                Result = null;
+                return;
+            }
+
+            Result = JsonDeserializationServer.BucketsResults(response);
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -22,23 +22,23 @@ namespace Raven.Server.Web.Studio.Processors
         {
         }
 
-        protected (int FromBucket, int ToBucket, int Range, int? ShardNumber) GetParameters()
+        protected (int FromBucket, int ToBucket, int Range) GetParameters()
         {
             var fromBucket = RequestHandler.GetIntValueQueryString("fromBucket", required: false) ?? 0;
             var toBucket = RequestHandler.GetIntValueQueryString("toBucket", required: false) ?? int.MaxValue;
             var range = RequestHandler.GetIntValueQueryString("range", required: false) ?? (32 * 1024);
-            var shardNumber = RequestHandler.GetIntValueQueryString(Constants.QueryString.ShardNumber, required: false);
-            return (fromBucket, toBucket, range, shardNumber);
+            
+            return (fromBucket, toBucket, range);
         }
 
         public override async ValueTask ExecuteAsync()
         {
-            (int fromBucket, int toBucket, int range, int? shardNumber) = GetParameters();
+            (int fromBucket, int toBucket, int range) = GetParameters();
             
             using(ContextPool.AllocateOperationContext(out TOperationContext context))
             using (var token = RequestHandler.CreateOperationToken())
             {
-                var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range, shardNumber, token.Token);
+                var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range,token.Token);
 
                 await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
                 {
@@ -47,7 +47,7 @@ namespace Raven.Server.Web.Studio.Processors
             }
         }
 
-        protected abstract ValueTask<BucketsResults> GetBucketsResults(TOperationContext context, int fromBucket, int toBucket, int range, int? shardNumber, CancellationToken token);
+        protected abstract ValueTask<BucketsResults> GetBucketsResults(TOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token);
     }
 
     public class GetBucketsCommand : RavenCommand<BucketsResults>

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Raven.Client.Http;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Extensions;
 using Raven.Server.Json;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -39,7 +40,7 @@ namespace Raven.Server.Web.Studio.Processors
 
                 await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
                 {
-                    writer.WriteObject(context.ReadObject(bucketsResults.ToJson(), "buckets/results"));
+                    writer.WriteObject(context.ReadObject(bucketsResults.ToJson(RequestHandler.HttpContext.Request.IsFromStudio()), "buckets/results"));
                 }
             }
         }

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -55,12 +55,14 @@ namespace Raven.Server.Web.Studio.Processors
         private readonly int _fromBucket;
         private readonly int _toBucket;
         private readonly int _range;
+        private readonly int? _shardNumber;
 
-        internal GetBucketsCommand(int fromBucket, int toBucket, int range)
+        internal GetBucketsCommand(int fromBucket, int toBucket, int range, int? shardNumber = null)
         {
             _fromBucket = fromBucket;
             _toBucket = toBucket;
             _range = range;
+            _shardNumber = shardNumber;
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
@@ -70,6 +72,9 @@ namespace Raven.Server.Web.Studio.Processors
             pathBuilder.Append($"&fromBucket={_fromBucket}");
             pathBuilder.Append($"&toBucket={_toBucket}");
             pathBuilder.Append($"&range={_range}");
+
+            if (_shardNumber.HasValue)
+                pathBuilder.Append($"&{Constants.QueryString.ShardNumber}={_shardNumber}");
 
             var request = new HttpRequestMessage
             {

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Web.Studio.Processors
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             var pathBuilder = new StringBuilder(node.Url);
-            pathBuilder.Append($"/databases/{node.Database}/buckets?");
+            pathBuilder.Append($"/databases/{node.Database}/debug/buckets?");
             pathBuilder.Append($"&fromBucket={_fromBucket}");
             pathBuilder.Append($"&toBucket={_toBucket}");
             pathBuilder.Append($"&range={_range}");

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Web.Studio.Processors
 
                 await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
                 {
-                    writer.WriteObject(context.ReadObject(bucketsResults.ToJson(RequestHandler.HttpContext.Request.IsFromStudio()), "buckets/results"));
+                    writer.WriteObject(context.ReadObject(bucketsResults.ToJson(), "buckets/results"));
                 }
             }
         }

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client;
 using Raven.Client.Http;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors;
@@ -21,22 +22,23 @@ namespace Raven.Server.Web.Studio.Processors
         {
         }
 
-        protected (int FromBucket, int ToBucket, int Range) GetParameters()
+        protected (int FromBucket, int ToBucket, int Range, int? ShardNumber) GetParameters()
         {
             var fromBucket = RequestHandler.GetIntValueQueryString("fromBucket", required: false) ?? 0;
             var toBucket = RequestHandler.GetIntValueQueryString("toBucket", required: false) ?? int.MaxValue;
             var range = RequestHandler.GetIntValueQueryString("range", required: false) ?? (32 * 1024);
-            return (fromBucket, toBucket, range);
+            var shardNumber = RequestHandler.GetIntValueQueryString(Constants.QueryString.ShardNumber, required: false);
+            return (fromBucket, toBucket, range, shardNumber);
         }
 
         public override async ValueTask ExecuteAsync()
         {
-            (int fromBucket, int toBucket, int range) = GetParameters();
+            (int fromBucket, int toBucket, int range, int? shardNumber) = GetParameters();
             
             using(ContextPool.AllocateOperationContext(out TOperationContext context))
             using (var token = RequestHandler.CreateOperationToken())
             {
-                var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range, token.Token);
+                var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range, shardNumber, token.Token);
 
                 await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
                 {
@@ -45,7 +47,7 @@ namespace Raven.Server.Web.Studio.Processors
             }
         }
 
-        protected abstract ValueTask<BucketsResults> GetBucketsResults(TOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token);
+        protected abstract ValueTask<BucketsResults> GetBucketsResults(TOperationContext context, int fromBucket, int toBucket, int range, int? shardNumber, CancellationToken token);
     }
 
     public class GetBucketsCommand : RavenCommand<BucketsResults>

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBucket.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBucket.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using NotImplementedException = System.NotImplementedException;
+
+namespace Raven.Server.Web.Studio.Processors
+{
+    internal class BucketsHandlerProcessorForGetBucket : AbstractBucketsHandlerProcessorForGetBucket<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public BucketsHandlerProcessorForGetBucket([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+        
+        protected override ValueTask<BucketInfo> GetBucketInfo(DocumentsOperationContext context, int bucket)
+        {
+            using (context.OpenReadTransaction())
+            {
+                var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(RequestHandler.Database);
+                var docs = database.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket, etag: 0);
+                var bucketStats = ShardedDocumentsStorage.GetBucketStatisticsFor(context, bucket);
+
+                if (bucketStats == null)
+                {
+                    return ValueTask.FromResult(new BucketInfo()
+                    {
+                        Bucket = bucket,
+                        Documents = docs.Select(d => d.Id.ToString()).ToList()
+                    });
+                }
+
+                var bucketInfo = new BucketInfo()
+                {
+                    Bucket = bucket,
+                    Size = bucketStats.Size,
+                    NumberOfDocuments = bucketStats.NumberOfDocuments,
+                    LastModified = bucketStats.LastModified,
+                    Documents = docs.Select(d => d.Id.ToString()).ToList()
+                };
+
+                return ValueTask.FromResult(bucketInfo);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Web.Studio.Processors
         {
             if (ShardHelper.TryGetShardNumberAndDatabaseName(RequestHandler.DatabaseName, out string shardedDatabaseName, out int shardNumber) == false)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Attempted to get buckets of a shard. Expected a shard database but instead got {RequestHandler.Database}");
             }
 
             using (context.OpenReadTransaction())
@@ -38,7 +38,6 @@ namespace Raven.Server.Web.Studio.Processors
                         existing.RangeSize += bucket.Size;
                         existing.DocumentsCount += bucket.NumberOfDocuments;
                         existing.LastModified = existing.LastModified > bucket.LastModified ? existing.LastModified : bucket.LastModified;
-                        existing.ToBucket = existing.ToBucket > bucket.Bucket ? existing.ToBucket : bucket.Bucket;
                         existing.NumberOfBuckets++;
 
                     }

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Web.Studio.Processors
+{
+    internal class BucketsHandlerProcessorForGetBuckets : AbstractBucketsHandlerProcessorForGetBuckets<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public BucketsHandlerProcessorForGetBuckets([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+        
+        protected override ValueTask<BucketsResults> GetBucketsResults(DocumentsOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
+        {
+            if (ShardHelper.TryGetShardNumberAndDatabaseName(RequestHandler.DatabaseName, out string shardedDatabaseName, out int shardNumber) == false)
+            {
+                throw new InvalidOperationException();
+            }
+
+            using (context.OpenReadTransaction())
+            {
+                long shardBucketsSize = 0;
+                var ranges = new Dictionary<int, BucketRange>();
+                foreach (var bucket in ShardedDocumentsStorage.GetBucketStatistics(context, fromBucket, toBucket))
+                {
+                    var id = (bucket.Bucket / range) * range;
+                    if (ranges.TryGetValue(id, out var existing))
+                    {
+                        existing.RangeSize += bucket.Size;
+                        existing.DocumentsCount += bucket.NumberOfDocuments;
+                        existing.LastModified = existing.LastModified > bucket.LastModified ? existing.LastModified : bucket.LastModified;
+                        existing.ToBucket = existing.ToBucket > bucket.Bucket ? existing.ToBucket : bucket.Bucket;
+                        existing.NumberOfBuckets++;
+
+                    }
+                    else
+                    {
+                        var bucketRange = new BucketRange()
+                        {
+                            ShardNumbers = { shardNumber },
+                            RangeSize = bucket.Size,
+                            FromBucket = id,
+                            NumberOfBuckets = 1,
+                            ToBucket = id + range,
+                            LastModified = bucket.LastModified,
+                            DocumentsCount = bucket.NumberOfDocuments
+                        };
+                        if (range == 1)
+                        {
+                            var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(RequestHandler.Database);
+                            bucketRange.Documents = database.ShardedDocumentsStorage.GetDocumentsByBucketFrom(context, bucket.Bucket, 0)
+                                .Select(x => (string)x.Id)
+                                .ToList();
+                        }
+                        ranges[id] = bucketRange;
+                    }
+
+                    shardBucketsSize += bucket.Size;
+                }
+
+                return ValueTask.FromResult(new BucketsResults()
+                {
+                    BucketRanges = ranges,
+                    TotalSize = shardBucketsSize
+                });
+            }
+        }
+    }
+
+    public class BucketRange : IDynamicJson
+    {
+        public long FromBucket;
+        public long ToBucket;
+        public long NumberOfBuckets;
+        public long RangeSize;
+        public HashSet<int> ShardNumbers = new();
+        public List<string> Documents;
+
+        public string RangeSizeHumane => Size.Humane(RangeSize);
+        public long DocumentsCount;
+        public DateTime LastModified;
+
+        public DynamicJsonValue ToJson()
+        {
+            var json = new DynamicJsonValue()
+            {
+                [nameof(RangeSizeHumane)] = RangeSizeHumane,
+                [nameof(ShardNumbers)] = new DynamicJsonArray(ShardNumbers),
+                [nameof(FromBucket)] = FromBucket,
+                [nameof(ToBucket)] = ToBucket,
+                [nameof(NumberOfBuckets)] = NumberOfBuckets,
+                [nameof(RangeSize)] = RangeSize,
+                [nameof(DocumentsCount)] = DocumentsCount,
+                [nameof(LastModified)] = LastModified,
+            };
+            if (Documents is {Count: > 0})
+            {
+                json[nameof(Documents)] = new DynamicJsonArray(Documents);
+            }
+            return json;
+        }
+    }
+
+    public class BucketsResults : IDynamicJson
+    {
+        public long TotalSize;
+        public string TotalSizeHumane => Size.Humane(TotalSize);
+        public Dictionary<int, BucketRange> BucketRanges = new();
+
+        public DynamicJsonValue ToJson()
+        {
+            var ranges = new DynamicJsonValue();
+            foreach (var range in BucketRanges)
+            {
+                ranges[range.Key.ToString()] = range.Value.ToJson();
+            }
+
+            return new DynamicJsonValue()
+            {
+                [nameof(TotalSizeHumane)] = TotalSizeHumane, 
+                [nameof(TotalSize)] = TotalSize, 
+                [nameof(BucketRanges)] = ranges
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -105,30 +105,21 @@ namespace Raven.Server.Web.Studio.Processors
         public string TotalSizeHumane => Size.Humane(TotalSize);
         public Dictionary<int, BucketRange> BucketRanges = new();
 
-        public DynamicJsonValue ToJson(bool fromStudio = false)
+        public DynamicJsonValue ToJson()
         {
-            var json = new DynamicJsonValue()
+            var json = new DynamicJsonValue
             {
                 [nameof(TotalSizeHumane)] = TotalSizeHumane,
                 [nameof(TotalSize)] = TotalSize,
             };
 
-            
-            if (fromStudio == false)
+            var ranges = new DynamicJsonValue();
+            foreach (var range in BucketRanges)
             {
-                var ranges = new DynamicJsonValue();
-                foreach (var range in BucketRanges)
-                {
-                    ranges[range.Key.ToString()] = range.Value.ToJson();
-                }
+                ranges[range.Key.ToString()] = range.Value.ToJson();
+            }
 
-                json[nameof(BucketRanges)] = ranges;
-            }
-            else
-            {
-                var ranges = new DynamicJsonArray(BucketRanges.Select(x => x.Value.ToJson()));
-                json[nameof(BucketRanges)] = ranges;
-            }
+            json[nameof(BucketRanges)] = ranges;
 
             return json;
         }

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Web.Studio.Processors
         {
         }
         
-        protected override ValueTask<BucketsResults> GetBucketsResults(DocumentsOperationContext context, int fromBucket, int toBucket, int range, int? _, CancellationToken token)
+        protected override ValueTask<BucketsResults> GetBucketsResults(DocumentsOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
         {
             if (ShardHelper.TryGetShardNumberAndDatabaseName(RequestHandler.DatabaseName, out string shardedDatabaseName, out int shardNumber) == false)
             {
@@ -49,7 +49,7 @@ namespace Raven.Server.Web.Studio.Processors
                             RangeSize = bucket.Size,
                             FromBucket = id,
                             NumberOfBuckets = 1,
-                            ToBucket = id + range,
+                            ToBucket = id + range - 1,
                             LastModified = bucket.LastModified,
                             DocumentsCount = bucket.NumberOfDocuments
                         };

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Web.Studio.Processors
         {
         }
         
-        protected override ValueTask<BucketsResults> GetBucketsResults(DocumentsOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
+        protected override ValueTask<BucketsResults> GetBucketsResults(DocumentsOperationContext context, int fromBucket, int toBucket, int range, int? _, CancellationToken token)
         {
             if (ShardHelper.TryGetShardNumberAndDatabaseName(RequestHandler.DatabaseName, out string shardedDatabaseName, out int shardNumber) == false)
             {

--- a/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Server.Documents;
+using Raven.Server.Routing;
+using Raven.Server.Web.Studio.Processors;
+
+namespace Raven.Server.Web.Studio.Sharding
+{
+    public class BucketsHandler : DatabaseRequestHandler
+    {
+        [RavenAction("/databases/*/buckets", "GET", AuthorizationStatus.Operator)]
+        public async Task GetBuckets()
+        {
+            using (var processor = new BucketsHandlerProcessorForGetBuckets(this))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Web.Studio.Sharding
 {
     public class BucketsHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/buckets", "GET", AuthorizationStatus.Operator)]
+        [RavenAction("/databases/*/debug/buckets", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetBuckets()
         {
             using (var processor = new BucketsHandlerProcessorForGetBuckets(this))

--- a/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/BucketsHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Raven.Server.Documents;
 using Raven.Server.Routing;
 using Raven.Server.Web.Studio.Processors;
@@ -8,10 +7,17 @@ namespace Raven.Server.Web.Studio.Sharding
 {
     public class BucketsHandler : DatabaseRequestHandler
     {
-        [RavenAction("/databases/*/debug/buckets", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
+        [RavenAction("/databases/*/debug/buckets", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetBuckets()
         {
             using (var processor = new BucketsHandlerProcessorForGetBuckets(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenAction("/databases/*/debug/bucket", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task GetBucket()
+        {
+            using (var processor = new BucketsHandlerProcessorForGetBucket(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBucket.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBucket.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Raven.Server.Web.Studio.Processors;
+
+namespace Raven.Server.Web.Studio.Sharding.Processors
+{
+    internal class ShardedBucketsHandlerProcessorForGetBucket : AbstractBucketsHandlerProcessorForGetBucket<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedBucketsHandlerProcessorForGetBucket([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+        protected override async ValueTask<BucketInfo> GetBucketInfo(TransactionOperationContext context, int bucket)
+        {
+            using (var token = RequestHandler.CreateOperationToken())
+            {
+                var shardNumber = ShardHelper.GetShardNumberFor(RequestHandler.DatabaseContext.DatabaseRecord.Sharding, bucket);
+                var cmd = new GetBucketInfoCommand(bucket);
+                return await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(cmd, shardNumber, token.Token);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
 using Raven.Client.Http;
 using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
@@ -18,8 +19,9 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
         {
         }
         
-        protected override async ValueTask<BucketsResults> GetBucketsResults(TransactionOperationContext context, int fromBucket, int toBucket, int range, int? shardNumber, CancellationToken token)
+        protected override async ValueTask<BucketsResults> GetBucketsResults(TransactionOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
         {
+            var shardNumber = RequestHandler.GetIntValueQueryString(Constants.QueryString.ShardNumber, required: false);
             if (shardNumber.HasValue)
                 return await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new GetBucketsCommand(fromBucket, toBucket, range), shardNumber.Value, token);
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -61,19 +61,6 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
                         existing.RangeSize += cur.RangeSize;
                         existing.NumberOfBuckets += cur.NumberOfBuckets;
                         existing.ShardNumbers.UnionWith(cur.ShardNumbers);
-
-                        // this can only happen if we have the *same* bucket in multiple shards at the same time, did we catch it mid-migration?
-                        if (existing.Documents != null)
-                        {
-                            if (cur.Documents != null)
-                            {
-                                existing.Documents.AddRange(cur.Documents);
-                            }
-                        }
-                        else
-                        {
-                            existing.Documents = cur.Documents;
-                        }
                     }
                     else
                     {

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Studio.Processors;
+
+namespace Raven.Server.Web.Studio.Sharding.Processors
+{
+    internal class ShardedBucketsHandlerProcessorForGetBuckets : AbstractBucketsHandlerProcessorForGetBuckets<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedBucketsHandlerProcessorForGetBuckets([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+        
+        protected override async ValueTask<BucketsResults> GetBucketsResults(TransactionOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
+        {
+            var shardedGetBucketsOperation = new ShardedGetBucketsOperation(RequestHandler.HttpContext.Request, fromBucket, toBucket, range);
+            return await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(shardedGetBucketsOperation, token);
+        }
+    }
+
+    public readonly struct ShardedGetBucketsOperation : IShardedOperation<BucketsResults>
+    {
+        private readonly HttpRequest _request;
+        private readonly int _fromBucket;
+        private readonly int _toBucket;
+        private readonly int _range;
+
+        public ShardedGetBucketsOperation(HttpRequest httpRequest, int fromBucket, int toBucket, int range)
+        {
+            _request = httpRequest;
+            _fromBucket = fromBucket;
+            _toBucket = toBucket;
+            _range = range;
+        }
+
+        public HttpRequest HttpRequest => _request;
+
+        public BucketsResults Combine(Dictionary<int, ShardExecutionResult<BucketsResults>> results)
+        {
+            var bucketRanges = new BucketsResults();
+
+            foreach (var shardResult in results.Values)
+            {
+                var shardStats = shardResult.Result;
+
+                bucketRanges.TotalSize += shardStats.TotalSize;
+                
+                foreach (var (range, cur) in shardStats.BucketRanges)
+                {
+                    if (bucketRanges.BucketRanges.TryGetValue(range, out var existing))
+                    {
+                        existing.DocumentsCount += cur.DocumentsCount;
+                        existing.LastModified = existing.LastModified > cur.LastModified ? existing.LastModified : cur.LastModified;
+                        existing.RangeSize += cur.RangeSize;
+                        existing.NumberOfBuckets += cur.NumberOfBuckets;
+                        existing.ShardNumbers.UnionWith(cur.ShardNumbers);
+
+                        // this can only happen if we have the *same* bucket in multiple shards at the same time, did we catch it mid-migration?
+                        if (existing.Documents != null)
+                        {
+                            if (cur.Documents != null)
+                            {
+                                existing.Documents.AddRange(cur.Documents);
+                            }
+                        }
+                        else
+                        {
+                            existing.Documents = cur.Documents;
+                        }
+                    }
+                    else
+                    {
+                        bucketRanges.BucketRanges[range] = cur;
+                    }
+                }
+            }
+
+            return bucketRanges;
+        }
+
+        public RavenCommand<BucketsResults> CreateCommandForShard(int shardNumber) => new GetBucketsCommand(_fromBucket, _toBucket, _range);
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -18,8 +18,11 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
         {
         }
         
-        protected override async ValueTask<BucketsResults> GetBucketsResults(TransactionOperationContext context, int fromBucket, int toBucket, int range, CancellationToken token)
+        protected override async ValueTask<BucketsResults> GetBucketsResults(TransactionOperationContext context, int fromBucket, int toBucket, int range, int? shardNumber, CancellationToken token)
         {
+            if (shardNumber.HasValue)
+                return await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new GetBucketsCommand(fromBucket, toBucket, range), shardNumber.Value, token);
+
             var shardedGetBucketsOperation = new ShardedGetBucketsOperation(RequestHandler.HttpContext.Request, fromBucket, toBucket, range);
             return await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(shardedGetBucketsOperation, token);
         }

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
@@ -13,5 +13,12 @@ namespace Raven.Server.Web.Studio.Sharding
             using (var processor = new ShardedBucketsHandlerProcessorForGetBuckets(this))
                 await processor.ExecuteAsync();
         }
+
+        [RavenShardedAction("/databases/*/debug/bucket", "GET")]
+        public async Task GetBucket()
+        {
+            using (var processor = new ShardedBucketsHandlerProcessorForGetBucket(this))
+                await processor.ExecuteAsync();
+        }
     }
 }

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.Web.Studio.Sharding
 {
     public class ShardedBucketsHandler : ShardedDatabaseRequestHandler
     {
-        [RavenShardedAction("/databases/*/buckets", "GET")]
+        [RavenShardedAction("/databases/*/debug/buckets", "GET")]
         public async Task GetBuckets()
         {
             using (var processor = new ShardedBucketsHandlerProcessorForGetBuckets(this))

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedBucketsHandler.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Routing;
+using Raven.Server.Web.Studio.Sharding.Processors;
+
+namespace Raven.Server.Web.Studio.Sharding
+{
+    public class ShardedBucketsHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/buckets", "GET")]
+        public async Task GetBuckets()
+        {
+            using (var processor = new ShardedBucketsHandlerProcessorForGetBuckets(this))
+                await processor.ExecuteAsync();
+        }
+    }
+}

--- a/src/Raven.Studio/typescript/commands/database/debug/getBucketsCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/debug/getBucketsCommand.ts
@@ -1,0 +1,25 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+import database = require("models/resources/database");
+
+class getBucketsCommand extends commandBase {
+    
+    static expectedNumberOfRanges = 32;
+    
+    constructor(private db: database, private range?: { from: number, to: number }) {
+        super();
+    }
+
+    execute(): JQueryPromise<Raven.Server.Web.Studio.Processors.BucketsResults> {
+        const args = this.range ? {
+            fromBucket: this.range.from,
+            toBucket: this.range.to,
+            range: (this.range.to - this.range.from) / getBucketsCommand.expectedNumberOfRanges
+        } : {};
+        const url = endpoints.databases.buckets.debugBuckets + this.urlEncodeArgs(args);
+        return this.query<Raven.Server.Web.Studio.Processors.BucketsResults>(url, null, this.db)
+            .fail((response: JQueryXHR) => this.reportError("Failed to buckets report", response.responseText, response.statusText));
+    }
+}
+
+export = getBucketsCommand;

--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -103,6 +103,7 @@ class appUrl {
         conflictResolution: ko.pureComputed(() => appUrl.forConflictResolution(appUrl.currentDatabase())),
 
         statusStorageReport: ko.pureComputed(() => appUrl.forStatusStorageReport(appUrl.currentDatabase())),
+        statusBucketsReport: ko.pureComputed(() => appUrl.forStatusBucketsReport(appUrl.currentDatabase())),
         isAreaActive: (routeRoot: string) => ko.pureComputed(() => appUrl.checkIsAreaActive(routeRoot)),
         isActive: (routeTitle: string) => ko.pureComputed(() => router.navigationModel().find(m => m.isActive() && m.title === routeTitle) != null),
         databasesManagement: ko.pureComputed(() => appUrl.forDatabases()),
@@ -322,6 +323,10 @@ class appUrl {
 
     static forStatusStorageReport(db: database | string): string {
         return '#databases/status/storage/report?' + appUrl.getEncodedDbPart(db);
+    }
+
+    static forStatusBucketsReport(db: database | string): string {
+        return '#databases/status/buckets/report?' + appUrl.getEncodedDbPart(db);
     }
 
     static forSettings(db: database): string {

--- a/src/Raven.Studio/typescript/common/shell/menu/items/stats.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/stats.ts
@@ -37,6 +37,16 @@ function getStatsMenuItem(appUrls: computedAppUrls) {
             dynamicHash: appUrls.statusStorageReport
         }),
         new leafMenuItem({
+            route: 'databases/status/buckets/report',
+            moduleId: require('viewmodels/database/status/bucketsReport'),
+            shardingMode: "allShards",
+            title: 'Buckets Report',
+            tooltip: "Buckets Report",
+            nav: true,
+            css: 'icon-storage', //TODO:
+            dynamicHash: appUrls.statusBucketsReport
+        }),
+        new leafMenuItem({
             route: "virtual", // here we only redirect to global section with proper db set in url
             moduleId: () => { /* empty */},
             title: 'Running Queries',

--- a/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
@@ -20,10 +20,13 @@ class bucketReportItem {
     w?: number; // used for storing text width
     lazyLoadChildren = false;
     
-    constructor(name: string, size: number, documentsCount: number, internalChildren: bucketReportItem[] = null) {
+    shards: number[] = [];
+    
+    constructor(name: string, size: number, documentsCount: number, shards: number[], internalChildren: bucketReportItem[] = null) {
         this.name = name;
         this.size = size;
         this.documentsCount = documentsCount;
+        this.shards = shards;
         this.internalChildren = internalChildren;
     }
 

--- a/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
@@ -1,0 +1,43 @@
+/// <reference path="../../../../typings/tsd.d.ts"/>
+
+import generalUtils = require("common/generalUtils");
+
+class bucketReportItem {
+    name: string;
+    internalChildren: bucketReportItem[];
+    size?: number;
+    length?: number;
+    x?: number;
+    y?: number;
+    dx?: number;
+    dy?: number;
+    
+    fromRange: number;
+    toRange: number;
+    
+    documentsCount: number = null;
+    parent?: bucketReportItem;
+    w?: number; // used for storing text width
+    lazyLoadChildren = false;
+    
+    constructor(name: string, size: number, documentsCount: number, internalChildren: bucketReportItem[] = null) {
+        this.name = name;
+        this.size = size;
+        this.documentsCount = documentsCount;
+        this.internalChildren = internalChildren;
+    }
+
+    formatSize() {
+        return generalUtils.formatBytesToSize(this.size);
+    }
+
+    formatPercentage(parentSize: number) {
+        return (this.size * 100 / parentSize).toFixed(2) + '%';
+    }
+
+    hasChildren(): boolean {
+        return (this.internalChildren && this.internalChildren.length > 0) || (this.lazyLoadChildren === true);
+    }
+}
+
+export = bucketReportItem;

--- a/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
@@ -1,0 +1,438 @@
+import router = require("plugins/router");
+import appUrl = require("common/appUrl");
+import accessManager = require("common/shell/accessManager");
+import getBucketsCommand = require("commands/database/debug/getBucketsCommand");
+import protractedCommandsDetector = require("common/notifications/protractedCommandsDetector");
+import generalUtils = require("common/generalUtils");
+import d3 = require("d3");
+import shardViewModelBase from "viewmodels/shardViewModelBase";
+import database from "models/resources/database";
+import bucketReportItem from "models/database/status/bucketReportItem";
+
+type positionAndSizes = {
+    dx: number,
+    dy: number,
+    x: number,
+    y: number
+}
+
+class bucketsReport extends shardViewModelBase {
+
+    view = require("views/database/status/bucketsReport.html");
+    
+    accessManager = accessManager.default.databasesView;
+
+    static readonly animationLength = 200;
+    static readonly maxChildrenToShow = 1000;
+
+    private currentPath: KnockoutComputed<Array<bucketReportItem>>;
+
+    private x: d3.scale.Linear<number, number>;
+    private y: d3.scale.Linear<number, number>;
+    private root: bucketReportItem;
+    private node = ko.observable<bucketReportItem>();
+    private treemap: d3.layout.Treemap<any>;
+    private svg: d3.Selection<any>;
+    private g: d3.Selection<any>;
+    private tooltip: d3.Selection<any>;
+
+    private w: number;
+    private h: number;
+
+    private transitioning = false;
+
+    showLoader = ko.observable<boolean>(false);
+
+    constructor(db: database, location: databaseLocationSpecifier) {
+        super(db, location);
+        this.bindToCurrentInstance("onClick");
+    }
+
+    activate(args: any) {
+        super.activate(args);
+
+        this.initObservables();
+
+        return new getBucketsCommand(this.db)
+            .execute()
+            .done(result => {
+                this.processData(result);
+            });
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        this.initGraph();
+        this.draw(undefined);
+    }
+
+    private initObservables() {
+        this.currentPath = ko.pureComputed(() => {
+            const node = this.node();
+
+            const items: bucketReportItem[] = [];
+
+            let currentItem = node;
+            while (currentItem) {
+                items.unshift(currentItem);
+                currentItem = currentItem.parent;
+            }
+
+            return items;
+        });
+    }
+
+    private processData(data: Raven.Server.Web.Studio.Processors.BucketsResults) {
+        const mappedData = Object.values<Raven.Server.Web.Studio.Processors.BucketRange>(data.BucketRanges).map(x => this.mapBucket(x));
+        
+        const totalSize = mappedData.reduce((p, c) => p + c.size, 0);
+        const totalDocuments = mappedData.reduce((p, c) => p + c.documentsCount, 0);
+        this.root = new bucketReportItem( "/", totalSize, totalDocuments, mappedData);
+
+        this.sortBySize(this.root);
+
+        this.node(this.root);
+    }
+
+    private sortBySize(node: bucketReportItem) {
+        if (node.internalChildren && node.internalChildren.length) {
+            node.internalChildren.forEach(x => this.sortBySize(x));
+
+            node.internalChildren.sort((a, b) => d3.descending(a.size, b.size));
+        }
+    }
+
+    private mapBucket(dto: Raven.Server.Web.Studio.Processors.BucketRange): bucketReportItem {
+        const name = dto.FromBucket + " - " + dto.ToBucket;
+        const item = new bucketReportItem(name, dto.RangeSize, dto.DocumentsCount);
+        item.fromRange = dto.FromBucket;
+        item.toRange = dto.ToBucket;
+        item.lazyLoadChildren = true;
+        return item;
+    }
+
+    private initGraph() {
+        this.detectContainerSize();
+        this.x = d3.scale.linear().range([0, this.w]);
+        this.y = d3.scale.linear().range([0, this.h]);
+
+        this.svg = d3.select("#storage-report-container .chart")
+            .append("svg:svg")
+            .attr("width", this.w)
+            .attr("height", this.h)
+            .attr("transform", "translate(.5,.5)");
+    }
+
+    private detectContainerSize() {
+        const $chartNode = $("#storage-report-container .chart");
+        this.w = $chartNode.width();
+        this.h = $chartNode.height();
+    }
+
+    private getChildren(node: bucketReportItem, depth: number) {
+        return depth === 0 ? node.internalChildren : [];
+    }
+
+    private draw(goingIn: boolean, forceOldLocation?: positionAndSizes) {
+        const levelDown = goingIn === true;
+        const levelUp = goingIn === false;
+
+        this.treemap = d3.layout.treemap<any>()
+            .children((n, depth) => this.getChildren(n, depth))
+            .value(d => d.size)
+            .size([this.w, this.h]);
+
+        this.tooltip = d3.select(".chart-tooltip");
+
+        const oldLocation: positionAndSizes = forceOldLocation || {
+            dx: this.node().dx,
+            dy: this.node().dy,
+            x: this.node().x,
+            y: this.node().y
+        };
+
+        const nodes = this.treemap.nodes(this.node())
+            .filter(n => !n.children);
+
+        if (levelDown) {
+            this.animateZoomIn(nodes, oldLocation);
+        } else if (levelUp) {
+            this.animateZoomOut(nodes);
+        } else {
+            // initial state
+            this.svg.select(".treemap")
+                .remove();
+            const container = this.svg.append("g")
+                .classed("treemap", true);
+            this.drawNewTreeMap(nodes, container);
+        }
+    }
+
+    private animateZoomIn(nodes: bucketReportItem[], oldLocation: positionAndSizes) {
+        this.transitioning = true;
+
+        const oldContainer = this.svg.select(".treemap");
+
+        const newGroup = this.svg.append("g")
+            .classed("treemap", true);
+
+        const scaleX = this.w / oldLocation.dx;
+        const scaleY = this.h / oldLocation.dy;
+        const transX = -oldLocation.x * scaleX;
+        const transY = -oldLocation.y * scaleY;
+
+        oldContainer
+            .selectAll("text")
+            .transition()
+            .duration(bucketsReport.animationLength / 4)
+            .style('opacity', 0);
+
+        oldContainer
+            .transition()
+            .duration(bucketsReport.animationLength)
+            .attr("transform", "translate(" + transX + "," + transY + ")scale(" + scaleX + "," + scaleY + ")")
+            .each("end", () => {
+                const newCells = this.drawNewTreeMap(nodes, newGroup);
+                newCells
+                    .style('opacity', 0)
+                    .transition()
+                    .duration(bucketsReport.animationLength)
+                    .style('opacity', 1)
+                    .each("end", () => {
+                        oldContainer.remove();
+                        this.transitioning = false;
+                    });
+            });
+    }
+
+    private animateZoomOut(nodes: bucketReportItem[]) {
+        this.transitioning = true;
+
+        const oldContainer = this.svg.select(".treemap");
+
+        const newGroup = this.svg.append("g")
+            .classed("treemap", true);
+
+        const newCells = this.drawNewTreeMap(nodes, newGroup);
+
+        newCells
+            .style('opacity', 0)
+            .transition()
+            .duration(bucketsReport.animationLength)
+            .style('opacity', 1)
+            .each("end", () => {
+                oldContainer.remove();
+                this.transitioning = false;
+            });
+    }
+
+    private drawNewTreeMap(nodes: bucketReportItem[], container: d3.Selection<any>) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        const showTypeOffset = 7;
+
+        const cell = container.selectAll("g.cell-no-such") // we always select non-existing nodes to draw from scratch - we don't update elements here
+            .data(nodes)
+            .enter().append("svg:g")
+            .attr("class", d => "cell")
+            .attr("transform", d => "translate(" + d.x + "," + d.y + ")")
+            .on("click", d => this.onClick(d, true))
+            .on("mouseover", d => this.onMouseOver(d))
+            .on("mouseout", () => this.onMouseOut())
+            .on("mousemove", () => this.onMouseMove());
+
+        const rectangles = cell.append("svg:rect")
+            .attr("width", d => Math.max(0, d.dx - 1))
+            .attr("height", d => Math.max(0, d.dy - 1))
+
+        rectangles
+            .filter(x => x.hasChildren() || x.lazyLoadChildren)
+            .style('cursor', 'pointer');
+
+        cell.append("svg:text")
+            .filter(d => d.dx > 20 && d.dy > 8)
+            .attr("x", d => d.dx / 2)
+            .attr("y", d => d.dy / 2)
+            .attr("dy", ".35em")
+            .attr("text-anchor", "middle")
+            .text(d => d.name)
+            .each(function (d) {
+                self.wrap(this, d.dx);
+            });
+        
+        return cell;
+    }
+
+    wrap($self: any, width: number) {
+        const self = d3.select($self);
+        let textLength = (self.node() as any).getComputedTextLength();
+        let text = self.text();
+        
+        while (textLength > (width - 6) && text.length > 0) {
+            text = text.slice(0, -1);
+            self.text(text + '...');
+            textLength = (self.node() as any).getComputedTextLength();
+        }
+    } 
+
+    private findDatafile(d: bucketReportItem): bucketReportItem {
+        while (d.parent.parent && d.parent.parent.name !== "/") {
+            d = d.parent;
+        }
+        
+        return d;
+    }
+    
+    private loadDetailedReport(d: bucketReportItem): JQueryPromise<any> { //TODO: typE
+        if (!d.lazyLoadChildren) {
+            return;
+        }
+
+        const datafile = this.findDatafile(d);
+        const full = datafile !== d; // load full details only when loadDetailedReport was requested from child of data file 
+        const env = datafile.parent;
+
+        const showLoaderTimer = setTimeout(() => {
+            this.showLoader(true);
+        }, 100);
+        
+        
+        return new getBucketsCommand(this.db, {
+            from: d.fromRange,
+            to: d.toRange
+        })
+            .execute()
+            .done(results => {
+                d.lazyLoadChildren = false;
+                d.internalChildren = Object.values<Raven.Server.Web.Studio.Processors.BucketRange>(results.BucketRanges).map(x => this.mapBucket(x));
+            })
+            .always(() => {
+                if (this.showLoader()) {
+                    this.showLoader(false);
+                } else {
+                    clearTimeout(showLoaderTimer);
+                }
+            });
+    }
+    
+    private getNodePath(d: bucketReportItem): string[] {
+        const result: string[] = [];
+        
+        do {
+            result.push(d.name);
+            d = d.parent;
+        } while (d.name !== "/");
+        
+        return result.reverse();
+    }
+    
+    private findNodeByPath(path: string[]): bucketReportItem {
+        let target = this.root;
+
+        for (const item of path) {
+            target = target.internalChildren.find(x => x.name === item);
+
+            if (!target) {
+                return null;
+            }
+        }
+        
+        return target;
+    }
+
+    onClick(d: bucketReportItem, goingIn: boolean) {
+        if (this.transitioning || this.node() === d) {
+            return;
+        }
+
+        if (d.lazyLoadChildren) {
+            const requestExecution = protractedCommandsDetector.instance.requestStarted(500);
+
+            const nodePath = this.getNodePath(d);
+            
+            // copy old positions as node references might change during load (data overwrite)
+            const oldLocation: positionAndSizes = {
+                dx: d.dx,
+                dy: d.dy,
+                x: d.x,
+                y: d.y
+            };
+            
+            this.loadDetailedReport(d)
+                .done(() => {
+                    const nodeAfterLoad = this.findNodeByPath(nodePath);
+                    
+                    if (d !== nodeAfterLoad) {
+                        // little magic here - we want to restore parent/child relations
+                        d3.layout.treemap<any>()
+                            .children((n) => n.internalChildren)
+                            .value(d => d.size)
+                            .size([this.w, this.h])
+                            .nodes(this.root);
+                    }
+                    
+                    this.sortBySize(nodeAfterLoad);
+                    this.node(nodeAfterLoad);
+                    
+                    this.draw(true, oldLocation);
+                })
+                .always(() => requestExecution.markCompleted());
+
+            if (d3.event) {
+                (d3.event as any).stopPropagation();
+            }
+            return;
+        }
+
+        if (!d.internalChildren || !d.internalChildren.length) {
+            return;
+        }
+
+        this.node(d);
+        this.draw(goingIn);
+
+        this.updateTooltips();
+        
+        if (d3.event) {
+            (d3.event as any).stopPropagation();
+        }
+    }
+    
+    private updateTooltips() {
+        $('#storage-report [data-toggle="tooltip"]').tooltip();
+    }
+
+    private onMouseMove() {
+        // eslint-disable-next-line prefer-const
+        let [x, y] = d3.mouse(this.svg.node());
+
+        const tooltipWidth = $(".chart-tooltip").width() + 20;
+
+        x = Math.min(x, Math.max(this.w - tooltipWidth, 0));
+
+        this.tooltip
+            .style("left", (x + 10) + "px")
+            .style("top", (y + 10) + "px");
+    }
+
+    private onMouseOver(d: bucketReportItem) {
+        this.tooltip.transition()
+            .duration(200)
+            .style("opacity", 1);
+        let html = "<div class='tooltip-li'>Range: <div class='value'>" + d.name + "</div></div>";
+        html += "<div class='tooltip-li'>Document Count: <div class='value'>" + d.documentsCount + "</div></div>";
+        html += "<div class='tooltip-li'>Size: <div class='value'>" + generalUtils.formatBytesToSize(d.size) + "</div></div>";
+
+        this.tooltip.html(html);
+        this.onMouseMove();
+    }
+
+    private onMouseOut() {
+        this.tooltip.transition()
+            .duration(500)
+            .style("opacity", 0);
+    }
+}
+
+export = bucketsReport;

--- a/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
@@ -88,7 +88,7 @@ class bucketsReport extends shardViewModelBase {
         
         const totalSize = mappedData.reduce((p, c) => p + c.size, 0);
         const totalDocuments = mappedData.reduce((p, c) => p + c.documentsCount, 0);
-        this.root = new bucketReportItem( "/", totalSize, totalDocuments, mappedData);
+        this.root = new bucketReportItem( "/", totalSize, totalDocuments, [], mappedData);
 
         this.sortBySize(this.root);
 
@@ -105,7 +105,7 @@ class bucketsReport extends shardViewModelBase {
 
     private mapBucket(dto: Raven.Server.Web.Studio.Processors.BucketRange): bucketReportItem {
         const name = dto.FromBucket + " - " + dto.ToBucket;
-        const item = new bucketReportItem(name, dto.RangeSize, dto.DocumentsCount);
+        const item = new bucketReportItem(name, dto.RangeSize, dto.DocumentsCount, dto.ShardNumbers);
         item.fromRange = dto.FromBucket;
         item.toRange = dto.ToBucket;
         item.lazyLoadChildren = true;
@@ -235,7 +235,7 @@ class bucketsReport extends shardViewModelBase {
         const cell = container.selectAll("g.cell-no-such") // we always select non-existing nodes to draw from scratch - we don't update elements here
             .data(nodes)
             .enter().append("svg:g")
-            .attr("class", d => "cell")
+            .attr("class", d => "cell index")
             .attr("transform", d => "translate(" + d.x + "," + d.y + ")")
             .on("click", d => this.onClick(d, true))
             .on("mouseover", d => this.onMouseOver(d))
@@ -422,6 +422,7 @@ class bucketsReport extends shardViewModelBase {
             .style("opacity", 1);
         let html = "<div class='tooltip-li'>Range: <div class='value'>" + d.name + "</div></div>";
         html += "<div class='tooltip-li'>Document Count: <div class='value'>" + d.documentsCount + "</div></div>";
+        html += "<div class='tooltip-li'>Shards: <div class='value'>" + d.shards.map(x => `<span># ${x}</span>`).join("") + "</div></div>";
         html += "<div class='tooltip-li'>Size: <div class='value'>" + generalUtils.formatBytesToSize(d.size) + "</div></div>";
 
         this.tooltip.html(html);

--- a/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
+++ b/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
@@ -80,6 +80,7 @@ interface computedAppUrls {
     ioStats: KnockoutComputed<string>;
 
     statusStorageReport: KnockoutComputed<string>;
+    statusBucketsReport: KnockoutComputed<string>;
     isAreaActive: (routeRoot: string) => KnockoutComputed<boolean>;
     isActive: (routeTitle: string) => KnockoutComputed<boolean>;
     databasesManagement: KnockoutComputed<string>;

--- a/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
@@ -1,0 +1,38 @@
+<div id="storage-report" class="content-margin">
+    <div id="storage-report-container" data-bind="css: { 'processing': showLoader() }">
+        <div class="chart-tooltip tooltip tooltip-inner" style="opacity: 0">
+        </div>
+        <div class="chart"></div>
+    </div>
+    <div class="current-path">
+            <span data-bind="foreach: currentPath">
+                <a href="#" data-bind="click: _.partial($root.onClick, $data, false)">
+                    <span data-bind="text: name"></span>
+                </a>
+                <i data-bind="visible: $index() < $root.currentPath().length - 1" class="icon-arrow-filled-right"></i>
+            </span>
+    </div>
+    <table class="table table-condensed table-striped on-base-background margin-top margin-top-sm" data-bind="if: node() && node().internalChildren">
+        <thead>
+            <tr>
+                <th class="column-min-width">Range</th>
+                <th>Documents count</th>
+                <th>Size (&sum; <span data-bind="text: node().formatSize()"></span>)</th>
+                <th>% Total</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: node().internalChildren">
+            <tr>
+                <td class="position-relative">
+                    <div class="table-items">
+                        <a href="#" class="table-item-name text-elipsis" data-bind="text: name, click: _.partial($root.onClick, $data, true), visible: hasChildren(), attr: { title: name }"></a>
+                        <span href="#" class="table-item-name text-elipsis" data-bind="text: name, visible: !hasChildren(), attr: { title: name }"></span>
+                    </div>
+                </td>
+                <td data-bind="text: documentsCount.toLocaleString()"></td>
+                <td data-bind="html: formatSize(false)"></td>
+                <td data-bind="text: formatPercentage($parent.node().size)"></td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
@@ -17,6 +17,7 @@
             <tr>
                 <th class="column-min-width">Range</th>
                 <th>Documents count</th>
+                <th>Shards</th>
                 <th>Size (&sum; <span data-bind="text: node().formatSize()"></span>)</th>
                 <th>% Total</th>
             </tr>
@@ -30,6 +31,13 @@
                     </div>
                 </td>
                 <td data-bind="text: documentsCount.toLocaleString()"></td>
+                <td>
+                    <!-- ko foreach: shards -->
+                        <span class="label label-primary" data-bind="text: '#' + $data">
+                            
+                        </span>
+                    <!-- /ko -->
+                </td>
                 <td data-bind="html: formatSize(false)"></td>
                 <td data-bind="text: formatPercentage($parent.node().size)"></td>
             </tr>

--- a/test/SlowTests/Sharding/StudioBucketsTests.cs
+++ b/test/SlowTests/Sharding/StudioBucketsTests.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Extensions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Server.Utils;
+using Raven.Server.Web.Studio.Processors;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding
+{
+    public class StudioBucketsTests : ClusterTestBase
+    {
+        public StudioBucketsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task GetBucketsView()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 2, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                var dict = new Dictionary<int, ShardBucketsStats>(); //shard to bucket stats
+                var executor = store.GetRequestExecutor();
+                using (var _ = executor.ContextPool.AllocateOperationContext(out var ctx))
+                {
+                    var sharding = await Sharding.GetShardingConfigurationAsync(store);
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var name = "s";
+                        for (int i = 0; i < 20; i++)
+                        {
+                            var id = $"user/{i}";
+                            var bucket = Sharding.GetBucket(id);
+                            var shardNumberForDoc = await Sharding.GetShardNumberFor(store, id);
+                            var user = new User()
+                            {
+                                Name = name
+                            };
+                            name += "s";
+
+                            await session.StoreAsync(user, id);
+
+                            if (dict.TryGetValue(shardNumberForDoc, out var shardBucketStats))
+                            {
+                                shardBucketStats.DocCount++;
+                                shardBucketStats.Buckets.Add(bucket);
+                            }
+                            else
+                            {
+                                dict.Add(shardNumberForDoc, new ShardBucketsStats() {Buckets = new HashSet<int>() {bucket}, DocCount = 1, TotalSize = 0,});
+                            }
+                        }
+
+                        await session.SaveChangesAsync();
+                    }
+
+                    for (int i = 0; i < 20; i++)
+                    {
+                        var id = $"user/{i}";
+                        var shardNumberForDoc = await Sharding.GetShardNumberFor(store, id);
+                        var cmd = new GetDocumentSizeCommand(id);
+                        executor.Execute(cmd, ctx);
+                        var size = cmd.Result.ActualSize;
+                        dict[shardNumberForDoc].TotalSize += size;
+                    }
+
+                    foreach (var shardNumber in sharding.Shards.Keys)
+                    {
+                        var shardRanges = await store.Operations.SendAsync(new GetBucketsOperation(shardNumber: shardNumber));
+
+                        Assert.Equal(dict[shardNumber].DocCount, shardRanges.BucketRanges.Sum(x => x.Value.DocumentsCount));
+                        Assert.Equal(dict[shardNumber].TotalSize, shardRanges.TotalSize);
+                        Assert.Equal(dict[shardNumber].TotalSize, shardRanges.BucketRanges.Sum(x => x.Value.RangeSize));
+                        Assert.Equal(dict[shardNumber].Buckets.Count, shardRanges.BucketRanges.Values.Sum(x => x.NumberOfBuckets));
+                        Assert.True(shardRanges.BucketRanges.Values.All(x => x.ShardNumbers.Count == 1 && x.ShardNumbers.Contains(shardNumber)));
+                    }
+                }
+
+                var results = await store.Operations.SendAsync(new GetBucketsOperation());
+                Assert.Equal(20, results.BucketRanges.Values.Sum(x => x.DocumentsCount));
+                
+                results = await store.Operations.SendAsync(new GetBucketsOperation(range: 1));
+                foreach (var stats in dict.Values)
+                {
+                    var shardDocsSize = 0L;
+                    foreach (var bucket in stats.Buckets)
+                    {
+                        Assert.True(results.BucketRanges.ContainsKey(bucket));
+                        Assert.Equal(bucket, results.BucketRanges[bucket].FromBucket);
+                        Assert.Equal(bucket, results.BucketRanges[bucket].ToBucket);
+                        shardDocsSize += results.BucketRanges[bucket].RangeSize;
+                    }
+                    Assert.Equal(stats.TotalSize, shardDocsSize);
+                }
+
+                Assert.Equal(dict.Sum(x => x.Value.TotalSize), results.TotalSize);
+
+                results = await store.Operations.SendAsync(new GetBucketsOperation(range: int.MaxValue));
+                Assert.Equal(1, results.BucketRanges.Count);
+                Assert.Equal(3, results.BucketRanges[0].ShardNumbers.Count);
+                Assert.Equal(dict.Sum(x => x.Value.TotalSize), results.TotalSize);
+                Assert.Equal(20, results.BucketRanges.Sum(x => x.Value.DocumentsCount));
+            }
+        }
+
+        public class ShardBucketsStats
+        {
+            public int TotalSize;
+            public int DocCount;
+            public HashSet<int> Buckets;
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task CanGetBucketInfo()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 2, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                var bucketInfos = new Dictionary<int, BucketInfo>();
+
+                var executor = store.GetRequestExecutor();
+                using (var _ = executor.ContextPool.AllocateOperationContext(out var ctx))
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        for (int i = 0; i < 20; i++)
+                        {
+                            var id = $"user/{i}";
+                            var bucket = Sharding.GetBucket(id);
+
+                            await session.StoreAsync(new User(), id);
+
+                            if (bucketInfos.TryGetValue(bucket, out var bucketInfo))
+                            {
+                                bucketInfo.Documents.Add(id);
+                                bucketInfo.NumberOfDocuments += 1;
+                            }
+                            else
+                            {
+                                bucketInfos.Add(bucket, new BucketInfo()
+                                {
+                                    Bucket = bucket,
+                                    Documents = new List<string>() { id },
+                                    NumberOfDocuments = 1
+                                });
+                            }
+                        }
+
+                        await session.SaveChangesAsync();
+
+                        for (int i = 0; i < 20; i++)
+                        {
+                            var id = $"user/{i}";
+                            var bucket = Sharding.GetBucket(id);
+                            var cmd = new GetDocumentSizeCommand(id);
+                            executor.Execute(cmd, ctx);
+                            var docSize = cmd.Result.ActualSize;
+
+                            bucketInfos[bucket].Size += docSize;
+                        }
+                    }
+                }
+                
+                foreach (var (bucket, info) in bucketInfos)
+                {
+                    var results = await store.Operations.SendAsync(new GetBucketInfoOperation(bucket));
+                    Assert.Equal(info.Bucket, results.Bucket);
+                    Assert.Equal(info.Documents.Count, results.NumberOfDocuments);
+                    Assert.True(EnumerableExtension.ElementsEqual(info.Documents, results.Documents));
+                    Assert.Equal(info.Size, results.Size);
+                }
+            }
+        }
+    }
+
+    public class GetBucketsOperation : IOperation<BucketsResults>
+    {
+        private readonly int _fromBucket;
+        private readonly int _toBucket;
+        private readonly int _range;
+        private readonly int? _shardNumber;
+
+        public GetBucketsOperation(int fromBucket = 0, int toBucket = int.MaxValue, int range = 32 * 1024, int? shardNumber = null)
+        {
+            _fromBucket = fromBucket;
+            _toBucket = toBucket;
+            _range = range;
+            _shardNumber = shardNumber;
+        }
+
+        public RavenCommand<BucketsResults> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
+        {
+            return new GetBucketsCommand(_fromBucket, _toBucket, _range, _shardNumber);
+        }
+    }
+
+    public class GetBucketInfoOperation : IOperation<BucketInfo>
+    {
+        private readonly int _bucket;
+        
+        public GetBucketInfoOperation(int bucket)
+        {
+            _bucket = bucket;
+        }
+        
+        public RavenCommand<BucketInfo> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
+        {
+            return new GetBucketInfoCommand(_bucket);
+        }
+    }
+}

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -585,6 +585,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(ThreadsInfo));
             scripter.AddType(typeof(MemoryDebugHandler.MemoryInfo));
             scripter.AddType(typeof(TombstoneCleaner.TombstonesState));
+            scripter.AddType(typeof(BucketsResults));
 
             // counters
             scripter.AddType(typeof(CounterBatch));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18433

### Additional description

Added endpoint that, for a given range of buckets, splits the range into smaller ranges and returns their overall size and number of docs .
If the range has 1 bucket, we return the its documents.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing 

- Tests have been added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
