### PR TITLE
RavenDB-19798 decreased number of fields that we are parsing when working with TimeSeries in ETL & Indexing

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -285,7 +285,7 @@ namespace Raven.Server.Documents.ETL
         {
             if (Transformation.ApplyToAllDocuments)
             {
-                var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.ChangeVector | TimeSeriesSegmentEntryFields.Segment).GetEnumerator();
+                var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.ForEtl).GetEnumerator();
                 scope.EnsureDispose(timeSeries);
                 merged.AddEnumerator(ConvertTimeSeriesEnumerator(context, timeSeries, null));
 
@@ -297,7 +297,7 @@ namespace Raven.Server.Documents.ETL
             {
                 foreach (var collection in Transformation.Collections)
                 {
-                    var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.ChangeVector | TimeSeriesSegmentEntryFields.Segment).GetEnumerator();
+                    var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.ForEtl).GetEnumerator();
                     scope.EnsureDispose(timeSeries);
                     merged.AddEnumerator(ConvertTimeSeriesEnumerator(context, timeSeries, collection));
 

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -285,7 +285,7 @@ namespace Raven.Server.Documents.ETL
         {
             if (Transformation.ApplyToAllDocuments)
             {
-                var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, fromEtag, long.MaxValue).GetEnumerator();
+                var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.ChangeVector | TimeSeriesSegmentEntryFields.Segment).GetEnumerator();
                 scope.EnsureDispose(timeSeries);
                 merged.AddEnumerator(ConvertTimeSeriesEnumerator(context, timeSeries, null));
 
@@ -297,7 +297,7 @@ namespace Raven.Server.Documents.ETL
             {
                 foreach (var collection in Transformation.Collections)
                 {
-                    var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, fromEtag, long.MaxValue).GetEnumerator();
+                    var timeSeries = Database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, fromEtag, long.MaxValue, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.ChangeVector | TimeSeriesSegmentEntryFields.Segment).GetEnumerator();
                     scope.EnsureDispose(timeSeries);
                     merged.AddEnumerator(ConvertTimeSeriesEnumerator(context, timeSeries, collection));
 

--- a/src/Raven.Server/Documents/ETL/ExtractedItem.cs
+++ b/src/Raven.Server/Documents/ETL/ExtractedItem.cs
@@ -85,6 +85,7 @@ namespace Raven.Server.Documents.ETL
 
             CounterGroupDocument?.Dispose();
             TimeSeriesDeletedRangeItem?.Dispose();
+            TimeSeriesSegmentEntry?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.TimeSeries;
+using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Indexes.Static.TimeSeries
@@ -107,7 +108,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
         protected override IndexItem GetItemByEtag(QueryOperationContext queryContext, long etag)
         {
-            var timeSeries = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeries(queryContext.Documents, etag);
+            var timeSeries = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeries(queryContext.Documents, etag, TimeSeriesSegmentEntryFields.ForIndexing);
             if (timeSeries == null)
                 return default;
 

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -16,6 +16,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Results.TimeSeries;
 using Raven.Server.Documents.Queries.Timings;
+using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Voron;
 
@@ -118,7 +119,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
         protected override IndexItem GetItemByEtag(QueryOperationContext queryContext, long etag)
         {
-            var timeSeries = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeries(queryContext.Documents, etag);
+            var timeSeries = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeries(queryContext.Documents, etag, TimeSeriesSegmentEntryFields.ForIndexing);
             if (timeSeries == null)
                 return default;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
 
         protected override IndexItem GetItem(DocumentsOperationContext databaseContext, Slice key)
         {
-            var timeSeries = _timeSeriesStorage.GetTimeSeries(databaseContext, key);
+            var timeSeries = _timeSeriesStorage.GetTimeSeries(databaseContext, key, TimeSeriesSegmentEntryFields.ForIndexing);
             if (timeSeries == null)
                 return null;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
 
         protected override IndexItem GetItem(DocumentsOperationContext databaseContext, Slice key)
         {
-            var timeSeries = _timeSeriesStorage.GetTimeSeries(databaseContext, key);
+            var timeSeries = _timeSeriesStorage.GetTimeSeries(databaseContext, key, TimeSeriesSegmentEntryFields.ForIndexing);
             if (timeSeries == null)
                 return null;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/MapTimeSeries.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/MapTimeSeries.cs
@@ -27,9 +27,9 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
         private IEnumerable<TimeSeriesSegmentEntry> GetTimeSeriesEnumerator(QueryOperationContext queryContext, string collection, long lastEtag, long pageSize)
         {
             if (collection == Constants.Documents.Collections.AllDocumentsCollection)
-                return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, lastEtag + 1, pageSize);
+                return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.LuceneKey | TimeSeriesSegmentEntryFields.Segment);
 
-            return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, collection, lastEtag + 1, pageSize);
+            return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, collection, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.LuceneKey | TimeSeriesSegmentEntryFields.Segment);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/MapTimeSeries.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/MapTimeSeries.cs
@@ -27,9 +27,9 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
         private IEnumerable<TimeSeriesSegmentEntry> GetTimeSeriesEnumerator(QueryOperationContext queryContext, string collection, long lastEtag, long pageSize)
         {
             if (collection == Constants.Documents.Collections.AllDocumentsCollection)
-                return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.LuceneKey | TimeSeriesSegmentEntryFields.Segment);
+                return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.ForIndexing);
 
