### PR TITLE
RavenDB-19913 TransactionOperationContext.AllocatedMemory doesn't take into account memory allocated by ByteStringContext allocator

### DIFF
--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -79,6 +79,8 @@ namespace Raven.Server.ServerWide.Context
 
         public override long AllocatedMemory => _arenaAllocator.Allocated + Allocator._totalAllocated;
 
+        public override long UsedMemory => _arenaAllocator.TotalUsed + Allocator._currentlyAllocated;
+
         public bool HasTransaction => Transaction != null && Transaction.Disposed == false;
 
         public short TransactionMarkerOffset;

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.ServerWide.Context
 
         protected abstract TTransaction CloneReadTransaction(TTransaction previous);
 
+        public override long AllocatedMemory => _arenaAllocator.Allocated + Allocator._totalAllocated;
+
         public bool HasTransaction => Transaction != null && Transaction.Disposed == false;
 
         public short TransactionMarkerOffset;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -33,7 +33,7 @@ namespace Sparrow.Json
         private readonly int _initialSize;
         private readonly int _longLivedSize;
         private readonly int _maxNumberOfAllocatedStringValues;
-        private readonly ArenaMemoryAllocator _arenaAllocator;
+        protected readonly ArenaMemoryAllocator _arenaAllocator;
         private ArenaMemoryAllocator _arenaAllocatorForLongLivedValues;
         private AllocatedMemoryData _tempBuffer;
 
@@ -84,7 +84,7 @@ namespace Sparrow.Json
 
         public int Generation => _generation;
 
-        public long AllocatedMemory => _arenaAllocator.TotalUsed;
+        public virtual long AllocatedMemory => _arenaAllocator.Allocated;
 
         protected readonly SharedMultipleUseFlag LowMemoryFlag;
 

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -86,6 +86,8 @@ namespace Sparrow.Json
 
         public virtual long AllocatedMemory => _arenaAllocator.Allocated;
 
+        public virtual long UsedMemory => _arenaAllocator.TotalUsed;
+
         protected readonly SharedMultipleUseFlag LowMemoryFlag;
 
         public static JsonOperationContext ShortTermSingleUse()

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ArenaMemoryAllocatorTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ArenaMemoryAllocatorTests.cs
@@ -76,7 +76,7 @@ public class ArenaMemoryAllocatorTests : NoDisposalNeeded
 
             for (var i = 0; i < 3; i++)
             {
-                memoryUsedBefore = context.AllocatedMemory;
+                memoryUsedBefore = context.UsedMemory;
 
                 BuildDocument(() =>
                 {
@@ -85,7 +85,7 @@ public class ArenaMemoryAllocatorTests : NoDisposalNeeded
                 });
             }
 
-            Assert.Equal(memoryUsedBefore + fragmentationSize, context.AllocatedMemory);
+            Assert.Equal(memoryUsedBefore + fragmentationSize, context.UsedMemory);
 
             void BuildDocument(Action beforeBuilderDispose = null)
             {

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -863,7 +863,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
 
                 for (var i = 0; i < 10; i++)
                 {
-                    var memoryUsedBefore = context.AllocatedMemory;
+                    var memoryUsedBefore = context.UsedMemory;
 
                     BuildDocument(() =>
                     {
@@ -871,7 +871,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                         context.GetMemory(fragmentationSize);
                     });
 
-                    Assert.Equal(memoryUsedBefore + fragmentationSize, context.AllocatedMemory);
+                    Assert.Equal(memoryUsedBefore + fragmentationSize, context.UsedMemory);
                 }
 
                 void BuildDocument(Action beforeBuilderDispose = null)

--- a/test/SlowTests/Issues/RavenDB_19913.cs
+++ b/test/SlowTests/Issues/RavenDB_19913.cs
@@ -1,0 +1,37 @@
+﻿using FastTests;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+using Sparrow.Global;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19913 : RavenLowLevelTestBase
+{
+    public RavenDB_19913(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ContextAllocatedMemoryShouldTakeIntoAccountAllocationsMadeByByteStringContextAllocator()
+    {
+        using (var database = CreateDocumentDatabase())
+        {
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var oneMb = new Size(1, SizeUnit.Megabytes);
+
+                context.GetMemory(64 * Constants.Size.Kilobyte);
+
+                context.Allocator.Allocate(512 * Constants.Size.Kilobyte, out var buffer); // this will allocate 1MB under the covers
+
+                Assert.Equal(oneMb, new Size(buffer.Size, SizeUnit.Bytes)); // precaution
+
+                var allocated = new Size(context.AllocatedMemory, SizeUnit.Bytes);
+
+                Assert.True(allocated >= oneMb, $"allocated isn't greater than 1MB - {allocated}");
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
+++ b/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Server.Documents.Patching
                     var query = new IndexQueryServerSide($"FROM index '{index.Name}'");
                     var patch = new PatchRequest("var u = this; u.is = true;", PatchRequestType.Patch, query.Metadata.DeclaredFunctions);
 
-                    var before = context.Documents.AllocatedMemory;
+                    var before = context.Documents.UsedMemory;
                     await database.QueryRunner.ExecutePatchQuery(
                         query,
                         new QueryOperationOptions { RetrieveDetails = true },
@@ -75,7 +75,7 @@ namespace SlowTests.Server.Documents.Patching
                         context,
                         p => { },
                         new OperationCancelToken(CancelAfter, CancellationToken.None, CancellationToken.None));
-                    var after = context.Documents.AllocatedMemory;
+                    var after = context.Documents.UsedMemory;
 
                     //In a case of fragmentation, we don't immediately freeing memory so the memory can be a little bit higher
                     const long threshold = 256;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19913/TransactionOperationContext.AllocatedMemory-doesnt-take-into-account-memory-allocated-by-ByteStringContext-allocator

https://issues.hibernatingrhinos.com/issue/RavenDB-19884

### Additional description

1. `JsonOperationContext.AllocatedMemory` returns `_arenaAllocator.Allocated` (instead of `_arenaAllocator.TotalUsed`)

2. `TransactionOperationContext.AllocatedMemory` returns sum of allocations made by `_arenaAllocator` and `ByteStringContext` allocator. This fix makes that a context which had many `ByteStringContext` allocations won't be returned to the pool but it will be disposed as it was intended:
https://github.com/ravendb/ravendb/blob/14e4fa05d0a24d9d964817b3727004d6edb2e892/src/Sparrow/Json/JsonContextPoolBase.cs#L151-L155


### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
