### PR TITLE
RavenDB-18881: throw on revisions subscription on sharded database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -15,6 +16,11 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
     {
         public AbstractSubscriptionsHandlerProcessorForPostSubscription([NotNull] TRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        public virtual SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            return SubscriptionConnection.ParseSubscriptionQuery(query);
         }
 
         protected abstract ValueTask CreateSubscriptionInternalAsync(BlittableJsonReaderObject bjro, long? id, bool? disabled, SubscriptionCreationOptions options, TransactionOperationContext context);

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPutSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPutSubscription.cs
@@ -2,6 +2,7 @@
 using JetBrains.Annotations;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Json;
 using Raven.Server.TrafficWatch;
 using Sparrow.Json;
@@ -14,6 +15,11 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
     {
         public AbstractSubscriptionsHandlerProcessorForPutSubscription([NotNull] TRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        public virtual SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            return SubscriptionConnection.ParseSubscriptionQuery(query);
         }
 
         protected abstract ValueTask CreateInternalAsync(BlittableJsonReaderObject bjro, SubscriptionCreationOptions options, TOperationContext context, long? id,

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForTrySubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForTrySubscription.cs
@@ -16,6 +16,11 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
         {
         }
 
+        public virtual SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            return SubscriptionConnection.ParseSubscriptionQuery(query);
+        }
+
         protected abstract ValueTask TryoutSubscriptionAsync(TOperationContext context, SubscriptionConnection.ParsedSubscription subscription, SubscriptionTryout tryout, int pageSize);
 
         public override async ValueTask ExecuteAsync()
@@ -25,7 +30,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 using var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), null);
                 var tryout = JsonDeserializationServer.SubscriptionTryout(json);
 
-                var sub = SubscriptionConnection.ParseSubscriptionQuery(tryout.Query);
+                var sub = ParseSubscriptionQuery(tryout.Query);
 
                 if (sub.Collection == null)
                     throw new ArgumentException("Collection must be specified");

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPostSubscription.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -17,7 +18,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {
-                await RequestHandler.CreateInternalAsync(bjro, options, context, id, disabled);
+                var sub = ParseSubscriptionQuery(options.Query);
+                await RequestHandler.CreateInternalAsync(bjro, options, context, id, disabled, sub);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPutSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPutSubscription.cs
@@ -16,7 +16,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
         {
             using (context.OpenReadTransaction())
             {
-                await RequestHandler.CreateInternalAsync(bjro, options, context, id, disabled);
+                var sub = ParseSubscriptionQuery(options.Query);
+                await RequestHandler.CreateInternalAsync(bjro, options, context, id, disabled, sub);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -98,12 +98,10 @@ namespace Raven.Server.Documents.Handlers
             return gotChanges;
         }
 
-        public async Task CreateInternalAsync(BlittableJsonReaderObject bjro, SubscriptionCreationOptions options, DocumentsOperationContext context, long? id, bool? disabled)
+        public async Task CreateInternalAsync(BlittableJsonReaderObject bjro, SubscriptionCreationOptions options, DocumentsOperationContext context, long? id, bool? disabled, SubscriptionConnection.ParsedSubscription sub)
         {
             if (TrafficWatchManager.HasRegisteredClients)
                 AddStringToHttpContext(bjro.ToString(), TrafficWatchChangeType.Subscriptions);
-
-            var sub = SubscriptionConnection.ParseSubscriptionQuery(options.Query);
 
             if (Enum.TryParse(options.ChangeVector, out Constants.Documents.SubscriptionChangeVectorSpecialStates changeVectorSpecialValue))
             {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPostSubscription.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -13,9 +15,22 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
         {
         }
 
+        public override SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            var parsed = base.ParseSubscriptionQuery(query);
+            if (parsed.Revisions)
+            {
+                // RavenDB-18881
+                throw new NotSupportedInShardingException(@"Revisions subscription is not supported for sharded database.");
+            }
+
+            return parsed;
+        }
+
         protected override async ValueTask CreateSubscriptionInternalAsync(BlittableJsonReaderObject bjro, long? id, bool? disabled, SubscriptionCreationOptions options, TransactionOperationContext context)
         {
-            await RequestHandler.CreateSubscriptionInternalAsync(bjro, id, disabled, options, context);
+            var sub = ParseSubscriptionQuery(options.Query);
+            await RequestHandler.CreateSubscriptionInternalAsync(bjro, id, disabled, options, context, sub);
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPutSubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPutSubscription.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -13,9 +15,22 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
         {
         }
 
+        public override SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            var parsed = base.ParseSubscriptionQuery(query);
+            if (parsed.Revisions)
+            {
+                // RavenDB-18881
+                throw new NotSupportedInShardingException(@"Revisions subscription is not supported for sharded database.");
+            }
+
+            return parsed;
+        }
+
         protected override async ValueTask CreateInternalAsync(BlittableJsonReaderObject bjro, SubscriptionCreationOptions options, TransactionOperationContext context, long? id, bool? disabled)
         {
-            await RequestHandler.CreateSubscriptionInternalAsync(bjro, id, disabled, options, context);
+            var sub = ParseSubscriptionQuery(options.Query);
+            await RequestHandler.CreateSubscriptionInternalAsync(bjro, id, disabled, options, context, sub);
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForTrySubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForTrySubscription.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.Documents.TcpHandlers;
@@ -14,6 +15,18 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
     {
         public ShardedSubscriptionsHandlerProcessorForTrySubscription([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        public override SubscriptionConnection.ParsedSubscription ParseSubscriptionQuery(string query)
+        {
+            var parsed = base.ParseSubscriptionQuery(query);
+            if (parsed.Revisions)
+            {
+                // RavenDB-18881
+                throw new NotSupportedInShardingException(@"Revisions subscription is not supported for sharded database.");
+            }
+
+            return parsed;
         }
 
         protected override async ValueTask TryoutSubscriptionAsync(TransactionOperationContext context, SubscriptionConnection.ParsedSubscription subscription, SubscriptionTryout tryout, int pageSize)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -33,12 +33,11 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 await processor.ExecuteAsync();
         }
         
-        public async Task CreateSubscriptionInternalAsync(BlittableJsonReaderObject bjro, long? id, bool? disabled, SubscriptionCreationOptions options, JsonOperationContext context)
+        public async Task CreateSubscriptionInternalAsync(BlittableJsonReaderObject bjro, long? id, bool? disabled, SubscriptionCreationOptions options, JsonOperationContext context, SubscriptionConnection.ParsedSubscription sub)
         {
             if (TrafficWatchManager.HasRegisteredClients)
                 AddStringToHttpContext(bjro.ToString(), TrafficWatchChangeType.Subscriptions);
 
-            var sub = SubscriptionConnection.ParseSubscriptionQuery(options.Query);
             var changeVectorValidationResult = await TryValidateChangeVector(options, sub);
 
             var (etag, _) = await ServerStore.SendToLeaderAsync(new PutShardedSubscriptionCommand(DatabaseContext.DatabaseName, options.Query, options.MentorNode, GetRaftRequestIdFromQuery())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18881

### Additional description

Disable creation of revision subscription on sharded database

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Non breaking change

### Is it platform specific issue?


- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Subscription with Revision 

### UI work

- No UI work is needed
