### PR TITLE
RavenDB-19746

### DIFF
--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -70,6 +70,8 @@ namespace Raven.Server.ServerWide.Context
             if (Transaction == null || Transaction.Disposed || Transaction.InnerTransaction.IsWriteTransaction)
                 ThrowReadTransactionMustBeOpen();
 
+            Allocator.DefragmentSegments();
+
             Transaction = CloneReadTransaction(Transaction);
 
             return Transaction;

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -861,7 +861,7 @@ namespace Sparrow.Server
             var newSegments = MergeSegments(segments, ascending: true);
             newSegments = MergeSegments(newSegments, ascending: false);
 
-            Debug.Assert(_internalReadyToUseMemorySegments.Count == 0);
+            Debug.Assert(_internalReadyToUseMemorySegments.Count == 0, $"{_internalReadyToUseMemorySegments.Count} == 0");
             _internalReadyToUseMemorySegments.AddRange(newSegments);
 
             static SegmentInformation FindSegment(List<SegmentInformation> segments, byte* start)
@@ -906,7 +906,7 @@ namespace Sparrow.Server
                     segments.RemoveAt(index);
 
                     var segmentSize = segment.Size;
-                    Debug.Assert(segment.Size == segment.SizeLeft);
+                    Debug.Assert(segment.Size == segment.SizeLeft, $"{segment.Size} == {segment.SizeLeft}");
 
                     var nextSegmentStart = segment.End;
 
@@ -1222,7 +1222,7 @@ namespace Sparrow.Server
                 _allocationBlockSize = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, _allocationBlockSize * 2);
                 var toAllocate = Math.Max(_allocationBlockSize, allocationUnit);
                 _internalCurrent = AllocateSegment(toAllocate);
-                Debug.Assert(_internalCurrent.SizeLeft >= allocationUnit);
+                Debug.Assert(_internalCurrent.SizeLeft >= allocationUnit, $"{_internalCurrent.SizeLeft} >= {allocationUnit}");
             }
 
             var byteString = Create(_internalCurrent.Current, length, allocationUnit, type);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19746

### Additional description

- fix issue with allocating less than allocation unit
- added the defragmentation mechanism for long running read transactions to avoid allocation pattern when the allocations are bigger than 4kb but less than _allocationBlockSize, which results in fragmentation of _internalCurrent segment and at the end results in allocation of new segments for _internalCurrent and high number of _internalReadyToUseMemorySegments which cannot be reused

### Type of change

- Optimization

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
