### PR TITLE
RavenDB-17341 Import/Export IndexesHistory from DatabaseRecord.

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
@@ -62,5 +62,6 @@ namespace Raven.Client.Documents.Smuggler
         PostgreSQLIntegration = 1 << 23,
         QueueConnectionStrings = 1 << 24,
         QueueEtls = 1 << 25,
+        IndexesHistory = 1 << 26
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -41,7 +41,8 @@ namespace Raven.Client.Documents.Smuggler
                                                                                   DatabaseRecordItemType.ElasticSearchEtls |
                                                                                   DatabaseRecordItemType.PostgreSQLIntegration |
                                                                                   DatabaseRecordItemType.QueueConnectionStrings |
-                                                                                  DatabaseRecordItemType.QueueEtls;
+                                                                                  DatabaseRecordItemType.QueueEtls |
+                                                                                  DatabaseRecordItemType.IndexesHistory;
 
         private const int DefaultMaxStepsForTransformScript = 10 * 1000;
 

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -297,6 +297,8 @@ namespace Raven.Client.Documents.Smuggler
             public bool QueueEtlsUpdated { get; set; }
 
             public bool QueueConnectionStringsUpdated { get; set; }
+            
+            public bool IndexesHistoryUpdated { get; set; }
 
             public override DynamicJsonValue ToJson()
             {
@@ -380,6 +382,9 @@ namespace Raven.Client.Documents.Smuggler
                 if (PostreSQLConfigurationUpdated)
                     json[nameof(PostreSQLConfigurationUpdated)] = PostreSQLConfigurationUpdated;
 
+                if (IndexesHistoryUpdated)
+                    json[nameof(IndexesHistoryUpdated)] = IndexesHistoryUpdated;
+                
                 return json;
             }
 
@@ -464,6 +469,8 @@ namespace Raven.Client.Documents.Smuggler
                 if (PostreSQLConfigurationUpdated)
                     sb.AppendLine("- PostgreSQL Integration");
 
+                if (IndexesHistoryUpdated)
+                    sb.AppendLine("- Indexes History");
 
                 if (sb.Length == 0)
                     return string.Empty;

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -222,8 +222,8 @@ namespace Raven.Client.ServerWide
                 }
             }
         }
