### PR TITLE
RDBCL-2500

### DIFF
--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -1196,18 +1196,21 @@ namespace Raven.Server.Documents.Handlers
 
                     foreach (var item in items)
                     {
-                        using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name).WithBaseline(item.Baseline))
+                        using (item)
                         {
-                            if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
+                            using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name).WithBaseline(item.Baseline))
                             {
-                                // on import we remove all @time-series from the document, so we need to re-add them
-                                tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name, NonPersistentDocumentFlags.FromSmuggler);
-                                continue;
+                                if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
+                                {
+                                    // on import we remove all @time-series from the document, so we need to re-add them
+                                    tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name, NonPersistentDocumentFlags.FromSmuggler);
+                                    continue;
+                                }
                             }
-                        }
 
-                        var values = item.Segment.YieldAllValues(context, context.Allocator, item.Baseline);
-                        tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, AppendOptionsForSmuggler);
+                            var values = item.Segment.YieldAllValues(context, context.Allocator, item.Baseline);
+                            tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, AppendOptionsForSmuggler);
+                        }
                     }
 
                     changes += items.Count;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
@@ -3,7 +3,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.TimeSeries
 {
-    public class TimeSeriesSegmentEntry
+    public class TimeSeriesSegmentEntry : IDisposable
     {
         public LazyStringValue Key;
 
@@ -24,5 +24,14 @@ namespace Raven.Server.Documents.TimeSeries
         public DateTime Start;
 
         public long Etag;
+
+        public void Dispose()
+        {
+            Key?.Dispose();
+            LuceneKey?.Dispose();
+            DocId?.Dispose();
+            Name?.Dispose();
+            Collection?.Dispose();
+        }
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2452,7 +2452,7 @@ namespace Raven.Server.Documents.TimeSeries
         public IEnumerable<TimeSeriesSegmentEntry> GetTimeSeriesFrom(DocumentsOperationContext context, long etag, long take) =>
             GetTimeSeries(context, etag, long.MaxValue, take);
 
-        public IEnumerable<TimeSeriesSegmentEntry> GetTimeSeries(DocumentsOperationContext context, long fromEtag, long toEtag, long take = long.MaxValue)
+        private static IEnumerable<TimeSeriesSegmentEntry> GetTimeSeries(DocumentsOperationContext context, long fromEtag, long toEtag, long take = long.MaxValue)
         {
             var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -21,6 +21,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Iteration;
 using Raven.Server.Utils.Enumerators;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Voron;
@@ -534,17 +535,20 @@ namespace Raven.Server.Smuggler.Documents
             var database = context.DocumentDatabase;
             foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, startEtag, long.MaxValue))
             {
-                yield return new TimeSeriesItem
+                using (ts)
                 {
-                    Name = database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(context, ts.DocId, ts.Name),
-                    DocId = ts.DocId,
-                    Baseline = ts.Start,
-                    ChangeVector = ts.ChangeVector,
-                    Collection = ts.Collection,
-                    SegmentSize = ts.SegmentSize,
-                    Segment = ts.Segment,
-                    Etag = ts.Etag
-                };
+                    yield return new TimeSeriesItem
+                    {
+                        Name = database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(context, ts.DocId, ts.Name),
+                        DocId = ts.DocId.Clone(context),
+                        Baseline = ts.Start,
+                        ChangeVector = ts.ChangeVector,
+                        Collection = ts.Collection.Clone(context),
+                        SegmentSize = ts.SegmentSize,
+                        Segment = ts.Segment,
+                        Etag = ts.Etag
+                    };
+                }
             }
         }
 
@@ -561,17 +565,20 @@ namespace Raven.Server.Smuggler.Documents
 
                 foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, etag, long.MaxValue))
                 {
-                    yield return new TimeSeriesItem
+                    using (ts)
                     {
-                        Name = database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(context, ts.DocId, ts.Name),
-                        DocId = ts.DocId,
-                        Baseline = ts.Start,
-                        ChangeVector = ts.ChangeVector,
-                        Collection = ts.Collection,
-                        SegmentSize = ts.SegmentSize,
-                        Segment = ts.Segment,
-                        Etag = ts.Etag,
-                    };
+                        yield return new TimeSeriesItem
+                        {
+                            Name = database.DocumentsStorage.TimeSeriesStorage.GetOriginalName(context, ts.DocId, ts.Name),
+                            DocId = ts.DocId.Clone(context),
+                            Baseline = ts.Start,
+                            ChangeVector = ts.ChangeVector,
+                            Collection = ts.Collection.Clone(context),
+                            SegmentSize = ts.SegmentSize,
+                            Segment = ts.Segment,
+                            Etag = ts.Etag,
+                        };
+                    }
                 }
             }
         }

--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -64,9 +64,9 @@ namespace Raven.Server.Smuggler.Documents
     }
 
 
