### PR TITLE
RavenDB-19890 & RavenDB-19779 Stop sharing same memory from arena between threads  when importing TimeSeries && Releasing memory from context after batch merging.

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/CsvStreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/CsvStreamSource.cs
@@ -429,7 +429,7 @@ namespace Raven.Server.Smuggler.Documents
             return AsyncEnumerable.Empty<(string Hub, ReplicationHubAccess Access)>();
         }
 
-        public IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(List<string> collectionsToExport)
+        public IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(ITimeSeriesActions action, List<string> collectionsToExport)
         {
             return AsyncEnumerable.Empty<TimeSeriesItem>();
         }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -65,10 +65,13 @@ namespace Raven.Server.Smuggler.Documents.Data
         JsonOperationContext GetContextForNewCompareExchangeValue();
     }
 
-    public interface INewDocumentActions
+    public interface INewItemActions
     {
         DocumentsOperationContext GetContextForNewDocument();
-
+    }
+    
+    public interface INewDocumentActions : INewItemActions
+    {
         Stream GetTempStream();
     }
 
@@ -115,10 +118,12 @@ namespace Raven.Server.Smuggler.Documents.Data
         ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerResult result, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
     }
 
-    public interface ITimeSeriesActions : IAsyncDisposable, INewDocumentActions
+    public interface ITimeSeriesActions : IAsyncDisposable, INewItemActions
     {
         ValueTask WriteTimeSeriesAsync(TimeSeriesItem ts);
         
         void RegisterForDisposal(IDisposable data);
+
+        void RegisterForReturnToTheContext(AllocatedMemoryData data);
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -115,8 +115,10 @@ namespace Raven.Server.Smuggler.Documents.Data
         ValueTask WriteDatabaseRecordAsync(DatabaseRecord databaseRecord, SmugglerResult result, AuthorizationStatus authorizationStatus, DatabaseRecordItemType databaseRecordItemType);
     }
 
-    public interface ITimeSeriesActions : IAsyncDisposable
+    public interface ITimeSeriesActions : IAsyncDisposable, INewDocumentActions
     {
         ValueTask WriteTimeSeriesAsync(TimeSeriesItem ts);
+        
+        void RegisterForDisposal(IDisposable data);
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         IAsyncEnumerable<(string Hub, ReplicationHubAccess Access)> GetReplicationHubCertificatesAsync();
 
-        IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(List<string> collectionsToExport);
+        IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(ITimeSeriesActions action, List<string> collectionsToExport);
 
         Task<long> SkipTypeAsync(DatabaseItemType type, Action<long> onSkipped, CancellationToken token);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -2279,6 +2279,11 @@ namespace Raven.Server.Smuggler.Documents
                 _cmd.AddToDisposal(data);
             }
 
+            public void RegisterForReturnToTheContext(AllocatedMemoryData data)
+            {
+                _cmd.AddToReturn(data);
+            }
+            
             private async ValueTask HandleBatchOfTimeSeriesIfNecessaryAsync()
             {
                 if (_segmentsSize < _maxBatchSize)
@@ -2322,11 +2327,6 @@ namespace Raven.Server.Smuggler.Documents
             {
                 _cmd.Context.CachedProperties.NewDocument();
                 return _cmd.Context;
-            }
-
-            public Stream GetTempStream()
-            {
-                throw new NotSupportedException("GetTempStream is never used in CounterActions. Shouldn't happen");
             }
         }
     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -2274,6 +2274,11 @@ namespace Raven.Server.Smuggler.Documents
                 await HandleBatchOfTimeSeriesIfNecessaryAsync();
             }
 
+            public void RegisterForDisposal(IDisposable data)
+            {
+                _cmd.AddToDisposal(data);
+            }
+
             private async ValueTask HandleBatchOfTimeSeriesIfNecessaryAsync()
             {
                 if (_segmentsSize < _maxBatchSize)
@@ -2311,6 +2316,17 @@ namespace Raven.Server.Smuggler.Documents
                 }
 
                 _cmd = null;
