### PR TITLE
RavenDB-19487_v5.4: Fix 'declared function' chopped by IAsyncDocumentQueryBase<T>.ToQueryable

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1109,13 +1109,16 @@ namespace Raven.Client.Documents.Session
             else
             {
                 newFieldsToFetch = null;
-                queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
+                if(FieldsToFetchToken != null)
+                   queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
                     FieldsToFetchToken.IsCustomFunction);
             }
 
 
             if (newFieldsToFetch != null)
                 UpdateFieldsToFetchToken(newFieldsToFetch);
+
+
 
             var query = new AsyncDocumentQuery<TResult>(
                 TheSession,

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1110,8 +1110,16 @@ namespace Raven.Client.Documents.Session
             {
                 newFieldsToFetch = null;
                 if (FieldsToFetchToken != null)
-                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
-                        FieldsToFetchToken.IsCustomFunction);
+                {
+
+                    var projections = FieldsToFetchToken.Projections == null ? FieldsToFetchToken.Projections : FieldsToFetchToken.Projections.ToArray();
+                    var declareTokens = DeclareTokens == null ? DeclareTokens : new List<DeclareToken>(DeclareTokens);
+                    var loadTokens = LoadTokens == null ? LoadTokens : new List<LoadToken>(LoadTokens);
+
+                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, projections, FromToken.Alias, declareTokens, loadTokens,
+                            FieldsToFetchToken.IsCustomFunction)
+                        { ProjectionBehavior = ProjectionBehavior };
+                }
             }
 
             if (newFieldsToFetch != null)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1107,7 +1107,12 @@ namespace Raven.Client.Documents.Session
                 newFieldsToFetch = FieldsToFetchToken.Create(fields, queryData.Projections.ToArray(), queryData.IsCustomFunction, sourceAlias);
             }
             else
+            {
                 newFieldsToFetch = null;
+                queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
+                    FieldsToFetchToken.IsCustomFunction);
+            }
+
 
             if (newFieldsToFetch != null)
                 UpdateFieldsToFetchToken(newFieldsToFetch);
@@ -1164,7 +1169,6 @@ namespace Raven.Client.Documents.Session
         public IRavenQueryable<T> ToQueryable()
         {
             var type = typeof(T);
-
             var queryStatistics = new QueryStatistics();
             var highlightings = new LinqQueryHighlightings();
 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1109,16 +1109,13 @@ namespace Raven.Client.Documents.Session
             else
             {
                 newFieldsToFetch = null;
-                if(FieldsToFetchToken != null)
-                   queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
-                    FieldsToFetchToken.IsCustomFunction);
+                if (FieldsToFetchToken != null)
+                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
+                        FieldsToFetchToken.IsCustomFunction);
             }
-
 
             if (newFieldsToFetch != null)
                 UpdateFieldsToFetchToken(newFieldsToFetch);
-
-
 
             var query = new AsyncDocumentQuery<TResult>(
                 TheSession,

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1179,8 +1179,14 @@ namespace Raven.Client.Documents.Session
             {
                 newFieldsToFetch = null;
                 if (FieldsToFetchToken != null)
-                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
-                        FieldsToFetchToken.IsCustomFunction);
+                {
+                    var projections = FieldsToFetchToken.Projections == null ? FieldsToFetchToken.Projections : FieldsToFetchToken.Projections.ToArray();
+                    var declareTokens = DeclareTokens == null ? DeclareTokens : new List<DeclareToken>(DeclareTokens);
+                    var loadTokens = LoadTokens == null ? LoadTokens : new List<LoadToken>(LoadTokens);
+
+                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, projections, FromToken.Alias, declareTokens, loadTokens,
+                        FieldsToFetchToken.IsCustomFunction) { ProjectionBehavior = ProjectionBehavior };
+                }
             }
 
             if (newFieldsToFetch != null)

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1176,7 +1176,12 @@ namespace Raven.Client.Documents.Session
                 newFieldsToFetch = FieldsToFetchToken.Create(fields, queryData.Projections.ToArray(), queryData.IsCustomFunction, sourceAlias);
             }
             else
