### PR TITLE
RavenDB-19926 Add implementation to import endpoint (GET method) on sharded database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -79,8 +79,4 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
 
         return HttpContext.Request.Body;
     }
-
-    public async void test()
-    {
-    }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Exceptions.Security;
+using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Handlers;
 using Sparrow.Json;
 
@@ -31,11 +32,13 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
         }
 
         operationId ??= GetOperationId();
+        var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
         await using (var file = await GetImportStream())
         await using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
+        using (var token = RequestHandler.CreateOperationToken())
         {
-            var token = RequestHandler.CreateOperationToken();
-            await DoImport(context, stream, options: null, result: null, onProgress: null, operationId.Value, token);
+            var result = await DoImport(context, stream, options, result: null, onProgress: null, operationId.Value, token);
+            await WriteSmugglerResultAsync(context, result, RequestHandler.ResponseBodyStream());
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Security;
+using Raven.Server.ServerWide;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Json;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents.Handlers.Processors.Smuggler;
+
+internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHandler, TOperationContext> : AbstractSmugglerHandlerProcessorForImport<TRequestHandler, TOperationContext>
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    where TOperationContext : JsonOperationContext
+{
+    protected AbstractSmugglerHandlerProcessorForImportGet([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected abstract ImportDelegate DoImport { get; }
+
+    protected abstract long GetOperationId();
+
+    protected override async ValueTask ImportAsync(JsonOperationContext context, long? operationId)
+    {
+        if (HttpContext.Request.Query.ContainsKey("file") == false &&
+            HttpContext.Request.Query.ContainsKey("url") == false)
+        {
+            throw new ArgumentException("'file' or 'url' are mandatory when using GET /smuggler/import");
+        }
+
+        operationId ??= GetOperationId();
+        await using (var file = await GetImportStream())
+        await using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
+        {
+            var token = RequestHandler.CreateOperationToken();
+            await DoImport(context, stream, options: null, result: null, onProgress: null, operationId.Value, token);
+        }
+    }
+
+    private async Task<Stream> GetImportStream()
+    {
+        HttpClient httpClient = new HttpClient();
+        var file = RequestHandler.GetStringQueryString("file", required: false);
+        if (string.IsNullOrEmpty(file) == false)
+        {
+            if (await RequestHandler.IsOperatorAsync() == false)
+                throw new AuthorizationException("The use of the 'file' query string parameters is limited operators and above");
+            return File.OpenRead(file);
+        }
+
+        var url = RequestHandler.GetStringQueryString("url", required: false);
+        if (string.IsNullOrEmpty(url) == false)
+        {
+            if (await RequestHandler.IsOperatorAsync() == false)
+                throw new AuthorizationException("The use of the 'url' query string parameters is limited operators and above");
+
+            if (HttpContext.Request.Method == "POST")
+            {
+                var msg = await httpClient.PostAsync(url, new StreamContent(HttpContext.Request.Body)
+                {
+                    Headers =
+                    {
+                        ContentType =  new System.Net.Http.Headers.MediaTypeHeaderValue(HttpContext.Request.ContentType)
+                    }
+                });
+                return await msg.Content.ReadAsStreamAsync();
+            }
+
+            return await httpClient.GetStreamAsync(url);
+        }
+
+        return HttpContext.Request.Body;
+    }
+
+    public async void test()
+    {
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/ShardedSmugglerHandlerProcessorForImportGet.cs
@@ -1,0 +1,17 @@
+﻿using JetBrains.Annotations;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Processors.Smuggler;
+
+internal class ShardedSmugglerHandlerProcessorForImportGet : AbstractSmugglerHandlerProcessorForImportGet<ShardedDatabaseRequestHandler, TransactionOperationContext>
+{
+    public ShardedSmugglerHandlerProcessorForImportGet([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override ImportDelegate DoImport => RequestHandler.DatabaseContext.Smuggler.GetImportDelegateForHandler(RequestHandler);
+
+    protected override long GetOperationId() => RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/SmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/SmugglerHandlerProcessorForImportGet.cs
@@ -1,0 +1,16 @@
+﻿using JetBrains.Annotations;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents.Handlers;
+
+namespace Raven.Server.Documents.Handlers.Processors.Smuggler;
+
+internal class SmugglerHandlerProcessorForImportGet : AbstractSmugglerHandlerProcessorForImportGet<SmugglerHandler, DocumentsOperationContext>
+{
+    public SmugglerHandlerProcessorForImportGet([NotNull] SmugglerHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override ImportDelegate DoImport => RequestHandler.DoImportInternalAsync;
+
+    protected override long GetOperationId() => RequestHandler.Database.Operations.GetNextOperationId();
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
@@ -17,7 +17,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
 {
     public class ShardedSmugglerHandler : ShardedDatabaseRequestHandler
     {
-        private static readonly HttpClient HttpClient = new HttpClient();
         [RavenShardedAction("/databases/*/smuggler/validate-options", "POST")]
         public async Task ValidateOptions()
         {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSmugglerHandler.cs
@@ -1,14 +1,23 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.Client.Exceptions.Security;
 using Raven.Server.Documents.Handlers.Processors.Smuggler;
 using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Smuggler;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers
 {
     public class ShardedSmugglerHandler : ShardedDatabaseRequestHandler
     {
+        private static readonly HttpClient HttpClient = new HttpClient();
         [RavenShardedAction("/databases/*/smuggler/validate-options", "POST")]
         public async Task ValidateOptions()
         {
@@ -42,7 +51,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         [RavenShardedAction("/databases/*/admin/smuggler/import", "GET")]
         public async Task GetImport()
         {
-            using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support Admin Smuggler operations."))
+            using (var processor = new ShardedSmugglerHandlerProcessorForImportGet(this))
                 await processor.ExecuteAsync();
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
 {
     public class SmugglerHandler : DatabaseRequestHandler
     {
-        private static readonly HttpClient HttpClient = new HttpClient();
+        public static readonly HttpClient HttpClient = new HttpClient();
 
         [RavenAction("/databases/*/smuggler/validate-options", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task ValidateOptions()

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -647,7 +647,7 @@ namespace Raven.Server.Web
             }
         }
 
-        protected async Task<bool> IsOperatorAsync()
+        public async Task<bool> IsOperatorAsync()
         {
             var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
             var status = feature?.Status;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19926/Add-implementation-to-import-endpoint-GET-method-on-sharded-database

### Additional description

Added implementation to the import endpoint (GET method) when using sharded database, and used processor to able to use also in non sharded database

### Type of change

- Bug fix

### Is it platform specific issue?

- Yes. v6.0>

### Testing by Contributor
- It has been verified by manual testing
