### PR TITLE
RavenDB-18741: add retry fact to AdditionalAssemblies with NuGet tests

### DIFF
--- a/test/SlowTests/Issues/RavenDB_15753.cs
+++ b/test/SlowTests/Issues/RavenDB_15753.cs
@@ -5,6 +5,7 @@ using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
+using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -62,7 +63,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public void AdditionalAssemblies_NuGet()
         {
             using (var store = GetDocumentStore())
@@ -83,7 +84,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public void AdditionalAssemblies_NuGet_InvalidName()
         {
             using (var store = GetDocumentStore())
@@ -106,7 +107,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public void AdditionalAssemblies_NuGet_InvalidSource()
         {
             using (var store = GetDocumentStore())
@@ -129,7 +130,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public void AdditionalAssemblies_NuGet_Live()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18741

### Additional description

retry tests that could fail due to network error

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
