### PR TITLE
RavenDB-16556 Added key(), sum() and count() handling for JavaScript projections

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -267,6 +267,8 @@ namespace Raven.Client
 
                     public const string CountFieldName = "Count";
 
+                    public const string SumFieldName = "Sum";
+
 #if FEATURE_CUSTOM_SORTING
                     public const string CustomSortFieldName = "__customSort";
 #endif

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -248,6 +248,9 @@ namespace Raven.Server.Documents.Patch
                 ScriptEngine.SetValue(GetMetadataMethod, new ClrFunctionInstance(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
                 ScriptEngine.SetValue("metadataFor", new ClrFunctionInstance(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
                 ScriptEngine.SetValue("id", new ClrFunctionInstance(ScriptEngine, "id", JavaScriptUtils.GetDocumentId));
+                ScriptEngine.SetValue("count", new ClrFunctionInstance(ScriptEngine, "count", JavaScriptUtils.Count));
+                ScriptEngine.SetValue("key", new ClrFunctionInstance(ScriptEngine, "key", JavaScriptUtils.Key));
+                ScriptEngine.SetValue("sum", new ClrFunctionInstance(ScriptEngine, "sum", JavaScriptUtils.Sum));
 
                 ScriptEngine.SetValue("output", new ClrFunctionInstance(ScriptEngine, "output", OutputDebug));
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1940,6 +1940,7 @@ namespace Raven.Server.Documents.Patch
 
                 try
                 {
+                    JavaScriptUtils.CurrentlyProcessedObject = _args[0];
                     var call = ScriptEngine.GetValue(method).TryCast<ICallable>();
                     var result = call.Call(Undefined.Instance, _args);
                     return new ScriptRunnerResult(this, result);
@@ -1957,6 +1958,7 @@ namespace Raven.Server.Documents.Patch
                 }
                 finally
                 {
+                    JavaScriptUtils.CurrentlyProcessedObject = null;
                     _refResolver.ExplodeArgsOn(null, null);
                     _scope = null;
                     _loadScope = null;

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -358,6 +358,23 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }
             }
 
+            if (query.Metadata.CountInJs.HasValue)
+            {
+                if (mapFields.TryGetValue(Constants.Documents.Indexing.Fields.CountFieldName, out var countField) == false)
+                {
+                    mapFields.Add(Constants.Documents.Indexing.Fields.CountFieldName, DynamicQueryMappingItem.Create(QueryFieldName.Count, AggregationOperation.Count));
+                }
+            }
+
+            if (query.Metadata.SumInJs is not null)
+            {
+                if (mapFields.TryGetValue(query.Metadata.SumInJs, out var sumField) == false)
+                {
+                    var queryFieldName = new QueryFieldName(query.Metadata.SumInJs, false);
+                    mapFields.Add(query.Metadata.SumInJs, DynamicQueryMappingItem.Create(queryFieldName, AggregationOperation.Sum));
+                }
+            }
+
             var result = new Dictionary<string, DynamicQueryMappingItem>(groupByFields.Length, StringComparer.Ordinal);
 
             for (int i = 0; i < groupByFields.Length; i++)

--- a/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
@@ -25,6 +25,23 @@ namespace Raven.Server.Documents.Queries
             {
                 switch (id.Name)
                 {
+                    case "count":
+                        _queryMetadata.CountInJs = true;
+                        break;
+                    case "sum":
+                        _queryMetadata.SumInJs = null;
+                        
+                        if (callExpression.Arguments.Count == 2)
+                        {
+                            var fieldNameNode = callExpression.Arguments.AsNodes()[1];
+
+                            if (fieldNameNode is Literal fieldNameLiteral)
+                            {
+                                _queryMetadata.SumInJs = fieldNameLiteral.StringValue;
+                            }
+                        }
+                        
+                        break;
                     case "load":
                     case "include":
                     case "loadPath":

--- a/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
@@ -30,17 +30,21 @@ namespace Raven.Server.Documents.Queries
                         break;
                     case "sum":
                         _queryMetadata.SumInJs = null;
-                        
-                        if (callExpression.Arguments.Count == 2)
-                        {
-                            var fieldNameNode = callExpression.Arguments.AsNodes()[1];
 
-                            if (fieldNameNode is Literal fieldNameLiteral)
+                        if (callExpression.Arguments.Count == 1)
+                        {
+                            if (callExpression.Arguments[0] is ArrowFunctionExpression afe)
                             {
-                                _queryMetadata.SumInJs = fieldNameLiteral.StringValue;
+                                if (afe.ChildNodes[1] is StaticMemberExpression sme)
+                                {
+                                    if (sme.Property is Identifier identifier)
+                                    {
+                                        _queryMetadata.SumInJs = identifier.Name;
+                                    }
+                                }
                             }
                         }
-                        
+
                         break;
                     case "load":
                     case "include":

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -241,6 +241,10 @@ function execute(doc, args){
 
         public List<SpatialShapeBase> SpatialShapes;
 
+        public bool? CountInJs;
+
+        public string SumInJs;
+        
         private void AddExistField(QueryFieldName fieldName, BlittableJsonReaderObject parameters)
         {
             IndexFieldNames.Add(GetIndexFieldName(fieldName, parameters));

--- a/src/Raven.Server/Documents/Queries/Results/ProjectionOptions.cs
+++ b/src/Raven.Server/Documents/Queries/Results/ProjectionOptions.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         public readonly bool MustExtractOrThrow;
 
-        private readonly IndexQueryServerSide _query;
+        internal readonly IndexQueryServerSide _query;
 
         public ProjectionOptions(IndexQueryServerSide query)
         {

--- a/test/SlowTests/Issues/RavenDB-16556.cs
+++ b/test/SlowTests/Issues/RavenDB-16556.cs
@@ -26,8 +26,8 @@ public class RavenDB_16556 : RavenTestBase
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(),
-		                    Value: sum(x => x.Price)
+                            Key: key(),
+                            Value: sum(x => x.Price)
                         }
                     }
 
@@ -39,8 +39,8 @@ public class RavenDB_16556 : RavenTestBase
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(),
-		                    Value: sum(x => x.Price)
+                            Key: key(),
+                            Value: sum(x => x.Price)
                         }
                     }
 
@@ -114,8 +114,8 @@ public class RavenDB_16556 : RavenTestBase
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(),
-		                    Value: count()
+                            Key: key(),
+                            Value: count()
                         }
                     }
 
@@ -179,8 +179,8 @@ public class RavenDB_16556 : RavenTestBase
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(),
-		                    Value: sum()
+                            Key: key(),
+                            Value: sum()
                         }
                     }
 
@@ -193,8 +193,8 @@ public class RavenDB_16556 : RavenTestBase
                     output(o){
                     var empId = key().EmpId;
                         return {
-		                    Key: empId,
-		                    Value: sum()
+                            Key: empId,
+                            Value: sum()
                         }
                     }
 
@@ -255,8 +255,8 @@ public class RavenDB_16556 : RavenTestBase
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(),
-		                    Value: count(x => x.Freight)
+                            Key: key(),
+                            Value: count(x => x.Freight)
                         }
                     }
 
