### PR TITLE
RavenDB-19636 Improve GenerateSchema method to consider multiple documents for determining column types

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19636.cs
+++ b/test/SlowTests/Issues/RavenDB-19636.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL
+{
+    public class RavenDB_19636 : PostgreSqlIntegrationTestBase
+    {
+        public RavenDB_19636(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Order
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string ExternalId { get; set; }
+        }
+
+        [Fact]
+        public async Task CanLoadCorrectlyWhenFirstRowHasNullValueInColumn()
+        {
+            string query = $"from Orders order by id()";
+
+            DoNotReuseServer(EnablePostgresSqlSettings);
+
+            using (var store = GetDocumentStore())
+            {
+                var order1 = new Order
+                {
+                    Id = "orders/1",
+                    Name = null,
+                };
+                
+                var order2 = new Order
+                {
+                    Id = "orders/2",
+                    Name = "OrderTwo",
+                };
+                
+                var order3 = new Order
+                {
+                    Id = "orders/3",
+                    Name = "OrderThree",
+                    ExternalId = "OT"
+                };
+                 
+                using (var session = store.OpenSession())
+                {
+                    session.Store(order1);
+                    session.Store(order2);
+                    session.Store(order3);
+                    session.SaveChanges();
+                }
+
+                var result = await Act(store, query, Server);
+                
+                Assert.Equal(result.Rows[0].ItemArray[0], "orders/1");
+                Assert.Equal(result.Rows[0].ItemArray[1], DBNull.Value);
+                Assert.Equal(result.Rows[0].ItemArray[2], DBNull.Value);
+                
+                Assert.Equal(result.Rows[1].ItemArray[0], "orders/2");
+                Assert.Equal(result.Rows[1].ItemArray[1], "OrderTwo");
+                Assert.Equal(result.Rows[1].ItemArray[2], DBNull.Value); 
+                
+                Assert.Equal(result.Rows[2].ItemArray[0], "orders/3");
+                Assert.Equal(result.Rows[2].ItemArray[1], "OrderThree");
+                Assert.Equal(result.Rows[2].ItemArray[2], "OT");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19636/PowerBI-When-the-value-of-a-column-in-the-first-row-is-null-the-entire-column-is-loaded-with-null-values

### Additional description

tl;dr we avoid writing null type to the schema, so we take more docs than just one to ensure column type

Sometimes, while generating a schema for Postgre based on our query results, we had a problem with some columns. All values were null in it.

Previously we took the first document, and basing on its' properties values, we figured out the schema.
But when the first document from the query result (`sample`) had some null values in it, we accidentally determined that all documents gonna have null-type values (basically `null`) in this column too.

To fix this issue, I've updated the schema generation method to consider up to 1000 documents when determining the types of columns. Now, if the first document has `null` values in some of its properties, we'll keep looking through the following documents until we find a non-null value for each column or we've examined 1000 documents. This ensures that we're accurately determining the types of columns, even if the first document has some `null` values. If we don't find any non-null values after considering 1000 documents, we'll leave the column types as null (`PgJson.Default`) in the schema.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
