### PR TITLE
RavenDB-16190 Fixed loading multiple attachments using LoadAttachments function with the usage of Select

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -138,7 +138,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             var id = GetSourceId(document);
 
-            return LoadAttachments(id, GetAttachmentNames());
+            return new DynamicArray(LoadAttachments(id, GetAttachmentNames()));
 
             IEnumerable<string> GetAttachmentNames()
             {

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Indexes.Static
             if (document == null)
                 throw new InvalidOperationException($"{nameof(LoadAttachments)} may only be called with a non-null entity as a parameter, but was called with a parameter of type {doc.GetType().FullName}: {doc}");
 
-            return new DynamicArray(CurrentIndexingScope.Current.LoadAttachments(document));
+            return CurrentIndexingScope.Current.LoadAttachments(document);
         }
 
         public dynamic LoadAttachment(dynamic doc, object attachmentName)

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Indexes.Static
             if (document == null)
                 throw new InvalidOperationException($"{nameof(LoadAttachments)} may only be called with a non-null entity as a parameter, but was called with a parameter of type {doc.GetType().FullName}: {doc}");
 
-            return CurrentIndexingScope.Current.LoadAttachments(document);
+            return new DynamicArray(CurrentIndexingScope.Current.LoadAttachments(document));
         }
 
         public dynamic LoadAttachment(dynamic doc, object attachmentName)

--- a/test/SlowTests/Issues/RavenDB-16190.cs
+++ b/test/SlowTests/Issues/RavenDB-16190.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_16190 : RavenTestBase
+{
+    public RavenDB_16190(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(@"from index 'Qs' as o select Content")]
+    [InlineData(@"from index 'MultipleAttachmentsIndex' as o select Content")]
+    public void CheckIfCanGetMultipleAttachmentsFromDocument(string query)
+    {
+        using var store = GetDocumentStore();
+
+        using var file1 = new MemoryStream();
+        using var file2 = new MemoryStream();
+        
+        file1.Write(Encodings.Utf8.GetBytes(new string('a', 5)).AsSpan());
+        file2.Write(Encodings.Utf8.GetBytes(new string('b', 4)).AsSpan());
+        
+        file1.Position = 0;
+        file2.Position = 0;
+        
+        using (var session = store.OpenSession())
+        {
+            Order o1 = new() { Price = 21 };
+
+            session.Store(o1);
+
+            session.Advanced.Attachments.Store(o1.Id, "f1.txt", file1);
+            session.Advanced.Attachments.Store(o1.Id, "f2.txt", file2);
+
+            session.SaveChanges();
+
+            var index = new MultipleAttachmentsIndex();
+            index.Execute(store);
+            
+            var qs = new Qs();
+            qs.Execute(store);
+            
+            Indexes.WaitForIndexing(store);
+            
+            WaitForUserToContinueTheTest(store);
+            
+            var res = session.Advanced
+                .RawQuery<Order>(query)
+                .WaitForNonStaleResults().ToList();
+            
+            Assert.Equal(res[0].Content, "aaaaabbbb");
+        }
+    }
+
+    private class MultipleAttachmentsIndex : AbstractIndexCreationTask<Order>
+    {
+        public MultipleAttachmentsIndex()
+        {
+            Map = orders => from o in orders
+                let attachments = LoadAttachments(o).Select(x => x.GetContentAsString())
+                select new { Content = attachments.Aggregate((s, s1) => s + s1) };
+            Stores.Add(x => x.Content, FieldStorage.Yes);
+        }
+    }
+
+    private class Qs : AbstractIndexCreationTask
+    {
+        public Qs()
+        {
+            
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition()
+            {
+                Maps = new()
+                {
+                    @"from o in docs.Orders
+                let attachments = LoadAttachments(o).Select(x => x.GetContentAsString())
+                select new { Content = attachments.Aggregate((s, s1) => s + s1) }"
+                },
+                Fields = new Dictionary<string, IndexFieldOptions>(){ { "Content", new IndexFieldOptions() { Storage = FieldStorage.Yes } } }
+            };
+        }
+    }
+    
+    private class Order
+    {
+        public string Id { get; set; }
+        public int Price { get; set; }
+        public string Content { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16190/Loading-multiple-attachments-doesnt-work

### Additional description

We wanted to load multiple attachments for a single document, and project them by calling Select on LoadAttachments function result

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
