### PR TITLE
RavenDB-19235: failing test fix

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2743,7 +2743,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }, true);
                 Assert.Null(afterDelayTaskBackupInfo.LastFullBackup);
                 Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                            afterDelayTaskBackupInfo.NextBackup.TimeSpan <= delayDuration);
+                            afterDelayTaskBackupInfo.NextBackup.TimeSpan <= delayDuration, 
+                    $"NextBackup in: `{afterDelayTaskBackupInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                    $"delayDuration: `{delayDuration}`");
 
                 // DelayUntil value in backup status and the time of scheduled next backup should be equal
                 var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
@@ -2814,7 +2816,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Null(periodicBackup.RunningTask);
                 Assert.Null(periodicBackup.RunningBackupStatus);
                 var nextBackup = periodicBackup.GetNextBackup().TimeSpan;
-                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration);
+                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration, 
+                    $"NextBackup in: `{nextBackup}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                    $"delayDuration: `{delayDuration}`");
 
                 onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                 Assert.NotNull(onGoingTaskInfo);
@@ -2858,7 +2862,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
                 await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
-
                 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
@@ -2897,12 +2900,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await WaitForValueAsync(async () =>
                 {
                     onGoingTaskBackup = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return onGoingTaskBackup != null;
+                    return onGoingTaskBackup is { OnGoingBackup: null } &&
+                           onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
+                           onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration;
                 }, true);
-
                 Assert.NotNull(onGoingTaskBackup.NextBackup);
-                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                            onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration);
                 Assert.NotEqual(onGoingTaskBackup.ResponsibleNode.NodeTag, serverToObserve.ServerStore.NodeTag);
 
                 // DelayUntil value in backup status and the time of scheduled next backup should be equal
@@ -2977,7 +2979,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                         var nextBackupTimeSpan = inMemoryStatus.DelayUntil - DateTime.UtcNow;
                         Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                                    nextBackupTimeSpan <= delayDuration);
+                                    nextBackupTimeSpan <= delayDuration,
+                            $"NextBackup in: `{nextBackupTimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                            $"delayDuration: `{delayDuration}`");
                     }
                 }
             }
@@ -3034,7 +3038,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }, true);
                 Assert.Null(onGoingTaskInfo.LastFullBackup);
                 Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                            onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration);
+                            onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration,
+                    $"NextBackup in: `{onGoingTaskInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                    $"delayDuration: `{delayDuration}`");
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19235/Add-the-ability-to-cancel-and-delay-server-wide-backups-by-Operator

### Additional description

In case the backup is causing problems for the server, we need to be able to delay and cancel such operation for a set time

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio