### PR TITLE
RavenDB-19852 MultiGetHandler will follow `AcceptEncoding` from request.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19852.cs
+++ b/test/SlowTests/Issues/RavenDB-19852.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using FastTests;
+using Raven.Client.Documents.Commands.MultiGet;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19852 : RavenTestBase
+{
+    public RavenDB_19852(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ResponseFromMultiGetIsCompressed()
+    {
+        using var store = GetDocumentStore();
+        const string docs = "/docs";
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Company() {Name = new string('a', 10), Id = "doc/1"}, id: "doc/1");
+            session.SaveChanges();
+        }
+
+        using (var commands = store.Commands())
+        {
+            using var firstCommand = new MultiGetCommandForCompressionTest(commands.RequestExecutor,
+                new List<GetRequest> {new GetRequest {Url = docs, Query = "?id=doc/1"}});
+
+            commands.RequestExecutor.Execute(firstCommand, commands.Context);
+        }
+    }
+
+    private class MultiGetCommandForCompressionTest : MultiGetCommand
+    {
+        public MultiGetCommandForCompressionTest(RequestExecutor requestExecutor, List<GetRequest> commands) : base(requestExecutor, commands)
+        {
+            ResponseType = RavenCommandResponseType.Raw;
+        }
+
+        internal MultiGetCommandForCompressionTest(RequestExecutor requestExecutor, List<GetRequest> commands, SessionInfo sessionInfo) : base(requestExecutor, commands,
+            sessionInfo)
+        {
+        }
+
+        public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
+        {
+            // Automatic decompression clears info about content-encodings. We've to assert by ContentType.
+            Assert.Contains("GZip", response.Content.GetType().Name);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19852 
### Additional description

We've to set `AcceptEncodings`  before writing a response.  Before optimization, it was done by the server automatically because we were writing immediately to the stream.

### Type of change

- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