-        
-        public void AddIndexHistory(IndexDefinition definition, string source, int revisionsToKeep, DateTime createdAt, Dictionary<string, RollingIndexDeployment> rollingIndexDeployment = null, bool isFromCommand = false, bool isRolling = false)
+
+        internal void AddIndexHistory(IndexDefinition definition, string source, int revisionsToKeep, DateTime createdAt, Dictionary<string, RollingIndexDeployment> rollingIndexDeployment = null, bool isFromCommand = false, bool isRolling = false)
         {
             IndexesHistory ??= new();
             List<IndexHistoryEntry> history;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -738,6 +738,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.ElasticSearchConnectionStrings = smugglerDatabaseRecord.ElasticSearchConnectionStrings;
                     databaseRecord.QueueEtls = smugglerDatabaseRecord.QueueEtls;
                     databaseRecord.QueueConnectionStrings = smugglerDatabaseRecord.QueueConnectionStrings;
+                    databaseRecord.IndexesHistory = smugglerDatabaseRecord.IndexesHistory;
 
                     // need to enable revisions before import
                     database.DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(smugglerDatabaseRecord);

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -1,12 +1,33 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
+using Raven.Client.ServerWide;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Extensions
 {
     public static class JsonSerializationExtensions
     {
+        public static DynamicJsonValue ToJson(this IndexHistoryEntry entry)
+        {
+            var result = new DynamicJsonValue
+            {
+                [nameof(IndexHistoryEntry.Source)] = entry.Source, 
+                [nameof(IndexHistoryEntry.CreatedAt)] = entry.CreatedAt,
+                [nameof(IndexHistoryEntry.Definition)] = entry.Definition.ToJson()
+            };
+            
+            if (entry.RollingDeployment != null)
+            {
+                var rollingObject = new DynamicJsonValue();
+                foreach (var rollingIndexDeployment in entry.RollingDeployment)
+                    rollingObject[rollingIndexDeployment.Key] = rollingIndexDeployment.Value.ToJson();
+                result[nameof(IndexHistoryEntry.RollingDeployment)] = rollingObject;
+            }
+
+            return result;
+        }
+        
         public static DynamicJsonValue ToJson(this IndexDefinition definition)
         {
             var result = new DynamicJsonValue();

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -158,6 +158,9 @@ namespace Raven.Server.ServerWide
             [nameof(PutDatabaseStudioConfigurationCommand)] = 54_001,
             [nameof(PutDatabaseSettingsCommand)] = 54_001,
             [nameof(PutDatabaseClientConfigurationCommand)] = 54_001,
+            
+            [nameof(PutIndexHistoryCommand)] = 54_101,
+            [nameof(DeleteIndexHistoryCommand)] = 54_101,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -159,8 +159,8 @@ namespace Raven.Server.ServerWide
             [nameof(PutDatabaseSettingsCommand)] = 54_001,
             [nameof(PutDatabaseClientConfigurationCommand)] = 54_001,
             
-            [nameof(PutIndexHistoryCommand)] = 54_101,
-            [nameof(DeleteIndexHistoryCommand)] = 54_101,
+            [nameof(PutIndexHistoryCommand)] = 54_002,
+            [nameof(DeleteIndexHistoryCommand)] = 54_002,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -473,6 +473,8 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdateUnusedDatabaseIdsCommand):
                     case nameof(EditLockModeCommand):
                     case nameof(EditPostgreSqlConfigurationCommand):
+                    case nameof(PutIndexHistoryCommand):    
+                    case nameof(DeleteIndexHistoryCommand):
                         UpdateDatabase(context, type, cmd, index, leader, serverStore);
                         break;
 
@@ -2497,6 +2499,8 @@ namespace Raven.Server.ServerWide
                 case nameof(EditDatabaseClientConfigurationCommand):
                 case nameof(EditLockModeCommand):
                 case nameof(EditPostgreSqlConfigurationCommand):
+                case nameof(PutIndexHistoryCommand):    
+                case nameof(DeleteIndexHistoryCommand):    
                     databaseRecord.EtagForBackup = index;
                     break;
             }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/DeleteIndexHistoryCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/DeleteIndexHistoryCommand.cs
@@ -1,0 +1,32 @@
+using Raven.Client.ServerWide;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Indexes;
+
+public class DeleteIndexHistoryCommand : UpdateDatabaseCommand
+{
+    public string IndexName { get; set; }
+
+    public DeleteIndexHistoryCommand()
+    {
+        //deserialization
+    }
+    
+    public DeleteIndexHistoryCommand(string indexName, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+    {
+        IndexName = indexName;
+    }
+    
+    public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+    {
+        if (record.IndexesHistory != null)
+        {
+            record.IndexesHistory.Remove(IndexName);
+        }
+    }
+
+    public override void FillJson(DynamicJsonValue json)
+    {
+        json[nameof(IndexName)] = IndexName;
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexHistoryCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexHistoryCommand.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Raven.Client.ServerWide;
+using Raven.Server.Extensions;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Indexes;
+
+public class PutIndexHistoryCommand : UpdateDatabaseCommand
+{
+    public string IndexName { get; set; }
+    public List<IndexHistoryEntry> IndexHistory { get; set; }
+    public int RevisionsToKeep { get; set; }
+
+    public PutIndexHistoryCommand()
+    {
+        //deserialization
+    }
+    
+    public PutIndexHistoryCommand(string indexName, List<IndexHistoryEntry> indexHistory, int revisionsToKeep, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+    {
+        IndexName = indexName;
+        IndexHistory = indexHistory;
+        RevisionsToKeep = revisionsToKeep;
+    }
+    
+    public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+    {
+        record.IndexesHistory ??= new();
+        
+        if (record.IndexesHistory.TryGetValue(IndexName, out var indexHistoryEntries) == false)
+            record.IndexesHistory[IndexName] = IndexHistory;
+        else
+        {
+            foreach (var entry in IndexHistory)
+            {
+                record.AddIndexHistory(entry.Definition, entry.Source, RevisionsToKeep, entry.CreatedAt, rollingIndexDeployment: entry.RollingDeployment, isFromCommand: true);
+            }
+        }
+    }
+
+    public override void FillJson(DynamicJsonValue json)
+    {
+        var histJson = new DynamicJsonArray();
+        foreach (var ih in IndexHistory)
+            histJson.Add(ih.ToJson());
+        
+        json[nameof(IndexName)] = IndexName;
+        json[nameof(IndexHistory)] = histJson;
+        json[nameof(RevisionsToKeep)] = RevisionsToKeep;
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -139,7 +139,7 @@ namespace Raven.Server.ServerWide
         public static Func<BlittableJsonReaderObject, SorterDefinition> SorterDefinition = GenerateJsonDeserializationRoutine<SorterDefinition>();
 
         public static Func<BlittableJsonReaderObject, PostgreSqlConfiguration> PostgreSqlConfiguration = GenerateJsonDeserializationRoutine<PostgreSqlConfiguration>();
-
+        
         public static readonly Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>> Commands = new Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>>
         {
             [nameof(UnregisterReplicationHubAccessCommand)] = GenerateJsonDeserializationRoutine<UnregisterReplicationHubAccessCommand>(),
@@ -252,7 +252,9 @@ namespace Raven.Server.ServerWide
             [nameof(EditPostgreSqlConfigurationCommand)] = GenerateJsonDeserializationRoutine<EditPostgreSqlConfigurationCommand>(),
             [nameof(PutDatabaseStudioConfigurationCommand)] = GenerateJsonDeserializationRoutine<PutDatabaseStudioConfigurationCommand>(),
             [nameof(PutDatabaseSettingsCommand)] = GenerateJsonDeserializationRoutine<PutDatabaseSettingsCommand>(),
-            [nameof(PutDatabaseClientConfigurationCommand)] = GenerateJsonDeserializationRoutine<PutDatabaseClientConfigurationCommand>()
+            [nameof(PutDatabaseClientConfigurationCommand)] = GenerateJsonDeserializationRoutine<PutDatabaseClientConfigurationCommand>(),
+            [nameof(PutIndexHistoryCommand)] = GenerateJsonDeserializationRoutine<PutIndexHistoryCommand>(),
+            [nameof(DeleteIndexHistoryCommand)] = GenerateJsonDeserializationRoutine<DeleteIndexHistoryCommand>()
         };
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Protocol;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
@@ -31,12 +32,14 @@ using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Extensions;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Web.System;
+using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -298,6 +301,13 @@ namespace Raven.Server.Smuggler.Documents
                     WriteAnalyzers(databaseRecord.Analyzers);
                 }
 
+                if (databaseRecordItemType.Contain(DatabaseRecordItemType.IndexesHistory))
+                {
+                    _writer.WriteComma();
+                    _writer.WritePropertyName(nameof(databaseRecord.IndexesHistory));
+                    WriteIndexesHistory(databaseRecord.IndexesHistory);
+                }
+                
                 switch (authorizationStatus)
                 {
                     case AuthorizationStatus.DatabaseAdmin:
@@ -508,6 +518,68 @@ namespace Raven.Server.Smuggler.Documents
                     _context.Write(_writer, analyzer.Value.ToJson());
                 }
 
+                _writer.WriteEndObject();
+            }
+
+            private void WriteIndexesHistory(Dictionary<string, List<IndexHistoryEntry>> indexesHistory)
+            {
+                if (indexesHistory == null)
+                {
+                    _writer.WriteNull();
+                    return;
+                }
+                
+                _writer.WriteStartObject();
+                
+                var first = true;
+                foreach (var historyOfIndex in indexesHistory)
+                {
+                    if (first == false)
+                        _writer.WriteComma();
+                    first = false;
+                    
+                    _writer.WritePropertyName(historyOfIndex.Key);
+                    bool isFirstChangeOfIndex = true;
+                    
+                    _writer.WriteStartArray();
+                    foreach (var changeOfIndex in historyOfIndex.Value)
+                    {
+                        if (isFirstChangeOfIndex == false)
+                            _writer.WriteComma();
+                        isFirstChangeOfIndex = false;
+                        
+                        _writer.WriteStartObject();
+                        
+                        _writer.WritePropertyName(nameof(changeOfIndex.Source));
+                        _writer.WriteString(changeOfIndex.Source);
+                        _writer.WriteComma();
+                        
+                        _writer.WritePropertyName(nameof(changeOfIndex.CreatedAt));
+                        _writer.WriteDateTime(changeOfIndex.CreatedAt, true);
+                        _writer.WriteComma();
+                        
+                        _writer.WritePropertyName(nameof(changeOfIndex.RollingDeployment));
+                        _writer.WriteStartObject();
+                        bool isFirstRolling = true;
+                        foreach (var (rollingName,rollingIndexDeployment) in changeOfIndex?.RollingDeployment)
+                        {
+                            if (isFirstRolling == false)
+                                _writer.WriteComma();
+                            isFirstRolling = false;
+                            _writer.WritePropertyName(rollingName);
+                            _context.Write(_writer, rollingIndexDeployment.ToJson());
+                        }
+                        _writer.WriteEndObject();
+                        _writer.WriteComma();
+                        
+                        _writer.WritePropertyName(nameof(changeOfIndex.Definition));
+                        _context.Write(_writer, changeOfIndex.Definition.ToJson());
+                        
+                        _writer.WriteEndObject();
+                    }
+                    _writer.WriteEndArray();
+                }
+                
                 _writer.WriteEndObject();
             }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -82,9 +82,16 @@ class exportDatabaseModel {
             }
         });
 
+        this.databaseModel.includeIndexHistory.subscribe(indexHistory => {
+            if (indexHistory) {
+                this.includeIndexes(true);
+            }
+        });
+
         this.includeIndexes.subscribe(indexes => {
             if (!indexes) {
                 this.removeAnalyzers(false);
+                this.databaseModel.includeIndexHistory(false);
             }
         });
 

--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -75,10 +75,17 @@ class importDatabaseModel {
                 this.includeIndexes(true);
             }
         });
+
+        this.databaseModel.includeIndexHistory.subscribe(indexHistory => {
+            if (indexHistory) {
+                this.includeIndexes(true);
+            }
+        });
         
         this.includeIndexes.subscribe(indexes => {
             if (!indexes) {
                 this.removeAnalyzers(false);
+                this.databaseModel.includeIndexHistory(false);
             }
         });
 

--- a/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
@@ -328,9 +328,16 @@ class migrateRavenDbDatabaseModel {
             }
         });
 
