### PR TITLE
RavenDB-18384 - SlowTests.Client.TimeSeries.Query.QueryFromMultipleTi…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
@@ -1043,7 +1043,88 @@ select out()
                     }
 
                     var expected = 8;
-                    if (now.Hour == 23 && (now.Minute > 0 || now.Second > 0))
+                    if (now.Hour == 23 && (now.Minute > 0 || now.Second >= 0))
+                        expected--; // if now is 23:00:34, we will not get any result for that day, only for the next one
+
+                    Assert.Equal(expected, days.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RavenDB_18384()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var raw = new RawTimeSeriesPolicy(TimeSpan.FromHours(24));
+                var p1 = new TimeSeriesPolicy("By1Day", TimeSpan.FromDays(1));
+
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            RawPolicy = raw,
+                            Policies = new List<TimeSeriesPolicy>
+                            {
+                                p1
+                            }
+                        }
+                    }
+                };
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                var now = new DateTime(2022, 8, 31, 23, 0, 0);
+                now = now.AddMilliseconds(1);
+                database.Time.UtcDateTime = () => now;
+
+                var baseline = now.AddDays(-12);
+                var total = TimeSpan.FromDays(12).TotalMinutes;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/karmel");
+                    for (int i = 0; i <= total; i++)
+                    {
+                        session.TimeSeriesFor("users/karmel", "Heartrate")
+                            .Append(baseline.AddMinutes(i), i, "watches/fitbit");
+                    }
+                    session.SaveChanges();
+                }
+
+                await database.TimeSeriesPolicyRunner.RunRollups();
+                await database.TimeSeriesPolicyRunner.DoRetention();
+
+                await TimeSeries.VerifyPolicyExecutionAsync(store, config.Collections["Users"], 12);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"
+declare timeseries out() 
+{
+    from Heartrate
+    between $start and $end
+    group by 1h
+    select avg()
+}
+from Users as u
+select out()
+")
+                        .AddParameter("start", now.AddDays(-7))
+                        .AddParameter("end", now);
+
+                    var aggregationResult = query.Single();
+
+                    var days = new HashSet<DateTime>();
+                    foreach (var g in aggregationResult.Results.GroupBy(r => new DateTime(r.From.Year, r.From.Month, r.From.Day)))
+                    {
+                        days.Add(g.Key);
+                    }
+
+                    var expected = 8;
+                    if (now.Hour == 23 && (now.Minute > 0 || now.Second >= 0))
                         expected--; // if now is 23:00:34, we will not get any result for that day, only for the next one
 
                     Assert.Equal(expected, days.Count);


### PR DESCRIPTION
…meSeries.SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.QueryFromMultipleTimeSeriesAtOnce_AggregationQuery_NoRetention

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18384/SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.Quer

### Additional description

Changes already exist for v5.3+

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
