### PR TITLE
RavenDB-19654 Change negotiation boundaries based on the `negotiation PrevLogIndex`

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -1014,11 +1014,11 @@ namespace Raven.Server.Rachis
                     {
                         if (_engine.GetTermFor(context, negotiation.PrevLogIndex) == negotiation.PrevLogTerm)
                         {
-                            minIndex = Math.Min(midpointIndex + 1, maxIndex);
+                            minIndex = Math.Min(negotiation.PrevLogIndex + 1, maxIndex);
                         }
                         else
                         {
-                            maxIndex = Math.Max(midpointIndex - 1, minIndex);
+                            maxIndex = Math.Max(negotiation.PrevLogIndex - 1, minIndex);
                         }
                     }
                 }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -786,7 +786,7 @@ namespace Raven.Server.Rachis
                 }
             }
             
-            public static unsafe void InsertToLogDirectly(ClusterOperationContext context, RachisConsensus node, long term, long index, CommandBase cmd, RachisEntryFlags flags)
+            public static unsafe void InsertToLogDirectlyForDebug(ClusterOperationContext context, RachisConsensus node, long term, long index, CommandBase cmd, RachisEntryFlags flags)
             {
                 var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
                 var djv = cmd.ToJson(context);
@@ -805,7 +805,7 @@ namespace Raven.Server.Rachis
                 }
             }
             
-            public static unsafe void UpdateStateDirectly(ClusterOperationContext context, RachisConsensus node, long commitIndex, long commitTerm, long lastTruncatedIndex, long lastTruncatedTerm)
+            public static unsafe void UpdateStateDirectlyForDebug(ClusterOperationContext context, RachisConsensus node, long commitIndex, long commitTerm, long lastTruncatedIndex, long lastTruncatedTerm)
             {
                 node.SetLastCommitIndex(context, commitIndex, commitTerm);
                 var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -785,6 +785,39 @@ namespace Raven.Server.Rachis
                     throw new TimeoutException("Something is wrong, throwing to avoid hanging");
                 }
             }
