### PR TITLE
RavenDB-19919 - Improve the Smuggler and Patching performance

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -594,7 +594,7 @@ namespace Raven.Client.Documents.Session.Operations
                     return;
                 }
 
-                if (_builder.NeedClearPropertiesCache())
+                if (_builderContext.CachedProperties.NeedClearPropertiesCache())
                 {
                     _builderContext.CachedProperties.ClearRenew();
                     return;

--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -76,6 +76,11 @@ namespace Raven.Server.Documents
                     context.Transaction.InnerTransaction.LowLevelTransaction.NumberOfModifiedPages +
                     context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes) / Constants.Storage.PageSize > _maxTransactionSizeInPages)
                     break;
+
+                if (context.CachedProperties.NeedClearPropertiesCache())
+                {
+                    context.CachedProperties.ClearRenew();
+                }
             }
 
             var tx = context.Transaction.InnerTransaction.LowLevelTransaction;

--- a/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
@@ -48,6 +48,11 @@ namespace Raven.Server.Smuggler.Documents
                 if (!(translatedResult is BlittableJsonReaderObject bjro))
                     return null;
 
+                if (ctx.CachedProperties.NeedClearPropertiesCache())
+                {
+                    ctx.CachedProperties.ClearRenew();
+                }
+
                 return document.CloneWith(ctx, bjro);
             }
         }

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -489,11 +489,6 @@ namespace Sparrow.Json
         {
             return "Building json for " + _debugTag;
         }
-
-        public bool NeedClearPropertiesCache()
-        {
-            return _context.CachedProperties.PropertiesDiscovered > CachedProperties.CachedPropertiesSize;
-        }
     }
 
     public interface IBlittableDocumentModifier

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -407,5 +407,10 @@ namespace Sparrow.Json
             DocumentNumber++;
             PropertiesDiscovered = 0;
         }
+
+        public bool NeedClearPropertiesCache()
+        {
+            return PropertiesDiscovered > CachedPropertiesSize;
+        }
     }
 }

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
@@ -192,7 +192,7 @@ namespace Sparrow.Json.Parsing
 
                 using (var builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "readArray/singleResult", parser, state))
                 {
-                    cachedItemsRenew = builder.NeedClearPropertiesCache();
+                    cachedItemsRenew = context.CachedProperties.NeedClearPropertiesCache();
                     ReadObject(builder, peepingTomStream, parser, buffer);
 
                     yield return builder.CreateReader();
@@ -234,7 +234,7 @@ namespace Sparrow.Json.Parsing
 
                 using (var builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "readArray/singleResult", parser, state))
                 {
-                    cachedItemsRenew = builder.NeedClearPropertiesCache();
+                    cachedItemsRenew = context.CachedProperties.NeedClearPropertiesCache();
                     await ReadObjectAsync(builder, peepingTomStream, parser, buffer).ConfigureAwait(false);
 
                     yield return builder.CreateReader();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19919/Slow-documents-export-with-a-transform-script

### Additional description

We cache the properties in order to improve performance.
If we have the same document structure, there is no issue, we'll reuse the properties cache.
If we have different properties for each document, then the cache becomes very large, and sorting those properties becomes expensive.
Clearing the cache (like we do for Streaming), when we exceed the number of cached properties improves the performance significantly.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### Is there any existing behavior change of other features due to this change?

- Smuggler, Patching
