### PR TITLE
RavenDB-19908 Reduce allocations caused by bool boxing

### DIFF
--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -15,6 +15,9 @@ namespace Sparrow.Json
 {
     public sealed unsafe class BlittableJsonReaderObject : BlittableJsonReaderBase, IDisposable
     {
+        private static readonly object BoxedTrue = true;
+        private static readonly object BoxedFalse = false;
+
         private AllocatedMemoryData _allocatedMemory;
         private UnmanagedWriteBuffer _buffer;
         private byte* _metadataPtr;
@@ -994,7 +997,7 @@ namespace Sparrow.Json
 
                 case BlittableJsonToken.Boolean:
                     isBlittableJsonReader = false;
-                    return ReadNumber(_mem + position, 1) == 1;
+                    return ReadNumber(_mem + position, 1) == 1 ? BoxedTrue : BoxedFalse;
 
                 case BlittableJsonToken.Null:
                     isBlittableJsonReader = false;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19908

### Additional description

A lot of unnecessary bool boxing can be caused in `BlittableJsonReaderObject.GetObjectUnlikely`.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests cover

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
