### PR TITLE
RavenDB-19148 Add Security.WellKnownIssuers.Admin option - allowing u…

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -143,8 +143,15 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(null)]
         [ConfigurationEntry("Security.WellKnownCertificates.Admin", ConfigurationEntryScope.ServerWideOnly)]
         public string[] WellKnownAdminCertificates { get; set; }
+        
+        
+        [Description("Well known issuer certificate in base 64 format or a file path that will be used to validate a new client certificate when the issuer's certificate has changed.")]
+        [DefaultValue(null)]
+        [ConfigurationEntry("Security.WellKnownIssuers.Admin", ConfigurationEntryScope.ServerWideOnly)]
+        public string[] WellKnownIssuers { get; set; }
 
-        [Description("Well known issuer 'Public Key Pinning Hashes' that will be used to validate a new client certificate when the issuer's certificate has changed.")]
+
+        [Description("OBSOLETE: This is no longer supported or used, use 'Security.WellKnownIssuers.Admin' instead.")]
         [DefaultValue(null)]
         [ConfigurationEntry("Security.WellKnownIssuerHashes.Admin", ConfigurationEntryScope.ServerWideOnly)]
         public string[] WellKnownIssuerHashes { get; set; }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/WellKnownAdminIssuers.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/WellKnownAdminIssuers.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using Lextm.SharpSnmpLib;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server
