### PR TITLE
RavenDB-16926/RavenDB-17846 - RemoveEntryFromRaftLogTest and RemoveEntryFromRaftLogEP fail.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-15900.cs
+++ b/test/SlowTests/Issues/RavenDB-15900.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Issues
 
 
             // Get last raft index from leader
-            var testCmdIndex = await WaitForCommandIndex(nodes, nameof(RachisConsensusTestBase.TestCommandWithRaftId));
+            var testCmdIndex = await Cluster.WaitForRaftCommandToBeAppendedInClusterAsync(nodes, nameof(RachisConsensusTestBase.TestCommandWithRaftId));
             Assert.NotEqual(testCmdIndex, -1);
 
             // Wait for all nodes to be updated to leader last raft index
@@ -175,7 +175,7 @@ namespace SlowTests.Issues
             _ = leader.ServerStore.Engine.CurrentLeader.PutAsync(testCmd, TimeSpan.FromSeconds(2));
 
             // Get last raft index from leader
-            var testCmdIndex = await WaitForCommandIndex(nodes, nameof(RachisConsensusTestBase.TestCommandWithRaftId));
+            var testCmdIndex = await Cluster.WaitForRaftCommandToBeAppendedInClusterAsync(nodes, nameof(RachisConsensusTestBase.TestCommandWithRaftId));
             Assert.NotEqual(testCmdIndex, -1);
 
             // Wait for all nodes to be updated to leader last raft index
@@ -226,37 +226,6 @@ namespace SlowTests.Issues
                 Assert.True(val);
             }
 
-        }
-
-        private async Task<long> WaitForCommandIndex(List<RavenServer> nodes, string commandType, long timeout = 15_000, long interval = 100)
-        {
-            var sw = Stopwatch.StartNew();
-            long index = -1;
-            while (sw.ElapsedMilliseconds < timeout)
-            {
-                foreach (var server in nodes)
-                {
-                    try
-                    {
-                        var lastIndex = Cluster.LastRaftIndexForCommand(server, commandType);
-                        index = lastIndex;
-                    }
-                    catch (TrueException)
-                    {
-                        index = -1;
-                        break;
-                    }
-                }
-
-                if (index != -1)
-                {
-                    return index;
-                }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(interval));
-            }
-
-            return index;
         }
 
         public async Task AssertRaftIndexToBeUpdatedOnNodesAsync(long index, List<RavenServer> nodes, int timeout = 15000, int interval = 100)

--- a/test/SlowTests/Issues/RavenDB_12601.cs
+++ b/test/SlowTests/Issues/RavenDB_12601.cs
@@ -150,7 +150,6 @@ namespace SlowTests.Issues
         {
             DoNotReuseServer();
             long trxn1 = -1;
-            long trxn2 = -1;
             using (var store = GetDocumentStore())
             {
                 const string userId = "users/1";
@@ -206,7 +205,7 @@ namespace SlowTests.Issues
                     user.Age++;
                     session.SaveChanges();
                     var changeVector = session.Advanced.GetChangeVectorFor(user);
-                    trxn2 = Cluster.LastRaftIndexForCommand(Server, "ClusterTransactionCommand");
+                    var trxn2 = Cluster.LastRaftIndexForCommand(Server, "ClusterTransactionCommand");
                     Assert.True(trxn2 > trxn1);
                     Assert.True(changeVector.Contains("RAFT:2"), $"{changeVector}.Contains('RAFT:2')");
                     Assert.True(changeVector.Contains($"TRXN:{trxn2}"), $"{changeVector}.Contains('TRXN:{trxn2}')");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16926/SlowTests.Issues.RavenDB15900.RemoveEntryFromRaftLogTest
https://issues.hibernatingrhinos.com/issue/RavenDB-17846/SlowTests.Issues.RavenDB15900.RemoveEntryFromRaftLogEP

### Additional description

the tests `RemoveEntryFromRaftLogTest` and `RemoveEntryFromRaftLogEP` fail.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