-            return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, collection, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.Key | TimeSeriesSegmentEntryFields.DocIdNameAndStart | TimeSeriesSegmentEntryFields.LuceneKey | TimeSeriesSegmentEntryFields.Segment);
+            return _timeSeriesStorage.GetTimeSeriesFrom(queryContext.Documents, collection, lastEtag + 1, pageSize, TimeSeriesSegmentEntryFields.ForIndexing);
         }
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.TimeSeries
@@ -32,6 +33,29 @@ namespace Raven.Server.Documents.TimeSeries
             DocId?.Dispose();
             Name?.Dispose();
             Collection?.Dispose();
+        }
+    }
+
+    [Flags]
+    public enum TimeSeriesSegmentEntryFields
+    {
+        Default = 0,
+        Key = 1 << 0,
+        DocIdNameAndStart = 1 << 1,
+        LuceneKey = 1 << 2,
+        ChangeVector = 1 << 3,
+        Segment = 1 << 4,
+        Collection = 1 << 5,
+
+        All = Key | DocIdNameAndStart | LuceneKey | ChangeVector | Segment | Collection,
+    }
+
+    public static class EnumExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Contain(this TimeSeriesSegmentEntryFields current, TimeSeriesSegmentEntryFields flag)
+        {
+            return (current & flag) == flag;
         }
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
@@ -47,6 +47,9 @@ namespace Raven.Server.Documents.TimeSeries
         Segment = 1 << 4,
         Collection = 1 << 5,
 
+        ForIndexing = Key | DocIdNameAndStart | LuceneKey | Segment,
+        ForEtl = Key | DocIdNameAndStart | ChangeVector | Segment,
+        ForSmuggler = Key | DocIdNameAndStart | ChangeVector | Segment | Collection,
         All = Key | DocIdNameAndStart | LuceneKey | ChangeVector | Segment | Collection,
     }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSegmentEntry.cs
@@ -28,11 +28,20 @@ namespace Raven.Server.Documents.TimeSeries
 
         public void Dispose()
         {
-            Key?.Dispose();
-            LuceneKey?.Dispose();
-            DocId?.Dispose();
-            Name?.Dispose();
-            Collection?.Dispose();
+            if (Key != null && Key.IsDisposed == false)
+                Key.Dispose();
+
+            if (LuceneKey != null && LuceneKey.IsDisposed == false)
+                LuceneKey.Dispose();
+
+            if (DocId != null && DocId.IsDisposed == false)
+                DocId.Dispose();
+
+            if (Name != null && Name.IsDisposed == false)
+                Name.Dispose();
+
+            if (Collection != null && Collection.IsDisposed == false)
+                Collection.Dispose();
         }
     }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -16,6 +16,7 @@ using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Client.Util;
 using Raven.Server.Documents;
+using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
@@ -533,7 +534,7 @@ namespace Raven.Server.Smuggler.Documents
         private static IEnumerable<TimeSeriesItem> GetAllTimeSeriesItems(DocumentsOperationContext context, long startEtag)
         {
             var database = context.DocumentDatabase;
-            foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, startEtag, long.MaxValue))
+            foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, startEtag, long.MaxValue, TimeSeriesSegmentEntryFields.ForSmuggler))
             {
                 using (ts)
                 {
@@ -563,7 +564,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 state.CurrentCollection = collection;
 
-                foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, etag, long.MaxValue))
+                foreach (var ts in database.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, collection, etag, long.MaxValue, TimeSeriesSegmentEntryFields.ForSmuggler))
                 {
                     using (ts)
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19798

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
