### PR TITLE
RavenDB-19731 Show the Raft Index tooltip after saving

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/cmpXchg/editCmpXchg.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/cmpXchg/editCmpXchg.ts
@@ -300,15 +300,7 @@ class editCmpXchg extends viewModelBase {
                 placement: "bottom"
             });
         
-        popoverUtils.longWithHover($(".raft-index-info"),
-            {
-                content: `<ul class="margin-top margin-top-xs margin-bottom-xs margin-right">
-                              <li><small>The Raft Index indicates the <strong>Compare-Exchange item's version</strong>.</small></li>
-                              <li><small>Used for concurrency control.</small></li>
-                          </ul>`,
-                html: true,
-                placement: "bottom"
-            });
+        this.initTooltipAfterSave();
     }
 
     compositionComplete() {
@@ -338,6 +330,18 @@ class editCmpXchg extends viewModelBase {
                     }
                 });
         }
+    }
+    
+    private initTooltipAfterSave() {
+        popoverUtils.longWithHover($(".raft-index-info"),
+            {
+                content: `<ul class="margin-top margin-top-xs margin-bottom-xs margin-right">
+                              <li><small>The Raft Index indicates the <strong>Compare-Exchange item's version</strong>.</small></li>
+                              <li><small>Used for concurrency control.</small></li>
+                          </ul>`,
+                html: true,
+                placement: "bottom"
+            });
     }
 
     private maybeConfirmWarnings(): JQueryPromise<boolean> | boolean {
@@ -429,6 +433,7 @@ class editCmpXchg extends viewModelBase {
             this.updateUrl(this.key());
             this.dirtyFlag().reset();
             this.isCreatingNewItem(false);
+            this.initTooltipAfterSave();
             
             messagePublisher.reportSuccess(`Compare exchange item with key: ${this.key()} was saved successfully`);
         } else {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19731

### Additional description
Show the raft index tooltip after saving.
In previous versions, we navigated back to the list view after saving,
but now we stay on the same page, so need to re-init the tooltip.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?.
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No need

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
