### PR TITLE
RavenDB-19657 - Failing test StressTests.Client.TimeSeries.TimeSeries…

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1276,10 +1276,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                                             $"The supported time formats are:{Environment.NewLine}" +
                                             $"{string.Join(Environment.NewLine, SupportedDateTimeFormats.OrderBy(f => f.Length))}");
 
-            if (date == DateTime.MaxValue || date == DateTime.MinValue)
-                return DateTime.SpecifyKind(date, DateTimeKind.Utc);
-
-            return new DateTime(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Millisecond, DateTimeKind.Utc);
+            return TimeSeriesStorage.EnsureMillisecondsPrecision(date);
         }
 
         private static readonly string[] SupportedDateTimeFormats =

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1276,6 +1276,9 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                                             $"The supported time formats are:{Environment.NewLine}" +
                                             $"{string.Join(Environment.NewLine, SupportedDateTimeFormats.OrderBy(f => f.Length))}");
 
+            if (date == DateTime.MaxValue || date == DateTime.MinValue)
+                return DateTime.SpecifyKind(date, DateTimeKind.Utc);
+
             return new DateTime(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Millisecond, DateTimeKind.Utc);
         }
 

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1275,7 +1275,8 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                 throw new ArgumentException($"Unable to parse timeseries from/to values. Got: {valueAsStr}{Environment.NewLine}" +
                                             $"The supported time formats are:{Environment.NewLine}" +
                                             $"{string.Join(Environment.NewLine, SupportedDateTimeFormats.OrderBy(f => f.Length))}");
-            return DateTime.SpecifyKind(date, DateTimeKind.Utc);
+
+            return new DateTime(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Millisecond, DateTimeKind.Utc);
         }
 
         private static readonly string[] SupportedDateTimeFormats =

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1276,7 +1276,8 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                                             $"The supported time formats are:{Environment.NewLine}" +
                                             $"{string.Join(Environment.NewLine, SupportedDateTimeFormats.OrderBy(f => f.Length))}");
 
-            return TimeSeriesStorage.EnsureMillisecondsPrecision(date);
+            date = TimeSeriesStorage.EnsureMillisecondsPrecision(date);
+            return DateTime.SpecifyKind(date, DateTimeKind.Utc);
         }
 
         private static readonly string[] SupportedDateTimeFormats =


### PR DESCRIPTION
…Stress.PatchTimestamp_IntegrationTest

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19657/Failing-test-StressTests.Client.TimeSeries.TimeSeriesStress.PatchTimestampIntegrationTest

### Additional description

**.NET 7** recent updates include new Property for `DateTime` -> `DateTime.Microsecond`. 
For operations such as parsing a `string` to `DateTime` - we might get `DateTime.Microsecond =! 0` - _BUT_, our implementation  for TimeSeries is based on milliseconds precision (meaning that the entries in the table have `DateTime.Microsecond == 0`); therefore, we may get false results for `DateTime` operations (as '`==`', '`<`',...)


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