+            
+            public static unsafe void InsertToLogDirectly(ClusterOperationContext context, RachisConsensus node, long term, long index, CommandBase cmd, RachisEntryFlags flags)
+            {
+                var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
+                var djv = cmd.ToJson(context);
+                using (var cmdJson = context.ReadObject(djv, "raft/command"))
+                {
+                    using (table.Allocate(out TableValueBuilder tvb))
+                    {
+                        tvb.Add(Bits.SwapBytes(index));
+                        tvb.Add(term);
+                        tvb.Add(cmdJson.BasePointer, cmdJson.Size);
+                        tvb.Add((int)flags);
+                        table.Insert(tvb);
+                    }
+
+                    node.LogHistory.InsertHistoryLog(context, index, term, cmdJson);
+                }
+            }
+            
+            public static unsafe void UpdateStateDirectly(ClusterOperationContext context, RachisConsensus node, long commitIndex, long commitTerm, long lastTruncatedIndex, long lastTruncatedTerm)
+            {
+                node.SetLastCommitIndex(context, commitIndex, commitTerm);
+                var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
+                using (state.DirectAdd(LastTruncatedSlice, sizeof(long) * 2, out byte* ptr))
+                {
+                    var data = (long*)ptr;
+                    data[0] = lastTruncatedIndex;
+                    data[1] = lastTruncatedTerm;
+                }
+
+                node.CurrentTerm = lastTruncatedIndex;
+            }
         }
 
         internal void SetNewStateInTx(ClusterOperationContext context,

--- a/test/RachisTests/RavenDB_19654.cs
+++ b/test/RachisTests/RavenDB_19654.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace RachisTests;
+
+public class RavenDB_19654 : RachisConsensusTestBase
+{
+    public RavenDB_19654(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private Dictionary<string, LogInfo> TestData = new Dictionary<string, LogInfo>
+    {
+        ["A"] = new LogInfo
+        {
+            CommitIndex = 664033464,
+            LastTruncatedIndex = 664033448,
+            LastTruncatedTerm = 1163367,
+            FirstEntryIndex = 664033449,
+            LastLogEntryIndex = 664033464,
+            Entries = new (long Index, long Term)[]
+            {
+                (Index: 664033449, Term: 1163368),
+                (Index: 664033454, Term: 1163370),
+            }
+        },
+        ["B"] = new LogInfo
+        {
+            CommitIndex = 664033453,
+            LastTruncatedIndex = 664033430,
+            LastTruncatedTerm = 1163367,
+            FirstEntryIndex = 664033431,
+            LastLogEntryIndex = 664033464,
+            Entries = new (long Index, long Term)[]
+            {
+                (Index: 664033431, Term: 1163367),
+                (Index: 664033449, Term: 1163368),
+            }
+        }
+    };
+    
+    [Fact]
+    public async Task CanHandleLogDivergence()
+    {
+        var leader = await CreateNetworkAndGetLeader(2);
+        var follower = GetFollowers().Single();
+
+        using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        using (follower.ContextPool.AllocateOperationContext(out ClusterOperationContext context2))
+        using (var tx1 = context.OpenWriteTransaction())
+        using (var tx2 = context2.OpenWriteTransaction())
+        {
+            leader.CurrentLeader?.StepDown(forceElection: false);
+
+            LastCommittedTerm(leader, context, TestData["A"]);
+            LastCommittedTerm(follower, context2, TestData["B"]);
+
+            var basePath = "/home/haludi/work/ravendb/RavenDB-19654/Logs";
+             var currentDir = DateTime.Now.ToString("yyyyMMdd-hhmmss");
+             LoggingSource.Instance.SetupLogMode(LogMode.Information, Path.Combine(basePath, currentDir), TimeSpan.MaxValue, long.MaxValue, false);
+            
+            tx2.Commit();
+            tx1.Commit();
+        }
+
+        long lastIndex;
+        using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            lastIndex = leader.GetLastCommitIndex(context);
+        }
+
+        await follower.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex);
+    }
+
+    private static void LastCommittedTerm(RachisConsensus<CountingStateMachine> node, ClusterOperationContext context, LogInfo info)
+    {
+        node.ClearAppendedEntriesAfter(context, 0);
+        var lastCommittedTerm = -1L;
+
+        foreach (var (term, index) in info)
+        {
+            if (info.CommitIndex == index)
+                lastCommittedTerm = term;
+
+            var cmd = new TestCommand {Name = "test", Value = 1};
+            RachisConsensus.TestingStuff.InsertToLogDirectly(context, node, term, index, cmd, RachisEntryFlags.StateMachineCommand);
+        }
+
+        RachisConsensus.TestingStuff.UpdateStateDirectly(context, node, info.CommitIndex, lastCommittedTerm, info.LastTruncatedIndex, info.LastTruncatedTerm);
+    }
+
+    private class LogInfo : IEnumerable<(long Term, long Index)>
+    {
+        public long CommitIndex;
+        public long LastTruncatedIndex;
+        public long LastTruncatedTerm;
+        public long FirstEntryIndex;
+        public long LastLogEntryIndex;
+
+        public (long Index, long Term)[] Entries;
+        public IEnumerator<(long Term, long Index)> GetEnumerator()
+        {
+            var entries = Entries;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                var firstInTerm = entries[i];
+                var firstInNextTerm = i + 1 < entries.Length ? entries[i + 1].Index - 1 : LastLogEntryIndex;
+                for (long j = firstInTerm.Index; j <= firstInNextTerm; j++)
+                {
+                    yield return (firstInTerm.Term, j);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19654

### Additional description

In the follower, we compare the term of `negotiation.PrevLogIndex` in the follower to the term in the leader (negotiation.PrevLogTerm) to decide if we need to cut the boundaries from the bottom or from the top.
But we modify the min/max due to `midpointIndex`.
With this modification, the binderies can pass the desired value.
That trigger starts the negotiation from scratch but if the initial state leads to the same situation it will happen again and again and again...

### Type of change
- Bug fix

### How risky is the change?
- High

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Test added

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
