### PR TITLE
RavenDB-19750: changed type from int to long for '_requestId' at Rave…

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -388,7 +388,7 @@ namespace Raven.Client.Documents.Changes
     internal class TrafficWatchHttpChange : TrafficWatchChangeBase
     {
         public override TrafficWatchType TrafficWatchType => TrafficWatchType.Http;
-        public int RequestId { get; set; }
+        public long RequestId { get; set; }
         public string HttpMethod { get; set; }
         public long ElapsedMilliseconds { get; set; }
         public int ResponseStatusCode { get; set; }

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -44,7 +44,7 @@ namespace Raven.Server
     {
         private RequestRouter _router;
         private RavenServer _server;
-        private int _requestId;
+        private long _requestId;
         private readonly Logger _logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("Server");
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)


### PR DESCRIPTION
…nServerStartup.cs  & for RequestId at ChangeNotification.cs

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19750/Change-requestId-type-to-long

### Additional description

changed type from int to long for '_requestId' at RavenServerStartup.cs  & for RequestId at ChangeNotification.cs


### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
