### PR TITLE
RavenDB-19442: Fail properly and reset the index entry writer.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -38,62 +38,70 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
         // We prepare for the next entry.
         ref var entryWriter = ref GetEntriesWriter();
 
-        object value;
-        foreach (var indexField in _fields.Values)
+        try
         {
-            if (indexField.Spatial is AutoSpatialOptions spatialOptions)
+            foreach (var indexField in _fields.Values)
             {
-                var spatialField = CurrentIndexingScope.Current.GetOrCreateSpatialField(indexField.Name);
-
-                switch (spatialOptions.MethodType)
+                object value;
+                if (indexField.Spatial is AutoSpatialOptions spatialOptions)
                 {
-                    case AutoSpatialOptions.AutoSpatialMethodType.Wkt:
-                        if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[0], out var wktValue) == false)
-                            continue;
+                    var spatialField = CurrentIndexingScope.Current.GetOrCreateSpatialField(indexField.Name);
 
-                        value = StaticIndexBase.CreateSpatialField(spatialField, wktValue);
-                        break;
-                    case AutoSpatialOptions.AutoSpatialMethodType.Point:
-                        if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[0], out var latValue) == false)
-                            continue;
+                    switch (spatialOptions.MethodType)
+                    {
+                        case AutoSpatialOptions.AutoSpatialMethodType.Wkt:
+                            if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[0], out var wktValue) == false)
+                                continue;
 
-                        if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[1], out var lngValue) == false)
-                            continue;
+                            value = StaticIndexBase.CreateSpatialField(spatialField, wktValue);
+                            break;
+                        case AutoSpatialOptions.AutoSpatialMethodType.Point:
+                            if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[0], out var latValue) == false)
+                                continue;
 
-                        value = StaticIndexBase.CreateSpatialField(spatialField, latValue, lngValue);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException($"{spatialOptions.MethodType} is not implemented.");
+                            if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, spatialOptions.MethodArguments[1], out var lngValue) == false)
+                                continue;
+
+                            value = StaticIndexBase.CreateSpatialField(spatialField, latValue, lngValue);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException($"{spatialOptions.MethodType} is not implemented.");
+                    }
+
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
                 }
-
-                InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
-            }
-            else if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, indexField.OriginalName ?? indexField.Name, out value))
-            {
-                InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
-            }
-        }
-
-        if (key != null)
-        {
-            Debug.Assert(document.LowerId == null || (key == document.LowerId));
-            scope.Write(string.Empty, 0, id.AsSpan(), ref entryWriter);
-        }
-        
-        if (_storeValue)
-        {
-            unsafe
-            {
-                using (Allocator.Allocate(document.Data.Size, out Span<byte> blittableBuffer))
+                else if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, indexField.OriginalName ?? indexField.Name, out value))
                 {
-                    fixed (byte* bPtr = blittableBuffer)
-                        document.Data.CopyTo(bPtr);
-
-                    scope.Write(string.Empty, GetKnownFieldsForWriter().Count - 1, blittableBuffer, ref entryWriter);
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
                 }
             }
-        }
 
-        return entryWriter.Finish(out output);
+            if (key != null)
+            {
+                Debug.Assert(document.LowerId == null || (key == document.LowerId));
+                scope.Write(string.Empty, 0, id.AsSpan(), ref entryWriter);
+            }
+            
+            if (_storeValue)
+            {
+                unsafe
+                {
+                    using (Allocator.Allocate(document.Data.Size, out Span<byte> blittableBuffer))
+                    {
+                        fixed (byte* bPtr = blittableBuffer)
+                            document.Data.CopyTo(bPtr);
+
+                        scope.Write(string.Empty, GetKnownFieldsForWriter().Count - 1, blittableBuffer, ref entryWriter);
+                    }
+                }
+            }
+
+            return entryWriter.Finish(out output);
+        }
+        catch
+        {
+            ResetEntriesWriter();
+            throw;
+        }
     }
 }

--- a/test/FastTests/Corax/Bugs/RavenDB-19442.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19442.cs
@@ -1,15 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using Raven.Client.Documents.Indexes;
-using Tests.Infrastructure;
-using System;
-using System.Linq;
-using FastTests;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,7 +44,6 @@ namespace FastTests.Corax.Bugs
 
             new ComplexIndex().Execute(store);
             Indexes.WaitForIndexing(store);
-            //WaitForUserToContinueTheTest(store);
 
             using (var session = store.OpenSession())
             {

--- a/test/FastTests/Corax/Bugs/RavenDB-19442.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19442.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs
+{
+    public class RavenDB_19442 : RavenTestBase
+    {
+        public RavenDB_19442(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public void WhenIndexingFailedOnItemTheRestIsAlsoCorrupted(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            {
+                using var session = store.OpenSession();
+                session.Store(new TestData()
+                {
+                    Identifier = "hehe",
+                    Name = "a",
+                    Second = "b"
+                });
+                session.Store(new TestData()
+                {
+                    Identifier = "hehe2",
+                    Name = "a2",
+                    Second = "b2"
+                });
+
+                session.Store(new TestData()
+                {
+                    Identifier = "hehe3",
+                    Name = "a2",
+                    Second = "b3"
+                });
+
+                session.SaveChanges();
+            }
+
+            new ComplexIndex().Execute(store);
+            Indexes.WaitForIndexing(store);
+            //WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenSession())
+            {
+                var users = session
+                    .Query<TestData, ComplexIndex>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(x => x.Identifier == "hehe3")
+                    .ToList();
+
+                Assert.Equal(1, users.Count);
+            }
+        }
+
+        public class TestData
+        {
+            public string Name { get; set; }
+            public string Second { get; set; }
+            public string Identifier { get; set; }
+        }
+        private class ComplexIndex : AbstractIndexCreationTask<TestData>
+        {
+            public ComplexIndex()
+            {
+                Map = datas => datas.Select(i => new { Identifier = i.Identifier, Complex = new { i.Name, i.Second } });
+
+                Index("Complex", FieldIndexing.Exact);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19442

### Additional description

Failing to serialize an index entry will cause the index to fail and also the index writer to be left on an inconsistent state. 

### Type of change
- Bug fix

### How risky is the change?
- Low 