### PR TITLE
RavenDB-19907 Fix param name in log message (2)

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1658,7 +1658,8 @@ namespace Raven.Server.Commercial
             {
                 if (_skipLeasingErrorsLogging == false && Logger.IsInfoEnabled)
                 {
-                    Logger.Info("Skipping checking the license support options because 'Licensing.DisableLicenseSupportMode' is set to true");
+                    var configurationKey = RavenConfiguration.GetKey(x => x.Licensing.DisableLicenseSupportCheck);
+                    Logger.Info($"Skipping checking the license support options because '{configurationKey}' is set to true");
                 }
                 return GetDefaultLicenseSupportInfo();
             }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19907

### Additional description
Fix param name in log msg:
`DisableLicenseSupportMode => DisableLicenseSupportCheck`

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
