### PR TITLE
RavenDB-16500 - Cannot start SinkToHub replication

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -69,6 +69,17 @@ namespace Raven.Client.Documents.Operations.Replication
                 {
                     throw new InvalidOperationException("Your server is unsecured and therefore you can't define pull replication with a certificate.");
                 }
+
+                if (WithFiltering)
+                {
+                    throw new InvalidOperationException($"Server must be secured in order to use filtering in pull replication {Name}.");
+                }
+
+                if (Mode.HasFlag(PullReplicationMode.SinkToHub))
+                {
+                    throw new InvalidOperationException(
+                        $"Server must be secured in order to use {nameof(Mode)} {nameof(PullReplicationMode.SinkToHub)} in pull replication {Name}");
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16500

### Additional description

`SinkToHub` replication is not allowed on an unsecured hub.
Now throwing in handler if there is an attempt to create a hub definition with this mode (and it is unsecured).
Also throwing if trying to create this with a `WithFiltering`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
