### PR TITLE
Implement a JsString wrapper for LazyStringValue and LazyCompressedStringValue

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
@@ -7,11 +7,8 @@ using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint;
 using Jint.Native;
-using Jint.Native.Array;
 using Jint.Native.Function;
-using Jint.Native.Object;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Patch;
 using Raven.Server.ServerWide;
@@ -257,8 +254,8 @@ namespace Raven.Server.Documents.Indexes.Static
                         {
                             BlittableJsonReaderObject bjro => new BlittableObjectInstance(Engine, null, bjro, null, null, null),
                             Document doc => new BlittableObjectInstance(Engine, null, doc.Data, doc),
-                            LazyStringValue lsv => new JsString(lsv.ToString()),
-                            LazyCompressedStringValue lcsv => new JsString(lcsv.ToString()),
+                            LazyStringValue lsv => new LazyJsString(lsv),
+                            LazyCompressedStringValue lcsv => new LazyCompressedJsString(lcsv),
                             LazyNumberValue lnv => new JsNumber(lnv.ToDouble(CultureInfo.InvariantCulture)),
                             _ => JsValue.FromObject(Engine, value)
                         };

--- a/src/Raven.Server/Documents/Indexes/Static/LazyCompressedJsString.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/LazyCompressedJsString.cs
@@ -1,0 +1,49 @@
+using Jint.Native;
+using Jint.Runtime;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Indexes.Static;
+
+internal sealed class LazyCompressedJsString : JsString
+{
+    internal readonly LazyCompressedStringValue _lazyValue;
+
+    public LazyCompressedJsString(LazyCompressedStringValue lazyValue) : base(null)
+    {
+        _lazyValue = lazyValue;
+    }
+
+    public override string ToString()
+    {
+        return _lazyValue.ToString();
+    }
+
+    public override bool Equals(JsString obj)
+    {
+        return obj switch
+        {
+            LazyCompressedJsString lazyCompressedJsString => _lazyValue.Equals(lazyCompressedJsString._lazyValue),
+            LazyJsString lazyJsString => _lazyValue.Equals(lazyJsString._lazyValue),
+            _ => obj is not null && _lazyValue.Equals(obj.ToString())
+        };
+    }
+
+    public override bool IsLooselyEqual(JsValue value)
+    {
+        return value switch
+        {
+            LazyCompressedJsString lazyCompressedJsString => _lazyValue.Equals(lazyCompressedJsString._lazyValue),
+            LazyJsString lazyJsString => _lazyValue.Equals(lazyJsString._lazyValue),
+            _ => value is not null && _lazyValue.Equals(TypeConverter.ToString(value)),
+        };
+    }
+
+    public override int GetHashCode()
+    {
+        return _lazyValue.GetHashCode();
+    }
+
+    public override char this[int index] => _lazyValue.ToString()[index];
+
+    public override int Length => _lazyValue.UncompressedSize;
+}

--- a/src/Raven.Server/Documents/Indexes/Static/LazyJsString.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/LazyJsString.cs
@@ -1,0 +1,49 @@
+using Jint.Native;
+using Jint.Runtime;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Indexes.Static;
+
+internal sealed class LazyJsString : JsString
+{
+    internal readonly LazyStringValue _lazyValue;
+
+    public LazyJsString(LazyStringValue lazyValue) : base(null)
+    {
+        _lazyValue = lazyValue;
+    }
+
+    public override string ToString()
+    {
+        return _lazyValue.ToString();
+    }
+
+    public override bool Equals(JsString obj)
+    {
+        return obj switch
+        {
+            LazyJsString lazyJsString => _lazyValue.Equals(lazyJsString._lazyValue),
+            LazyCompressedJsString lazyCompressedJsString => _lazyValue.Equals(lazyCompressedJsString._lazyValue.ToLazyStringValue()),
+            _ => obj is not null && _lazyValue.Equals(obj.ToString())
+        };
+    }
+
+    public override bool IsLooselyEqual(JsValue value)
+    {
+        return value switch
+        {
+            LazyJsString lazyJsString => _lazyValue.Equals(lazyJsString._lazyValue),
+            LazyCompressedJsString lazyCompressedJsString => _lazyValue.Equals(lazyCompressedJsString._lazyValue.ToLazyStringValue()),
+            _ => value is not null && _lazyValue.Equals(TypeConverter.ToString(value)),
+        };
+    }
+
+    public override int GetHashCode()
+    {
+        return _lazyValue.GetHashCode();
+    }
+
+    public override char this[int index] => _lazyValue.ToString()[index];
+
+    public override int Length => _lazyValue.Length;
+}

