### PR TITLE
RavenDB-19843 Lucene - order by ticks when field contains dates.

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -458,6 +458,12 @@ namespace Raven.Server.Config.Categories
             ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex { get; set; }
         
+        [Description("Sort by ticks when field contains dates.")]
+        [DefaultValue(true)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool OrderByTicksAutomaticallyWhenDatesAreInvolved { get; set; }
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -670,7 +670,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
                 var fieldName = field.Name.Value;
                 var sortOptions = SortField.STRING;
-
                 switch (field.OrderingType)
                 {
                     case OrderByFieldType.Custom:
@@ -689,6 +688,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     case OrderByFieldType.Double:
                         sortOptions = SortField.DOUBLE;
                         fieldName += Constants.Documents.Indexing.Fields.RangeFieldSuffixDouble;
+                        break;
+                    case OrderByFieldType.Implicit:
+                        if (index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(fieldName))
+                        {
+                            sortOptions = SortField.LONG;
+                            fieldName += Constants.Documents.Indexing.Fields.TimeFieldSuffix;
+                        }
+
                         break;
                 }
 

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -35,7 +35,8 @@ class configurationItem {
         "Indexing.Lucene.UseCompoundFileInMerging",
         "Indexing.Lucene.IndexInputType",
         "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
-        "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb"
+        "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
+        "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -78,6 +78,7 @@ namespace FastTests.Issues
                 "Indexing.Lucene.IndexInputType",
                 "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
                 "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
+                "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19843/Lucene-order-by-ticks-when-field-contains-dates.

### Additional description

Implemented sorting by ticks when order by field is date

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured.
- Can be revert by configuration option

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using QA Required tag.

### Is there any existing behavior change of other features due to this change?

- Yes.
Querying with order by date field

### UI work

- No UI work is needed
