### PR TITLE
RavenDB-19545 - Deleting TimeSeries entry should affect the cache

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
@@ -385,7 +385,11 @@ namespace Raven.Client.Documents.Session
                 // add current range from cache to the merged list.
                 // in order to avoid duplication, skip first item in range if needed
 
-                mergedValues.AddRange(ranges[i].Entries.Skip(mergedValues.Count == 0 ? 0 : 1));
+                bool shouldSkip = false;
+                if (mergedValues.Count > 0)
+                    shouldSkip = ranges[i].Entries[0].Timestamp == mergedValues[mergedValues.Count - 1].Timestamp;
+
+                mergedValues.AddRange(ranges[i].Entries.Skip(shouldSkip == false ? 0 : 1));
             }
 
             if (currentResultIndex < resultFromServer.Count)

--- a/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionTimeSeriesBase.cs
@@ -122,6 +122,11 @@ namespace Raven.Client.Documents.Session
             {
                 Session.Defer(new TimeSeriesBatchCommandData(DocId, Name, appends: null, deletes: new List<TimeSeriesOperation.DeleteOperation> { op }));
             }
+
+            if (Session.TimeSeriesByDocId.TryGetValue(DocId, out var cache))
+            {
+                cache.Remove(Name);
+            }
         }
 
         private static void ThrowDocumentAlreadyDeletedInSession(string documentId, string timeseries)

--- a/test/SlowTests/Issues/RavenDB_19545.cs
+++ b/test/SlowTests/Issues/RavenDB_19545.cs
@@ -41,6 +41,42 @@ public class RavenDB_19545 : RavenTestBase
     }
 
     [Fact]
+    public void RemovingTimeSeriesEntryShouldAffectCache2()
+    {
+        const string docId = "user/1";
+        const string timeSeriesName = "HeartRates";
+        const string tag = "watches/fitbit";
+        var baseline = DateTime.UtcNow;
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Lev" }, docId);
+
+                var tsf = session.TimeSeriesFor(docId, timeSeriesName);
+                for (int i = 1; i <= 10; i++)
+                {
+                    tsf.Append(baseline.AddDays(i), i, tag);
+                    session.SaveChanges();
+                }
+
+                var entries = session.TimeSeriesFor(docId, timeSeriesName).Get(baseline.AddDays(9), baseline.AddDays(11));
+                Assert.Equal(1, entries.Length);
+
+                entries = session.TimeSeriesFor(docId, timeSeriesName).Get(baseline.AddDays(3), baseline.AddDays(8));
+                Assert.Equal(5, entries.Length);
+
+                session.TimeSeriesFor(docId, timeSeriesName).Delete(baseline.AddDays(4), baseline.AddDays(7));
+                session.SaveChanges();
+
+                var entries2 = session.TimeSeriesFor(docId, timeSeriesName).Get();
+                Assert.Equal(5, entries2.Length);
+            }
+        }
+    }
+
+    [Fact]
     public async Task RemovingTimeSeriesEntryShouldAffectCacheAsync()
     {
         const string docId = "user/1";

--- a/test/SlowTests/Issues/RavenDB_19545.cs
+++ b/test/SlowTests/Issues/RavenDB_19545.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19545 : RavenTestBase
+{
+    public RavenDB_19545(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void RemovingTimeSeriesEntryShouldAffectCache()
+    {
+        const string docId = "user/1";
+        const string timeSeriesName = "HeartRates";
+        const string tag = "watches/fitbit";
+
+        using (var store = GetDocumentStore())
+        using (var session = store.OpenSession())
+        {
+            session.Store(new User { Name = "Lev" }, docId);
+
+            var tsf = session.TimeSeriesFor(docId, timeSeriesName);
+            tsf.Append(DateTime.Today.AddHours(23), new[] { 67d }, tag);
+            session.SaveChanges();
+
+            var entries = session.TimeSeriesFor(docId, timeSeriesName).Get();
+            Assert.Equal(1, entries.Length);
+
+            session.TimeSeriesFor(docId, timeSeriesName).Delete(DateTime.MinValue, DateTime.MaxValue);
+            session.SaveChanges();
+
+            var entries2 = session.TimeSeriesFor(docId, timeSeriesName).Get();
+            Assert.Null(entries2);
+        }
+    }
+
+    [Fact]
+    public async Task RemovingTimeSeriesEntryShouldAffectCacheAsync()
+    {
+        const string docId = "user/1";
+        const string timeSeriesName = "HeartRates";
+        const string tag = "watches/fitbit";
+
+        using (var store = GetDocumentStore())
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Lev" }, docId);
+
+            var tsf = session.TimeSeriesFor(docId, timeSeriesName);
+            tsf.Append(DateTime.Today.AddHours(23), new[] { 67d }, tag);
+            await session.SaveChangesAsync();
+
+            var entries = await session.TimeSeriesFor(docId, timeSeriesName).GetAsync();
+            Assert.Equal(1, entries.Length);
+
+            session.TimeSeriesFor(docId, timeSeriesName).Delete();
+            await session.SaveChangesAsync();
+
+            var entries2 = await session.TimeSeriesFor(docId, timeSeriesName).GetAsync();
+            Assert.Null(entries2);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19545/Deleting-TimeSeries-entry-should-affect-the-cache


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
