### PR TITLE
RavenDB-18992 Fixing ocassionally failing test with different number of journal files than we expected. Likely the reason was different compression rate.

### DIFF
--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -166,7 +166,7 @@ namespace FastTests.Voron
             return Tuple.Create(item1, item2);
         }
 
-        private void ForceConstantCompressionAcceleration(StorageEnvironmentOptions options)
+        protected void ForceConstantCompressionAcceleration(StorageEnvironmentOptions options)
         {
             options.ForTestingPurposesOnly().WriteToJournalCompressionAcceleration = 1;
         }

--- a/test/SlowTests/Issues/RavenDB_15930.cs
+++ b/test/SlowTests/Issues/RavenDB_15930.cs
@@ -19,6 +19,8 @@ namespace SlowTests.Issues
             options.MaxLogFileSize = 8 * 1024 * 1024; // 8mb
             options.ManualFlushing = manualFlushing;
 
+            ForceConstantCompressionAcceleration(options);
+
             return options;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18992/SlowTests.Issues.RavenDB15930.ShouldNotReuseRecycledJournalIfItExceedMaxLogFileSizeOnSmallTxSize

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing test will verify the fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
