### PR TITLE
RavenDB-19235: Add the ability to cancel and delay ongoing backups by Operator

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2739,10 +2739,10 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await WaitForValueAsync(async () =>
                 {
                     afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return afterDelayTaskBackupInfo?.OnGoingBackup == null;
+                    return afterDelayTaskBackupInfo is { OnGoingBackup: null };
                 }, true);
                 Assert.Null(afterDelayTaskBackupInfo.LastFullBackup);
-                Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
+                Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
                             afterDelayTaskBackupInfo.NextBackup.TimeSpan <= delayDuration);
 
                 // DelayUntil value in backup status and the time of scheduled next backup should be equal
@@ -2814,7 +2814,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Null(periodicBackup.RunningTask);
                 Assert.Null(periodicBackup.RunningBackupStatus);
                 var nextBackup = periodicBackup.GetNextBackup().TimeSpan;
-                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) && nextBackup <= delayDuration);
+                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration);
 
                 onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
@@ -2901,7 +2901,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }, true);
 
                 Assert.NotNull(onGoingTaskBackup.NextBackup);
-                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
+                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
                             onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration);
                 Assert.NotEqual(onGoingTaskBackup.ResponsibleNode.NodeTag, serverToObserve.ServerStore.NodeTag);
 
@@ -2976,7 +2976,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         }, true);
 
                         var nextBackupTimeSpan = inMemoryStatus.DelayUntil - DateTime.UtcNow;
-                        Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
+                        Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
                                     nextBackupTimeSpan <= delayDuration);
                     }
                 }
@@ -3026,13 +3026,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
                 // Check that there is no ongoing backup and new task scheduled properly
+                onGoingTaskInfo = null;
                 await WaitForValueAsync( async () =>
                 {
                     onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return onGoingTaskInfo?.OnGoingBackup == null;
+                    return onGoingTaskInfo is { OnGoingBackup: null };
                 }, true);
                 Assert.Null(onGoingTaskInfo.LastFullBackup);
-                Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
+                Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
                             onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration);
             }
         }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2730,8 +2730,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
-                var sw = new Stopwatch();
-                sw.Start();
+                var sw = Stopwatch.StartNew();
                 await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
                 // There should be no OnGoingBackup operation in the OngoingTaskBackup
@@ -2805,8 +2804,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
-                var sw = new Stopwatch();
-                sw.Start();
+                var sw = Stopwatch.StartNew();
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
@@ -2864,8 +2862,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
-                var sw = new Stopwatch();
-                sw.Start();
+                var sw = Stopwatch.StartNew();
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
@@ -2950,8 +2947,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
-                var sw = new Stopwatch();
-                sw.Start();
+                var sw = Stopwatch.StartNew();
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
@@ -3025,8 +3021,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var delayDuration = TimeSpan.FromHours(1);
-                var sw = new Stopwatch();
-                sw.Start();
+                var sw = Stopwatch.StartNew();
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2730,14 +2730,20 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
+                var sw = new Stopwatch();
+                sw.Start();
                 await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
                 // There should be no OnGoingBackup operation in the OngoingTaskBackup
                 // The next backup should be scheduled in almost 1 hour
-                var afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(afterDelayTaskBackupInfo);
-                Assert.Null(afterDelayTaskBackupInfo.OnGoingBackup);
-                Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromSeconds(1)) &&
+                OngoingTaskBackup afterDelayTaskBackupInfo = null;
+                await WaitForValueAsync(async () =>
+                {
+                    afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    return afterDelayTaskBackupInfo?.OnGoingBackup == null;
+                }, true);
+                Assert.Null(afterDelayTaskBackupInfo.LastFullBackup);
+                Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
                             afterDelayTaskBackupInfo.NextBackup.TimeSpan <= delayDuration);
 
                 // DelayUntil value in backup status and the time of scheduled next backup should be equal
