### PR TITLE
RavenDB-18765 Sharding - Query - Facets 

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -268,7 +268,8 @@ namespace Raven.Client
                 internal const string OrderByFields = "@order-by-fields";
 
                 internal const string ShardNumber = "@shard-number";
-                internal const string SuggestionPopularityFields = "@suggestions-popularity";
+
+                internal const string SuggestionsPopularityFields = "@suggestions-popularity";
             }
 
             public class Collections

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
@@ -41,7 +41,7 @@ internal abstract class AbstractQueriesHandlerProcessor<TRequestHandler, TOperat
         return new RequestTimeTracker(HttpContext, Logger, NotificationCenter, Configuration, "Query");
     }
 
-    public async ValueTask<IndexQueryServerSide> GetIndexQueryAsync(JsonOperationContext context, HttpMethod method, RequestTimeTracker tracker, bool addSpatialProperties = false, bool returnMissingIncludeAsNull = false)
+    public async ValueTask<IndexQueryServerSide> GetIndexQueryAsync(JsonOperationContext context, HttpMethod method, RequestTimeTracker tracker, bool addSpatialProperties = false)
     {
         if (method == HttpMethod.Get)
             return await ReadIndexQueryAsync(context, tracker, addSpatialProperties);
@@ -63,7 +63,7 @@ internal abstract class AbstractQueriesHandlerProcessor<TRequestHandler, TOperat
             json = q;
         }
 
-        return IndexQueryServerSide.Create(_httpContext, json, QueryMetadataCache, tracker, addSpatialProperties, returnMissingIncludeAsNull, queryType: queryType);
+        return IndexQueryServerSide.Create(_httpContext, json, QueryMetadataCache, tracker, addSpatialProperties, queryType: queryType);
     }
 
     private async ValueTask<IndexQueryServerSide> ReadIndexQueryAsync(JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -92,7 +92,7 @@ public class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         
         UpdateFacetResults(results, query, facetsByName);
 
-        CompleteFacetCalculationsStage(results);
+        CompleteFacetCalculationsStage(results, query);
         CoraxIndexReadOperation.QueryPool.Return(ids);
         return results.Values
             .Select(x => x.Result)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
             UpdateFacetResults(results, query, facetsByName);
 
-            CompleteFacetCalculationsStage(results);
+            CompleteFacetCalculationsStage(results, query);
 
             foreach (var readerFacetInfo in returnedReaders)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
@@ -1,6 +1,7 @@
 ﻿using Lucene.Net.Search;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Sharding;
@@ -38,6 +39,10 @@ public partial class LuceneIndexReadOperation
                 case OrderByFieldType.Distance:
                     documentWithOrderByFields.AddDoubleOrderByField(d.Distance.Value.Distance);
                     break;
+                case OrderByFieldType.Score:
+                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "RavenDB-13927 Order by score");
+
+                    throw new NotSupportedInShardingException("Ordering by score is not supported in sharding");
                 default:
                     documentWithOrderByFields.AddStringOrderByField(_searcher.IndexReader.GetStringValueFor(field.OrderByName, doc, _state));
                     break;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.Sharding.cs
@@ -15,11 +15,7 @@ public sealed partial  class LuceneSuggestionIndexReader : SuggestionIndexReader
 
         if (result is SuggestionResultWithPopularity resultWithPopularity)
         {
-            resultWithPopularity.SuggestionsPopularity.Add(new SuggestionResultWithPopularity.Popularity
-            {
-                Freq = suggestion.Freq,
-                Score = suggestion.Score
-            });
+            resultWithPopularity.SuggestionsWithPopularity.Values.Add(suggestion);
         }
         else
         {
@@ -27,9 +23,12 @@ public sealed partial  class LuceneSuggestionIndexReader : SuggestionIndexReader
             {
                 Name = result.Name,
                 Suggestions = result.Suggestions,
-                SuggestionsPopularity = new List<SuggestionResultWithPopularity.Popularity>
+                SuggestionsWithPopularity = new SuggestionResultWithPopularity.Popularity
                 {
-                    new() {Freq = suggestion.Freq, Score = suggestion.Score}
+                    Values = new List<SuggestWord>
+                    {
+                        suggestion
+                    }
                 }
             };
         }

--- a/src/Raven.Server/Documents/Queries/Facets/FacetField.cs
+++ b/src/Raven.Server/Documents/Queries/Facets/FacetField.cs
@@ -27,6 +27,8 @@ namespace Raven.Server.Documents.Queries.Facets
             Ranges = new List<QueryExpression>();
         }
 
