### PR TITLE
RavenDB-19858 - Communications with previous versions servers' fails after adding Tcp Compression on cluster communication

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpNegotiation.cs
@@ -73,11 +73,9 @@ namespace Raven.Client.ServerWide.Tcp
                 }
 
                 var supportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(parameters.Operation, current);
-
-                return new TcpConnectionHeaderMessage.SupportedFeatures(supportedFeatures)
-                {
-                    DataCompression = dataCompression
-                };
+                var results = new TcpConnectionHeaderMessage.SupportedFeatures(supportedFeatures);
+                results.DataCompression &= dataCompression;
+                return results;
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19858/Communications-with-previous-versions-servers-fails-after-adding-Tcp-Compression-on-cluster-communication

### Additional description

Fixing Communications with previous versions servers fails after adding Tcp Compression on cluster communication.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- No tests added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
