### PR TITLE
RavenDB-19760 - fix gc dump output file

### DIFF
--- a/tools/Raven.Debug/GCDump/GCHeapDump.cs
+++ b/tools/Raven.Debug/GCDump/GCHeapDump.cs
@@ -1,6 +1,5 @@
 ﻿using FastSerialization;
 using Graphs;
-using Microsoft.Diagnostics.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,11 +17,11 @@ using Address = System.UInt64;
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName))
+        this(new Deserializer(inputFileName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName))
+        this(new Deserializer(inputStream, streamName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
     { }
 
     /// <summary>
@@ -193,7 +192,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        var serializer = new Serializer(outputFileName, this);
+        var serializer = new Serializer(new IOStreamStreamWriter(outputFileName, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), this);
         serializer.Close();
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19760/GC-dump-outputs-a-corrupted-file

### Additional description

The dump file output was corrupted and couldn't be used in `PerfView`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing by Contributor

- It has been verified by manual testing