+        internal bool HasOptions => _options != null || _optionsAsStringOrParameterName != null;
+
         public FacetOptions GetOptions(JsonOperationContext context, BlittableJsonReaderObject parameters)
         {
             if (_options != null)

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -41,6 +41,9 @@ namespace Raven.Server.Documents.Queries
         public long? FilterLimit { get; set; }
 
         [JsonDeserializationIgnore]
+        public bool ReturnRawFacetResults;
+
+        [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
 
         [JsonDeserializationIgnore]
@@ -138,7 +141,6 @@ namespace Raven.Server.Documents.Queries
             QueryMetadataCache cache,
             RequestTimeTracker tracker,
             bool addSpatialProperties = false,
-            bool returnMissingIncludeAsNull = false,
             string clientQueryId = null,
             QueryType queryType = QueryType.Select)
         {
@@ -147,7 +149,6 @@ namespace Raven.Server.Documents.Queries
             {
                 result = JsonDeserializationServer.IndexQuery(json);
                 result.ClientQueryId = clientQueryId;
-                result.ReturnMissingIncludeAsNull = returnMissingIncludeAsNull;
 
                 if (result.PageSize == 0 && json.TryGet(nameof(PageSize), out int _) == false)
                     result.PageSize = int.MaxValue;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             {
                 var queryProcessor = new ShardedQueryStreamProcessor(context, RequestHandler, query, debug, ignoreLimit, token.Token);
 
-                queryProcessor.Initialize();
+                await queryProcessor.InitializeAsync();
 
                 return await queryProcessor.ExecuteShardedOperations();
             }

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Commands.Querying;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Operations.Queries;
+
+public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TIncludes> : IShardedReadOperation<QueryResult, TCombinedResult>
+{
+    private readonly ShardedDatabaseRequestHandler _requestHandler;
+
+    private readonly Dictionary<int, ShardedQueryCommand> _queryCommands;
+
+    protected readonly TransactionOperationContext Context;
+    protected long CombinedResultEtag;
+
+    protected AbstractShardedQueryOperation(Dictionary<int, ShardedQueryCommand> queryCommands, TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, string expectedEtag)
+    {
+        _queryCommands = queryCommands;
+        Context = context;
+        _requestHandler = requestHandler;
+        ExpectedEtag = expectedEtag;
+    }
+
+    public HttpRequest HttpRequest { get => _requestHandler.HttpContext.Request; }
+
+    public string ExpectedEtag { get; }
+
+    public HashSet<string> MissingDocumentIncludes { get; private set; }
+
+    RavenCommand<QueryResult> IShardedOperation<QueryResult, ShardedReadResult<TCombinedResult>>.CreateCommandForShard(int shardNumber) => _queryCommands[shardNumber];
+
+    public string CombineCommandsEtag(Dictionary<int, ShardExecutionResult<QueryResult>> commands)
+    {
+        CombinedResultEtag = 0;
+
+        foreach (var cmd in commands.Values)
+        {
+            CombinedResultEtag = Hashing.Combine(CombinedResultEtag, cmd.Result.ResultEtag);
+        }
+
+        return CharExtensions.ToInvariantString(CombinedResultEtag);
+    }
+
+    public abstract TCombinedResult CombineResults(Dictionary<int, ShardExecutionResult<QueryResult>> results);
+
+    protected static void CombineSingleShardResultProperties(QueryResult<List<TResult>, List<TIncludes>> combinedResult, QueryResult singleShardResult)
+    {
+        combinedResult.TotalResults += singleShardResult.TotalResults;
+        combinedResult.IsStale |= singleShardResult.IsStale;
+        combinedResult.SkippedResults += singleShardResult.SkippedResults;
+        combinedResult.IndexName = singleShardResult.IndexName;
+        combinedResult.IncludedPaths = singleShardResult.IncludedPaths;
+
+        if (combinedResult.IndexTimestamp < singleShardResult.IndexTimestamp)
+            combinedResult.IndexTimestamp = singleShardResult.IndexTimestamp;
+
+        if (combinedResult.LastQueryTime < singleShardResult.LastQueryTime)
+            combinedResult.LastQueryTime = singleShardResult.LastQueryTime;
+
+        if (singleShardResult.RaftCommandIndex.HasValue)
+        {
+            if (combinedResult.RaftCommandIndex == null || singleShardResult.RaftCommandIndex > combinedResult.RaftCommandIndex)
+                combinedResult.RaftCommandIndex = singleShardResult.RaftCommandIndex;
+        }
+    }
+
+    protected void HandleDocumentIncludes(QueryResult cmdResult, QueryResult<List<TResult>, List<TIncludes>> result)
+    {
+        foreach (var id in cmdResult.Includes.GetPropertyNames())
+        {
+            if (cmdResult.Includes.TryGet(id, out BlittableJsonReaderObject include) && include != null)
+            {
+                if (result.Includes is List<BlittableJsonReaderObject> blittableIncludes)
+                    blittableIncludes.Add(include.Clone(Context));
+                else if (result.Includes is List<Document> documentIncludes)
+                    documentIncludes.Add(new Document { Id = Context.GetLazyString(id), Data = include.Clone(Context)});
+                else
+                    throw new NotSupportedException($"Unknown includes type: {result.Includes.GetType().FullName}");
+            }
+            else
+            {
+                (MissingDocumentIncludes ??= new HashSet<string>()).Add(id);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryOperation.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.Facets;
+using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.Facets;
+using Raven.Server.Documents.Sharding.Commands.Querying;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+using Sparrow.Json;
+using static Corax.Constants;
+
+namespace Raven.Server.Documents.Sharding.Queries.Facets;
+
+public class ShardedFacetedQueryOperation : IShardedReadOperation<QueryResult, FacetedQueryResult>
+{
+    private readonly ShardedDatabaseRequestHandler _requestHandler;
+    private readonly Dictionary<int, ShardedQueryCommand> _queryCommands;
+    private long _combinedResultEtag;
+    private readonly Dictionary<string, FacetOptions> _facetOptions;
+    private readonly IndexQueryServerSide _query;
+    private readonly TransactionOperationContext _context;
+
+    public ShardedFacetedQueryOperation(Dictionary<string, FacetOptions> facetOptions, IndexQueryServerSide query, TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, Dictionary<int, ShardedQueryCommand> queryCommands, string expectedEtag)
+    {
+        _facetOptions = facetOptions;
+        _query = query;
+        _context = context;
+        _requestHandler = requestHandler;
+        _queryCommands = queryCommands;
+        ExpectedEtag = expectedEtag;
+    }
+
+    public string ExpectedEtag { get; }
+
+    public HttpRequest HttpRequest { get => _requestHandler.HttpContext.Request; }
+
+    RavenCommand<QueryResult> IShardedOperation<QueryResult, ShardedReadResult<FacetedQueryResult>>.CreateCommandForShard(int shardNumber) => _queryCommands[shardNumber];
+
+    public string CombineCommandsEtag(Dictionary<int, ShardExecutionResult<QueryResult>> commands)
+    {
+        _combinedResultEtag = 0;
+
+        foreach (var cmd in commands.Values)
+        {
+            _combinedResultEtag = Hashing.Combine(_combinedResultEtag, cmd.Result.ResultEtag);
+        }
+
+        return CharExtensions.ToInvariantString(_combinedResultEtag);
+    }
+
+    public FacetedQueryResult CombineResults(Dictionary<int, ShardExecutionResult<QueryResult>> results)
+    {
+        var result = new FacetedQueryResult
+        {
+            ResultEtag = _combinedResultEtag
+        };
+
+        var facets = new Dictionary<string, CombinedFacet>();
+
+        var deserializer = DocumentConventions.DefaultForServer.Serialization.DefaultConverter;
+
+        foreach (var cmdResult in results.Values)
+        {
+            var queryResult = cmdResult.Result;
+
+            ShardedQueryOperation.CombineSingleShardResultProperties(result, queryResult);
+
+            foreach (BlittableJsonReaderObject facetJson in cmdResult.Result.Results)
+            {
+                var facetResult = deserializer.FromBlittable<FacetResult>(facetJson, "facet/result");
+
+                var fieldName = facetResult.Name;
+
+                if (facets.TryGetValue(fieldName, out CombinedFacet combinedFacet) == false)
+                {
+                    FacetOptions options = null;
+                    _facetOptions?.TryGetValue(fieldName, out options);
+
+                    combinedFacet = new CombinedFacet(options);
+                    facets[fieldName] = combinedFacet;
+                }
+
+                combinedFacet.Add(facetResult);
+            }
+        }
+
+        result.Results = facets.Values.Select(x => x.GetResult()).ToList();
+        
+        return result;
+    }
+
+    private class CombinedFacet
+    {
+        private readonly FacetOptions _options;
+        private FacetResult _combined;
+
+        private Dictionary<string, FacetValue> _valuesByRanges;
+
+        public CombinedFacet(FacetOptions options)
+        {
+            _options = options;
+        }
+
+        public void Add(FacetResult facetResult)
+        {
+            if (_combined == null)
+            {
+                _combined = new FacetResult
+                {
+                    Name = facetResult.Name,
+                    RemainingHits = facetResult.RemainingHits,
+                    RemainingTerms = facetResult.RemainingTerms,
+                    RemainingTermsCount = facetResult.RemainingTermsCount,
+                    Values = new List<FacetValue>(facetResult.Values.Count)
+                };
+
+                _valuesByRanges = new Dictionary<string, FacetValue>(facetResult.Values.Count);
+
+                foreach (FacetValue value in facetResult.Values)
+                {
+                    _valuesByRanges.Add(value.Range, new FacetValue
+                    {
+                        Average = value.Average,
+                        Count = value.Count,
+                        Max = value.Max,
+                        Min = value.Min,
+                        Name = value.Name,
+                        Range = value.Range,
+                        Sum = value.Sum
+                    });
+                }
+            }
+            else
+            {
+                foreach (FacetValue value in facetResult.Values)
+                {
+                    if (_valuesByRanges.TryGetValue(value.Range, out var existing) == false)
+                    {
+                        existing = new FacetValue
+                        {
+                            Average = value.Average,
+                            Count = value.Count,
+                            Max = value.Max,
+                            Min = value.Min,
+                            Name = value.Name,
+                            Range = value.Range,
+                            Sum = value.Sum
+                        };
+
+                        _valuesByRanges[value.Range] = existing;
+                    }
+                    else
+                    {
+                        existing.Count += value.Count;
+                        existing.Average += value.Average; // we'll convert it to avg value at the end of processing
+
+                        if (value.Max > existing.Max)
+                            existing.Max = value.Max;
+
+                        if (value.Min < existing.Min)
+                            existing.Min = value.Min;
+
+                        existing.Sum += value.Sum;
+                    }
+                }
+            }
+        }
+
+        public FacetResult GetResult()
+        {
+            if (_options != null)
+            {
+                var valuesCount = 0;
+                var valuesSumOfCounts = 0;
+                var values = new List<FacetValue>();
+                List<string> allTerms = IndexFacetReadOperationBase.GetAllTermsSorted(_options.TermSortMode, _valuesByRanges, x => x.Value.Count);
+
+                var start = _options.Start;
+                var pageSize = Math.Min(allTerms.Count, _options.PageSize);
+
+                foreach (var term in allTerms.Skip(start).TakeWhile(term => valuesCount < pageSize))
+                {
+                    valuesCount++;
+                    
+                    var facetValues = _valuesByRanges[term];
+
+                    values.Add(facetValues);
+
+                    valuesSumOfCounts += facetValues.Count;
+                }
+
+                var previousHits = allTerms.Take(start).Sum(allTerm =>
+                {
+                    if (_valuesByRanges.TryGetValue(allTerm, out var facetValues) == false || facetValues == null || facetValues.Count == 0)
+                        return 0;
+
+                    return facetValues.Count;
+                });
+
+                _combined.Values = values;
+                _combined.RemainingTermsCount = allTerms.Count - (start + valuesCount);
+                _combined.RemainingHits = _valuesByRanges.Values.Sum(x => x.Count) - (previousHits + valuesSumOfCounts);
+
+                if (_options.IncludeRemainingTerms)
+                    _combined.RemainingTerms = allTerms.Skip(start + valuesCount).ToList();
+            }
+            else
+            {
+                foreach (var item in _valuesByRanges)
+                {
+                    var value = item.Value;
+
+                    if (value.Average.HasValue)
+                    {
+                        if (value.Count == 0)
+                            value.Average = double.NaN;
+                        else
+                            value.Average /= value.Count;
+                    }
+
+                    _combined.Values.Add(value);
+                }
+            }
+            return _combined;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.Facets;
+using Raven.Client.Exceptions.Documents;
+using Raven.Client.Util;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.Facets;
+using Raven.Server.Documents.Queries.Suggestions;
+using Raven.Server.Documents.Sharding.Commands.Querying;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Documents.Sharding.Queries.Suggestions;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Sharding.Queries.Facets;
+
+public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryCommand, QueryResult, FacetedQueryResult>
+{
+    private readonly long? _existingResultEtag;
+
+    private readonly string _raftUniqueRequestId;
+
+    private Dictionary<string, FacetOptions> _optionsByFacet;
+
+    public ShardedFacetedQueryProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, IndexQueryServerSide query,
+        long? existingResultEtag, CancellationToken token) : base(context, requestHandler, query, false, false, token)
+    {
+        _existingResultEtag = existingResultEtag;
+        _raftUniqueRequestId = _requestHandler.GetRaftRequestIdFromQuery() ?? RaftIdGenerator.NewId();
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        HashSet<string> facetSetupDocumentIds = null;
+
+        foreach (var selectField in _query.Metadata.SelectFields)
+        {
+            if (selectField.IsFacet == false)
+                continue;
+
+            var facetField = (FacetField)selectField;
+
+            if (facetField.FacetSetupDocumentId != null)
+            {
+                facetSetupDocumentIds ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                if (facetSetupDocumentIds.Add(facetField.FacetSetupDocumentId) == false)
+                    continue;
+
+                GetDocumentsResult documentResult = await GetFacetSetupDocument(facetField);
+
+                if (documentResult.Results.Length == 0)
+                    throw new DocumentDoesNotExistException($"Facet setup document {facetField.FacetSetupDocumentId} was not found");
+
+                var document = (BlittableJsonReaderObject)documentResult.Results[0];
+
+                _query.QueryParameters.Modifications ??= new DynamicJsonValue(_query.QueryParameters);
+
+                _query.QueryParameters.Modifications[facetField.FacetSetupDocumentId] = document;
+
+                var facetSetupDocument = FacetSetup.Create(facetField.FacetSetupDocumentId, document);
+
+                foreach (var facet in facetSetupDocument.Facets)
+                {
+                    AddFacetOptions(facet.FieldName, facet.Options ?? FacetOptions.Default);
+                }
+            }
+            else if (facetField.Ranges == null || facetField.Ranges.Count == 0)
+            {
+                AddFacetOptions(facetField.Name, facetField.HasOptions ? facetField.GetOptions(_context, _query.QueryParameters) : FacetOptions.Default);
+            }
+        }
+
+        if (_query.QueryParameters.Modifications != null)
+            _query.QueryParameters = _context.ReadObject(_query.QueryParameters, "facet-query-parameters");
+
+        await base.InitializeAsync();
+
+        async Task<GetDocumentsResult> GetFacetSetupDocument(FacetField facetField)
+        {
+            int shardNumber = _requestHandler.DatabaseContext.GetShardNumberFor(_context, facetField.FacetSetupDocumentId);
+
+            var result = await _requestHandler.DatabaseContext.ShardExecutor.ExecuteSingleShardAsync(_context,
+                new GetDocumentsCommand(facetField.FacetSetupDocumentId, includes: null, metadataOnly: false), shardNumber, _token);
+
+            return result;
+        }
+
+        void AddFacetOptions(string name, FacetOptions options)
+        {
+            _optionsByFacet ??= new Dictionary<string, FacetOptions>();
+            _optionsByFacet.Add(name, options);
+        }
+    }
+
+    public override async Task<FacetedQueryResult> ExecuteShardedOperations()
+    {
+        var commands = GetOperationCommands();
+        
+        var operation = new ShardedFacetedQueryOperation(_optionsByFacet, _query, _context, _requestHandler, commands, _existingResultEtag?.ToString());
+
+        var shardedReadResult = await _requestHandler.ShardExecutor.ExecuteParallelForShardsAsync(commands.Keys.ToArray(), operation, _token);
+
+        if (shardedReadResult.StatusCode == (int)HttpStatusCode.NotModified)
+        {
+            return FacetedQueryResult.NotModifiedResult;
+        }
+
+        var result = shardedReadResult.Result;
+
+        if (_isAutoMapReduceQuery && result.RaftCommandIndex.HasValue)
+        {
+            // we are waiting here for all nodes, we should wait for all of the orchestrators at least to apply that
+            // so further queries would not throw index does not exist in case of a failover
+            await _requestHandler.DatabaseContext.Cluster.WaitForExecutionOnAllNodesAsync(result.RaftCommandIndex.Value);
+        }
+
+        return result;
+    }
+
+    protected override ShardedQueryCommand CreateCommand(BlittableJsonReaderObject query)
+    {
+        return new ShardedQueryCommand(_context.ReadObject(query, "query"), _query, _metadataOnly, _indexEntriesOnly, _query.Metadata.IndexName,
+            canReadFromCache: _existingResultEtag != null, raftUniqueRequestId: _raftUniqueRequestId);
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -29,7 +29,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
     private Dictionary<string, FacetOptions> _optionsByFacet;
 
     public ShardedFacetedQueryProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, IndexQueryServerSide query,
-        long? existingResultEtag, CancellationToken token) : base(context, requestHandler, query, false, false, token)
+        long? existingResultEtag, CancellationToken token) : base(context, requestHandler, query, metadataOnly: false, indexEntriesOnly: false, token)
     {
         _existingResultEtag = existingResultEtag;
         _raftUniqueRequestId = _requestHandler.GetRaftRequestIdFromQuery() ?? RaftIdGenerator.NewId();
@@ -116,12 +116,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
 
         var result = shardedReadResult.Result;
 
-        if (_isAutoMapReduceQuery && result.RaftCommandIndex.HasValue)
-        {
-            // we are waiting here for all nodes, we should wait for all of the orchestrators at least to apply that
-            // so further queries would not throw index does not exist in case of a failover
-            await _requestHandler.DatabaseContext.Cluster.WaitForExecutionOnAllNodesAsync(result.RaftCommandIndex.Value);
-        }
+        await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex);
 
         if (operation.MissingDocumentIncludes is { Count: > 0 })
         {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -112,12 +112,7 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
 
         var result = shardedReadResult.Result;
 
-        if (_isAutoMapReduceQuery && result.RaftCommandIndex.HasValue)
-        {
-            // we are waiting here for all nodes, we should wait for all of the orchestrators at least to apply that
-            // so further queries would not throw index does not exist in case of a failover
-            await _requestHandler.DatabaseContext.Cluster.WaitForExecutionOnAllNodesAsync(result.RaftCommandIndex.Value);
-        }
+        await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex);
 
         if (operation.MissingDocumentIncludes is {Count: > 0})
         {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -20,6 +19,7 @@ using Raven.Server.Documents.Sharding.Commands.Querying;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Counters;
 using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Documents.Sharding.Operations.Queries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
@@ -147,21 +147,6 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-17889 Add a test for that");
 
         return result;
-    }
-
-    private async Task HandleMissingDocumentIncludes(HashSet<string> missingIncludes, ShardedQueryResult result)
-    {
-        var missingIncludeIdsByShard = ShardLocator.GetDocumentIdsByShards(_context, _requestHandler.DatabaseContext, missingIncludes);
-        var missingIncludesOp = new FetchDocumentsFromShardsOperation(_context, _requestHandler, missingIncludeIdsByShard, null, null, counterIncludes: default, null, null, null, _metadataOnly);
-        var missingResult = await _requestHandler.DatabaseContext.ShardExecutor.ExecuteParallelForShardsAsync(missingIncludeIdsByShard.Keys.ToArray(), missingIncludesOp, _token);
-
-        foreach (var (_, missing) in missingResult.Result.Documents)
-        {
-            if (missing == null)
-                continue;
-
-            result.Includes.Add(missing);
-        }
     }
 
     private async Task HandleMissingCounterInclude(HashSet<string> missingCounterIncludes, ShardedQueryResult result)

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -98,9 +98,11 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
             var timeSeriesKeys = _query.Metadata.TimeSeriesIncludes.TimeSeries.Keys;
         }
 
-        var operation = new ShardedQueryOperation(_query, _context, _requestHandler, _commands, documentsComparer, _existingResultEtag?.ToString());
+        var commands = GetOperationCommands();
 
-        int[] shards = _filteredShardIndexes == null ? _commands.Keys.ToArray() : _commands.Keys.Intersect(_filteredShardIndexes).ToArray();
+        var operation = new ShardedQueryOperation(_query, _context, _requestHandler, commands, documentsComparer, _existingResultEtag?.ToString());
+
+        int[] shards = _filteredShardIndexes == null ? commands.Keys.ToArray() : commands.Keys.Intersect(_filteredShardIndexes).ToArray();
         var shardedReadResult = await _requestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shards, operation, _token);
 
         if (shardedReadResult.StatusCode == (int)HttpStatusCode.NotModified)

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -21,7 +21,8 @@ namespace Raven.Server.Documents.Sharding.Queries
         private readonly string _debug;
         private readonly bool _ignoreLimit;
 
-        public ShardedQueryStreamProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, IndexQueryServerSide query, string debug, bool ignoreLimit, CancellationToken token) : base(context, requestHandler, query, false, false, token)
+        public ShardedQueryStreamProcessor(TransactionOperationContext context, ShardedDatabaseRequestHandler requestHandler, IndexQueryServerSide query, string debug,
+            bool ignoreLimit, CancellationToken token) : base(context, requestHandler, query, metadataOnly: false, indexEntriesOnly: false, token)
         {
             _debug = debug;
             _ignoreLimit = ignoreLimit;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -46,13 +46,15 @@ namespace Raven.Server.Documents.Sharding.Queries
                 ? new ShardedDocumentsComparer(_query.Metadata, isMapReduce: false)
                 : new ShardedStreamingHandlerProcessorForGetStreamQuery.DocumentBlittableLastModifiedComparer();
 
+            var commands = GetOperationCommands();
+
             var op = new ShardedStreamQueryOperation(_requestHandler.HttpContext, () =>
             {
                 IDisposable returnToContextPool = _requestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext ctx);
                 return (ctx, returnToContextPool);
-            }, comparer, _commands, skip: _query.Offset ?? 0, take: _query.Limit ?? int.MaxValue, _token);
+            }, comparer, commands, skip: _query.Offset ?? 0, take: _query.Limit ?? int.MaxValue, _token);
 
-            return _requestHandler.ShardExecutor.ExecuteParallelForShardsAsync(_commands.Keys.ToArray(), op, _token);
+            return _requestHandler.ShardExecutor.ExecuteParallelForShardsAsync(commands.Keys.ToArray(), op, _token);
         }
 
         protected override PostQueryStreamCommand CreateCommand(BlittableJsonReaderObject query)

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
@@ -4,13 +4,12 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Documents.Queries.Suggestions;
 using Raven.Client.Util;
 using Raven.Server.Documents.Queries;
-using Raven.Server.Documents.Queries.Sharding;
 using Raven.Server.Documents.Queries.Suggestions;
 using Raven.Server.Documents.Sharding.Commands.Querying;
 using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Operations.Queries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/SuggestionResultWithPopularity.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/SuggestionResultWithPopularity.cs
@@ -1,16 +1,15 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Queries.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Suggestions;
 
 namespace Raven.Server.Documents.Sharding.Queries.Suggestions;
 
-public class SuggestionResultWithPopularity : SuggestionResult
+internal class SuggestionResultWithPopularity : SuggestionResult
 {
-    public List<Popularity> SuggestionsPopularity;
+    public Popularity SuggestionsWithPopularity;
 
-    public class Popularity
+    internal class Popularity
     {
-        public float Score;
-        
-        public int Freq;
+        public List<SuggestWord> Values;
     }
 }

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -370,19 +370,23 @@ namespace Raven.Server.Json
 
             writer.WriteArray(nameof(result.Suggestions), result.Suggestions);
 
-            if (result is SuggestionResultWithPopularity {SuggestionsPopularity.Count: > 0} suggestionResultWithPopularity)
+            if (result is SuggestionResultWithPopularity {SuggestionsWithPopularity: {Values.Count: > 0} suggestionsPopularity})
             {
                 writer.WriteComma();
 
                 writer.WritePropertyName(Constants.Documents.Metadata.Key);
                 writer.WriteStartObject();
 
-                writer.WritePropertyName(Constants.Documents.Metadata.SuggestionPopularityFields);
+                writer.WritePropertyName(Constants.Documents.Metadata.SuggestionsPopularityFields);
+                
+                writer.WriteStartObject();
+                writer.WritePropertyName(nameof(suggestionsPopularity.Values));
+
                 writer.WriteStartArray();
 
                 var firstPopularity = true;
 
-                foreach (var popularity in suggestionResultWithPopularity.SuggestionsPopularity)
+                foreach (var popularity in suggestionsPopularity.Values)
                 {
                     if (firstPopularity == false)
                         writer.WriteComma();
@@ -405,6 +409,8 @@ namespace Raven.Server.Json
                 writer.WriteEndArray();
                 
                 writer.WriteEndObject();
+                writer.WriteEndObject();
+
             }
 
             writer.WriteEndObject();

--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -202,8 +202,8 @@ public class RavenIntegration : RavenTestBase
 
     private record DoubleItem(double Value);
 
-    [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void CanCreateFacetsOnDynamicFields(Options options)
     {
         using var store = DatabaseForDynamicIndex(options);

--- a/test/SlowTests/Bugs/Facets/DateTimeFacets.cs
+++ b/test/SlowTests/Bugs/Facets/DateTimeFacets.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Bugs.Facets
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void PrestonThinksDateRangeQueryShouldProduceCorrectResultsWhenBuiltWithClient(Options options)
         {
             var cameras = GetCameras(30);

--- a/test/SlowTests/Bugs/Facets/FacetErrors.cs
+++ b/test/SlowTests/Bugs/Facets/FacetErrors.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Exceptions;
+using Tests.Infrastructure;
 using Xunit.Abstractions;
 
 namespace SlowTests.Bugs.Facets
@@ -15,8 +16,9 @@ namespace SlowTests.Bugs.Facets
         {
         }
 
-        [Fact]
-        public void PrestonThinksFacetsShouldNotHideOtherErrors()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void PrestonThinksFacetsShouldNotHideOtherErrors(Options options)
         {
             var cameras = GetCameras(30);
             var now = DateTime.Now;
@@ -35,7 +37,7 @@ namespace SlowTests.Bugs.Facets
                 now.AddDays(7)
             };
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 CreateCameraCostIndex(store);
 

--- a/test/SlowTests/Core/Commands/Querying.cs
+++ b/test/SlowTests/Core/Commands/Querying.cs
@@ -147,7 +147,8 @@ namespace SlowTests.Core.Commands
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Skip = "RavenDB-17966")]
         public void CanGetFacets(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Core/Querying/Searching.cs
+++ b/test/SlowTests/Core/Querying/Searching.cs
@@ -336,7 +336,7 @@ namespace SlowTests.Core.Querying
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedSearchAndLazyFacatedSearch(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-10329.cs
+++ b/test/SlowTests/Issues/RavenDB-10329.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Facets;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetFacetsOnFieldsWithNamesThatAreReserevedKeywords(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-10538.cs
+++ b/test/SlowTests/Issues/RavenDB-10538.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetWithNullableDateTime(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-10538.cs
+++ b/test/SlowTests/Issues/RavenDB-10538.cs
@@ -71,8 +71,8 @@ namespace SlowTests.Issues
 
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task TestGeneratedFacetsTest(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-11089.cs
+++ b/test/SlowTests/Issues/RavenDB-11089.cs
@@ -231,7 +231,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenExplicitData(searchEngine: RavenSearchEngineMode.Lucene)]
+        [RavenExplicitData(searchEngine: RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformDynamicFacetedSearch_Embedded(RavenTestParameters config)
         {
             var cameras = GetCameras(30);

--- a/test/SlowTests/Issues/RavenDB-12902.cs
+++ b/test/SlowTests/Issues/RavenDB-12902.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task AfterAggregationQueryExecutedShouldBeExecutedOnlyOnce(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -496,7 +496,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanGetValidStatisticsInAggregationQuery(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-3136.cs
+++ b/test/SlowTests/Issues/RavenDB-3136.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void AggregateByIntegerShouldReturnResultWithValuesAndCountEvenWithLambdaExpression(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void AggregateByIntegerShouldReturnResultWithValuesAndCount(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -84,7 +84,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void AggregateByStringShouldReturnResultWithValuesAndCount(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-3179.cs
+++ b/test/SlowTests/Issues/RavenDB-3179.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,10 +18,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task To_Facet_Lazy_Async()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task To_Facet_Lazy_Async(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new AdviceSearch().Execute(store);
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Issues/RavenDB-3179.cs
+++ b/test/SlowTests/Issues/RavenDB-3179.cs
@@ -19,7 +19,8 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded, Skip = "RavenDB-13927 Order by score")]
         public async Task To_Facet_Lazy_Async(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_10163.cs
+++ b/test/SlowTests/Issues/RavenDB_10163.cs
@@ -12,8 +12,8 @@ namespace SlowTests.Issues
         {
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void SupportForFacetOnAllResults(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_1466.cs
+++ b/test/SlowTests/Issues/RavenDB_1466.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanSearchByMultiFacetQueries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_15825.cs
+++ b/test/SlowTests/Issues/RavenDB_15825.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task ShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_2672.cs
+++ b/test/SlowTests/Issues/RavenDB_2672.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
 using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,10 +24,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void FacetSearchShouldThrowIfIndexDoesNotExist()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void FacetSearchShouldThrowIfIndexDoesNotExist(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_8026.cs
+++ b/test/SlowTests/Issues/RavenDB_8026.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void OptionsShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                         .OrderByDescending(x => x)
                         .ToList();
 
-                    Assert.Equal(counts, orderedCounts);
+                    Assert.Equal(orderedCounts, counts);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_9096.cs
+++ b/test/SlowTests/Issues/RavenDB_9096.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task TestNullIntTest(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_9269.cs
+++ b/test/SlowTests/Issues/RavenDB_9269.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void ShouldNotThrowNRE(Options options)
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB_9481.cs
+++ b/test/SlowTests/Issues/RavenDB_9481.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task AggregateQueryTest(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_9721.cs
+++ b/test/SlowTests/Issues/RavenDB_9721.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Should_include_last_tombstone_as_cutoff_etag(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDb_2215.cs
+++ b/test/SlowTests/Issues/RavenDb_2215.cs
@@ -51,7 +51,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryReturningMultipleValues(Options options)
         {
 
@@ -100,7 +100,7 @@ namespace SlowTests.Issues
 
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryReturningMultipleValuesWithDifferentNames(Options options)
         {
             using (var store = GetDocumentStore())
@@ -150,7 +150,7 @@ namespace SlowTests.Issues
 
         }
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryCantReturnMultipleAggregationValuesWithSameName(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -199,7 +199,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryReturningMultipleValuesOnDifferentArguments(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -239,7 +239,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanQueryReturningMultipleValuesOnDifferentArguments_Legacy(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -281,7 +281,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryReturningMultipleValuesSameArg(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/CanFacetOnList.cs
+++ b/test/SlowTests/MailingList/CanFacetOnList.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void CanFacetOnList()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanFacetOnList(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new BlogIndex().Execute(store);
 

--- a/test/SlowTests/MailingList/CanRetrieveFacetCountsOfQueryResults.cs
+++ b/test/SlowTests/MailingList/CanRetrieveFacetCountsOfQueryResults.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,10 +68,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void CanRetrieveFacetCounts()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanRetrieveFacetCounts(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/MailingList/CanRetrieveFacetCountsOfQueryResults2.cs
+++ b/test/SlowTests/MailingList/CanRetrieveFacetCountsOfQueryResults2.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -66,10 +67,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void CanRetrieveFacetCounts()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanRetrieveFacetCounts(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/MailingList/FacetCountTest.cs
+++ b/test/SlowTests/MailingList/FacetCountTest.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -83,10 +84,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void TestFacetsCount()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void TestFacetsCount(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 InsertData(store);
 

--- a/test/SlowTests/MailingList/FacetHits.cs
+++ b/test/SlowTests/MailingList/FacetHits.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -46,8 +47,9 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void CanSearchOnAllProperties()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanSearchOnAllProperties(Options options)
         {
             using (var store = GetDocumentStore())
             {

--- a/test/SlowTests/MailingList/Georgiosd.cs
+++ b/test/SlowTests/MailingList/Georgiosd.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void CanGet304FromLazyFacets()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanGet304FromLazyFacets(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new OrgIndex());
 

--- a/test/SlowTests/MailingList/JustFacetSearch.cs
+++ b/test/SlowTests/MailingList/JustFacetSearch.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -158,10 +159,11 @@ namespace SlowTests.MailingList
             foreach (var article in articles) session.Store(article);
         }
 
-        [Fact]
-        public void JustReturnFacets()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void JustReturnFacets(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new Advice_Search().Execute(store);
 

--- a/test/SlowTests/MailingList/LazyAggregationEmbedded.cs
+++ b/test/SlowTests/MailingList/LazyAggregationEmbedded.cs
@@ -21,7 +21,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Test(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/Samina3.cs
+++ b/test/SlowTests/MailingList/Samina3.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries.Facets;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,15 +26,16 @@ namespace SlowTests.MailingList
         }
 
 
-        [Fact]
-        public void Querying_a_sub_collection_in_an_index()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Querying_a_sub_collection_in_an_index(Options options)
         {
             DateTime startDate1 = DateTime.Now;
             DateTime endDate1 = DateTime.Now.AddDays(10);
             DateTime startDate2 = DateTime.Now.AddDays(15);
             DateTime endDate2 = DateTime.Now.AddDays(20);
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/MailingList/TomCabanski.cs
+++ b/test/SlowTests/MailingList/TomCabanski.cs
@@ -4,6 +4,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void CanEscapeGetFacets()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanEscapeGetFacets(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {new IndexDefinition
                 {

--- a/test/SlowTests/MailingList/Wade.cs
+++ b/test/SlowTests/MailingList/Wade.cs
@@ -49,7 +49,7 @@ namespace SlowTests.MailingList
 
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void DateTime_Facet_Works_As_Expected(Options options)
         {
             using (var documentStore = GetDocumentStore(options))
@@ -120,10 +120,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void Nested_DateTime_Facet_Works_As_Expected()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Nested_DateTime_Facet_Works_As_Expected(Options options)
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = GetDocumentStore(options))
             {
 
                 CreateIndexes(documentStore);
@@ -190,8 +191,9 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void Nested_Enumberables_DateTime_Facet_Works_As_Expected()
+        [RavenTheory(RavenTestCategory.Facets)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Nested_Enumberables_DateTime_Facet_Works_As_Expected(Options options)
         {
             using (var documentStore = GetDocumentStore())
             {

--- a/test/SlowTests/SlowTests/Faceted/FacetPaging.cs
+++ b/test/SlowTests/SlowTests/Faceted/FacetPaging.cs
@@ -21,7 +21,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc(Options options)
         {
             //also specify more results than we have

--- a/test/SlowTests/SlowTests/RavenDB-14600.cs
+++ b/test/SlowTests/SlowTests/RavenDB-14600.cs
@@ -18,7 +18,7 @@ namespace SlowTests.SlowTests
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanIncludeFacetResult(Options options)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Tests/Faceted/Aggregation.cs
+++ b/test/SlowTests/Tests/Faceted/Aggregation.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_AnonymousTypes_Double(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -82,7 +82,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_AnonymousTypes_Float(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -120,7 +120,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_AnonymousTypes_Int(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -158,7 +158,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_AnonymousTypes_Long(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -196,7 +196,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -228,7 +228,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_MultipleItems(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -268,7 +268,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_MultipleAggregations(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -303,7 +303,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_LongDataType(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -333,7 +333,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_DateTimeDataType(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -398,7 +398,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_Ranges(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -442,7 +442,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_DateTimeDataType_WithRangeCounts(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -484,7 +484,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_DateTimeDataType_WithRangeCounts_AndInOperator_AfterOtherWhere(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -528,7 +528,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_DateTimeDataType_WithRangeCounts_AndInOperator_BeforeOtherWhere(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/Aggregation.cs
+++ b/test/SlowTests/Tests/Faceted/Aggregation.cs
@@ -55,8 +55,8 @@ namespace SlowTests.Tests.Faceted
                 using (var session = store.OpenSession())
                 {
 
-                    var obj = new { Currency = Currency.EUR, Product = "Milk", Total = 1.1, Region = 1 };
-                    var obj2 = new { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 1 };
+                    var obj = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1.1M, Region = 1 };
+                    var obj2 = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 1 };
 
                     session.Store(obj);
                     session.Store(obj2);
@@ -92,8 +92,8 @@ namespace SlowTests.Tests.Faceted
                 using (var session = store.OpenSession())
                 {
 
-                    var obj = new { Currency = Currency.EUR, Product = "Milk", Total = 1.1, Region = 1, Tax = 1 };
-                    var obj2 = new { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 1, Tax = 1.5 };
+                    var obj = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1.1M, Region = 1, Tax = 1 };
+                    var obj2 = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 1, Tax = 1.5f };
 
                     session.Store(obj);
                     session.Store(obj2);
@@ -130,8 +130,8 @@ namespace SlowTests.Tests.Faceted
                 using (var session = store.OpenSession())
                 {
 
-                    var obj = new { Currency = Currency.EUR, Product = "Milk", Quantity = 1.0, Total = 1.1, Region = 1, Tax = 1 };
-                    var obj2 = new { Currency = Currency.EUR, Product = "Milk", Quantity = 2, Total = 1, Region = 1, Tax = 1.5 };
+                    var obj = new Order { Currency = Currency.EUR, Product = "Milk", Quantity = 1, Total = 1.1M, Region = 1, Tax = 1 };
+                    var obj2 = new Order { Currency = Currency.EUR, Product = "Milk", Quantity = 2, Total = 1, Region = 1, Tax = 1.5f };
 
                     session.Store(obj);
                     session.Store(obj2);
@@ -168,8 +168,8 @@ namespace SlowTests.Tests.Faceted
                 using (var session = store.OpenSession())
                 {
 
-                    var obj = new { Currency = Currency.EUR, Product = "Milk", Total = 1.1, Region = 1.0, Tax = 1 };
-                    var obj2 = new { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 2, Tax = 1.5 };
+                    var obj = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1.1M, Region = 1, Tax = 1 };
+                    var obj2 = new Order { Currency = Currency.EUR, Product = "Milk", Total = 1, Region = 2, Tax = 1.5f };
 
                     session.Store(obj);
                     session.Store(obj2);

--- a/test/SlowTests/Tests/Faceted/AggregationFacet.cs
+++ b/test/SlowTests/Tests/Faceted/AggregationFacet.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleMaxFacet_LowLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -54,7 +54,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleCountFacet_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -78,7 +78,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleMaxFacet_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -102,7 +102,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleMinFacet_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -125,7 +125,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleSumFacet_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -149,7 +149,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleAverageFacet_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -172,7 +172,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanHandleAverageFacetAsync_HighLevel(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -195,7 +195,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetAggregationQueryString(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -212,7 +212,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetAggregationQueryString_Async(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/DynamicFacets.cs
+++ b/test/SlowTests/Tests/Faceted/DynamicFacets.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformDynamicFacetedSearch_Embedded(Options options)
         {
             var cameras = GetCameras(30);
@@ -56,7 +56,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformDynamicFacetedSearch_Remotely(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/FacetedIndexLimit.cs
+++ b/test/SlowTests/Tests/Faceted/FacetedIndexLimit.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformSearchWithTwoDefaultFacets(Options options)
         {
             var facets = new List<Facet> { new Facet { FieldName = "Manufacturer" }, new Facet { FieldName = "Model" } };
@@ -84,7 +84,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_TermAsc(Options options)
         {
             var facets = new List<Facet>
@@ -140,7 +140,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_TermDesc(Options options)
         {
             var facets = new List<Facet>
@@ -198,7 +198,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_HitsAsc(Options options)
         {
             var facets = new List<Facet>
@@ -247,10 +247,6 @@ namespace SlowTests.Tests.Faceted
                         Assert.Equal(inMemoryCount, facet.Count);
                     }
 
-                    if (manufacturer.RemainingHits == 2)
-                    {
-                        WaitForUserToContinueTheTest(store, debug: false);
-                    }
                     Assert.Equal(3, manufacturer.RemainingTermsCount);
                     Assert.Equal(3, manufacturer.RemainingTerms.Count());
                     Assert.Equal(camerasByHits[2], manufacturer.RemainingTerms[0]);
@@ -266,7 +262,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_HitsDesc(Options options)
         {
             //also specify more results than we have
@@ -306,8 +302,7 @@ namespace SlowTests.Tests.Faceted
 
                     Assert.Equal(5, facetResults["Manufacturer"].Values.Count());
                     Assert.Equal(camerasByHits[0], facetResults["Manufacturer"].Values[0].Range);
-                    if (camerasByHits[1] != facetResults["Manufacturer"].Values[1].Range)
-                        WaitForUserToContinueTheTest(store, debug: false);
+                    
                     Assert.Equal(camerasByHits[1], facetResults["Manufacturer"].Values[1].Range);
                     Assert.Equal(camerasByHits[2], facetResults["Manufacturer"].Values[2].Range);
                     Assert.Equal(camerasByHits[3], facetResults["Manufacturer"].Values[3].Range);
@@ -327,7 +322,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformSearchWithTwoDefaultFacets_LuceneQuery(Options options)
         {
             var facets = new List<Facet> { new Facet { FieldName = "Manufacturer" }, new Facet { FieldName = "Model" } };
@@ -383,7 +378,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_TermAsc_LuceneQuery(Options options)
         {
             var facets = new List<Facet>
@@ -440,7 +435,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_TermDesc_LuceneQuery(Options options)
         {
             var facets = new List<Facet>
@@ -498,7 +493,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_HitsAsc_LuceneQuery(Options options)
         {
             var facets = new List<Facet>
@@ -561,7 +556,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformFacetedLimitSearch_HitsDesc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -601,8 +596,8 @@ namespace SlowTests.Tests.Faceted
 
                     Assert.Equal(5, facetResults["Manufacturer"].Values.Count());
                     Assert.Equal(camerasByHits[0], facetResults["Manufacturer"].Values[0].Range);
-                    if (camerasByHits[1] != facetResults["Manufacturer"].Values[1].Range)
-                        WaitForUserToContinueTheTest(store, debug: false);
+                    
+
                     Assert.Equal(camerasByHits[1], facetResults["Manufacturer"].Values[1].Range);
                     Assert.Equal(camerasByHits[2], facetResults["Manufacturer"].Values[2].Range);
                     Assert.Equal(camerasByHits[3], facetResults["Manufacturer"].Values[3].Range);

--- a/test/SlowTests/Tests/Faceted/FacetsWithParameters.cs
+++ b/test/SlowTests/Tests/Faceted/FacetsWithParameters.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Tests.Faceted
 
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetShouldUseParameters_WithFacetBaseList(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -113,7 +113,7 @@ namespace SlowTests.Tests.Faceted
 
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetShouldUseParameters_WithTypedRangeFacetList(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -156,7 +156,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetShouldUseParameters_WithIFacetBuilder(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -191,7 +191,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetShouldUseParameters_WithUntypedRangeFacetList(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -235,7 +235,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetSetupDocument_ShouldNotUseParameters(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -310,7 +310,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task TwoDifferentAsyncQueriesThatAreUsingTheSameFacetWithParametersShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -363,7 +363,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryUsingMultipuleFacetsWithParametersShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -429,7 +429,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void FacetShouldUseParameters_WithNumbers(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/LargeFacets.cs
+++ b/test/SlowTests/Tests/Faceted/LargeFacets.cs
@@ -40,7 +40,8 @@ namespace SlowTests.Tests.Faceted
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Skip = "RavenDB-17966")]
         public void CanGetSameResult(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/RavenDB_12748.cs
+++ b/test/SlowTests/Tests/Faceted/RavenDB_12748.cs
@@ -422,7 +422,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldThrow(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Faceted/RavenDB_12748.cs
+++ b/test/SlowTests/Tests/Faceted/RavenDB_12748.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -255,7 +255,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCorrectlyAggregate_Ranges(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -422,7 +422,7 @@ namespace SlowTests.Tests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void ShouldThrow(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18765/Sharding-Query-Facets

### Additional description

Adds support for facet queries agains a sharded database. Implementations notes:

1) if a query uses the syntax where a facet setup document id is specified then the orchestrator gets the document from the shard where it exists and sends it as a query parameter to other shards 

2) if paging is involved then we return all results and the orchestrator handles the paging

3) when "average" is requested then shards return Average as a sum. The correct value is calculated as Average = Average / Count on the orchestrator side after combining results from all shards

4) support for includes is handled the same way as for regular queries

### Type of change

- Sharding implementation of existing feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests were modified to be run in sharded env

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
