### PR TITLE
RavenDB-17760 delete the stats tree when it is empty

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                             {
                                 if (msg.Document != null)
                                 {
-                                    EnsureNotDeleted(_server.NodeTag);
+                                    EnsureNotDeleted();
 
                                     using (var writer = new BlittableJsonTextWriter(msg.Context, _stream))
                                     {
@@ -569,7 +569,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             });
         }
 
-        protected abstract void EnsureNotDeleted(string nodeTag);
+        protected abstract void EnsureNotDeleted();
 
         protected abstract void InvokeOnDocumentsReceived();
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -9,11 +9,13 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Config;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Exceptions;
@@ -80,8 +82,14 @@ namespace Raven.Server.Documents.Replication.Incoming
             _replicationFromAnotherSource.Set();
         }
 
-        protected override void EnsureNotDeleted(string nodeTag)
+        protected override void EnsureNotDeleted()
         {
+            if (_database is ShardedDocumentDatabase shardedDatabase)
+            {
+                _parent.EnsureNotDeleted(DatabaseRecord.GetKeyForDeletionInProgress(_parent.Server.NodeTag, shardedDatabase.ShardNumber));
+                return;
+            }
+
             _parent.EnsureNotDeleted(_parent._server.NodeTag);
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -272,7 +272,7 @@ namespace Raven.Server.Documents.Replication
                 if (hub == null)
                     return;
 
-                foreach (var (_, repl) in _incoming)
+                foreach (var (key, repl) in _incoming)
                 {
                     if (repl is IncomingPullReplicationHandler pullHandler == false)
                         continue;
@@ -288,6 +288,7 @@ namespace Raven.Server.Documents.Replication
                         if (_logger.IsInfoEnabled)
                             _logger.Info($"Resetting {repl.ConnectionInfo} for {hub} on {certThumbprint} because replication configuration changed. Will be reconnected.");
                         repl.Dispose();
+                        _incoming.TryRemove(key, out _);
                     }
                     catch
                     {
@@ -308,6 +309,7 @@ namespace Raven.Server.Documents.Replication
                     try
                     {
                         repl.Dispose();
+                        _outgoing.TryRemove(repl);
                     }
                     catch
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             }
         }
 
-        protected override void EnsureNotDeleted(string nodeTag) => _parent.EnsureNotDeleted(_parent.Server.NodeTag);
+        protected override void EnsureNotDeleted() => _parent.EnsureNotDeleted(_parent.Server.NodeTag);
 
         protected override void InvokeOnFailed(Exception exception) => _parent.InvokeOnFailed(this, exception);
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -266,6 +266,12 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
                     stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
                 }
 
+                if (stats.Size == 0 && stats.NumberOfDocuments == 0)
+                {
+                    tree.Delete(keySlice);
+                    continue;
+                }
+
                 using (tree.DirectAdd(keySlice, sizeof(Documents.BucketStats), out byte* ptr))
                     *(Documents.BucketStats*)ptr = stats;
             }

--- a/test/SlowTests/Sharding/Cluster/BucketStats.cs
+++ b/test/SlowTests/Sharding/Cluster/BucketStats.cs
@@ -577,8 +577,7 @@ namespace SlowTests.Sharding.Cluster
                 using (ctx.OpenReadTransaction())
                 {
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
-                    Assert.Equal(0, stats.Size);
-                    Assert.Equal(0, stats.NumberOfDocuments);
+                    Assert.Null(stats);
                 }
             }
         }
@@ -739,6 +738,13 @@ namespace SlowTests.Sharding.Cluster
             using (ctx.OpenReadTransaction())
             {
                 var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+                if (stats == null)
+                {
+                    Assert.Equal(expectedSize, 0);
+                    Assert.Equal(expectedDocs, 0);
+                    return;
+                }
+
                 Assert.Equal(expectedSize, stats.Size);
                 Assert.Equal(expectedDocs, stats.NumberOfDocuments);
             }

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -1086,9 +1086,7 @@ namespace SlowTests.Sharding.Cluster
                     Assert.Equal(0, tombsCount);
 
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(context, bucket);
-                    Assert.Equal(bucket, stats.Bucket);
-                    Assert.Equal(0, stats.Size);
-                    Assert.Equal(0, stats.NumberOfDocuments);
+                    Assert.Null(stats);
                 }
 
                 var newLocation = await Sharding.GetShardNumberFor(store, id1);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17760 

### Additional description

delete the stats tree when it is empty otherwise we can accumulate many empty trees & the view for the bucket breakdown will show shards that doesn't have anything on them 

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Current tests cover this
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
