### PR TITLE
RavenDB-19854 `Logs.Microsoft.ConfigurationPath` as `ReadOnlyPath`

### DIFF
--- a/src/Raven.Server/Config/Categories/LogsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LogsConfiguration.cs
@@ -68,6 +68,7 @@ namespace Raven.Server.Config.Categories
         public PathSetting MicrosoftLogsPath { get; set; }
         
         [Description("The path to json configuration file of Microsoft logs")]
+        [ReadOnlyPath]
         [DefaultValue("settings.logs.microsoft.json")]
         [ConfigurationEntry("Logs.Microsoft.ConfigurationPath", ConfigurationEntryScope.ServerWideOnly)]
         public PathSetting MicrosoftLogsConfigurationPath { get; set; }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19854

### Additional description
Avoid writing privilege check for  `Logs.Microsoft.ConfigurationPath`

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
