### PR TITLE
RavenDB-19857 Use universal time when validating certificate for developer license

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -949,8 +949,8 @@ namespace Raven.Server.Commercial
             X509Certificate2 certificate = null;
             if (_serverStore.Server.Certificate.Certificate != null)
             {
-                certificateNotBefore  = _serverStore.Server.Certificate.Certificate.NotBefore; 
-                certificateNotAfter  = _serverStore.Server.Certificate.Certificate.NotAfter; 
+                certificateNotBefore  = _serverStore.Server.Certificate.Certificate.NotBefore.ToUniversalTime(); 
+                certificateNotAfter  = _serverStore.Server.Certificate.Certificate.NotAfter.ToUniversalTime(); 
                 certificate = _serverStore.Server.Certificate.Certificate;   
             }
             


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19857

### Additional description
The comparison does not take into account the difference in the offset between the `DateTime` s 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- It requires further work in the Studio
- No UI work is needed
