### PR TITLE
RavenDB-18447 Sharding - The document's properties pane hides the sha…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/shell.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell.html
@@ -3,8 +3,8 @@
     <aside class="top-alert" data-bind="visible: developerLicense">
         Developer License - Not for Production Use
     </aside>
-    <aside class="top-alert" data-bind="visible: singleShardName">
-        <span>Displayed data is sourced from only a single shard (<span data-bind="text: singleShardName"></span>) <a data-bind="attr: { href: allShardsUrl }">Go to all shards mode</a></span>
+    <aside class="top-alert shard-debug" data-bind="visible: singleShardName">
+        <span>Displayed data is sourced from only a single shard &nbsp;&nbsp; (<i class="icon-shard"></i><strong data-bind="text: singleShardName"></strong> ) &nbsp;&nbsp;<a data-bind="attr: { href: allShardsUrl }"> <i class="icon-sharding"></i> Go to all shards mode</a></span>
     </aside>
     <aside class="top-alert" data-bind="visible: applyColorCustomization">
         !!! Running as Cloud Cluster Admin !!!  <a href="#" data-bind="click: disableColorCustomization">Disable color customization</a>

--- a/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
+++ b/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
@@ -22,6 +22,7 @@
 @color-recent: @color-4-1;
 @color-attachments: @color-3-1;
 @color-related: @color-4-3;
+@color-shard: @color-4-1;
 
 @text-emphasis: @gray-lighter;
 

--- a/src/Raven.Studio/wwwroot/Content/css/root.less
+++ b/src/Raven.Studio/wwwroot/Content/css/root.less
@@ -38,17 +38,29 @@ body {
 
     .top-alert {
         grid-area: alert;
-        padding: 1px 7.5px !important;
+        padding: @gutter-xxs @gutter !important;
         display: block;
         width: 100%;
-        font-size: 16px;
-        height: @top-alert-height;
+        font-size: 14px;
+        letter-spacing: .15em;
+        min-height: @top-alert-height;
         text-align: center;
-        line-height: 19px;
         color: @gray-dark;
         font-weight: bold;
         background-color: darken(@brand-warning-light, 10%);
         text-transform: uppercase;
+
+        &.shard-debug {
+            background-color: @color-shard;
+            color: @black;
+            a{ 
+                color: @white;
+                text-decoration: none;
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+        }
     }
 
     .navbar {

--- a/src/Raven.Studio/wwwroot/Content/scss/_colors.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_colors.scss
@@ -194,6 +194,6 @@ $color-support-professional: $color-4-2;
 $color-support-production: $color-5;
 
 $node-color: $color-3;
-$shard-color: $color-4;
+$shard-color: $color-4-1;
 $orchestrator-color: $color-2-1;
 $progress-color: $color-2-3;

--- a/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
@@ -227,9 +227,9 @@ $gradient: linear-gradient(180deg, rgba($white, 0.15), rgba($white, 0)) !default
 $spacer: $gutter !default;
 $spacer-ratio: 1.618 !default;
 
-$spacer-sm: $spacer / $spacer-ratio;
-$spacer-xs: $spacer-sm / $spacer-ratio;
-$spacer-xxs: $spacer-xs / $spacer-ratio;
+$spacer-sm: math.div($spacer , $spacer-ratio);
+$spacer-xs: math.div($spacer-sm, $spacer-ratio);
+$spacer-xxs: math.div($spacer-xs, $spacer-ratio);
 
 $spacer-md: $spacer * $spacer-ratio;
 $spacer-lg: $spacer-md * $spacer-ratio;
@@ -416,7 +416,7 @@ $font-weight-bolder: bolder !default;
 $font-weight-base: $font-weight-normal !default;
 
 $line-height-base: $gutter-ratio !default;
-$line-height-sm: 1 / $gutter-ratio !default;
+$line-height-sm: math.div(1, $gutter-ratio) !default;
 $line-height-lg: $gutter-ratio * $gutter-ratio !default;
 
 $heading-size-base: 10px;
@@ -441,7 +441,7 @@ $font-sizes: (
 // scss-docs-end font-sizes
 
 // scss-docs-start headings-variables
-$headings-margin-bottom: $spacer / $gutter-ratio !default;
+$headings-margin-bottom: math.div($spacer, $gutter-ratio) !default;
 $headings-font-family: null !default;
 $headings-font-style: null !default;
 $headings-font-weight: 500 !default;


### PR DESCRIPTION
…rds view settings

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18447/Sharding-The-documents-properties-pane-hides-the-shards-view-settings

### Additional description

modified the style of "top-alert" and fixed scss warnings

### Type of change

- Cosmetics

### How risky is the change?

- Not relevant

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing
