### PR TITLE
RavenDB-19887 - Cluster-wide transactions on session throws ClusterTransactionConcurrencyException after failover (V5.2)

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -76,8 +76,7 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            if (_supportsAtomicWrites == null ||
-                node.SupportsAtomicClusterWrites != _supportsAtomicWrites)
+            if (_supportsAtomicWrites == null)
             {
                 _supportsAtomicWrites = node.SupportsAtomicClusterWrites;
                 for (var i = 0; i < _commands.Count; i++)

--- a/test/SlowTests/Issues/RavenDB-19887.cs
+++ b/test/SlowTests/Issues/RavenDB-19887.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper.Configuration;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Core.AdminConsole;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19887 : ClusterTestBase
+    {
+        public RavenDB_19887(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ClusterWideTransactions2Test()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count,
+                RunInMemory = false
+            });
+
+            using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc = new Doc { Id = "doc-1", NumVal = 1 };
+                session.Store(doc);
+                session.SaveChanges();
+            }
+
+            Assert.True(WaitForChangeVectorInCluster(nodes, store.Database));
+
+            using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc1 = session.Load<Doc>("doc-1");
+                doc1.NumVal++;
+
+                // if the node used for document loading is brought down here, the session.SaveChanges() below fails:
+                // Raven.Client.Exceptions.ClusterTransactionConcurrencyException:
+                // 'Failed to execute cluster transaction due to the following issues: Guard compare exchange value
+                // 'rvn-atomic/doc-1' index does not match the transaction index's 0 change vector on doc-1
+                // Concurrency check failed for putting the key 'rvn-atomic/doc-1'.Requested index: 0, actual index: 342'
+                var responsibleNodeTag = store.GetRequestExecutor(store.Database).Topology.Nodes[0].ClusterTag;
+                var responsibleNode = nodes.Single(n => n.ServerStore.NodeTag == responsibleNodeTag);
+                var result0 = await DisposeServerAndWaitForFinishOfDisposalAsync(responsibleNode);
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc1 = await session.LoadAsync<Doc>("doc-1");
+                Assert.Equal(doc1.NumVal, 2);
+            }
+        }
+
+        private class Doc
+        {
+            public string Id { get; set; }
+            public int NumVal { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19887/Cluster-wide-transactions-on-session-throws-ClusterTransactionConcurrencyException-after-failover

### Additional description

Cluster-wide transactions on session throws ClusterTransactionConcurrencyException after failover.
We call 3 times to "RequestExecutor.SendAsync":
First when we load in node A.
Second, we try to saveChanges in nodeA (send ClusterWideBatchCommand) but fail.
Third, we perform failover and ask from node B to "saveChanges".
In the first and the second times, we have the full info about nodeA (including: "SupportsAtomicClusterWrites" = is true) that we get from "RequestExecutor.FirstTopologyUpdate" method when we create RequestExecutor.
In the third time we don't have the full info ("SupportsAtomicClusterWrites") of nodeB so when we use "ClusterWideBatchCommand.SingleNodeBatchCommand.CreateRequest", the "node.SupportsAtomicClusterWrites" is false (by default) so we don't add the field "OriginalChangeVector" to the json because of it.
Because we don't send "OriginalChangeVector" to nodeB we get index 0 on the server side of nodeB and then it throws "ClusterTransactionConcurrencyException" (in BatchHandler).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
