### PR TITLE
RavenDB-19361 - use a struct allocator to avoid heap allocation when …

### DIFF
--- a/src/Corax/Queries/AllEntriesMatch.cs
+++ b/src/Corax/Queries/AllEntriesMatch.cs
@@ -16,7 +16,7 @@ namespace Corax.Queries
     {
         private readonly Transaction _tx;
         private readonly long _count;
-        private IEnumerator<long> _entriesPagesIt;
+        private Container.AllPagesIterator _entriesPagesIt;
         private int _offset;
         private int _itemsLeftOnCurrentPage;
         private Page _currentPage;
@@ -38,7 +38,7 @@ namespace Corax.Queries
             }
             
             _entriesContainerId = tx.OpenContainer(Constants.IndexWriter.EntriesContainerSlice);
-            _entriesPagesIt = Container.GetAllPagesSet(tx.LowLevelTransaction, _entriesContainerId).GetEnumerator();
+            _entriesPagesIt = Container.GetAllPagesSet(tx.LowLevelTransaction, _entriesContainerId);
             _offset = 0;
             _itemsLeftOnCurrentPage = 0;
             _currentPage = new Page(null);
@@ -58,12 +58,12 @@ namespace Corax.Queries
             {
                 if (_currentPage.IsValid == false || _itemsLeftOnCurrentPage == 0)
                 {
-                    if (_entriesPagesIt.MoveNext() == false)
+                    if (_entriesPagesIt.TryMoveNext(out var pageNum) == false)
                     {
                         return results;
                     }
 
-                    _currentPage = _tx.LowLevelTransaction.GetPage(_entriesPagesIt.Current);
+                    _currentPage = _tx.LowLevelTransaction.GetPage(pageNum);
                     _offset = 0;
                 }
 

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -451,7 +451,8 @@ namespace Voron.Debugging
             if (includeDetails)
             {
                 pageDensities = new();
-                foreach (var pageNum in Container.GetAllPagesSet(_tx, page))
+                var it = Container.GetAllPagesSet(_tx, page);
+                while(it.TryMoveNext(out var pageNum))
                 {
                     Page cur = _tx.GetPage(pageNum);
                     if (cur.IsOverflow)


### PR DESCRIPTION
…scanning through all entries

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19361 

### Additional description

Implement a struct based enumerator to avoid heap allocations on common codepath