+{
+    public class WellKnownAdminIssuers : ScalarObjectBase<OctetString>
+    {
+        private readonly OctetString _wellKnownAdminCertificates;
+
+        public WellKnownAdminIssuers(ServerStore store)
+            : base(SnmpOids.Server.WellKnownAdminCertificates)
+        {
+            var wellKnownIssuersThumbprints = store.Server.WellKnownIssuersThumbprints;
+            if (wellKnownIssuersThumbprints == null || wellKnownIssuersThumbprints.Length == 0)
+                return;
+
+            _wellKnownAdminCertificates = new OctetString(string.Join(";", wellKnownIssuersThumbprints));
+        }
+
+        protected override OctetString GetData()
+        {
+            return _wellKnownAdminCertificates;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -247,6 +247,9 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("List of well known admin certificate thumbprints")]
             public const string WellKnownAdminCertificates = "1.11.3";
 
+            [Description("List of well known admin certificate issuers")]
+            public const string WellKnownAdminIssuers = "1.11.4";
+
             [Description("Number of processor on the machine")]
             public const string MachineProcessorCount = "1.12.1";
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2772,7 +2772,7 @@ namespace Raven.Server
 
                 if (chain.Build(cert))
                 {
-                    issuer = knownIssuer.SubjectName.Name;
+                    issuer = knownIssuer.SubjectName.Name + " - " +knownIssuer.Thumbprint;
                     return true;
                 } 
             }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -148,6 +149,7 @@ namespace Raven.Server
         {
             var sp = Stopwatch.StartNew();
             Certificate = LoadCertificateAtStartup() ?? new CertificateUtils.CertificateHolder();
+            ReadWellKnownIssuers();
 
             CpuUsageCalculator = string.IsNullOrEmpty(Configuration.Monitoring.CpuUsageMonitorExec)
                 ? CpuHelper.GetOSCpuUsageCalculator()
@@ -1520,8 +1522,6 @@ namespace Raven.Server
 
             public AuthenticationStatus StatusForAudit => _status;
 
-            public string IssuerHash;
-
             public AuthenticationStatus Status
             {
                 get
@@ -1593,6 +1593,18 @@ namespace Raven.Server
             {
                 authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
             }
+            else if (CertificateHasWellKnownIssuer(certificate, out var issuer))
+            {
+                if (_authAuditLog.IsInfoEnabled)
+                {
+                    _authAuditLog.Info(
+                        $"Connection from {GetRemoteAddress(connectionInfo)} with new certificate '{certificate.Subject} ({certificate.Thumbprint})' which is not registered in the cluster. " +
+                        "Allowing the connection based on the certificate's *issuer* which is trusted by the cluster. " +
+                        $"Registering the new certificate explicitly based on permissions of existing certificate '{issuer}'. Security Clearance: {AuthenticationStatus.ClusterAdmin}");
+                }
+
+                authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
+            }
             else
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
@@ -1634,14 +1646,13 @@ namespace Raven.Server
             }
 
             CertificateDefinition certWithSameHash = null;
-            string issuerHash = null;
 
             foreach (var certDef in certificatesWithSameHash.OrderByDescending(x => x.NotAfter))
             {
                 // Hash is good, let's validate it was signed by a known issuer, otherwise users can use the private key to register a new cert with a different issuer.
                 using (var goodKnownCert = CertificateLoaderUtil.CreateCertificate(Convert.FromBase64String(certDef.Certificate)))
                 {
-                    if (CertificateUtils.CertHasKnownIssuer(certificate, goodKnownCert, Configuration.Security, out issuerHash))
+                    if (CertificateUtils.CertHasKnownIssuer(certificate, goodKnownCert, Configuration.Security))
                     {
                         certWithSameHash = certDef;
                         break;
@@ -1649,28 +1660,16 @@ namespace Raven.Server
                 }
             }
 
-            string remoteAddress = null;
-            switch (connectionInfo)
-            {
-                case TcpClient tcp:
-                    remoteAddress = tcp.Client.RemoteEndPoint.ToString();
-                    break;
-
-                case HttpConnectionFeature http:
-                    remoteAddress = $"{http.RemoteIpAddress}:{http.RemotePort}";
-                    break;
-            }
+            string remoteAddress = GetRemoteAddress(connectionInfo);
 
             if (certWithSameHash == null)
             {
                 if (_authAuditLog.IsInfoEnabled)
                     _authAuditLog.Info($"Connection from {remoteAddress} with certificate '{certificate.Subject} ({certificate.Thumbprint})' which is not registered in the cluster. " +
                                        "Tried to allow the connection implicitly based on the client certificate's Public Key Pinning Hash but the client certificate was signed by an unknown issuer - closing the connection. " +
-                                       $"To fix this, the admin can register the pinning hash of the *issuer* certificate: '{issuerHash}' in the '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuerHashes)}' configuration entry." +
                                        $"Alternatively, the admin can register the actual certificate ({certificate.FriendlyName} '{certificate.Thumbprint}') explicitly in the cluster.");
 
                 authenticationStatus.Status = AuthenticationStatus.UnfamiliarIssuer;
-                authenticationStatus.IssuerHash = issuerHash;
                 return;
             }
 
@@ -1720,10 +1719,30 @@ namespace Raven.Server
             cert = ctx.ReadObject(newCertDef.ToJson(), "Client/Certificate/Definition");
         }
 
+        private static string GetRemoteAddress(object connectionInfo)
+        {
+            string remoteAddress = null;
+            switch (connectionInfo)
+            {
+                case TcpClient tcp:
+                    remoteAddress = tcp.Client.RemoteEndPoint.ToString();
+                    break;
+
+                case HttpConnectionFeature http:
+                    remoteAddress = $"{http.RemoteIpAddress}:{http.RemotePort}";
+                    break;
+            }
+
+            return remoteAddress;
+        }
+
 
         public string WebUrl { get; private set; }
 
         internal CertificateUtils.CertificateHolder Certificate;
+        
+        internal X509Certificate2[] WellKnownIssuers;
+        internal string[] WellKnownIssuersThumbprints = Array.Empty<string>();
 
         public class TcpListenerStatus
         {
@@ -2490,8 +2509,9 @@ namespace Raven.Server
                             throw new InvalidOperationException("Unknown operation " + header.Operation);
                     }
                 case AuthenticationStatus.UnfamiliarIssuer:
-                    msg = $"The client certificate {certificate.FriendlyName} is not registered in the cluster. Tried to allow the connection implicitly based on the client certificate's Public Key Pinning Hash but the client certificate was signed by an unknown issuer - closing the connection. " +
-                          $"To fix this, the admin can register the pinning hash of the *issuer* certificate: '{auth.IssuerHash}' in the '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuerHashes)}' configuration entry. Alternatively, the admin can register the actual certificate ({certificate.FriendlyName} '{certificate.Thumbprint}') explicitly in the cluster.";
+                    msg = $"The client certificate {certificate.FriendlyName} is not registered in the cluster. " +
+                          "Tried to allow the connection implicitly based on the client certificate's Public Key Pinning Hash but the client certificate was signed by an unknown issuer - closing the connection. " +
+                          $"The admin can register the actual certificate ({certificate.FriendlyName} '{certificate.Thumbprint}') explicitly in the cluster.";
                     return false;
 
                 case AuthenticationStatus.UnfamiliarCertificate:
@@ -2734,8 +2754,90 @@ namespace Raven.Server
             {
                 internal string[] RoutesToSkip = new string[] { };
             }
+        }
 
+        public bool CertificateHasWellKnownIssuer(X509Certificate2 cert, out string issuer)
+        {
+            issuer = null;
+            if (WellKnownIssuers == null)
+                return false;
 
+            foreach (var knownIssuer in WellKnownIssuers)
+            {
+                using var chain = new X509Chain(false);
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.DisableCertificateDownloads = true;
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(knownIssuer);
+
+                if (chain.Build(cert))
+                {
+                    issuer = knownIssuer.SubjectName.Name;
+                    return true;
+                } 
+            }
+
+            return false;
+        }
+        
+        private void ReadWellKnownIssuers()
+        {
+            if (Configuration.Security.WellKnownIssuerHashes is { Length: > 0 })
+            {
+                throw new InvalidOperationException(
+                    $"The configuration option '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuerHashes)}' has been deprecated and should not be used. You should instead use '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)}'.");
+            }
+            if (Configuration.Security.WellKnownIssuers == null)
+                return;
+
+            WellKnownIssuersThumbprints = new string[Configuration.Security.WellKnownIssuers.Length];
+            WellKnownIssuers = new X509Certificate2[Configuration.Security.WellKnownIssuers.Length];
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(8192);
+            for (int index = 0; index < Configuration.Security.WellKnownIssuers.Length; index++)
+            {
+                string issuer = Configuration.Security.WellKnownIssuers[index];
+                if (issuer.Length > buffer.Length) // the rate is actually 75%, but easier to just assume 1:1 here, we have enough space
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    buffer = ArrayPool<byte>.Shared.Rent(issuer.Length);
+                }
+
+                X509Certificate2 certificate;
+                if (Convert.TryFromBase64String(issuer, buffer, out var read))
+                {
+                    try
+                    {
+                        certificate = new X509Certificate2(buffer[0..read]);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException(
+                            $"Unable to parse the provided '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)}' value: {issuer[..Math.Min(64, issuer.Length)]}",
+                            e);
+                    }
+                }
+                else // maybe it's a path?
+                {
+                    try
+                    {
+                        certificate = new X509Certificate2(issuer);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException($"Unable to read file provided via '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)}' from: {issuer}",
+                            e);
+                    }
+                }
+
+                if (certificate.HasPrivateKey)
+                    throw new InvalidOperationException(
+                        $"The certificate provided by '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)}' configuration for {certificate.SubjectName} {certificate.Thumbprint} includes the PRIVATE KEY, that is not a secured model, and was rejected by RavenDB");
+                
+                WellKnownIssuers[index] = certificate;
+                WellKnownIssuersThumbprints[index] = certificate.Thumbprint;
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
         }
     }
 }

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -425,9 +425,7 @@ namespace Raven.Server.Routing
                 }
                 else if (feature.Status == RavenServer.AuthenticationStatus.UnfamiliarIssuer)
                 {
-                    message = $"The supplied client certificate '{name}' is unknown to the server but has a known Public Key Pinning Hash. Will not use it to authenticate because the issuer is unknown. " +
-                              Environment.NewLine +
-                              $"To fix this, the admin can register the pinning hash of the *issuer* certificate: '{feature.IssuerHash}' in the '{RavenConfiguration.GetKey(x => x.Security.WellKnownIssuerHashes)}' configuration entry.";
+                    message = $"The supplied client certificate '{name}' is unknown to the server but has a known Public Key Pinning Hash. Will not use it to authenticate because the issuer is unknown. ";
                 }
                 else if (feature.Status == RavenServer.AuthenticationStatus.Allowed)
                 {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -4349,7 +4349,7 @@ namespace Raven.Server.ServerWide
                 new Span<byte>(p, size).CopyTo(buffer);
                 using var knownCert = CertificateLoaderUtil.CreateCertificate(buffer);
 
-                if (CertificateUtils.CertHasKnownIssuer(userCert, knownCert, securityConfiguration, out var _) == false)
+                if (CertificateUtils.CertHasKnownIssuer(userCert, knownCert, securityConfiguration) == false)
                     continue;
 
                 access = JsonDeserializationCluster.DetailedReplicationHubAccess(obj);

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -117,7 +117,7 @@ namespace Raven.Server.Utils
         public static byte[] CreateSelfSignedTestCertificate(string commonNameValue, string issuerName, StringBuilder log = null)
         {
             // Note this is for tests only!
-            CreateCertificateAuthorityCertificate(commonNameValue + "-CA", out var ca, out var caSubjectName, log);
+            CreateCertificateAuthorityCertificate(commonNameValue + " CA", out var ca, out var caSubjectName, log);
             CreateSelfSignedCertificateBasedOnPrivateKey(commonNameValue, caSubjectName, ca, false, false, DateTime.UtcNow.Date.AddMonths(3), out var certBytes, log: log);
             var selfSignedCertificateBasedOnPrivateKey = CertificateLoaderUtil.CreateCertificate(certBytes);
             selfSignedCertificateBasedOnPrivateKey.Verify();

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -38,9 +38,8 @@ namespace Raven.Server.Utils
 
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(CertificateUtils).FullName);
 
-        internal static bool CertHasKnownIssuer(X509Certificate2 userCertificate, X509Certificate2 knownCertificate, SecurityConfiguration securityConfiguration, out string issuerPinningHash)
+        internal static bool CertHasKnownIssuer(X509Certificate2 userCertificate, X509Certificate2 knownCertificate, SecurityConfiguration securityConfiguration)
         {
-            issuerPinningHash = null;
             X509Certificate2 issuerCertificate = null;
 
             var userChain = new X509Chain();
@@ -69,7 +68,6 @@ namespace Raven.Server.Utils
                 issuerCertificate = userChain.ChainElements.Count > 1
                     ? userChain.ChainElements[1].Certificate
                     : userChain.ChainElements[0].Certificate;
-                issuerPinningHash = issuerCertificate.GetPublicKeyPinningHash();
             }
             catch (Exception e)
             {
@@ -77,10 +75,6 @@ namespace Raven.Server.Utils
                     Logger.Info($"Cannot extract pinning hash from the client certificate's issuer '{issuerCertificate?.FriendlyName} {issuerCertificate?.Thumbprint}'.", e);
                 return false;
             }
-
-            var wellKnown = securityConfiguration.WellKnownIssuerHashes;
-            if (wellKnown != null && wellKnown.Contains(issuerPinningHash, StringComparer.Ordinal)) // Case sensitive, base64
-                return true;
 
             try
             {
@@ -102,7 +96,6 @@ namespace Raven.Server.Utils
                 var currentElementPinningHash = userChain.ChainElements[i].Certificate.GetPublicKeyPinningHash();
                 if (currentElementPinningHash != knownCertChain.ChainElements[i].Certificate.GetPublicKeyPinningHash())
                 {
-                    issuerPinningHash = currentElementPinningHash;
                     return false;
                 }
             }
@@ -124,7 +117,7 @@ namespace Raven.Server.Utils
         public static byte[] CreateSelfSignedTestCertificate(string commonNameValue, string issuerName, StringBuilder log = null)
         {
             // Note this is for tests only!
-            CreateCertificateAuthorityCertificate(commonNameValue + " CA", out var ca, out var caSubjectName, log);
+            CreateCertificateAuthorityCertificate(commonNameValue + "-CA", out var ca, out var caSubjectName, log);
             CreateSelfSignedCertificateBasedOnPrivateKey(commonNameValue, caSubjectName, ca, false, false, DateTime.UtcNow.Date.AddMonths(3), out var certBytes, log: log);
             var selfSignedCertificateBasedOnPrivateKey = CertificateLoaderUtil.CreateCertificate(certBytes);
             selfSignedCertificateBasedOnPrivateKey.Verify();
@@ -331,7 +324,7 @@ namespace Raven.Server.Utils
             log?.AppendLine($"cert in base64 = {Convert.ToBase64String(certBytes)}");
         }
 
-        public static void CreateCertificateAuthorityCertificate(string commonNameValue,
+        public static X509Certificate2 CreateCertificateAuthorityCertificate(string commonNameValue,
             out (AsymmetricKeyParameter PrivateKey, AsymmetricKeyParameter PublicKey) ca,
             out X509Name name, StringBuilder log = null)
         {
@@ -353,6 +346,13 @@ namespace Raven.Server.Utils
             certificateGenerator.SetSubjectDN(subjectDN);
             log?.AppendLine($"issuerDN = {issuerDN}");
             log?.AppendLine($"subjectDN = {subjectDN}");
+            
+            certificateGenerator.AddExtension(
+                X509Extensions.BasicConstraints.Id, true, new BasicConstraints(true));
+            certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true, 
+                new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.CrlSign | KeyUsage.KeyCertSign));
+            certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true,
+                new ExtendedKeyUsage(KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth));
 
             // Valid For
             DateTime notBefore = DateTime.UtcNow.Date.AddDays(-7);