@@ -269,8 +269,8 @@ public class RavenDB_16556 : RavenTestBase
                     output(o){
                     var empId = key().EmpId;
                         return {
-		                    Key: empId,
-		                    Value: count(""Freight"")
+                            Key: empId,
+                            Value: count(""Freight"")
                         }
                     }
 

--- a/test/SlowTests/Issues/RavenDB-16556.cs
+++ b/test/SlowTests/Issues/RavenDB-16556.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_16556 : RavenTestBase
+{
+    public RavenDB_16556(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(@"from Orders as o
+                                        group by o.CompId, o.EmpId
+                                        order by count() as long desc
+                                        load o.EmpId as e
+                                        select 
+                                        {
+                                            Key: key(o),
+                                            Value: sum(o, ""Price"")
+                                        }")]
+    [InlineData(@"declare function 
+                    output(o){
+                        return {
+		                    Key: key(o),
+		                    Value: sum(o, ""Price"")
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId, o.EmpId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    public void CanGetKeyWithMultipleGroupByFieldsFromAutoMapReduceIndexViaJs(string query)
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            Employee e1 = new() { Name = "Maciej" };
+            Employee e2 = new() { Name = "Michal" };
+
+            Company c1 = new() { Name = "Company1" };
+            Company c2 = new() { Name = "Company2" };
+
+            session.Store(e1);
+            session.Store(e2);
+
+            session.Store(c1);
+            session.Store(c2);
+            
+            Order o1 = new (){EmpId = e1.Id, CompId = c1.Id, Price = 21};
+            Order o2 = new (){EmpId = e2.Id, CompId = c2.Id, Price = 37};
+            Order o3 = new (){EmpId = e1.Id, CompId = c2.Id, Price = 44};
+            
+            session.Store(o1);
+            session.Store(o2);
+            session.Store(o3);
+
+            session.SaveChanges();
+            
+            var res = session.Advanced
+                .RawQuery<DtoWithJson>(query)
+                .WaitForNonStaleResults().ToList();
+
+            var dict1 = new Dictionary<string, object> { { "CompId", "companies/1-A" }, { "EmpId", "employees/1-A" } };
+            var dict2 = new Dictionary<string, object> { { "CompId", "companies/2-A" }, { "EmpId", "employees/2-A" } };
+            var dict3 = new Dictionary<string, object> { { "CompId", "companies/2-A" }, { "EmpId", "employees/1-A" } };
+
+            var expected = new List<DtoWithJson>{
+                new(){Value = 21, Key = dict1 }, 
+                new(){Value = 37, Key = dict2 },
+                new(){Value = 44, Key = dict3 }
+            };
+
+            Assert.Equal(expected[0].Value, res[0].Value);
+            Assert.Equal(expected[1].Value, res[1].Value);
+            Assert.Equal(expected[2].Value, res[2].Value);
+            
+            Assert.Equal(expected[0].Key, res[0].Key);
+            Assert.Equal(expected[1].Key, res[1].Key);
+            Assert.Equal(expected[2].Key, res[2].Key);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(@"from Orders as o
+                                        group by o.CompId
+                                        order by count() as long desc
+                                        load o.EmpId as e
+                                        select 
+                                        {
+                                            Key: key(o),
+                                            Value: count(o)
+                                        }")]
+    [InlineData(@"declare function 
+                    output(o){
+                        return {
+		                    Key: key(o),
+		                    Value: count(o)
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    public void CanGetKeyAndCountFromAutoMapReduceIndexViaJs(string query)
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            Employee e1 = new() { Name = "Maciej" };
+            Employee e2 = new() { Name = "Michal" };
+
+            Company c1 = new() { Name = "Company1" };
+            Company c2 = new() { Name = "Company2" };
+
+            session.Store(e1);
+            session.Store(e2);
+
+            session.Store(c1);
+            session.Store(c2);
+            
+            Order o1 = new (){EmpId = e1.Id, CompId = c1.Id, Price = 21};
+            Order o2 = new (){EmpId = e2.Id, CompId = c2.Id, Price = 37};
+            Order o3 = new (){EmpId = e1.Id, CompId = c2.Id, Price = 44};
+            
+            session.Store(o1);
+            session.Store(o2);
+            session.Store(o3);
+
+            session.SaveChanges();
+
+            var res = session.Advanced
+                .RawQuery<Dto>(query)
+                .WaitForNonStaleResults().ToList();
+            
+            var expected = new List<Dto>{new(){Value = 2, Key = "companies/2-A"}, new(){Value = 1, Key = "companies/1-A"}};
+            
+            Assert.Equal(expected[0].Key, res[0].Key);
+            Assert.Equal(expected[1].Key, res[1].Key);
+            
+            Assert.Equal(expected[0].Value, res[0].Value);
+            Assert.Equal(expected[1].Value, res[1].Value);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(@"from Orders as o
+                                        group by o.CompId
+                                        order by count() as long desc
+                                        load o.EmpId as e
+                                        select 
+                                        {
+                                            Key: key(o),
+                                            Value: sum(o)
+                                        }")]
+    [InlineData(@"declare function 
+                    output(o){
+                        return {
+		                    Key: key(o),
+		                    Value: sum(o)
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    [InlineData(@"declare function 
+                    output(o){
+                    var empId = key(o).EmpId;
+                        return {
+		                    Key: empId,
+		                    Value: sum(o)
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    public void CheckIfInvalidQueryExceptionIsThrownForIncorrectNumberOfArgsInSum(string query)
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            Employee e1 = new() { Name = "Maciej" };
+            Employee e2 = new() { Name = "Michal" };
+
+            Company c1 = new() { Name = "Company1" };
+            Company c2 = new() { Name = "Company2" };
+
+            session.Store(e1);
+            session.Store(e2);
+
+            session.Store(c1);
+            session.Store(c2);
+
+            Order o1 = new() { EmpId = e1.Id, CompId = c1.Id, Price = 21 };
+            Order o2 = new() { EmpId = e2.Id, CompId = c2.Id, Price = 37 };
+            Order o3 = new() { EmpId = e1.Id, CompId = c2.Id, Price = 44 };
+
+            session.Store(o1);
+            session.Store(o2);
+            session.Store(o3);
+
+            session.SaveChanges();
+            
+            Assert.Throws<Raven.Client.Exceptions.RavenException>(() =>
+            {
+                var res = session.Advanced
+                    .RawQuery<Dto>(query)
+                    .WaitForNonStaleResults().ToList();
+            });
+        }
+    }
+
+    private class Order
+    {
+        public string Id { get; set; }
+        public string EmpId { get; set; }
+        public string CompId { get; set; }
+        
+        public int Price { get; set; }
+    }
+
+    private class Company
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private class Employee
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Key { get; set; }
+        public int Value { get; set; }
+    }
+    
+    private class DtoWithJson
+    {
+        public Dictionary<string, object> Key { get; set; }
+        public int Value { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-16556.cs
+++ b/test/SlowTests/Issues/RavenDB-16556.cs
@@ -19,14 +19,27 @@ public class RavenDB_16556 : RavenTestBase
                                         load o.EmpId as e
                                         select 
                                         {
-                                            Key: key(o),
-                                            Value: sum(o, ""Price"")
+                                            Key: key(),
+                                            Value: sum(""Price"")
                                         }")]
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(o),
-		                    Value: sum(o, ""Price"")
+		                    Key: key(),
+		                    Value: sum(""Price"")
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId, o.EmpId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    [InlineData(@"declare function 
+                    output(o){
+                        return {
+		                    Key: key(),
+		                    Value: sum(x => x.Price)
                         }
                     }
 
@@ -94,14 +107,14 @@ public class RavenDB_16556 : RavenTestBase
                                         load o.EmpId as e
                                         select 
                                         {
-                                            Key: key(o),
-                                            Value: count(o)
+                                            Key: key(),
+                                            Value: count()
                                         }")]
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(o),
-		                    Value: count(o)
+		                    Key: key(),
+		                    Value: count()
                         }
                     }
 
@@ -159,14 +172,14 @@ public class RavenDB_16556 : RavenTestBase
                                         load o.EmpId as e
                                         select 
                                         {
-                                            Key: key(o),
-                                            Value: sum(o)
+                                            Key: key(),
+                                            Value: sum()
                                         }")]
     [InlineData(@"declare function 
                     output(o){
                         return {
-		                    Key: key(o),
-		                    Value: sum(o)
+		                    Key: key(),
+		                    Value: sum()
                         }
                     }
 
@@ -177,10 +190,10 @@ public class RavenDB_16556 : RavenTestBase
                 select output(o)")]
     [InlineData(@"declare function 
                     output(o){
-                    var empId = key(o).EmpId;
+                    var empId = key().EmpId;
                         return {
 		                    Key: empId,
-		                    Value: sum(o)
+		                    Value: sum()
                         }
                     }
 

--- a/test/SlowTests/Issues/RavenDB-16556.cs
+++ b/test/SlowTests/Issues/RavenDB-16556.cs
@@ -21,13 +21,13 @@ public class RavenDB_16556 : RavenTestBase
                                         select 
                                         {
                                             Key: key(),
-                                            Value: sum(""Price"")
+                                            Value: sum(x => x.Price)
                                         }")]
     [InlineData(@"declare function 
                     output(o){
                         return {
 		                    Key: key(),
-		                    Value: sum(""Price"")
+		                    Value: sum(x => x.Price)
                         }
                     }
 
@@ -203,7 +203,7 @@ public class RavenDB_16556 : RavenTestBase
                 order by count() as long desc
                 load o.EmpId as e
                 select output(o)")]
-    public void CheckIfInvalidQueryExceptionIsThrownForIncorrectNumberOfArgsInSum(string query)
+    public void CheckIfInvalidOperationExceptionIsThrownForIncorrectNumberOfArgsInSum(string query)
     {
         using var store = GetDocumentStore();
 
@@ -239,6 +239,82 @@ public class RavenDB_16556 : RavenTestBase
             });
             
             Assert.Contains("sum(field) must be called with a single argument", ex.Message);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(@"from Orders as o
+                                        group by o.CompId
+                                        order by count() as long desc
+                                        load o.EmpId as e
+                                        select 
+                                        {
+                                            Key: key(),
+                                            Value: count(2)
+                                        }")]
+    [InlineData(@"declare function 
+                    output(o){
+                        return {
+		                    Key: key(),
+		                    Value: count(x => x.Freight)
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    [InlineData(@"declare function 
+                    output(o){
+                    var empId = key().EmpId;
+                        return {
+		                    Key: empId,
+		                    Value: count(""Freight"")
+                        }
+                    }
+
+                from Orders as o
+                group by o.CompId
+                order by count() as long desc
+                load o.EmpId as e
+                select output(o)")]
+    public void CheckIfInvalidOperationExceptionIsThrownForIncorrectNumberOfArgsInCount(string query)
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            Employee e1 = new() { Name = "Maciej" };
+            Employee e2 = new() { Name = "Michal" };
+
+            Company c1 = new() { Name = "Company1" };
+            Company c2 = new() { Name = "Company2" };
+
+            session.Store(e1);
+            session.Store(e2);
+
+            session.Store(c1);
+            session.Store(c2);
+
+            Order o1 = new() { EmpId = e1.Id, CompId = c1.Id, Price = 21 };
+            Order o2 = new() { EmpId = e2.Id, CompId = c2.Id, Price = 37 };
+            Order o3 = new() { EmpId = e1.Id, CompId = c2.Id, Price = 44 };
+
+            session.Store(o1);
+            session.Store(o2);
+            session.Store(o3);
+
+            session.SaveChanges();
+            
+            RavenException ex = Assert.Throws<RavenException>(() =>
+            {
+                var res = session.Advanced
+                    .RawQuery<Dto>(query)
+                    .WaitForNonStaleResults().ToList();
+            });
+            
+            Assert.Contains("count() must be called without arguments", ex.Message);
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB-16556.cs
+++ b/test/SlowTests/Issues/RavenDB-16556.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FastTests;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -230,12 +231,14 @@ public class RavenDB_16556 : RavenTestBase
 
             session.SaveChanges();
             
-            Assert.Throws<Raven.Client.Exceptions.RavenException>(() =>
+            RavenException ex = Assert.Throws<RavenException>(() =>
             {
                 var res = session.Advanced
                     .RawQuery<Dto>(query)
                     .WaitForNonStaleResults().ToList();
             });
+            
+            Assert.Contains("sum(field) must be called with a single argument", ex.Message);
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16556/Implement-count-for-JavaScript-projections

### Additional description

We want to mark count(doc), key(doc) and sum(doc, field) in JavaScript query projection, so we can handle them in our ScriptRunner and return correct projection fields values. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
