### PR TITLE
RavenDB-19866 Prevent ISerializable support by default in the serializer

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/DefaultRavenContractResolver.cs
@@ -49,6 +49,9 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson
 
             _conventions = (NewtonsoftJsonSerializationConventions)conventions;
 
+            IgnoreSerializableAttribute = true;
+            IgnoreSerializableInterface = true;
+            
             if (MembersSearchFlag == null)
             {
                 return; // use the JSON.Net default, primarily here because it allows user to turn this off if this is a compact issue.


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19866 

### Additional description

Avoid support `ISerializable` - since there are no good scenarios for its use, and it can be surprising down the line

### Type of change

- Task

### How risky is the change?

- Low
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

