### PR TITLE
RavenDB-18803 - Prevent removing last orchestrator

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/RemoveNodeFromOrchestratorTopologyOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/RemoveNodeFromOrchestratorTopologyOperation.cs
@@ -13,28 +13,25 @@ namespace Raven.Client.ServerWide.Sharding
     {
         private readonly string _databaseName;
         private readonly string _node;
-        private readonly bool _force;
-
-        public RemoveNodeFromOrchestratorTopologyOperation(string databaseName, string node, bool force = false)
+        
+        public RemoveNodeFromOrchestratorTopologyOperation(string databaseName, string node)
         {
             ResourceNameValidator.AssertValidDatabaseName(databaseName);
             _node = node;
             _databaseName = databaseName;
-            _force = force;
         }
 
         public RavenCommand<ModifyOrchestratorTopologyResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new RemoveNodeFromOrchestratorTopologyCommand(_databaseName, _node, _force);
+            return new RemoveNodeFromOrchestratorTopologyCommand(_databaseName, _node);
         }
 
         private class RemoveNodeFromOrchestratorTopologyCommand : RavenCommand<ModifyOrchestratorTopologyResult>, IRaftCommand
         {
             private readonly string _databaseName;
             private readonly string _node;
-            private readonly bool _force;
 
-            public RemoveNodeFromOrchestratorTopologyCommand(string databaseName, string node, bool force = false)
+            public RemoveNodeFromOrchestratorTopologyCommand(string databaseName, string node)
             {
                 if (string.IsNullOrEmpty(databaseName))
                     throw new ArgumentNullException(databaseName);
@@ -44,12 +41,11 @@ namespace Raven.Client.ServerWide.Sharding
 
                 _databaseName = databaseName;
                 _node = node;
-                _force = force;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                url = $"{node.Url}/admin/databases/orchestrator?name={Uri.EscapeDataString(_databaseName)}&node={Uri.EscapeDataString(_node)}&force={_force}";
+                url = $"{node.Url}/admin/databases/orchestrator?name={Uri.EscapeDataString(_databaseName)}&node={Uri.EscapeDataString(_node)}";
                 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
@@ -132,7 +132,6 @@ namespace Raven.Server.Web.System
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name").Trim();
             var node = GetStringQueryString("node", required: true);
-            var force = GetBoolValueQueryString("force", required: false) ?? false;
             var raftRequestId = GetRaftRequestIdFromQuery();
 
             AssertNotAShardDatabaseName(name);
@@ -161,8 +160,8 @@ namespace Raven.Server.Web.System
                     if (topology.RelevantFor(node) == false)
                         throw new InvalidOperationException($"Can't remove node {node} from {name} topology because it is already not a part of it");
 
-                    if (topology.Members.Count == 1 && force == false)
-                        throw new InvalidOperationException($"Can't remove node {node} from {name} orchestrator topology because it is the only one in the topology. To remove it anyway, use force=true");
+                    if (topology.Members.Count == 1)
+                        throw new InvalidOperationException($"Can't remove node {node} from {name} orchestrator topology because it is the only one in the topology.");
                 }
 
                 topology.RemoveFromTopology(node);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18803

### Additional description

Removed the option to "force" delete the last orchestrator

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
