### PR TITLE
RavenDB-19842 - Purge the field cache for order by when we are in low memory state

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/IndexReadOperation.cs
@@ -62,6 +62,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         private FastVectorHighlighter _highlighter;
         private FieldQuery _highlighterQuery;
+        private static LuceneCleaner _luceneCleaner;
+
+        static IndexReadOperation()
+        {
+            _luceneCleaner = new LuceneCleaner();
+        }
 
         public IndexReadOperation(Index index, LuceneVoronDirectory directory, IndexSearcherHolder searcherHolder, QueryBuilderFactories queryBuilderFactories, Transaction readTransaction, IndexQueryServerSide query)
             : base(index, LoggingSource.Instance.GetLogger<IndexReadOperation>(index._indexStorage.DocumentDatabase.Name))

--- a/src/Raven.Server/Indexing/LuceneCleaner.cs
+++ b/src/Raven.Server/Indexing/LuceneCleaner.cs
@@ -1,0 +1,21 @@
+﻿using Lucene.Net.Search;
+using Sparrow.LowMemory;
+
+namespace Raven.Server.Indexing;
+
+public class LuceneCleaner : ILowMemoryHandler
+{
+    public LuceneCleaner()
+    {
+        LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
+    }
+
+    public void LowMemory(LowMemorySeverity lowMemorySeverity)
+    {
+        FieldCache_Fields.DEFAULT.PurgeAllCaches();
+    }
+
+    public void LowMemoryOver()
+    {
+    }
+}

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -114,7 +114,6 @@ namespace Raven.Server.ServerWide
 
         private readonly NotificationsStorage _notificationsStorage;
         private readonly OperationsStorage _operationsStorage;
-        private readonly LuceneCleaner _luceneCleaner;
         public ConcurrentDictionary<string, Dictionary<string, long>> IdleDatabases;
 
         private RequestExecutor _clusterRequestExecutor;
@@ -168,8 +167,6 @@ namespace Raven.Server.ServerWide
             ThreadsInfoNotifications = new ThreadsInfoNotifications(ServerShutdown);
 
             _operationsStorage = new OperationsStorage();
-
-            _luceneCleaner = new LuceneCleaner();
 
             Operations = new Operations(null, _operationsStorage, NotificationCenter, null,
                 (PlatformDetails.Is32Bits || Configuration.Storage.ForceUsing32BitsPager

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -92,7 +92,7 @@ namespace Raven.Server.ServerWide
     /// <summary>
     /// Persistent store for server-wide configuration, such as cluster settings, database configuration, etc
     /// </summary>
-    public class ServerStore : IDisposable
+    public class ServerStore : IDisposable, ILowMemoryHandler
     {
         private const string ResourceName = nameof(ServerStore);
 
@@ -230,6 +230,8 @@ namespace Raven.Server.ServerWide
                     }
                 }
             });
+
+            LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }
 
         internal readonly FifoSemaphore ServerWideConcurrentlyRunningIndexesLock;
@@ -3411,6 +3413,15 @@ namespace Raven.Server.ServerWide
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
+        }
+
+        public void LowMemory(LowMemorySeverity lowMemorySeverity)
+        {
+            FieldCache_Fields.DEFAULT.PurgeAllCaches();
+        }
+
+        public void LowMemoryOver()
+        {
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19842/Unmanged-memory-isnt-cleaned-in-case-of-low-memory-event

### Additional description

Purge the field cache for order by when we are in low memory state.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
