### PR TITLE
RavenDB-16167 Added SpreadElement handling in EsprimaVisitor

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/EsprimaVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/EsprimaVisitor.cs
@@ -321,6 +321,9 @@ namespace Raven.Server.Documents.Indexes.Static
                 case Nodes.ArrowFunctionExpression:
                     VisitArrowFunctionExpression(expression.As<ArrowFunctionExpression>());
                     break;
+                case Nodes.SpreadElement:
+                    VisitSpreadElement(expression.As<SpreadElement>());
+                    break;
                 default:
                     VisitUnknownNode(expression);
                     break;
@@ -706,6 +709,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public virtual void VisitSpreadElement(SpreadElement spreadElement)
         {
+            VisitIdentifier(spreadElement.Argument.As<Identifier>());
         }
 
         public virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)

--- a/test/SlowTests/Issues/RavenDB-16167.cs
+++ b/test/SlowTests/Issues/RavenDB-16167.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_16167: RavenTestBase
+{
+    public RavenDB_16167(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfSpreadOperatorWorksForJsIndex()
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            Order o1 = new() { Price = 21 };
+            Order o2 = new() { Price = 37 };
+            
+            session.Store(o1);
+            session.Store(o2);
+            
+            var index = new SpreadOperatorIndex();
+            
+            var query = $@"from index ""{index.IndexName}"" as o select Result";
+            
+            index.Execute(store);
+
+            Indexes.WaitForIndexing(store);
+
+            session.SaveChanges();
+            
+            var res = session.Advanced
+                .RawQuery<Dto>(query)
+                .WaitForNonStaleResults().ToList();
+            
+            Assert.Equal(6, res.First().Result[0]);
+        }
+    }
+
+    private class SpreadOperatorIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public SpreadOperatorIndex()
+        {
+            Maps = new HashSet<string>(new string[]{
+@"map(""Orders"", (order) => {
+    var result = [];
+    var a = [1, 2, 3];
+    var x = function(a, b, c){
+        return a + b + c;
+    }
+    result.push(x(...a));
+    return {
+        Result: result
+    };
+})"});
+
+            Fields = new Dictionary<string, IndexFieldOptions>() { { "Result", new IndexFieldOptions() { Storage = FieldStorage.Yes } } };
+        }
+    }
+
+    private class Order
+    {
+        public string Id { get; set; }
+        public int Price { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public double[] Result { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16167/Spread-operator-is-not-supported-in-js-indexes

### Additional description

We want to handle SpreadElement node type in our EsprimaVisitor.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