--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -11,6 +11,7 @@ using Jint.Runtime.Interop;
 using Lucene.Net.Store;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.JavaScript;
 using Raven.Server.Documents.Queries.Results;
 using Sparrow.Json;
@@ -206,7 +207,7 @@ namespace Raven.Server.Documents.Patch
                             return true;
 
                         case Client.Constants.Documents.Indexing.Fields.EmptyString:
-                            value = string.Empty;
+                            value = JsString.Empty;
                             return true;
                     }
                 }
@@ -240,7 +241,7 @@ namespace Raven.Server.Documents.Patch
                 get => _value;
                 set
                 {
-                    if (Equals(value, _value))
+                    if (Equals(_value, value))
                         return;
                     _value = value;
                     _parent.MarkChanged();
@@ -293,10 +294,10 @@ namespace Raven.Server.Documents.Patch
                         return GetJsValueForLazyNumber(owner?.Engine, (LazyNumberValue)value);
 
                     case BlittableJsonToken.String:
-                        return value.ToString();
+                        return new LazyJsString((LazyStringValue)value);
 
                     case BlittableJsonToken.CompressedString:
-                        return value.ToString();
+                        return new LazyCompressedJsString((LazyCompressedStringValue)value);
 
                     case BlittableJsonToken.StartObject:
                         Changed = true;
@@ -310,10 +311,10 @@ namespace Raven.Server.Documents.Patch
                                 return GetArrayInstanceFromBlittableArray(owner.Engine, blittableArray, owner);
 
                             case LazyStringValue asLazyStringValue:
-                                return asLazyStringValue.ToString();
+                                return new LazyJsString(asLazyStringValue);
 
                             case LazyCompressedStringValue asLazyCompressedStringValue:
-                                return asLazyCompressedStringValue.ToString();
+                                return new LazyCompressedJsString(asLazyCompressedStringValue);
 
                             default:
                                 blittable.NoCache = true;
@@ -396,7 +397,7 @@ namespace Raven.Server.Documents.Patch
             if (property.IsString() == false)
                 return PropertyDescriptor.Undefined;
 
-            return GetOwnProperty(property.AsString());
+            return GetOwnProperty(property.ToString());
         }
 
         public PropertyDescriptor GetOwnProperty(string property)

--- a/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Patch
         protected JsValue _selfInstance;
         protected BlittableObjectInstance _args;
 
