### PR TITLE
RavenDB-16751 Allow to get number of revisions in ETL script

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -378,12 +378,17 @@ namespace Raven.Server.Documents.ETL
 
             return false;
         }
-        
-        private JsValue GetRevisionsCount(JsValue self, JsValue[] args) => 
-            (Current.Document.Flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions 
-                ? Database.DocumentsStorage.RevisionsStorage.GetRevisionsCount(Context, Current.DocumentId)
-                : JsValue.Null;
 
+        private JsValue GetRevisionsCount(JsValue self, JsValue[] args)
+        {
+            if (args.Length != 0)
+                ThrowInvalidScriptMethodCall("getRevisionsCount() must be called without any argument");
+            
+            return (Current.Document.Flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions 
+                    ? Database.DocumentsStorage.RevisionsStorage.GetRevisionsCount(Context, Current.DocumentId)
+                    : 0L;
+        }
+        
         protected abstract string[] LoadToDestinations { get; }
 
         protected abstract void LoadToFunction(string tableName, ScriptRunnerResult colsAsObject);

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -83,6 +83,8 @@ namespace Raven.Server.Documents.ETL
             DocumentScript.ScriptEngine.SetValue("getCounters", new ClrFunctionInstance(DocumentScript.ScriptEngine, "getCounters", GetCounters));
 
             DocumentScript.ScriptEngine.SetValue("hasCounter", new ClrFunctionInstance(DocumentScript.ScriptEngine, "hasCounter", HasCounter));
+
+            DocumentScript.ScriptEngine.SetValue("getRevisionsCount", new ClrFunctionInstance(DocumentScript.ScriptEngine, "getRevisionsCount", GetRevisionsCount));
             
             const string hasTimeSeries = Transformation.TimeSeriesTransformation.HasTimeSeries.Name;
             DocumentScript.ScriptEngine.SetValue(hasTimeSeries, new ClrFunctionInstance(DocumentScript.ScriptEngine, hasTimeSeries, HasTimeSeries));
@@ -377,6 +379,11 @@ namespace Raven.Server.Documents.ETL
             return false;
         }
         
+        private JsValue GetRevisionsCount(JsValue self, JsValue[] args) => 
+            (Current.Document.Flags & DocumentFlags.HasRevisions) == DocumentFlags.HasRevisions 
+                ? Database.DocumentsStorage.RevisionsStorage.GetRevisionsCount(Context, Current.DocumentId)
+                : JsValue.Null;
+
         protected abstract string[] LoadToDestinations { get; }
 
         protected abstract void LoadToFunction(string tableName, ScriptRunnerResult colsAsObject);

--- a/test/SlowTests/Issues/RavenDB-16751.cs
+++ b/test/SlowTests/Issues/RavenDB-16751.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_16751:EtlTestBase
+{
+    public RavenDB_16751(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+
+    [Fact]
+    public async Task CanGetRevisionsCountInEtlScript()
+    {
+        // Arrange
+        using (var src = GetDocumentStore())
+        using (var dest = GetDocumentStore())
+        {
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, src.Database);
+            
+            // Act
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User {Name = "Gracjan"});
+                session.SaveChanges();
+            }
+            using (var session = src.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                user.LastName = "Sadowicz";
+                session.SaveChanges();
+            }
+            using (var session = src.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                user.Name = "Graziano";
+                session.SaveChanges();
+            }
+            
+            AddEtl(src, dest, "Users", script: @"var metadata = getMetadata(this);
+                                                            metadata[""RevisionsCountFromEtl""] = getRevisionsCount();
+                                                            loadToUsers(this);");
+                
+            var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses > 0);
+            etlDone.Wait(TimeSpan.FromMinutes(1));
+            
+            // Assert
+            List<User> revisions;
+            
+            using (var session = src.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                revisions = session.Advanced.Revisions.GetFor<User>(user.Id);
+            }
+
+            using (var session = dest.OpenSession())
+            {
+                var user = session.Load<User>("users/1-A");
+                Assert.NotNull(user);
+                var metadata = session.Advanced.GetMetadataFor(user);
+                Assert.Equal((long)revisions.Count, metadata["RevisionsCountFromEtl"]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16751/Allow-to-get-number-of-revisions-in-ETL-script

### Additional description

Added and registered a new method for the ETL Scripts that allows getting the revisions count (returns `long`). 
I've used [`RevisionsStorage.GetRevisionsCount`](https://github.com/ravendb/ravendb/blob/1c7184e318b0f97d35b06941c93208f5b595a554/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs#L1545) under the hood.


### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