@@ -373,11 +373,39 @@ namespace Raven.Server.Utils
             var issuerKeyPair = subjectKeyPair;
             ISignatureFactory signatureFactory = new Asn1SignatureFactory("SHA512WITHRSA", issuerKeyPair.Private, random);
 
+            var authorityKeyIdentifier =
+                new AuthorityKeyIdentifier(
+                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerKeyPair.Public),
+                    new GeneralNames(new GeneralName(issuerDN)),
+                    serialNumber);
+            certificateGenerator.AddExtension(
+                X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
+            
+            var subjectKeyIdentifier =
+                new SubjectKeyIdentifier(
+                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectKeyPair.Public));
+            certificateGenerator.AddExtension(
+                X509Extensions.SubjectKeyIdentifier.Id, false, subjectKeyIdentifier);
+
             // selfsign certificate
             var certificate = certificateGenerator.Generate(signatureFactory);
 
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
+
+            var store = new Pkcs12Store();
+            string friendlyName = certificate.SubjectDN.ToString();
+            var certificateEntry = new X509CertificateEntry(certificate);
+            var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
+
+            log?.AppendLine($"certificateEntry.Certificate = {certificateEntry.Certificate}");
+
+            store.SetCertificateEntry(friendlyName, certificateEntry);
+            store.SetKeyEntry(friendlyName, keyEntry, new[] { certificateEntry });
+            var stream = new MemoryStream();
+            store.Save(stream, Array.Empty<char>(), random);
+
+            return new X509Certificate2(stream.ToArray());
         }
 
         // generating this can take a while, so we cache that at the process level, to significantly speed up the tests

