### PR TITLE
RavenDB-19798 decrease number of held items in ocumentBuilder for x86 to avoid holding more than 300mb of managed memory when running process for a long time

### DIFF
--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -16,6 +16,15 @@ namespace Sparrow.Json
 
         protected readonly FastStack<BuildingState> _continuationState;
 
+        private static readonly PerCoreContainer<GlobalPoolItem> GlobalCache;
+
+        static AbstractBlittableJsonDocumentBuilder()
+        {
+            GlobalCache = PlatformDetails.Is32Bits 
+                ? new PerCoreContainer<GlobalPoolItem>(4) 
+                : new PerCoreContainer<GlobalPoolItem>();
+        }
+
         protected AbstractBlittableJsonDocumentBuilder()
         {
             if (GlobalCache.TryPull(out _cacheItem) == false)
@@ -45,8 +54,6 @@ namespace Sparrow.Json
                 _positionsCache.Return(ref state.Positions);
             }
         }
-
-        private static readonly PerCoreContainer<GlobalPoolItem> GlobalCache = new PerCoreContainer<GlobalPoolItem>();
 
         protected struct BuildingState
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19798

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
