### PR TITLE
RavenDB-19527 - deleting a document that already has a tombstone unde…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2007,9 +2007,9 @@ namespace Raven.Server.Documents
         }
 
         // long - Etag, byte - separator char
-        private const int ConflictedTombstoneOverhead = sizeof(long) + sizeof(byte);
+        protected const int ConflictedTombstoneOverhead = sizeof(long) + sizeof(byte);
 
-        protected static LazyStringValue UnwrapLowerIdIfNeeded(JsonOperationContext context, LazyStringValue lowerId)
+        private static LazyStringValue UnwrapLowerIdIfNeeded(JsonOperationContext context, LazyStringValue lowerId)
         {
             if (lowerId.Size < ConflictedTombstoneOverhead + 1)
                 return lowerId;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2023,17 +2023,12 @@ namespace Raven.Server.Documents
             return lsv;
         }
 
-        protected static void UnwrapLowerIdIfNeeded(Transaction tx, ref byte* lowerId, ref int size)
+        protected static int UnwrapLowerIdIfNeeded(byte* lowerId,int size)
         {
             if (NeedToUnwrapLowerId(lowerId, size) == false)
-                return;
+                return size;
 
-            size -= ConflictedTombstoneOverhead;
-            using var scope = tx.Allocator.Allocate(size + 1, out var buffer); // we need this extra byte to mark that there is no escaping
-            buffer.Ptr[size] = 0;
-
-            Memory.Copy(buffer.Ptr, lowerId, size);
-            lowerId = buffer.Ptr;
+            return size - ConflictedTombstoneOverhead;
         }
 
         private static bool NeedToUnwrapLowerId(byte* lowerId, int size)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2023,7 +2023,7 @@ namespace Raven.Server.Documents
             return lsv;
         }
 
-        protected static int UnwrapLowerIdIfNeeded(byte* lowerId,int size)
+        protected static int GetSizeOfTombstoneId(byte* lowerId, int size)
         {
             if (NeedToUnwrapLowerId(lowerId, size) == false)
                 return size;
@@ -2033,13 +2033,15 @@ namespace Raven.Server.Documents
 
         private static bool NeedToUnwrapLowerId(byte* lowerId, int size)
         {
-            if (size < ConflictedTombstoneOverhead + 1 ||
-                lowerId[size - ConflictedTombstoneOverhead] != SpecialChars.RecordSeparator)
+            if (size < ConflictedTombstoneOverhead + 1)
+                return false;
+
+            if (lowerId[size - ConflictedTombstoneOverhead] != SpecialChars.RecordSeparator)
                 return false;
 
             return true;
         }
-      
+
         public static bool IsTombstoneOfId(Slice tombstoneKey, Slice lowerId)
         {
             if (tombstoneKey.Size < ConflictedTombstoneOverhead + 1)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2009,7 +2009,7 @@ namespace Raven.Server.Documents
         // long - Etag, byte - separator char
         private const int ConflictedTombstoneOverhead = sizeof(long) + sizeof(byte);
 
-        private static LazyStringValue UnwrapLowerIdIfNeeded(JsonOperationContext context, LazyStringValue lowerId)
+        protected static LazyStringValue UnwrapLowerIdIfNeeded(JsonOperationContext context, LazyStringValue lowerId)
         {
             if (lowerId.Size < ConflictedTombstoneOverhead + 1)
                 return lowerId;

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -154,7 +154,7 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKey(Transaction tx, int idIndex, int etagIndex, ref TableValueReader tvr, out Slice slice)
     {
         var lowerId = tvr.Read(idIndex, out int size);
-        size = UnwrapLowerIdIfNeeded(lowerId, size);
+        size = GetSizeOfTombstoneId(lowerId, size);
         var etag = *(long*)tvr.Read(etagIndex, out _);
         return GenerateBucketAndEtagSlice(tx, lowerId, size, etag, out slice);
     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -154,9 +154,8 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKey(Transaction tx, int idIndex, int etagIndex, ref TableValueReader tvr, out Slice slice)
     {
         var lowerId = tvr.Read(idIndex, out int size);
-        UnwrapLowerIdIfNeeded(tx, ref lowerId, ref size);
+        size = UnwrapLowerIdIfNeeded(lowerId, size);
         var etag = *(long*)tvr.Read(etagIndex, out _);
-
         return GenerateBucketAndEtagSlice(tx, lowerId, size, etag, out slice);
     }
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_19527.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19527.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_19527 : RavenTestBase
+    {
+        public RavenDB_19527(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task TombstonesBucketAndEtagIndexShouldMapToSameBucket()
+        {
+            const string id = "foo/bar";
+            var bucket = Sharding.GetBucket(id);
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var shard = ShardHelper.GetShardNumberFor(record.Sharding, bucket);
+
+                var db = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shard)) as ShardedDocumentDatabase;
+                Assert.NotNull(db);
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var numberOfTombstones = db.DocumentsStorage.GetNumberOfTombstones(ctx);
+                    Assert.Equal(2, numberOfTombstones);
+
+                    var tombs = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(ctx, bucket, 0).ToList();
+                    Assert.Equal(2, tombs.Count);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…r a different collection, will cause 'TombstonesBucketAndEtag' index to map the 2 tombstones to 2 different buckets

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19527/deleting-a-document-that-already-has-a-tombstone-under-a-different-collection-will-cause-TombstonesBucketAndEtag-index-to-map

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
