### PR TITLE
RavenDB-15629 Added extracting index fields for JS indexes when possible

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -157,7 +157,7 @@ namespace Raven.Server.Documents.Indexes.Static
                             HasBoostedFields = true;
                         else if (IsCreateDynamicExpression(ce))
                             HasDynamicReturns = true;
-                        else if (ce.Arguments.Count == 1 && ce.Arguments.AsNodes()[0] is ArrowFunctionExpression afe && afe.Body is ObjectExpression oea)
+                        else if (IsArrowFunctionExpressionWithObjectExpressionBody(ce, out var oea))
                         {
                             foreach (var prop in oea.Properties)
                             {
@@ -187,6 +187,15 @@ namespace Raven.Server.Documents.Indexes.Static
             static bool IsCreateDynamicExpression(Expression expression)
             {
                 return expression is CallExpression ce && ce.Callee is Identifier identifier && identifier.Name == "createField";
+            }
+
+            static bool IsArrowFunctionExpressionWithObjectExpressionBody(CallExpression callExpression, out ObjectExpression oea)
+            {
+                oea = null;
+                if (callExpression.Arguments.Count == 1 && callExpression.Arguments.AsNodes()[0] is ArrowFunctionExpression afe && afe.Body is ObjectExpression _oea)
+                    oea = _oea;
+                
+                return oea != null;
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-15629.cs
+++ b/test/SlowTests/Issues/RavenDB-15629.cs
@@ -1,0 +1,86 @@
+using System.Net.Http;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_15629 : RavenTestBase
+{
+    public RavenDB_15629(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private class GetIndexFieldsForStudioCommand : RavenCommand<object>
+    {
+        public GetIndexFieldsForStudioCommand()
+        {
+            
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/studio/index-fields";
+
+            var payload = new { Map = @"timeSeries.map('Users', 'HeartRate', function (ts) {
+                            return ts.Entries.map(entry => ({
+                                HeartBeat: entry.Value,
+                                Date: new Date(entry.Timestamp.getFullYear(), entry.Timestamp.getMonth(), entry.Timestamp.getDate()),
+                                User: ts.DocumentId,
+                                Count: 1
+                            }));
+                        })" };
+            
+            var payloadJson = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(payload, ctx);
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await ctx.WriteAsync(stream, payloadJson);
+                })
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+            
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+     }
+
+    [Fact]
+    public void CheckIfCorrectIndexFieldsAreReturnedForJsIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var cmd = new GetIndexFieldsForStudioCommand();
+                commands.Execute(cmd);
+
+                var res = cmd.Result;
+                var result = ((BlittableJsonReaderObject)res)["Results"] as BlittableJsonReaderArray;
+                Assert.NotNull(result);
+                Assert.Equal("HeartBeat", result[0]);
+                Assert.Equal("Date", result[1]);
+                Assert.Equal("User", result[2]);
+                Assert.Equal("Count", result[3]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15629/StudioIndexHandler.PostIndexFields-returns-no-results-for-JavaScript-indexes

### Additional description

We want to return index fields for JavaScript indexes when it's possible to extract them

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
