### PR TITLE
RavenDB-19823 Opening counters tab on a document ends with TypeError:…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1505,6 +1505,7 @@ class normalCrudActions implements editDocumentCrudActions {
                         .filter(x => x.CounterName.toLocaleLowerCase().includes(nameFilter));
                 }
                 const mappedResults = result.Counters
+                    .filter(x => x) //RavenDB-19823 - server return nulls in counters -> then ignore it
                     .map(x => normalCrudActions.resultItemToCounterItem(x));
 
                 fetchTask.resolve({


### PR DESCRIPTION
… Cannot read properties of null (reading 'CounterValues')

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19823

### Additional description

Filter out empty counters. 


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change
