### PR TITLE
RavenDB-19928: Zip-file created by the cluster debug package is broken

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -114,17 +114,19 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext jsonOperationContext))
                 await using (var ms = new MemoryStream())
-                using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                 {
-                    foreach (var (tag, url) in topology.AllNodes)
+                    using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                     {
-                        try
+                        foreach (var (tag, url) in topology.AllNodes)
                         {
-                            await WriteDebugInfoPackageForNodeAsync(jsonOperationContext, archive, tag, url, clusterOperationToken, timeoutInSecPerNode);
-                        }
-                        catch (Exception e)
-                        {
-                            await DebugInfoPackageUtils.WriteExceptionAsZipEntryAsync(e, archive, $"Node - [{ServerStore.NodeTag}]");
+                            try
+                            {
+                                await WriteDebugInfoPackageForNodeAsync(jsonOperationContext, archive, tag, url, clusterOperationToken, timeoutInSecPerNode);
+                            }
+                            catch (Exception e)
+                            {
+                                await DebugInfoPackageUtils.WriteExceptionAsZipEntryAsync(e, archive, $"Node - [{ServerStore.NodeTag}]");
+                            }
                         }
                     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19928/Zip-file-created-by-the-cluster-debug-package-is-broken

### Additional description

Need to `Dispose()` for `ZipArchive` before stream is copied to `ResponseBodyStream`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed