### PR TITLE
RavenDB-19661 :  fix database deletion on sharded restore failure

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
@@ -25,6 +24,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
             IRestoreSource restoreSource, OperationCancelToken operationCancelToken) : base(serverStore, restoreConfiguration, restoreSource, filesToRestore, operationCancelToken)
         {
             DatabaseValidation = false;
+            DeleteDatabaseOnFailure = false; // orchestrator will handle that
+
             _shardNumber = ShardHelper.GetShardNumberFromDatabaseName(DatabaseName);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19661

### Additional description

on failure during sharded restore, single-shard restore tasks should not try to delete shards, instead let the sharded restore orchestrator handle deleting entire sharded database from all nodes

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
