### PR TITLE
RavenDB-19516 - Delay Replication on missing attachments loop

### DIFF
--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1150,7 +1150,7 @@ namespace Raven.Server.Documents.Replication
                 case ReplicationMessageReply.ReplyType.MissingAttachments:
                     if (++MissingAttachmentsRetries > 1)
                         RaiseAlertAndThrowMissingAttachmentException($"Failed to send batch successfully to {Destination.FromString()}. " +
-                                                                     $"Destination reported missing attachments {MissingAttachmentsRetries} times.\n" +
+                                                                     $"Destination reported missing attachments {MissingAttachmentsRetries} times.{Environment.NewLine}" +
                                                                      $"{replicationBatchReply.Exception}");
 
                     if (_log.IsInfoEnabled)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19516/Delay-Replication-on-missing-attachments-loop

### Additional description

Moving the notification to the database level & add more info to the notification message.

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
