### PR TITLE
RavenDB-18193: fix asserting the wrong task

### DIFF
--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1206,7 +1206,8 @@ namespace SlowTests.Client.Subscriptions
                     mreAck1.Set();
                     return Task.CompletedTask;
                 };
-                var t1 = subsWorker1.Run(_ => { }).ContinueWith(res =>
+                var t1 = subsWorker1.Run(_ => { });
+                _ = t1.ContinueWith(res =>
                 {
                     finishedWorkersCde.Signal();
                 });
@@ -1228,7 +1229,8 @@ namespace SlowTests.Client.Subscriptions
                     mreAck2.Set();
                     return Task.CompletedTask;
                 };
-                var t2 = subsWorker2.Run(_ => { }).ContinueWith(res =>
+                var t2 = subsWorker2.Run(_ => { });
+                _ = t2.ContinueWith(res =>
                 {
                     finishedWorkersCde.Signal();
                 });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18193

### Additional description

I was asserting the completion of wrong task (the task of ContinueWith)

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
