### PR TITLE
RavenDB-19785: Handle TaskCanceledException when disposing document database right after Initialize

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -869,7 +869,20 @@ namespace Raven.Server.Documents
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, "Waiting for cluster transactions executor task to complete");
                 exceptionAggregator.Execute(() =>
                 {
-                    clusterTransactionsTask.Wait();
+                    try
+                    {
+                        clusterTransactionsTask.Wait();
+                    }
+                    catch (AggregateException e)
+                    {
+                        if (e.ExtractSingleInnerException() is TaskCanceledException)
+                        {
+                            // _clusterTransactionsTask might be TaskCanceled in case we dispose right after Initialize
+                            return;
+                        }
+
+                        throw;
+                    }
                 });
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, "Finished waiting for cluster transactions executor task to complete");
             }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19785

### Additional description

When we dispose right after `Initialize()` finishes, we cancel `DatabaseShutdown` token. And in `Initialize()` we create `_clusterTransactionsTask` using `Task.Run()` with providing the `DatabaseShutdown` token, `Task.Run()` might return `CanceledTask` task which will make us throw an `TaskCanceledException` when we `Wait()` for `_clusterTransactionsTask` on `DocumentDatabase.Dispose()`.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
