### PR TITLE
RavenDB-19735 : Sharding - Bucket Stats - wrong stats when tree has multiple pages

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents
         public DocumentPutAction DocumentPut;
         public StorageEnvironment Environment { get; private set; }
 
-        public Action<LowLevelTransaction> OnBeforeCommit { get; protected set; }
+        public Action<Transaction> OnBeforeCommit { get; protected set; }
 
         protected Dictionary<string, CollectionName> _collectionsCache;
         private static readonly Slice LastReplicatedEtagsSlice;

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents
             _changes = changes;
 
             transaction.Owner = _context.DocumentDatabase;
-            transaction.LowLevelTransaction.OnBeforeCommit += _context.DocumentDatabase.DocumentsStorage.OnBeforeCommit;
+            transaction.OnBeforeCommit += _context.DocumentDatabase.DocumentsStorage.OnBeforeCommit;
         }
 
         public DocumentsTransaction BeginAsyncCommitAndStartNewTransaction(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -239,15 +239,15 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
         inMemoryBucketStats[bucket] = bucketStats;
     }
 
-    internal void UpdateBucketStatsTreeBeforeCommit(LowLevelTransaction llt)
+    internal void UpdateBucketStatsTreeBeforeCommit(Transaction tx)
     {
         if (_bucketStatistics == null)
             return;
 
-        var tree = llt.Transaction.ReadTree(BucketStatsSlice);
+        var tree = tx.ReadTree(BucketStatsSlice);
         foreach ((int bucket, Documents.BucketStats inMemoryStats) in _bucketStatistics)
         {
-            using (llt.Allocator.Allocate(sizeof(int), out var keyBuffer))
+            using (tx.Allocator.Allocate(sizeof(int), out var keyBuffer))
             {
                 *(int*)keyBuffer.Ptr = bucket;
                 var keySlice = new Slice(keyBuffer);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -125,7 +125,6 @@ namespace Voron.Impl
         /// </summary>
         public event Action<IPagerLevelTransactionState> OnRollBack;
         public event Action<LowLevelTransaction> AfterCommitWhenNewTransactionsPrevented;
-        public event Action<LowLevelTransaction> OnBeforeCommit;
 
         private readonly IFreeSpaceHandling _freeSpaceHandling;
         internal FixedSizeTree _freeSpaceTree;
@@ -970,7 +969,6 @@ namespace Voron.Impl
         internal void PrepareForCommit()
         {
             _root.PrepareForCommit();
-            OnBeforeCommit?.Invoke(this);
         }
 
         public void Commit()

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -36,6 +36,8 @@ namespace Voron.Impl
 
         public bool IsWriteTransaction => _lowLevelTransaction.Flags == TransactionFlags.ReadWrite;
 
+        public event Action<Transaction> OnBeforeCommit;
+
         internal Dictionary<long, ByteString> CachedDecompressedBuffersByStorageId =>
             _cachedDecompressedBuffersByStorageId ??= new Dictionary<long, ByteString>();
 
@@ -229,6 +231,8 @@ namespace Voron.Impl
 
         internal void PrepareForCommit()
         {
+            OnBeforeCommit?.Invoke(this);
+
             if (_multiValueTrees != null)
             {
                 foreach (var multiValueTree in _multiValueTrees)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19735

### Additional description

invoke `UpdateBucketStatsTreeBeforeCommit` event before `Transaction.PrepareForCommit`, 
so that `Transaction.Trees` will contain `BucketStats` tree and apply tree preparations before commit on it

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