--- a/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
@@ -213,13 +213,16 @@ namespace Raven.Server.Utils.Monitoring
     {
         public double? ServerCertificateExpirationLeftInSec { get; set; }
         public string[] WellKnownAdminCertificates { get; set; }
+        
+        public string[] WellKnownAdminIssuers { get; set; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(ServerCertificateExpirationLeftInSec)] = ServerCertificateExpirationLeftInSec,
-                [nameof(WellKnownAdminCertificates)] = WellKnownAdminCertificates
+                [nameof(WellKnownAdminCertificates)] = WellKnownAdminCertificates,
+                [nameof(WellKnownAdminIssuers)] = WellKnownAdminIssuers
             };
         }
     }

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -464,6 +464,8 @@ namespace Raven.Server.Web.Authentication
                         writer.WriteString(Server.Certificate.Certificate?.Thumbprint);
                         writer.WriteComma();
                         writer.WriteArray("WellKnownAdminCerts", wellKnown);
+                        writer.WriteComma();
+                        writer.WriteArray("WellKnownIssuers", Server.WellKnownIssuers?.Select(x=>x.Thumbprint) ?? Array.Empty<string>());
                         writer.WriteEndObject();
                     }
                 }
@@ -604,6 +606,19 @@ namespace Raven.Server.Web.Authentication
                             PublicKeyPinningHash = clientCert.GetPublicKeyPinningHash()
                         };
                         certificate = ctx.ReadObject(wellKnownCertDef.ToJson(), "WellKnown/Certificate/Definition");