@@ -2799,6 +2805,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
+                var sw = new Stopwatch();
+                sw.Start();
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
@@ -2808,7 +2816,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Null(periodicBackup.RunningTask);
                 Assert.Null(periodicBackup.RunningBackupStatus);
                 var nextBackup = periodicBackup.GetNextBackup().TimeSpan;
-                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromSeconds(5)) && nextBackup <= delayDuration);
+                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) && nextBackup <= delayDuration);
 
                 onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
@@ -2817,7 +2825,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 // We'll check another (not leader) nodes in cluster
                 foreach (var server in nodes.Where(node => node != leaderServer))
                 {
-                    await AssertNextBackupSchedule(server, delayDuration, databaseName, taskId, 20);
+                    await AssertNextBackupSchedule(server, delayDuration, databaseName, taskId, sw);
                 }
             }
         }
@@ -2853,8 +2861,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
 
+                
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
+                var sw = new Stopwatch();
+                sw.Start();
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
@@ -2870,12 +2881,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 });
                 Assert.NotNull(newServer);
 
-                await AssertNextBackupSchedule(serverToObserve: newServer, delayDuration, databaseName, taskId, accuracyInSec: 30);
+                await AssertNextBackupSchedule(serverToObserve: newServer, delayDuration, databaseName, taskId, sw);
             }
         }
 
-        private static async Task AssertNextBackupSchedule(RavenServer serverToObserve, TimeSpan delayDuration, string databaseName,
-            long taskId, long accuracyInSec)
+        private static async Task AssertNextBackupSchedule(RavenServer serverToObserve, TimeSpan delayDuration, string databaseName, long taskId, Stopwatch sw)
         {
             using (var store = new DocumentStore
                    {
@@ -2889,22 +2899,12 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 OngoingTaskBackup onGoingTaskBackup = null;
                 await WaitForValueAsync(async () =>
                 {
-                    try
-                    {
-                        onGoingTaskBackup =
-                            await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    }
-                    catch (Exception)
-                    {
-                        //ignore
-                    }
-
+                    onGoingTaskBackup = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                     return onGoingTaskBackup != null;
                 }, true);
 
-                Assert.Equal(serverToObserve.ServerStore.LeaderTag, onGoingTaskBackup.MentorNode);
                 Assert.NotNull(onGoingTaskBackup.NextBackup);
-                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromSeconds(accuracyInSec)) &&
+                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
                             onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration);
                 Assert.NotEqual(onGoingTaskBackup.ResponsibleNode.NodeTag, serverToObserve.ServerStore.NodeTag);
 
@@ -2950,6 +2950,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
+                var sw = new Stopwatch();
+                sw.Start();
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
@@ -2969,11 +2971,16 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                         var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                         documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().BackupStatusFromMemoryOnly = true;
-                        var inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
-                        Assert.NotNull(inMemoryStatus);
+                        
+                        PeriodicBackupStatus inMemoryStatus = null;
+                        WaitForValue(() =>
+                        {
+                            inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
+                            return inMemoryStatus != null;
+                        }, true);
 
                         var nextBackupTimeSpan = inMemoryStatus.DelayUntil - DateTime.UtcNow;
-                        Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromSeconds(5)) &&
+                        Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
                                     nextBackupTimeSpan <= delayDuration);
                     }
                 }
@@ -3018,14 +3025,19 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
                 var delayDuration = TimeSpan.FromHours(1);
+                var sw = new Stopwatch();
+                sw.Start();
                 var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
                 // Check that there is no ongoing backup and new task scheduled properly
-                onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(onGoingTaskInfo);
-                Assert.Null(onGoingTaskInfo.OnGoingBackup);
-                Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromSeconds(60)) &&
+                await WaitForValueAsync( async () =>
+                {
+                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    return onGoingTaskInfo?.OnGoingBackup == null;
+                }, true);
+                Assert.Null(onGoingTaskInfo.LastFullBackup);
+                Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds)) &&
                             onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19235/Add-the-ability-to-cancel-and-delay-server-wide-backups-by-Operator

### Additional description

In case the backup is causing problems for the server, we need to be able to delay and cancel such operation for a set time

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio