### PR TITLE
RavenDB-19732 SlowTests.Issues.RavenDB_19519.SchemaUpgradeAddedToInitLog - increased Server.MaxTimeForTaskToWaitForDatabaseToLoad

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19519.cs
+++ b/test/SlowTests/Issues/RavenDB-19519.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                        RegisterForDisposal = false,
                    }))
             {
-                server.Configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad = new TimeSetting(100, TimeUnit.Milliseconds);
+                server.Configuration.Server.MaxTimeForTaskToWaitForDatabaseToLoad = new TimeSetting(5, TimeUnit.Seconds);
 
                 var sm = new SemaphoreSlim(initialCount: 0);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19732/SlowTests.Issues.RavenDB19519.SchemaUpgradeAddedToInitLog

###Additional description

We increased the time of the Server.MaxTimeForTaskToWaitForDatabaseToLoad

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No