### PR TITLE
RavenDB-19633 EmbeddedTest configure log path to uniq location

### DIFF
--- a/test/EmbeddedTests/BasicTests.cs
+++ b/test/EmbeddedTests/BasicTests.cs
@@ -13,15 +13,11 @@ namespace EmbeddedTests
         [Fact]
         public void TestEmbedded()
         {
-            var paths = CopyServer();
+            var options = CopyServerAndCreateOptions();
 
             using (var embedded = new EmbeddedServer())
             {
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 using (var store = embedded.GetDocumentStore(new DatabaseOptions("Test")
                 {
@@ -48,11 +44,7 @@ namespace EmbeddedTests
 
             using (var embedded = new EmbeddedServer())
             {
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 using (var store = embedded.GetDocumentStore("Test"))
                 {
@@ -73,15 +65,11 @@ namespace EmbeddedTests
         [Fact]
         public async Task TestEmbeddedRestart()
         {
-            var paths = CopyServer();
+            var options = CopyServerAndCreateOptions();
 
             using (var embedded = new EmbeddedServer())
             {
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 var pid1 = await embedded.GetServerProcessIdAsync();
                 Assert.True(pid1 > 0);
@@ -124,16 +112,10 @@ namespace EmbeddedTests
         [Fact]
         public async Task TestEmbedded_RuntimeFrameworkVersionMatcher()
         {
-            var paths = CopyServer();
+            var options = CopyServerAndCreateOptions();
 
             using (var embedded = new EmbeddedServer())
             {
-                var options = new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                };
-
                 var frameworkVersion = new RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion(options.FrameworkVersion)
                 {
                     Patch = null

--- a/test/EmbeddedTests/EmbeddedTestBase.cs
+++ b/test/EmbeddedTests/EmbeddedTestBase.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using EmbeddedTests.Platform;
+using Raven.Embedded;
 using Sparrow.Collections;
 
 namespace EmbeddedTests
@@ -76,6 +77,12 @@ namespace EmbeddedTests
             return (serverDirectory, dataDirectory);
         }
 
+        protected ServerOptions CopyServerAndCreateOptions()
+        {
+            var (severDirectory, dataDirectory) = CopyServer();
+            return new ServerOptions { ServerDirectory = severDirectory, DataDirectory = dataDirectory, LogsPath = Path.Combine(severDirectory, "Logs") };
+        }
+        
         public virtual void Dispose()
         {
             foreach (var path in _localPathsToDelete)

--- a/test/EmbeddedTests/Issues/RavenDB_15885.cs
+++ b/test/EmbeddedTests/Issues/RavenDB_15885.cs
@@ -11,16 +11,12 @@ namespace EmbeddedTests.Issues
         [Fact]
         public void Can_Use_Custom_Analyzer()
         {
-            var paths = CopyServer();
-            CopyCustomAnalyzer(paths.ServerDirectory);
+            var options = CopyServerAndCreateOptions();
+            CopyCustomAnalyzer(options.ServerDirectory);
 
             using (var embedded = new EmbeddedServer())
             {
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 using (var store = embedded.GetDocumentStore("DatabaseWithCustomAnalyzers"))
                 {

--- a/test/EmbeddedTests/SmugglerTests.cs
+++ b/test/EmbeddedTests/SmugglerTests.cs
@@ -21,16 +21,12 @@ namespace EmbeddedTests
         [Fact]
         public async Task SmugglerImportFileShouldThrowTimeout()
         {
-            var paths = CopyServer();
+            var options = CopyServerAndCreateOptions();
 
             using (var embedded = new EmbeddedServer())
             {
                 const string fileName = "dump.cmp";
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 const string databaseName = "test";
                 var dummyDump = CreateDummyDump(1);
@@ -77,15 +73,11 @@ namespace EmbeddedTests
         [Fact]
         public async Task SmugglerImportStreamShouldThrowTimeout()
         {
-            var paths = CopyServer();
+            var options = CopyServerAndCreateOptions();
 
             using (var embedded = new EmbeddedServer())
             {
-                embedded.StartServer(new ServerOptions
-                {
-                    ServerDirectory = paths.ServerDirectory,
-                    DataDirectory = paths.DataDirectory,
-                });
+                embedded.StartServer(options);
 
                 const string databaseName = "test";
                 var dummyDump = CreateDummyDump(1);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19633

### Additional description

Fix failing EmbeddedTest 
The problem is that the path of the MicrosoftLog is created only if the feature is enabled.
While settings the configurations the server checks if it can write to configuration paths that are not defined as ReadOnly.
If the path is a directory and it does not exist, the server creates a directory in the same place to mimic write.
We don't have this issue with the regular log because in this step the log directory already exists.

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