-        public virtual bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+        public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
         {
             JsValue referencedName = reference.GetReferencedName();
 

--- a/src/Raven.Server/Documents/Patch/JintPreventResolvingTasksReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintPreventResolvingTasksReferenceResolver.cs
@@ -8,7 +8,7 @@ using Jint.Runtime.References;
 
 namespace Raven.Server.Documents.Patch
 {
-    public class JintPreventResolvingTasksReferenceResolver : JintNullPropagationReferenceResolver
+    public sealed class JintPreventResolvingTasksReferenceResolver : JintNullPropagationReferenceResolver
     {
         public void ExplodeArgsOn(JsValue self, BlittableObjectInstance args)
         {
@@ -18,8 +18,7 @@ namespace Raven.Server.Documents.Patch
 
         public override bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value)
         {
-            if (value.IsObject() &&
-                value.AsObject() is ObjectWrapper objectWrapper &&
+            if (value is ObjectWrapper objectWrapper &&
                 objectWrapper.Target is Task task &&
                 reference.GetReferencedName() == nameof(Task<int>.Result) &&
                 task.IsCompleted == false)

--- a/src/Raven.Server/Documents/Patch/JintStringConverter.cs
+++ b/src/Raven.Server/Documents/Patch/JintStringConverter.cs
@@ -1,20 +1,31 @@
 ﻿using Jint;
 using Jint.Native;
 using Jint.Runtime.Interop;
+using Raven.Server.Documents.Indexes.Static;
 using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Patch
 {
-    public class JintStringConverter : IObjectConverter
+    public sealed class JintStringConverter : IObjectConverter
     {
         public bool TryConvert(Engine engine, object value, out JsValue result)
         {
-            if (value is StringSegment ||
-                value is LazyStringValue ||
-                value is LazyCompressedStringValue)
+            if (value is StringSegment)
             {
                 result = value.ToString();
+                return true;
+            }
+
+            if (value is LazyStringValue lazyStringValue)
+            {
+                result = new LazyJsString(lazyStringValue);
+                return true;
+            }
+
+            if (value is LazyCompressedStringValue lazyCompressedStringValue)
+            {
+                result = new LazyCompressedJsString(lazyCompressedStringValue);
                 return true;
             }
 

--- a/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
+++ b/src/Raven.Server/Documents/Patch/JsBlittableBridge.cs
@@ -15,6 +15,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Raven.Client;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Extensions;
 using Sparrow;
 using Sparrow.Extensions;
@@ -69,6 +70,10 @@ namespace Raven.Server.Documents.Patch
                     _writer.WriteValue(js.AsBoolean());
                 else if (js.IsUndefined() || js.IsNull())
                     _writer.WriteValueNull();
+                else if (js is LazyCompressedJsString lazyCompressedJsString)
+                    _writer.WriteValue(lazyCompressedJsString._lazyValue);
+                else if (js is LazyJsString lazyJsString)
+                    _writer.WriteValue(lazyJsString._lazyValue);
                 else if (js.IsString())
                     _writer.WriteValue(js.AsString());
                 else if (js.IsDate())

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -106,7 +106,13 @@ namespace Raven.Server.Documents.Patch
         {
             try
             {
-                ScriptsSource.Add(Engine.PrepareScript(script));
+                var strict = _parent.Configuration.Patching.StrictMode;
+                if (script.StartsWith("function __selectOutput(", StringComparison.OrdinalIgnoreCase))
+                {
+                    // we cannot be sure about projected elements, they might use strict mode reserved words like 'package'
+                    strict = false;
+                }
+                ScriptsSource.Add(Engine.PrepareScript(script, strict: strict));
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -164,7 +164,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Jint" Version="3.0.0-beta-2044" />
+    <PackageReference Include="Jint" Version="3.0.0-beta-2046" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="4.3.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.1.0" />
     <PackageReference Include="Lextm.SharpSnmpLib.Engine" Version="11.3.102" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19829

### Additional description

This change reduces need to materialize `LazyString`  types when not actually needed (strict and loose equality; indexOf, startsWith, endsWith etc when string length too long to match). We've seen in our patching memory profiling a lot of string materialization even when we are just checking of equality or existence like using `if (!doc.FirstName || doc.LastName === doc.FirstName)`.

This shows the current possibilities in Jint:

https://github.com/sebastienros/jint/blob/4839fd19c7829753e753317d213da8d8e77dadc2/Jint.Tests.PublicInterface/RavenApiUsageTests.cs#L165-L207

Includes Jint upgrade to [version 2046](https://github.com/sebastienros/jint/releases/tag/v3.0.0-beta-2046) which brings JsString API surface.

### Type of change

- Optimization

### How risky is the change?

- Small

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests should cover string handling, tests implemented on Jint side too to ensure API available and works as expected.

### Testing by RavenDB QA team

- Unsure

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