+            }
+
+            public DocumentsOperationContext GetContextForNewDocument()
+            {
+                _cmd.Context.CachedProperties.NewDocument();
+                return _cmd.Context;
+            }
+
+            public Stream GetTempStream()
+            {
+                throw new NotSupportedException("GetTempStream is never used in CounterActions. Shouldn't happen");
             }
         }
     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -1164,7 +1164,7 @@ namespace Raven.Server.Smuggler.Documents
             await using (var actions = _destination.TimeSeries())
             {
                 var isFullBackup = _source.GetSourceType() == SmugglerSourceType.FullExport;
-                await foreach (var ts in _source.GetTimeSeriesAsync(_options.Collections))
+                await foreach (var ts in _source.GetTimeSeriesAsync(actions, _options.Collections))
                 {
                     _token.ThrowIfCancellationRequested();
                     result.TimeSeries.ReadCount += ts.Segment.NumberOfEntries;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -505,7 +505,7 @@ namespace Raven.Server.Smuggler.Documents
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
-        public async IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(List<string> collectionsToExport)
+        public async IAsyncEnumerable<TimeSeriesItem> GetTimeSeriesAsync(ITimeSeriesActions action, List<string> collectionsToExport)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             Debug.Assert(_context != null);

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -986,8 +986,11 @@ namespace Raven.Server.Smuggler.Documents
 
         private class StreamTimeSeriesActions : StreamActionsBase, ITimeSeriesActions
         {
+            private readonly DocumentsOperationContext _context;
+
             public StreamTimeSeriesActions(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName) : base(writer, propertyName)
             {
+                _context = context;
             }
 
             public async ValueTask WriteTimeSeriesAsync(TimeSeriesItem item)
@@ -1038,6 +1041,22 @@ namespace Raven.Server.Smuggler.Documents
 
                     await Writer.MaybeFlushAsync();
                 }
+            }
+
+            public void RegisterForDisposal(IDisposable data)
+            {
+                throw new NotSupportedException($"{nameof(RegisterForDisposal)} is never used in {nameof(StreamTimeSeriesActions)}. Shouldn't happen.");
+            }
+
+            public DocumentsOperationContext GetContextForNewDocument()
+            {
+                _context.CachedProperties.NewDocument();
+                return _context;
+            }
+
+            public Stream GetTempStream()
+            {
+                throw new NotSupportedException($"{nameof(GetTempStream)} is never used in {nameof(StreamTimeSeriesActions)}. Shouldn't happen.");
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1048,15 +1048,15 @@ namespace Raven.Server.Smuggler.Documents
                 throw new NotSupportedException($"{nameof(RegisterForDisposal)} is never used in {nameof(StreamTimeSeriesActions)}. Shouldn't happen.");
             }
 
+            public void RegisterForReturnToTheContext(AllocatedMemoryData data)
+            {
+                throw new NotSupportedException($"{nameof(RegisterForReturnToTheContext)} is never used in {nameof(StreamTimeSeriesActions)}. Shouldn't happen.");
+            }
+
             public DocumentsOperationContext GetContextForNewDocument()
             {
                 _context.CachedProperties.NewDocument();
                 return _context;
-            }
-
-            public Stream GetTempStream()
-            {
-                throw new NotSupportedException($"{nameof(GetTempStream)} is never used in {nameof(StreamTimeSeriesActions)}. Shouldn't happen.");
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -773,7 +773,7 @@ namespace Raven.Server.Smuggler.Documents
                     continue;
                 }
 
-                var segment = await ReadSegmentAsync(size);
+                var segment = await ReadSegmentAsync(action, size);
                 action.RegisterForDisposal(reader);
                 
                 yield return new TimeSeriesItem
@@ -800,9 +800,10 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        private async Task<TimeSeriesValuesSegment> ReadSegmentAsync(int segmentSize)
+        private async Task<TimeSeriesValuesSegment> ReadSegmentAsync(ITimeSeriesActions action, int segmentSize)
         {
-            var mem = _context.GetMemory(segmentSize);
+            var mem = action.GetContextForNewDocument().GetMemory(segmentSize);
+            action.RegisterForReturnToTheContext(mem);
             var offset = 0;
 
             var size = segmentSize;
@@ -1237,7 +1238,7 @@ namespace Raven.Server.Smuggler.Documents
             return count;
         }
 
-        private async IAsyncEnumerable<BlittableJsonReaderObject> ReadArrayAsync(INewDocumentActions actions = null)
+        private async IAsyncEnumerable<BlittableJsonReaderObject> ReadArrayAsync(INewItemActions actions = null)
         {
             if (await UnmanagedJsonParserHelper.ReadAsync(_peepingTomStream, _parser, _state, _buffer) == false)
                 UnmanagedJsonParserHelper.ThrowInvalidJson("Unexpected end of json", _peepingTomStream, _parser);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19890 
https://issues.hibernatingrhinos.com/issue/RavenDB-19779


### Additional description

Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR.

_Please delete below the options that are not relevant_

### Type of change

- Regression bug fix
- Optimization


### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing:
- - This is extremely hard to reproduce by test. I managed to reproduce sharing memory issue with 5B TimeSeries items so adding a test for this requires adding 200MB dataset into the project.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
