### PR TITLE
RavenDB-19538 Metadata not tracked in the subscription session

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -44,8 +44,7 @@ namespace Raven.Client.Documents.Subscriptions
             public BlittableJsonReaderObject RawResult { get; internal set; }
             public BlittableJsonReaderObject RawMetadata { get; internal set; }
 
-            private IMetadataDictionary _metadata;
-            public IMetadataDictionary Metadata => _metadata ?? (_metadata = new MetadataAsDictionary(RawMetadata));
+            public IMetadataDictionary Metadata { get; internal set; }
         }
 
         public int NumberOfItemsInBatch => Items?.Count ?? 0;
@@ -180,6 +179,7 @@ namespace Raven.Client.Documents.Subscriptions
                     Id = item.Id,
                     Document = item.RawResult,
                     Metadata = item.RawMetadata,
+                    MetadataInstance = item.Metadata,
                     ChangeVector = item.ChangeVector,
                     Entity = item.Result,
                     IsNewDocument = false
@@ -262,6 +262,7 @@ namespace Raven.Client.Documents.Subscriptions
                     Id = id,
                     RawResult = curDoc,
                     RawMetadata = metadata,
+                    Metadata = new MetadataAsDictionary(metadata),
                     Result = instance,
                     ExceptionMessage = item.Exception,
                     Projection = projection,

--- a/test/SlowTests/Issues/RavenDB-19538.cs
+++ b/test/SlowTests/Issues/RavenDB-19538.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19538 : RavenTestBase
+    {
+        private int _reasonableWaitTime = 3000;
+
+        public RavenDB_19538(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanModifyMetadataInSubscriptionBatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var sub = store.Subscriptions.Create(new SubscriptionCreationOptions<User> { Filter = user => user.Count > 0 });
+
+                var subscription = store.Subscriptions.GetSubscriptionWorker<User>(
+                    new SubscriptionWorkerOptions(sub) { TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5), MaxDocsPerBatch = 2 });
+
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        var user = new User { Count = 1, Id = $"Users/{i}" };
+                        session.Store(user);
+                    }
+
+                    session.SaveChanges();
+                }
+
+                var docs = new CountdownEvent(2);
+                var date1 = DateTime.UtcNow.AddHours(1).ToString();
+                var date2 = DateTime.UtcNow.AddHours(2).ToString();
+
+                _ = subscription.Run(x =>
+                {
+                    using (var session = x.OpenSession())
+                    {
+                        foreach (var item in x.Items)
+                        {
+                            var meta = session.Advanced.GetMetadataFor(item.Result);
+                            meta["Test1"] = date1;
+                            item.Metadata["Test2"] = date2;
+                        }
+
+                        session.SaveChanges();
+                        docs.Signal(x.NumberOfItemsInBatch);
+                    }
+                });
+
+                docs.Wait(_reasonableWaitTime);
+                for (int i = 0; i < 2; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var u = await session.LoadAsync<User>($"Users/{i}");
+                        var meta = session.Advanced.GetMetadataFor(u);
+                        var metaDate1 = meta["Test1"];
+                        var metaDate2 = meta["Test2"];
+                        Assert.Equal(date1, metaDate1);
+                        Assert.Equal(date2, metaDate2);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19538/Metadata-not-tracked-in-the-subscription-session

### Additional description

We added initialization to the metadata of the items in SubscriptionBatch

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing 

- Tests have been added that prove the fix is effective or that the feature works) 
- It has been verified by manual testing

