### PR TITLE
RavenDB-16108  Backup restore: show that indexes were skipped in the result table (when user set skip indexes).

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -337,7 +337,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                             DisableOngoingTasksIfNeeded(databaseRecord);
 
-                            Raven.Server.Smuggler.Documents.DatabaseSmuggler.EnsureProcessed(result, skipped: false);
+                            Raven.Server.Smuggler.Documents.DatabaseSmuggler.EnsureProcessed(result, skipped: false, indexesSkipped: result.Indexes.Skipped);
 
                             onProgress.Invoke(result.Progress);
                         }
@@ -678,9 +678,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var lastFilePath = GetBackupPath(filesToRestore.Last());
 
             result.AddInfo($"Restoring file {filesToRestore.Count:#,#;;0}/{filesToRestore.Count:#,#;;0}");
+            result.Indexes.Skipped = RestoreFromConfiguration.SkipIndexes;
 
             onProgress.Invoke(result.Progress);
-
             await ImportSingleBackupFile(database, onProgress, result, lastFilePath, context, destination, options, isLastFile: true,
                 onIndexAction: indexAndType =>
                 {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public static void EnsureProcessed(SmugglerResult result, bool skipped = true)
+        public static void EnsureProcessed(SmugglerResult result, bool skipped = true, bool? indexesSkipped = null)
         {
             EnsureStepProcessed(result.DatabaseRecord, skipped);
             EnsureStepProcessed(result.Documents, skipped);
@@ -141,7 +141,7 @@ namespace Raven.Server.Smuggler.Documents
             EnsureStepProcessed(result.Counters, skipped);
             EnsureStepProcessed(result.Tombstones, skipped);
             EnsureStepProcessed(result.Conflicts, skipped);
-            EnsureStepProcessed(result.Indexes, skipped);
+            EnsureStepProcessed(result.Indexes,  indexesSkipped ?? skipped);
             EnsureStepProcessed(result.Identities, skipped);
             EnsureStepProcessed(result.CompareExchange, skipped);
             EnsureStepProcessed(result.CompareExchangeTombstones, skipped);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16108  

### Additional description

Set `restore configuration` into operation progress.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
