### PR TITLE
RavenDB-17071 - SlowTests.Cluster.CompareExchangeExpirationTest.CanAd…

### DIFF
--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Cluster
                 }))
                 {
                     server.ServerStore.Observer.Time.UtcDateTime = () => DateTime.UtcNow;
-                    server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks = DateTime.UtcNow.Ticks;
+                    var local = server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks = DateTime.UtcNow.Ticks;
 
                     var rnd = new Random(DateTime.Now.Millisecond);
                     var user = new User { Name = new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray()) };
@@ -99,6 +99,16 @@ namespace SlowTests.Cluster
                     }, 0);
 
                     Assert.Equal(0, val);
+
+                    var val2 = await WaitForValueAsync(() =>
+                    {
+                        if (local == server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks)
+                            return false;
+
+                        return true;
+                    }, true);
+
+                    Assert.Equal(true, val2);
                 }
             }
         }

--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -63,6 +63,9 @@ namespace SlowTests.Cluster
                     Server = server
                 }))
                 {
+                    server.ServerStore.Observer.Time.UtcDateTime = () => DateTime.UtcNow;
+                    server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks = DateTime.UtcNow.Ticks;
+
                     var rnd = new Random(DateTime.Now.Millisecond);
                     var user = new User { Name = new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray()) };
                     var expiry = DateTime.Now.AddMinutes(2);
@@ -96,9 +99,6 @@ namespace SlowTests.Cluster
                     }, 0);
 
                     Assert.Equal(0, val);
-
-                    server.ServerStore.Observer.Time.UtcDateTime = () => DateTime.UtcNow;
-                    server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks = DateTime.UtcNow.Ticks;
                 }
             }
         }


### PR DESCRIPTION
…dCompareExchangeWithExpiration

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17071/SlowTests.Cluster.CompareExchangeExpirationTest.CanAddCompareExchangeWithExpiration

### Additional description

In the test, at the end of each `foreach` iteration, we are setting the values of: 

- `server.ServerStore.Observer.Time `              

- `server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks `

_BUT_, there is a race condition -> we may be in the middle of `DeleteExpiredCompareExchangeCommand`, that can change the value of `_lastExpiredCompareExchangeCleanupTimeInTicks` right after we set the value from the test (https://github.com/ravendb/ravendb/blob/v5.2/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs#L101) 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
