### PR TITLE
RavenDB-19890 Dispose of command in `TimeSeriesAction`

### DIFF
--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -115,8 +115,7 @@ namespace Raven.Server.Documents
         }
 
         /// <summary>
-        /// Enqueue the command to be eventually executed. If the command implements
-        ///  IDisposable, the command will be disposed after it is run and a tx is committed.
+        /// Enqueue the command to be eventually executed.
         /// </summary>
         public async Task Enqueue(MergedTransactionCommand cmd)
         {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -2318,7 +2318,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 if (prevCommand != null)
                 {
-                    await prevCommandTask;
+                    using (prevCommand)
+                    {
+                        await prevCommandTask;
+                    }
                 }
 
                 _cmd = new TimeSeriesHandler.SmugglerTimeSeriesBatchCommand(_database);
@@ -2330,7 +2333,11 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (_prevCommand != null)
                 {
-                    await _prevCommandTask;
+                    using (_prevCommand)
+                    {
+                        await _prevCommandTask;
+                    }
+
                     _prevCommand = null;
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19890 

### Additional description

Now it has better memory consumption (~1GB difference at the peak, mostly much more).

Also, I've removed an obsolete comment from `TransactionOperationMerger`.

##### Previously
![wod](https://user-images.githubusercontent.com/86351904/217474332-69e3857d-b426-49f8-9dec-dbadc85f7e4b.png)

##### Current:
![with_dispose](https://user-images.githubusercontent.com/86351904/217474623-fa8e79c3-b8bd-4d7d-9cd3-bd094dda177a.png)


### Type of change


- Optimization

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
