### PR TITLE
RavenDB-19758: Disable VxSort in architectures without hardware PopCount instructions

### DIFF
--- a/src/Sparrow.Server/Utils/VxSort/VectorizedSort.cs
+++ b/src/Sparrow.Server/Utils/VxSort/VectorizedSort.cs
@@ -28,7 +28,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
 
-            if (!Avx2.IsSupported)
+            if (Avx2.IsSupported == false || Popcnt.IsSupported == false)
             {
                 MemoryExtensions.Sort(array.AsSpan());
                 return;
@@ -47,7 +47,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
 
-            if (!Avx2.IsSupported)
+            if (Avx2.IsSupported == false || Popcnt.IsSupported == false)
             {
                 MemoryExtensions.Sort(array);
                 return;
@@ -67,7 +67,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (start == null)
                 throw new ArgumentNullException(nameof(start));
 
-            if (!Avx2.IsSupported)
+            if (Avx2.IsSupported == false || Popcnt.IsSupported == false)
             {
                 MemoryExtensions.Sort(new Span<T>(start, count));
                 return;

--- a/src/Sparrow.Server/Utils/VxSort/VectorizedSort.generated.cs
+++ b/src/Sparrow.Server/Utils/VxSort/VectorizedSort.generated.cs
@@ -13,7 +13,7 @@ namespace Sparrow.Server.Utils.VxSort
         [SkipLocalsInit]
         public unsafe static void Run<T>(T* left, T* right) where T : unmanaged
         { 
-            if (!Avx2.IsSupported)
+            if (Avx2.IsSupported == false || Popcnt.IsSupported == false)
             {
                 MemoryExtensions.Sort(new Span<T>(left, (int)(right - left) + 1));
                 return;

--- a/src/Sparrow.Server/Utils/VxSort/codegen/sorting_main.py
+++ b/src/Sparrow.Server/Utils/VxSort/codegen/sorting_main.py
@@ -22,7 +22,7 @@ namespace {g.namespace}
         [SkipLocalsInit]
         public unsafe static void Run<T>(T* left, T* right) where T : unmanaged
         {{ 
-            if (!Avx2.IsSupported)
+            if (Avx2.IsSupported == false || Popcnt.IsSupported == false)
             {{
                 MemoryExtensions.Sort(new Span<T>(left, (int)(right - left) + 1));
                 return;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19758

### Additional description
Some architectures may not implement PopCount even if they have support for AVX2. 

### Type of change
Bug fix

### How risky is the change?
Low 

### Is it platform specific issue?
Yes. Older architecture without hardware accelerated PopCount.
