### PR TITLE
RavenDB-19858 -  Add tests for cluster communication with tcp compression

### DIFF
--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -77,7 +77,7 @@ namespace InterversionTests
         }
 
         protected async Task<(RavenServer Leader, List<ProcessNode> Peers, List<RavenServer> LocalPeers)> CreateMixedCluster(
-            string[] peers, int localPeers = 0, IDictionary<string, string> customSettings = null, X509Certificate2 certificate = null)
+            string[] peers, int localPeers = 0, IDictionary<string, string> customSettings = null, X509Certificate2 certificate = null, bool watcherCluster = true)
         {
             var leaderServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
             await leaderServer.ServerStore.EnsureNotPassiveAsync(leaderServer.WebUrl);
@@ -105,7 +105,7 @@ namespace InterversionTests
                 for (int i = 0; i < localPeers; i++)
                 {
                     var peer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
-                    var addCommand = new AddClusterNodeCommand(peer.WebUrl);
+                    var addCommand = new AddClusterNodeCommand(peer.WebUrl, watcher: watcherCluster);
                     await requestExecutor.ExecuteAsync(addCommand, context);
                     Assert.True(nodeAdded.WaitOne(TimeSpan.FromSeconds(30)));
                     nodeAdded.Reset();

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -860,6 +860,20 @@ namespace InterversionTests
 
         }
 
+        [Fact]
+        public async Task ClusterTcpCompressionTest()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var (leader, peers, local) = await CreateMixedCluster(new [] { "5.4.0", "5.4.0", "5.4.0" }, watcherCluster: true);
+            await UpgradeServerAsync("current", peers[0]);
+            var database = GetDatabaseName();
+            var (disposable, stores) = await GetStores(database, peers);
+            using (disposable)
+            {
+                await CreateDatabase(stores, database, peers.Count);
+            }
+        }
+
         [Fact(Skip = "WIP")]
         public async Task V40Cluster_V41Client_Counters()
         {

--- a/test/SlowTests/RavenDB-18634.cs
+++ b/test/SlowTests/RavenDB-18634.cs
@@ -22,10 +22,12 @@ namespace SlowTests
         {
         }
 
-        [Fact]
-        public async Task DisableTcpCompressionIn1ServerOutOf2InCluster()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DisableTcpCompressionIn1ServerOutOf2InCluster(bool watcherCluster)
         {
-            var (nodes, leader) = await CreateRaftCluster(2);
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: watcherCluster);
 
             // modify configuration
             AdminJsConsoleTests.ExecuteScript(leader, database: null, "server.Configuration.Server.DisableTcpCompression = true;");
@@ -38,6 +40,5 @@ namespace SlowTests
             Assert.NotNull(db0);
             Assert.NotNull(db1);
         }
-
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19858/Communications-with-previous-versions-servers-fails-after-adding-Tcp-Compression-on-cluster-communication

### Additional description

Adding test for a node whose data compression is disabled on a watcher cluster, and test for mix versions cluster whose leader is the only node that is updated and supports cluster communication with TCP compression.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