+        this.databaseModel.includeIndexHistory.subscribe(indexHistory => {
+            if (indexHistory) {
+                this.includeIndexes(true);
+            }
+        });
+
         this.includeIndexes.subscribe(indexes => {
             if (!indexes) {
                 this.removeAnalyzers(false);
+                this.databaseModel.includeIndexHistory(false);
             }
         });
 

--- a/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
@@ -34,6 +34,7 @@ class smugglerDatabaseRecord {
     includeHubReplications = ko.observable<boolean>(true);
     includeSinkReplications = ko.observable<boolean>(true);
     includePostgreSqlIntegration = ko.observable<boolean>(true);
+    includeIndexHistory = ko.observable<boolean>(false);
 
     hasIncludes: KnockoutComputed<boolean>;
 
@@ -88,7 +89,7 @@ class smugglerDatabaseRecord {
         const result: Raven.Client.Documents.Smuggler.DatabaseRecordItemType[] = [];
         
         if (!this.customizeDatabaseRecordTypes()) {
-            return ["None"];
+            return this.includeIndexHistory() ? ["IndexesHistory"] : ["None"];
         }
         
         if (this.includeConflictSolverConfig()) {
@@ -162,6 +163,9 @@ class smugglerDatabaseRecord {
         }
         if (this.includePostgreSqlIntegration()) {
             result.push("PostgreSQLIntegration")
+        }
+        if (this.includeIndexHistory()) {
+            result.push("IndexesHistory")
         }
         
         return result;

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
@@ -63,6 +63,11 @@
                             </div>
                             <div class="margin-left margin-left-lg">
                                 <div class="toggle">
+                                    <input id="toggleIndexHistory" type="checkbox"
+                                           data-bind="checked: databaseModel.includeIndexHistory, enable: includeIndexes" />
+                                    <label for="toggleIndexHistory">Include Index History</label>
+                                </div>
+                                <div class="toggle">
                                     <input id="toggleAnalyzers" type="checkbox" 
                                            data-bind="checked: removeAnalyzers, enable: includeIndexes" />
                                     <label for="toggleAnalyzers">Remove Analyzers</label>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
@@ -99,7 +99,13 @@
                             </div>
                             <div class="margin-left margin-left-lg">
                                 <div class="toggle">
-                                    <input id="importAnalyzers" type="checkbox" data-bind="checked: removeAnalyzers" />
+                                    <input id="toggleIndexHistory" type="checkbox"
+                                           data-bind="checked: databaseModel.includeIndexHistory, enable: includeIndexes" />
+                                    <label for="toggleIndexHistory">Include Index History</label>
+                                </div>
+                                <div class="toggle">
+                                    <input id="importAnalyzers" type="checkbox"
+                                           data-bind="checked: removeAnalyzers, enable: includeIndexes" />
                                     <label for="importAnalyzers">Remove Analyzers</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
@@ -193,7 +193,13 @@
                                 </div>
                                 <div class="margin-left margin-left-lg">
                                     <div class="toggle">
-                                        <input id="migrate_remove_analyzers" type="checkbox" data-bind="checked: removeAnalyzers" />
+                                        <input id="toggleIndexHistory" type="checkbox"
+                                               data-bind="checked: databaseModel.includeIndexHistory, enable: includeIndexes" />
+                                        <label for="toggleIndexHistory">Include Index History</label>
+                                    </div>
+                                    <div class="toggle">
+                                        <input id="migrate_remove_analyzers" type="checkbox"
+                                               data-bind="checked: removeAnalyzers, enable: includeIndexes" />
                                         <label for="migrate_remove_analyzers">Remove Analyzers</label>
                                     </div>
                                 </div>

--- a/test/SlowTests/Smuggler/RavenDB-17341.cs
+++ b/test/SlowTests/Smuggler/RavenDB-17341.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Smuggler;
+
+public class RavenDB_17341 : RavenTestBase
+{
+    public RavenDB_17341(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private void DeployIndex(IDocumentStore store, bool isUpdate = false)
+    {
+        var first = new IndexDefinition
+        {
+            Name = "Users_ByName",
+            Maps = { "from user in docs.Users select new { user.Name }" },
+            Type = IndexType.Map
+        };
+        
+        var second = new IndexDefinition
+        {
+            Name = "Users_ByName",
+            Maps = { "from user in docs.Users select new { user.Name, user.Age }" },
+            Type = IndexType.Map
+        };
+
+        store.Maintenance.Send(isUpdate == false 
+            ? new PutIndexesOperation(first) 
+            : new PutIndexesOperation(second));
+    }
+
+    [Fact]
+    public async Task IndexesAreExportedAndImportedWithIndexHistory()
+    {
+        const int WaitToCompleteInMin = 1;
+        var file = GetTempFileName();
+        try
+        {
+            using (var store1 = GetDocumentStore(new Options {ModifyDatabaseName = s => $"{s}_1"}))
+            using (var store2 = GetDocumentStore(new Options {ModifyDatabaseName = s => $"{s}_2"}))
+            {
+                DeployIndex(store1);
+                Indexes.WaitForIndexing(store1);
+                DeployIndex(store1, isUpdate: true);
+                Indexes.WaitForIndexing(store1);
+
+                var recordToExport = await store1.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store1.Database));
+                Assert.Equal(1, recordToExport.IndexesHistory.Count);
+                Assert.Equal(2, recordToExport.IndexesHistory["Users_ByName"].Count);
+
+                var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions()
+                {
+                    OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.DatabaseRecord,
+                    OperateOnDatabaseRecordTypes = DatabaseRecordItemType.IndexesHistory | DatabaseRecordItemType.Revisions
+                }, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(WaitToCompleteInMin));
+
+                operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()
+                {
+                    OperateOnTypes = DatabaseItemType.Indexes | DatabaseItemType.DatabaseRecord, 
+                    OperateOnDatabaseRecordTypes = DatabaseRecordItemType.IndexesHistory
+                }, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(WaitToCompleteInMin));
+
+                var recordImported = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store2.Database));
+                Assert.Equal(1, recordImported.IndexesHistory.Count);
+                Assert.Equal(2, recordImported.IndexesHistory["Users_ByName"].Count);
+                WaitForUserToContinueTheTest(store2);
+            }
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}

--- a/test/SlowTests/Smuggler/RavenDB-17341.cs
+++ b/test/SlowTests/Smuggler/RavenDB-17341.cs
@@ -1,11 +1,9 @@
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17341 

### Additional description

Import and export of IndexesHistory.

When we import indexes with `IndexesHistory`  `Smuggler ` is creating a new entry in `IndexesHistory`. In such case, we check if the latest index definition in the local `databaseRecord` is exactly the same as the latest from import  When it is, we restore previous history information into Smuggler's `IndexHistoryEntry`. When it's not, we append the entry to the end.

In case when indexes are deployed in a `Rolling manner` we do not update Smuggler's entry because `RollingDeployment` can be completely different.

### Type of change

- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Ensured. Please explain how has it been implemented?
- - Cluster versioning.


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
