### PR TITLE
RavenDB-19240 Add AsAsyncEnumerable to RavenQueryableExtensions

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.Highlighting;
@@ -20,7 +21,7 @@ namespace Raven.Client.Documents.Linq
     /// <summary>
     /// Implements <see cref="IRavenQueryable{T}"/>
     /// </summary>
-    public class RavenQueryInspector<T> : IRavenQueryable<T>, IRavenQueryInspector
+    public class RavenQueryInspector<T> : IRavenQueryable<T>, IRavenQueryInspector, IAsyncEnumerable<T>
     {
         private Expression _expression;
         private IRavenQueryProvider _provider;
@@ -88,6 +89,18 @@ namespace Raven.Client.Documents.Linq
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
+        {
+            var execute = GetAsyncDocumentQuery();
+            var list =  await ((IAsyncDocumentQuery<T>)execute)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var item in list)
+            {
+                yield return item;
+            }
         }
 
         #endregion

--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -93,8 +93,8 @@ namespace Raven.Client.Documents.Linq
 
         public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
         {
-            var execute = GetAsyncDocumentQuery();
-            var list =  await ((IAsyncDocumentQuery<T>)execute)
+            var asyncDocumentQuery = GetAsyncDocumentQuery();
+            var list =  await asyncDocumentQuery
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var item in list)

--- a/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
@@ -142,16 +142,12 @@ namespace Raven.Client.Documents.Linq
         /// <summary>
         /// Implementation of AsAsyncEnumerable
         /// </summary>
-        public static async IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(this IRavenQueryable<TSource> source)
+        public static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(this IQueryable<TSource> source)
         {
-            var provider = (IRavenQueryProvider)source.Provider;
-            var documentQuery = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
+            if (source is IAsyncEnumerable<TSource> asyncEnumerable)
+                return asyncEnumerable;
 
-            var list = await documentQuery.ToListAsync().ConfigureAwait(false);
-            foreach (var item in list)
-            {
-                yield return item;
-            }
+            throw new InvalidOperationException($"The source 'IQueryable' doesn't implement 'IAsyncEnumerable<{typeof(TSource)}>'");
         }
     }
 }

--- a/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Raven.Client.Documents.Session;
 
 namespace Raven.Client.Documents.Linq
 {
@@ -113,6 +115,7 @@ namespace Raven.Client.Documents.Linq
         {
             return (IRavenQueryable<TSource>)Queryable.Skip(source, count);
         }
+
         public static IRavenQueryable<TSource> Take<TSource>(this IRavenQueryable<TSource> source, int count)
         {
             return (IRavenQueryable<TSource>)Queryable.Take(source, count);
@@ -134,6 +137,21 @@ namespace Raven.Client.Documents.Linq
         {
             throw new InvalidOperationException(
                 "This method isn't meant to be called directly, it just exists as a place holder for the LINQ provider");
+        }
+
+        /// <summary>
+        /// Implementation of AsAsyncEnumerable
+        /// </summary>
+        public static async IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>(this IRavenQueryable<TSource> source)
+        {
+            var provider = (IRavenQueryProvider)source.Provider;
+            var documentQuery = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
+
+            var list = await documentQuery.ToListAsync();
+            foreach (var item in list)
+            {
+                yield return item;
+            }
         }
     }
 }

--- a/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryableExtensions.cs
@@ -147,7 +147,7 @@ namespace Raven.Client.Documents.Linq
             var provider = (IRavenQueryProvider)source.Provider;
             var documentQuery = provider.ToAsyncDocumentQuery<TSource>(source.Expression);
 
-            var list = await documentQuery.ToListAsync();
+            var list = await documentQuery.ToListAsync().ConfigureAwait(false);
             foreach (var item in list)
             {
                 yield return item;

--- a/test/SlowTests/Issues/RavenDB-19240.cs
+++ b/test/SlowTests/Issues/RavenDB-19240.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
-using MySqlX.XDevAPI.Relational;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -20,7 +16,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task Test()
+        public async Task Can_Use_AsAsyncEnumerable()
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/Issues/RavenDB-19240.cs
+++ b/test/SlowTests/Issues/RavenDB-19240.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using MySqlX.XDevAPI.Relational;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19240 : RavenTestBase
+    {
+        public RavenDB_19240(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Test()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        session.Store(new User { Name = "User" + i });
+                    }
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var users = session.Query<User>().AsEnumerable();
+                    int i = 0;
+
+                    Assert.Equal(0, session.Advanced.NumberOfRequests);
+
+                    foreach (var user in users)
+                    {
+                        Assert.Equal("User" + i++, user.Name);
+                    }
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var users = session.Query<User>().AsAsyncEnumerable();
+                    int i = 0;
+
+                    Assert.Equal(0, session.Advanced.NumberOfRequests);
+
+                    await foreach (var user in users)
+                    {
+                        Assert.Equal("User" + i++, user.Name);
+                    }
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Tests/Linq/WhereClause.cs
+++ b/test/SlowTests/Tests/Linq/WhereClause.cs
@@ -540,12 +540,12 @@ namespace SlowTests.Tests.Linq
             }
         }
 
-        private static RavenQueryInspector<IndexedUser> GetRavenQueryInspector(IDocumentSession session)
+        private static IRavenQueryable<IndexedUser> GetRavenQueryInspector(IDocumentSession session)
         {
             return (RavenQueryInspector<IndexedUser>)session.Query<IndexedUser>();
         }
 
-        private static RavenQueryInspector<IndexedUser> GetRavenQueryInspectorStatic(IDocumentSession session)
+        private static IRavenQueryable<IndexedUser> GetRavenQueryInspectorStatic(IDocumentSession session)
         {
             return (RavenQueryInspector<IndexedUser>)session.Query<IndexedUser>("static");
         }
@@ -723,7 +723,7 @@ namespace SlowTests.Tests.Linq
             {
                 using (var session = store.OpenSession())
                 {
-                    var indexedUsers = GetRavenQueryInspector(session);
+                    var indexedUsers = (IRavenQueryable<IndexedUser>)GetRavenQueryInspector(session);
                     var q = from user in indexedUsers
                             select user;
                     Assert.Equal("from 'IndexedUsers'", q.ToString());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19240/Add-AsAsyncEnumerable-to-RavenQueryableExtensions

### Type of change

- Bug fix

### How risky is the change?

- Low

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

