### PR TITLE
RavenDB-19697 IndexVisitor can scan multiselect / where in InvocationExpression

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
         public bool IsSuitedForMerge { get; set; }
         public string Comment { get; set; }
 
+        public bool IsFanout { get; set; }
+
         public string Collection { get; set; }
         public InvocationExpressionSyntax InvocationExpression { get; set; }
         public IndexDefinition Index => _index;

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexVisitor.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using NetTopologySuite.GeometriesGraph;
 
 namespace Raven.Server.Documents.Indexes.IndexMerging
 {
@@ -20,6 +22,8 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
         public override SyntaxNode VisitQueryExpression(QueryExpressionSyntax node)
         {
+            AssertSufficientStack();
+
             _indexData.FromExpression = node.FromClause.Expression;
             _indexData.FromIdentifier = node.FromClause.Identifier.ValueText;
             _indexData.NumberOfFromClauses++;
@@ -31,47 +35,58 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
         public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
         {
-            _indexData.Collection ??= node.Name.Identifier.ValueText;
+            AssertSufficientStack();
             return base.VisitMemberAccessExpression(node);
         }
-
+        
         public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax invocationExpression)
         {
-            var selectExpressions = new Dictionary<string, ExpressionSyntax>();
-            var visitor = new CaptureSelectExpressionsAndNewFieldNamesVisitor(false, new HashSet<string>(), selectExpressions);
-            invocationExpression.Accept(visitor);
+            AssertSufficientStack();
 
-            var memberAccessExpression = invocationExpression.Expression as MemberAccessExpressionSyntax;
-
-            // select new { x = t.Select(x)
-            if (memberAccessExpression == null || invocationExpression?.Parent is AnonymousObjectMemberDeclaratorSyntax)
+            var memberAccessExpressionSyntax = invocationExpression.Expression as MemberAccessExpressionSyntax;
+            switch (memberAccessExpressionSyntax?.Name.Identifier.ValueText)
             {
-                return base.VisitInvocationExpression(invocationExpression);
+                case "LoadDocument":
+                    _indexData.HasLet = true;
+                    return base.VisitInvocationExpression(invocationExpression);
+                case "Where":
+                    _indexData.HasWhere = true;
+                    return base.VisitInvocationExpression(invocationExpression);
+                case "SelectMany":
+                    _indexData.IsFanout = true;
+                    return base.VisitInvocationExpression(invocationExpression);
             }
+            
+            if (_indexData.NumberOfSelectClauses >= 1 || _indexData.IsFanout || _indexData.HasLet || _indexData.HasOrder || _indexData.HasWhere || _indexData.HasGroup) //skip multiselect indexes for now.
+                return base.VisitInvocationExpression(invocationExpression);
 
-            if (memberAccessExpression.Name.Identifier.ValueText == "Where")
-                _indexData.HasWhere = true;
-
-            _indexData.SelectExpressions = selectExpressions;
+            if (memberAccessExpressionSyntax?.Name.Identifier.ValueText == "Select")
+                _indexData.NumberOfSelectClauses++;
+            
             _indexData.InvocationExpression = invocationExpression;
             _indexData.FromIdentifier = (invocationExpression.ArgumentList.Arguments[0].Expression as SimpleLambdaExpressionSyntax)?.Parameter.Identifier.ValueText;
+            
+            var arguments = invocationExpression.ArgumentList.Arguments;
+            var lambdaExpression = arguments[0].Expression as SimpleLambdaExpressionSyntax;
 
-            if (memberAccessExpression.Expression is IdentifierNameSyntax identifierNameSyntax)
+            var expressionSyntaxes = new Dictionary<string, ExpressionSyntax>();
+            var evaluator = new CaptureSelectExpressionsAndNewFieldNamesVisitor(false, new(), expressionSyntaxes);
+            switch (lambdaExpression!.ExpressionBody)
             {
-                _indexData.Collection = identifierNameSyntax.Identifier.ValueText;
-                return base.VisitInvocationExpression(invocationExpression);
+                case AnonymousObjectCreationExpressionSyntax aoces:
+                    evaluator.VisitAnonymousObjectCreationExpression(aoces);
+                    break;
             }
 
-            if (memberAccessExpression.Expression is MemberAccessExpressionSyntax innerMemberAccessExpression)
-            {
-                _indexData.Collection = innerMemberAccessExpression.Name.Identifier.ValueText;
-            }
-
+            _indexData.SelectExpressions = expressionSyntaxes;
+            
             return base.VisitInvocationExpression(invocationExpression);
         }
-
+        
         public override SyntaxNode VisitQueryBody(QueryBodySyntax node)
         {
+            AssertSufficientStack();
+            
             if ((node.SelectOrGroup is SelectClauseSyntax) == false)
             {
                 return base.VisitQueryBody(node);
@@ -82,39 +97,52 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             var visitor = new CaptureSelectExpressionsAndNewFieldNamesVisitor(false, new HashSet<string>(), selectExpressions);
             node.Accept(visitor);
 
+            
             _indexData.SelectExpressions = selectExpressions;
             _indexData.NumberOfSelectClauses++;
+           
             return base.VisitQueryBody(node);
         }
 
         public override SyntaxNode VisitWhereClause(WhereClauseSyntax queryWhereClause)
         {
+            AssertSufficientStack();
             _indexData.HasWhere = true;
             return base.VisitWhereClause(queryWhereClause);
         }
 
         public override SyntaxNode VisitOrderByClause(OrderByClauseSyntax queryOrderClause)
         {
+            AssertSufficientStack();
             _indexData.HasOrder = true;
             return base.VisitOrderByClause(queryOrderClause);
         }
 
         public override SyntaxNode VisitOrdering(OrderingSyntax queryOrdering)
         {
+            AssertSufficientStack();
             _indexData.HasOrder = true;
             return base.VisitOrdering(queryOrdering);
         }
 
         public override SyntaxNode VisitGroupClause(GroupClauseSyntax queryGroupClause)
         {
+            AssertSufficientStack();
             _indexData.HasGroup = true;
             return base.VisitGroupClause(queryGroupClause);
         }
 
         public override SyntaxNode VisitLetClause(LetClauseSyntax queryLetClause)
         {
+            AssertSufficientStack();
             _indexData.HasLet = true;
             return base.VisitLetClause(queryLetClause);
+        }
+
+        private void AssertSufficientStack()
+        {
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack() == false)
+                throw new InvalidDataException($"Index is too complex for {nameof(IndexMerger)}.");
         }
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19697 

### Additional description

When index is in SyntaxQuery we trying to find more metadata about index.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
