### PR TITLE
RavenDB-19830 Fields to fetch should not be case insensitive for fiel…

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -4038,7 +4038,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
         protected bool Equals(FieldToFetch other)
         {
-            return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) && string.Equals(Alias, other.Alias, StringComparison.Ordinal);
+            return string.Equals(Name, other.Name) && string.Equals(Alias, other.Alias, StringComparison.Ordinal);
         }
 
         public override bool Equals(object obj)
@@ -4056,7 +4056,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         {
             unchecked
             {
-                return ((Name != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Name) : 0) * 397) ^ (Alias != null ? StringComparer.Ordinal.GetHashCode(Alias) : 0);
+                return ((Name != null ? StringComparer.Ordinal.GetHashCode(Name) : 0) * 397) ^ (Alias != null ? StringComparer.Ordinal.GetHashCode(Alias) : 0);
             }
         }
     }

--- a/test/SlowTests/Issues/GH-15633.cs
+++ b/test/SlowTests/Issues/GH-15633.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class GH_15633 : RavenTestBase
+{
+    public GH_15633(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public async Task CanProjectWhenFieldAndPropertyNameAreTheSameWithDifferentCasing() {
+        const string id = "testdocument/1";
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenAsyncSession()) {
+            var testDoc = new DocWithLambdaProperties {
+                Id = id,
+                Str = "hello"
+            };
+
+            await session.StoreAsync(testDoc);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession()) {
+            var testDocs =
+                await session.Query<DocWithLambdaProperties>()
+                    .ToArrayAsync();
+            Assert.Equal("hello", testDocs[0].Str);   // <-- SUCCEEDS
+        }
+
+        using (var session = store.OpenAsyncSession()) {
+            var testDocs =
+                await session.Query<DocWithLambdaProperties>()
+                    .ProjectInto<DocWithLambdaProperties>()
+                    .ToArrayAsync();
+            Assert.Equal("hello", testDocs[0].Str);   
+        }
+    }
+    
+    public class DocWithLambdaProperties {
+        private string str;
+        public string Id { get; set; }
+        public string Str {
+            get => str;
+            set => str = value;
+        }
+    }
+
+    public class DocWithPlainProperties {
+        public string Id { get; set; }
+        public string Str { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19830.cs
+++ b/test/SlowTests/Issues/RavenDB_19830.cs
@@ -6,19 +6,22 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
-public class GH_15633 : RavenTestBase
+public class RavenDB_19830 : RavenTestBase
 {
-    public GH_15633(ITestOutputHelper output) : base(output)
+    public RavenDB_19830(ITestOutputHelper output) : base(output)
     {
     }
-    
+
     [Fact]
-    public async Task CanProjectWhenFieldAndPropertyNameAreTheSameWithDifferentCasing() {
+    public async Task CanProjectWhenFieldAndPropertyNameAreTheSameWithDifferentCasing()
+    {
         const string id = "testdocument/1";
         using var store = GetDocumentStore();
 
-        using (var session = store.OpenAsyncSession()) {
-            var testDoc = new DocWithLambdaProperties {
+        using (var session = store.OpenAsyncSession())
+        {
+            var testDoc = new DocWithLambdaProperties
+            {
                 Id = id,
                 Str = "hello"
             };
@@ -27,33 +30,32 @@ public class GH_15633 : RavenTestBase
             await session.SaveChangesAsync();
         }
 
-        using (var session = store.OpenAsyncSession()) {
+        using (var session = store.OpenAsyncSession())
+        {
             var testDocs =
                 await session.Query<DocWithLambdaProperties>()
                     .ToArrayAsync();
             Assert.Equal("hello", testDocs[0].Str);   // <-- SUCCEEDS
         }
 
-        using (var session = store.OpenAsyncSession()) {
+        using (var session = store.OpenAsyncSession())
+        {
             var testDocs =
                 await session.Query<DocWithLambdaProperties>()
                     .ProjectInto<DocWithLambdaProperties>()
                     .ToArrayAsync();
-            Assert.Equal("hello", testDocs[0].Str);   
-        }
-    }
-    
-    public class DocWithLambdaProperties {
-        private string str;
-        public string Id { get; set; }
-        public string Str {
-            get => str;
-            set => str = value;
+            Assert.Equal("hello", testDocs[0].Str);
         }
     }
 
-    public class DocWithPlainProperties {
+    private class DocWithLambdaProperties
+    {
+        private string str;
         public string Id { get; set; }
-        public string Str { get; set; }
+        public string Str
+        {
+            get => str;
+            set => str = value;
+        }
     }
 }


### PR DESCRIPTION
…d names

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19830 

### Additional description

If you have a field `str` and property name `Str`, then `ProjectInto` will try to project them both, but `str` (the wrong value) will be added first and prevent the other one from being added

We now compare field names for projection in case sensitive manner.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update


- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work


- No UI work is needed
