### PR TITLE
RavenDB-19865 - Use the AWS S3 API for uploading the backups

### DIFF
--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -101,6 +101,12 @@
     <LuceneQuery-Raven-Database-IndexingParser>$(ProjectDir)Indexing\LuceneQuery</LuceneQuery-Raven-Database-IndexingParser>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.Core.3.7.103.20\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.S3.3.7.101.58\lib\net45\AWSSDK.S3.dll</HintPath>
+    </Reference>
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.2.16.1.0\lib\net45\CsvHelper.dll</HintPath>
       <Private>True</Private>
@@ -1486,6 +1492,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\AWSSDK.S3.3.7.101.58\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
     <Analyzer Include="..\SharedLibs\Raven.CodeAnalysis.dll" />
   </ItemGroup>
   <ItemGroup Label="LuceneQuery-Raven-Database-IndexingFiles">

--- a/Raven.Database/packages.config
+++ b/Raven.Database/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AWSSDK.Core" version="3.7.103.20" targetFramework="net45" />
+  <package id="AWSSDK.S3" version="3.7.101.58" targetFramework="net45" />
   <package id="CsvHelper" version="2.16.1.0" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="ICSharpCode.NRefactory" version="5.3.0" targetFramework="net45" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19865/Add-support-for-uploading-more-than-5GB-to-S3

### Additional description

Use the AWS S3 API for uploading the backups in order to support backups that are larger than `5GB`.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