+            {
                 newFieldsToFetch = null;
+                if (FieldsToFetchToken != null)
+                    queryData = new QueryData(FieldsToFetchToken.FieldsToFetch, FieldsToFetchToken.Projections, FromToken.Alias, DeclareTokens, LoadTokens,
+                        FieldsToFetchToken.IsCustomFunction);
+            }
 
             if (newFieldsToFetch != null)
                 UpdateFieldsToFetchToken(newFieldsToFetch);

--- a/test/SlowTests/Issues/RavenDB_19487.cs
+++ b/test/SlowTests/Issues/RavenDB_19487.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19487 : RavenTestBase
+    {
+        public RavenDB_19487(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        [SuppressMessage("ReSharper", "Xunit.XunitTestWithConsoleOutput")]
+        public async Task TestCase()
+        {
+            using var store = GetDocumentStore();
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestObj { Prop = "1234" });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var queryable = from r in session.Query<TestObj>()
+                    let a = new { Prop = r.Prop }
+                    select new { A = a };
+
+
+                var queryableStr = queryable.ToString();
+
+                var documentQuery = queryable.ToAsyncDocumentQuery();
+                var documentQueryStr = documentQuery.ToString();
+                Assert.Equal(queryableStr, documentQueryStr);
+
+                var queryable2 = documentQuery.ToQueryable();
+                var queryable2Str = queryable2.ToString();
+                Assert.Equal(queryableStr, queryable2Str);
+                Assert.Equal(documentQueryStr, queryable2Str);
+
+                var queryableResult = await queryable.ToArrayAsync();
+                var documentQueryResult = await documentQuery.ToArrayAsync();
+                var queryable2Result = await queryable2.ToArrayAsync();
+
+                Assert.Equivalent(queryableResult, documentQueryResult);
+                Assert.Equivalent(queryableResult, queryable2Result);
+                Assert.Equivalent(documentQueryResult, queryable2Result);
+
+            }
+        }
+
+    }
+
+    class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19487.cs
+++ b/test/SlowTests/Issues/RavenDB_19487.cs
@@ -15,9 +15,15 @@ namespace SlowTests.Issues
         {
         }
 
+        class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+
+
         [Fact]
-        [SuppressMessage("ReSharper", "Xunit.XunitTestWithConsoleOutput")]
-        public async Task TestCase()
+        public async Task ToQueryableShouldNotChopDeclareFunctionAsync()
         {
             using var store = GetDocumentStore();
             using (var session = store.OpenAsyncSession())
@@ -31,7 +37,6 @@ namespace SlowTests.Issues
                 var queryable = from r in session.Query<TestObj>()
                     let a = new { Prop = r.Prop }
                     select new { A = a };
-
 
                 var queryableStr = queryable.ToString();
 
@@ -51,15 +56,44 @@ namespace SlowTests.Issues
                 Assert.Equivalent(queryableResult, documentQueryResult);
                 Assert.Equivalent(queryableResult, queryable2Result);
                 Assert.Equivalent(documentQueryResult, queryable2Result);
-
             }
         }
 
-    }
 
-    class TestObj
-    {
-        public string Id { get; set; }
-        public string Prop { get; set; }
+        [Fact]
+        public void ToQueryableShouldNotChopDeclareFunction()
+        {
+            using var store = GetDocumentStore();
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TestObj { Prop = "1234" });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var queryable = from r in session.Query<TestObj>()
+                    let a = new { Prop = r.Prop }
+                    select new { A = a };
+
+                var queryableStr = queryable.ToString();
+
+                var documentQuery = queryable.ToDocumentQuery();
+                var documentQueryStr = documentQuery.ToString();
+                Assert.Equal(queryableStr, documentQueryStr);
+
+                var queryable2 = documentQuery.ToQueryable();
+                var queryable2Str = queryable2.ToString();
+                Assert.Equal(queryableStr, queryable2Str);
+                Assert.Equal(documentQueryStr, queryable2Str);
+                var queryableResult = queryable.ToArray();
+                var documentQueryResult = documentQuery.ToArray();
+                var queryable2Result = queryable2.ToArray();
+
+                Assert.Equivalent(queryableResult, documentQueryResult);
+                Assert.Equivalent(queryableResult, queryable2Result);
+                Assert.Equivalent(documentQueryResult, queryable2Result);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19487

### Additional description

 Added QueryData Initialization, added equality assertion for strings and results objects

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