+                    }
+                    else if(Server.CertificateHasWellKnownIssuer(clientCert, out var issuer))
+                    {
+                        var wellKnownCertDef = new CertificateDefinition
+                        {
+                            Name = "Well Known Issuer Certificate: " + issuer,
+                            Permissions = new Dictionary<string, DatabaseAccess>(),
+                            SecurityClearance = SecurityClearance.ClusterAdmin,
+                            Thumbprint = clientCert.Thumbprint,
+                            PublicKeyPinningHash = clientCert.GetPublicKeyPinningHash()
+                        };
+                        certificate = ctx.ReadObject(wellKnownCertDef.ToJson(), "WellKnown/Certificate/Definition");
+
                     }
                 }
 

--- a/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
@@ -228,6 +228,7 @@ namespace Raven.Server.Web.System
             }
 
             result.WellKnownAdminCertificates = ServerStore.Configuration.Security.WellKnownAdminCertificates;
+            result.WellKnownAdminIssuers = Server.WellKnownIssuersThumbprints;
             return result;
         }
 

--- a/test/SlowTests/Issues/RavenDB-19148.cs
+++ b/test/SlowTests/Issues/RavenDB-19148.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Patch;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19148 : ClusterTestBase
+{
+    public RavenDB_19148(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task CanAuthUsingWellKnownIssuer()
+    {
+        var ca = CertificateUtils.CreateCertificateAuthorityCertificate("auth", out var caKey, out var caName);
+        CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey("admin", caName, caKey, true, false,
+            DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
+
+        byte[] caBytes = ca.Export(X509ContentType.Cert);
+        var result = await CreateRaftClusterWithSsl(1, true, customSettings:new Dictionary<string, string>
+        {
+            ["Security.WellKnownIssuers.Admin"] = Convert.ToBase64String(caBytes)
+        });
+
+        using (var store = new DocumentStore { 
+           Urls = new[]
+           {
+               result.Leader.WebUrl
+           }, 
+           Certificate = new X509Certificate2(certBytes) 
+       })
+        {
+            store.Initialize();
+            await store.Maintenance.Server.SendAsync(new GetBuildNumberOperation());
+        }
+    }
+}


### PR DESCRIPTION
…s to trust an issuer to generate temporary certs that would be trusted on the server as cluster admin.

This way, we can generate short lived certificates that can be authenticated without any additional steps and completely locally. Removes support for Security.WellKnownIssuerHashes.Admin, which never actually worked that well

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19148 

### Additional description

This adds the capacity to register a well known issuer within RavenDB that can be used to generate certificates that will be intrinsically trusted by RavenDB as a cluster admin.

This is meant to provide a way to generate a certificate with very short duration (to limit exposure) that can be used to auth against a remote server, even if there are network issues to contact a trusted authority problems, etc. 

### Type of change

- New feature

### How risky is the change?

- Low 
### Backward compatibility

- Breaking change

Removed `Security.WellKnownIssuerHashes.Admin`, which didn't actually work properly. 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

This is meant to be advanced / expert only feature. 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### UI work

- It requires further work in the Studio

Need to expose the well known issuers in the studio.