-    public class TimeSeriesItem
+    public class TimeSeriesItem : IDisposable
     {
-        public string DocId;
+        public LazyStringValue DocId;
 
         public string Name;
 
@@ -76,10 +76,16 @@ namespace Raven.Server.Smuggler.Documents
 
         public int SegmentSize;
 
-        public string Collection;
+        public LazyStringValue Collection;
 
         public DateTime Baseline;
 
         public long Etag;
+
+        public void Dispose()
+        {
+            DocId?.Dispose();
+            Collection?.Dispose();
+        }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -992,49 +992,52 @@ namespace Raven.Server.Smuggler.Documents
 
             public async ValueTask WriteTimeSeriesAsync(TimeSeriesItem item)
             {
-                if (First == false)
-                    Writer.WriteComma();
-                First = false;
-
-                Writer.WriteStartObject();
+                using (item)
                 {
-                    Writer.WritePropertyName(Constants.Documents.Blob.Document);
+                    if (First == false)
+                        Writer.WriteComma();
+                    First = false;
 
                     Writer.WriteStartObject();
                     {
-                        Writer.WritePropertyName(nameof(TimeSeriesItem.DocId));
-                        Writer.WriteString(item.DocId);
-                        Writer.WriteComma();
+                        Writer.WritePropertyName(Constants.Documents.Blob.Document);
 
-                        Writer.WritePropertyName(nameof(TimeSeriesItem.Name));
-                        Writer.WriteString(item.Name);
-                        Writer.WriteComma();
+                        Writer.WriteStartObject();
+                        {
+                            Writer.WritePropertyName(nameof(TimeSeriesItem.DocId));
+                            Writer.WriteString(item.DocId);
+                            Writer.WriteComma();
 
-                        Writer.WritePropertyName(nameof(TimeSeriesItem.ChangeVector));
-                        Writer.WriteString(item.ChangeVector);
-                        Writer.WriteComma();
+                            Writer.WritePropertyName(nameof(TimeSeriesItem.Name));
+                            Writer.WriteString(item.Name);
+                            Writer.WriteComma();
 
-                        Writer.WritePropertyName(nameof(TimeSeriesItem.Collection));
-                        Writer.WriteString(item.Collection);
-                        Writer.WriteComma();
+                            Writer.WritePropertyName(nameof(TimeSeriesItem.ChangeVector));
+                            Writer.WriteString(item.ChangeVector);
+                            Writer.WriteComma();
 
-                        Writer.WritePropertyName(nameof(TimeSeriesItem.Baseline));
-                        Writer.WriteDateTime(item.Baseline, true);
+                            Writer.WritePropertyName(nameof(TimeSeriesItem.Collection));
+                            Writer.WriteString(item.Collection);
+                            Writer.WriteComma();
+
+                            Writer.WritePropertyName(nameof(TimeSeriesItem.Baseline));
+                            Writer.WriteDateTime(item.Baseline, true);
+                        }
+                        Writer.WriteEndObject();
+
+                        Writer.WriteComma();
+                        Writer.WritePropertyName(Constants.Documents.Blob.Size);
+                        Writer.WriteInteger(item.SegmentSize);
                     }
                     Writer.WriteEndObject();
 
-                    Writer.WriteComma();
-                    Writer.WritePropertyName(Constants.Documents.Blob.Size);
-                    Writer.WriteInteger(item.SegmentSize);
-                }
-                Writer.WriteEndObject();
+                    unsafe
+                    {
+                        Writer.WriteMemoryChunk(item.Segment.Ptr, item.Segment.NumberOfBytes);
+                    }
 
-                unsafe
-                {
-                    Writer.WriteMemoryChunk(item.Segment.Ptr, item.Segment.NumberOfBytes);
+                    await Writer.MaybeFlushAsync();
                 }
-
-                await Writer.MaybeFlushAsync();
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -778,10 +778,10 @@ namespace Raven.Server.Smuggler.Documents
                     var segment = await ReadSegmentAsync(size);
                     yield return new TimeSeriesItem
                     {
-                        DocId = docId,
+                        DocId = docId.Clone(_context),
                         Name = name,
                         Baseline = baseline,
-                        Collection = collection,
+                        Collection = collection.Clone(_context),
                         ChangeVector = cv,
                         Segment = segment
                     };

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -754,7 +754,7 @@ namespace Raven.Server.Smuggler.Documents
                         throw new InvalidOperationException($"Trying to read time series entry without size specified: doc: {reader}");
 
                     if (reader.TryGet(Constants.Documents.Blob.Document, out BlittableJsonReaderObject blobMetadata) == false ||
-                        blobMetadata.TryGet(nameof(TimeSeriesItem.Collection), out string collection) == false)
+                        blobMetadata.TryGet(nameof(TimeSeriesItem.Collection), out LazyStringValue collection) == false)
                     {
                         await SkipEntryAsync(reader, size, skipDueToReadError: true);
                         continue;
@@ -766,7 +766,7 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    if (blobMetadata.TryGet(nameof(TimeSeriesItem.DocId), out string docId) == false ||
+                    if (blobMetadata.TryGet(nameof(TimeSeriesItem.DocId), out LazyStringValue docId) == false ||
                         blobMetadata.TryGet(nameof(TimeSeriesItem.Name), out string name) == false ||
                         blobMetadata.TryGet(nameof(TimeSeriesItem.ChangeVector), out string cv) == false ||
                         blobMetadata.TryGet(nameof(TimeSeriesItem.Baseline), out DateTime baseline) == false)


### PR DESCRIPTION
- releasing unmanaged allocations from TimeSeriesSegmentEntry when creating TimeSeriesItem for Smuggler
- releasing unmanaged allocations from TimeSeriesItem after processed by Smuggler

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
