### PR TITLE
RavenDB-19874 Fix param name in log message

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -602,7 +602,7 @@ namespace Raven.Server.Commercial
                     if (_skipLeasingErrorsLogging == false && Logger.IsInfoEnabled)
                     {
                         // ReSharper disable once MethodHasAsyncOverload
-                        Logger.Info("Skipping updating of the license from string or path or from api.ravendb.net because 'Licensing.DisableAutoLicenceUpdate' was set to true");
+                        Logger.Info("Skipping updating of the license from string or path or from api.ravendb.net because 'Licensing.DisableAutoUpdate' was set to true");
                     }
                     return null;
                 }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -602,7 +602,8 @@ namespace Raven.Server.Commercial
                     if (_skipLeasingErrorsLogging == false && Logger.IsInfoEnabled)
                     {
                         // ReSharper disable once MethodHasAsyncOverload
-                        Logger.Info("Skipping updating of the license from string or path or from api.ravendb.net because 'Licensing.DisableAutoUpdate' was set to true");
+                        var configurationKey = RavenConfiguration.GetKey(x => x.Licensing.DisableAutoUpdate);
+                        Logger.Info($"Skipping updating of the license from string or path or from api.ravendb.net because '{configurationKey}' was set to true");
                     }
                     return null;
                 }
@@ -616,7 +617,8 @@ namespace Raven.Server.Commercial
                     if (_skipLeasingErrorsLogging == false && Logger.IsInfoEnabled)
                     {
                         // ReSharper disable once MethodHasAsyncOverload
-                        Logger.Info("Skipping updating of the license from api.ravendb.net because 'Licensing.DisableAutoUpdateFromApi' was set to true");
+                        var configurationKey = RavenConfiguration.GetKey(x => x.Licensing.DisableAutoUpdateFromApi);
+                        Logger.Info($"Skipping updating of the license from api.ravendb.net because '{configurationKey}' was set to true");
                     }
                     return null;
                 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19874

### Additional description
Fix param name in log msg:
`Licensing.DisableAutoLicenceUpdate => Licensing.DisableAutoUpdate`

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team.
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
