### PR TITLE
RavenDB-19598: Added new Refresh method overload

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -81,7 +81,7 @@ namespace Raven.Client.Documents.Session
                 {
                     if (DocumentsByEntity.TryGetValue(entity, out var docInfo) == false)
                         throw new InvalidOperationException("Cannot refresh a transient instance");
-                    idsEntitiesPairs.TryAdd(docInfo.Id, (entity, docInfo));
+                    idsEntitiesPairs[docInfo.Id] = (entity, docInfo);
                 }
                 IncrementRequestCount();
 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -75,30 +75,28 @@ namespace Raven.Client.Documents.Session
         {
             using (AsyncTaskHolder())
             {
-                List<string> ids = new();
-                List<DocumentInfo> documentInfos = new();
+                var idsEntitiesPairs = new Dictionary<string, (object Entity, DocumentInfo Info)>();
 
                 foreach (var entity in entities)
                 {
                     if (DocumentsByEntity.TryGetValue(entity, out var docInfo) == false)
                         throw new InvalidOperationException("Cannot refresh a transient instance");
-                    documentInfos.Add(docInfo);
-                    ids.Add(docInfo.Id);
+                    idsEntitiesPairs.TryAdd(docInfo.Id, (entity, docInfo));
                 }
-
                 IncrementRequestCount();
 
-                var command = new GetDocumentsCommand(ids.ToArray(), includes: null, metadataOnly: false);
+                var command = new GetDocumentsCommand(idsEntitiesPairs.Keys.ToArray(), includes: null, metadataOnly: false);
                 await RequestExecutor.ExecuteAsync(command, Context, sessionInfo: _sessionInfo, token).ConfigureAwait(false);
 
-                var numOfCmdResults = command.Result.Results.Length;
+                var resultsCollection = command.Result.Results;
 
-                for (int i = 0; i < numOfCmdResults; i++)
+                foreach (BlittableJsonReaderObject result in resultsCollection)
                 {
-                    var commandResult = (BlittableJsonReaderObject)command.Result.Results[i];
-                    RefreshInternal(entities.ElementAt(i), commandResult, documentInfos[i]);
+                    var id = result.GetMetadata().GetId();
+                    if (idsEntitiesPairs.TryGetValue(id, out var tuple) == false)
+                        throw new InvalidOperationException($"Could not refresh a entity with id: {id}");
+                    RefreshInternal(tuple.Entity, result, tuple.Info);
                 }
-
             }
         }
 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -91,13 +91,14 @@ namespace Raven.Client.Documents.Session
                 var command = new GetDocumentsCommand(ids.ToArray(), includes: null, metadataOnly: false);
                 await RequestExecutor.ExecuteAsync(command, Context, sessionInfo: _sessionInfo, token).ConfigureAwait(false);
 
-                var j = 0;
-                foreach (var entity in entities)
+                var numOfCmdResults = command.Result.Results.Length;
+
+                for (int i = 0; i < numOfCmdResults; i++)
                 {
-                    var commandResult = (BlittableJsonReaderObject)command.Result.Results[j];
-                    RefreshInternal(entity, commandResult, documentInfos[j]);
-                    j++;
+                    var commandResult = (BlittableJsonReaderObject)command.Result.Results[i];
+                    RefreshInternal(entities.ElementAt(i), commandResult, documentInfos[i]);
                 }
+
             }
         }
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -164,7 +164,7 @@ namespace Raven.Client.Documents.Session
             {
                 if (DocumentsByEntity.TryGetValue(entity, out var docInfo) == false)
                     throw new InvalidOperationException("Cannot refresh a transient instance");
-                idsEntitiesPairs.TryAdd(docInfo.Id, (entity, docInfo));
+                idsEntitiesPairs[docInfo.Id] = (entity, docInfo);
             }
             IncrementRequestCount();
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -173,12 +173,12 @@ namespace Raven.Client.Documents.Session
             var command = new GetDocumentsCommand(ids.ToArray(), includes: null, metadataOnly: false);
             RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);
 
-            var j = 0;
-            foreach (var entity in entities)
+            var numOfCmdResults = command.Result.Results.Length;
+            
+            for (int i = 0; i < numOfCmdResults; i++)
             {
-                var commandResult = (BlittableJsonReaderObject)command.Result.Results[j];
-                RefreshInternal(entity, commandResult, documentInfos[j]);
-                j++;
+                var commandResult = (BlittableJsonReaderObject)command.Result.Results[i];
+                RefreshInternal(entities.ElementAt(i), commandResult, documentInfos[i]);
             }
 
         }

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -149,6 +149,19 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <summary>
+        /// Refreshes the specified entities from Raven server.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entities">The entities.</param>
+        public void Refresh<T>(T[] entities)
+        {
+            foreach (var entity in entities)
+            {
+                Refresh(entity);
+            }
+        }
+
+        /// <summary>
         /// Generates the document ID.
         /// </summary>
         /// <param name="entity">The entity.</param>

--- a/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
@@ -46,6 +46,12 @@ namespace Raven.Client.Documents.Session
         void Refresh<T>(T entity);
 
         /// <summary>
+        ///     Updates entities with latest changes from server
+        /// </summary>
+        /// <param name="entities">Collection of instances of an entity that will be refreshed</param>
+        void Refresh<T>(T[] entities);
+
+        /// <summary>
         /// Query the specified index using provided raw query
         /// </summary>
         /// <typeparam name="T">The query result type</typeparam>

--- a/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Raven.Client.Documents.Session.Operations.Lazy;
 
 namespace Raven.Client.Documents.Session
@@ -49,7 +50,7 @@ namespace Raven.Client.Documents.Session
         ///     Updates entities with latest changes from server
         /// </summary>
         /// <param name="entities">Collection of instances of an entity that will be refreshed</param>
-        void Refresh<T>(T[] entities);
+        void Refresh<T>(IEnumerable<T> entities);
 
         /// <summary>
         /// Query the specified index using provided raw query

--- a/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Session.Operations.Lazy;
@@ -53,7 +54,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         /// <param name="entities">Collection of instances of an entity that will be refreshed</param>
         /// <param name="token">The cancellation token.</param>
-        Task RefreshAsync<T>(T[] entities, CancellationToken token = default(CancellationToken));
+        Task RefreshAsync<T>(IEnumerable<T> entities, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Query the specified index using provided raw query

--- a/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.cs
@@ -49,6 +49,13 @@ namespace Raven.Client.Documents.Session
         Task RefreshAsync<T>(T entity, CancellationToken token = default (CancellationToken));
 
         /// <summary>
+        ///     Updates entity with latest changes from server
+        /// </summary>
+        /// <param name="entities">Collection of instances of an entity that will be refreshed</param>
+        /// <param name="token">The cancellation token.</param>
+        Task RefreshAsync<T>(T[] entities, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
         /// Query the specified index using provided raw query
         /// </summary>
         /// <typeparam name="T">The query result type</typeparam>

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2270,7 +2270,7 @@ more responsive application.
             {
                 var id = result.GetMetadata().GetId();
                 if (idsEntitiesPairs.TryGetValue(id, out var tuple) == false)
-                    ThrowCouldNotRefreshDocument($"Could not refresh a entity with id: {id}");
+                    ThrowCouldNotRefreshDocument($"Cannot refresh a transient instance with document id: {id}");
                 RefreshInternal(tuple.Entity, result, tuple.Info);
             }
         }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2243,9 +2243,9 @@ more responsive application.
             return true;
         }
 
-        protected void RefreshInternal<T>(T entity, RavenCommand<GetDocumentsResult> cmd, DocumentInfo documentInfo)
+        protected void RefreshInternal<T>(T entity, BlittableJsonReaderObject cmdResult, DocumentInfo documentInfo)
         {
-            var document = (BlittableJsonReaderObject)cmd.Result.Results[0];
+            var document = cmdResult;
             if (document == null)
                 throw new InvalidOperationException("Document '" + documentInfo.Id +
                                                     "' no longer exists and was probably deleted");

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
@@ -52,7 +53,7 @@ namespace SlowTests.Issues
                     sd2.Name = "gelbeKraehe";
 
                     // refresh and assertion
-                    session.Advanced.Refresh(new[]{sd,sd1,sd2});
+                    session.Advanced.Refresh(new[]{sd,sd1,sd2}.AsEnumerable());
 
                     Assert.Equal("grossesNashorn", sd.Name);
                     Assert.Equal("kleinesNashorn", sd1.Name);
@@ -101,7 +102,7 @@ namespace SlowTests.Issues
                     sd2.Name = "gelbeKraehe";
 
                    
-                    await session.Advanced.RefreshAsync(new[] { sd, sd1, sd2 });
+                    await session.Advanced.RefreshAsync(new[] { sd, sd1, sd2 }.AsEnumerable());
 
                     // equality assertion of current names and pre-override names
                     Assert.Equal("grossesNashorn", sd.Name);

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Threading.Tasks;
 using FastTests;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,6 +18,7 @@ namespace SlowTests.Issues
             {
                 using (var session = store.OpenSession())
                 {
+                    // creating documents and store them
                     SimpleDoc[] docs = new SimpleDoc[3];
                     docs[0] = new SimpleDoc() { Id = "TestDoc0", Name = "State0" };
                     docs[1] = new SimpleDoc() { Id = "TestDoc1", Name = "State1" };
@@ -29,37 +28,85 @@ namespace SlowTests.Issues
                     {
                         session.Store(doc);
                     }
-
                     session.SaveChanges();
 
-                    string[] cvsBeforeRefresh = new string[3];
-                    for (int i = 0; i < cvsBeforeRefresh.Length; i++)
-                    {
-                        cvsBeforeRefresh[i] = session.Advanced.GetChangeVectorFor(docs[i]);
-                    }
-                    
+                    // loading the stored docs and name field equality assertions
+                    SimpleDoc sd = session.Load<SimpleDoc>(docs[0].Id);
+                    Assert.Equal(docs[0].Name, sd.Name);
+
+                    SimpleDoc sd1 = session.Load<SimpleDoc>(docs[1].Id);
+                    Assert.Equal(docs[1].Name, sd1.Name);
+
+                    SimpleDoc sd2 = session.Load<SimpleDoc>(docs[2].Id);
+                    Assert.Equal(docs[2].Name, sd2.Name);
+
+                    // changing the name fields and saving the changes
+                    sd.Name = "grossesNashorn";
+                    sd1.Name = "kleinesNashorn";
+                    sd2.Name = "krassesNashorn";
+                    session.SaveChanges();
+
+                    // overriding locally the name fields (without saving)
+                    sd.Name = "schwarzeKraehe";
+                    sd1.Name = "weisseKraehe";
+                    sd2.Name = "gelbeKraehe";
+
+                    // refresh and assertion
+                    session.Advanced.Refresh(new[]{sd,sd1,sd2});
+
+                    Assert.Equal("grossesNashorn", sd.Name);
+                    Assert.Equal("kleinesNashorn", sd1.Name);
+                    Assert.Equal("krassesNashorn", sd2.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestRefreshOverloadAsync()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {  // creating documents and store them
+                    SimpleDoc[] docs = new SimpleDoc[3];
+                    docs[0] = new SimpleDoc() { Id = "TestDoc0", Name = "State0" };
+                    docs[1] = new SimpleDoc() { Id = "TestDoc1", Name = "State1" };
+                    docs[2] = new SimpleDoc() { Id = "TestDoc2", Name = "State2" };
+
                     foreach (var doc in docs)
                     {
-                        doc.Name = "Nashorn";
-                        session.Store(doc);
+                        await session.StoreAsync(doc);
+                    }
+                    await session.SaveChangesAsync();
+
+                    // loading the stored docs and name field equality assertions
+                    SimpleDoc sd = await session.LoadAsync<SimpleDoc>(docs[0].Id);
+                    Assert.Equal(docs[0].Name, sd.Name);
+
+                    SimpleDoc sd1 = await session.LoadAsync<SimpleDoc>(docs[1].Id);
+                    Assert.Equal(docs[1].Name, sd1.Name);
+
+                    SimpleDoc sd2 = await session.LoadAsync<SimpleDoc>(docs[2].Id);
+                    Assert.Equal(docs[2].Name, sd2.Name);
+
+                    // changing the name fields and saving the changes
+                    sd.Name = "grossesNashorn";
+                    sd1.Name = "kleinesNashorn";
+                    sd2.Name = "krassesNashorn";
+                    await session.SaveChangesAsync();
                     
-                    }
-                    
-                    session.SaveChanges();
+                    // overriding locally the name fields (without saving)
+                    sd.Name = "schwarzeKraehe";
+                    sd1.Name = "weisseKraehe";
+                    sd2.Name = "gelbeKraehe";
 
-                    session.Advanced.Refresh(docs);
+                   
+                    await session.Advanced.RefreshAsync(new[] { sd, sd1, sd2 });
 
-                    string[] cvsAfterRefresh = new string[3];
-                    for (int i = 0; i < cvsAfterRefresh.Length; i++)
-                    {
-                        cvsAfterRefresh[i] = session.Advanced.GetChangeVectorFor(docs[i]);
-                    }
-
-                    var cvsBeforeAndAfter = cvsBeforeRefresh.Zip(cvsAfterRefresh, (b, a) => new { cvBefore = b, cvAfter = a });
-                    foreach (var cvs in cvsBeforeAndAfter)
-                    {
-                        Assert.NotEqual(cvs.cvBefore, cvs.cvAfter);
-                    }
+                    // equality assertion of current names and pre-override names
+                    Assert.Equal("grossesNashorn", sd.Name);
+                    Assert.Equal("kleinesNashorn", sd1.Name);
+                    Assert.Equal("krassesNashorn", sd2.Name);
                 }
             }
         }
@@ -68,6 +115,7 @@ namespace SlowTests.Issues
         {
             public string Id { get; set; }
             public string Name { get; set; }
+
         }
 
     }

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -1,0 +1,74 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19598 : RavenTestBase
+    {
+        public RavenDB_19598(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void TestRefreshOverload()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    SimpleDoc[] docs = new SimpleDoc[3];
+                    docs[0] = new SimpleDoc() { Id = "TestDoc0", Name = "State0" };
+                    docs[1] = new SimpleDoc() { Id = "TestDoc1", Name = "State1" };
+                    docs[2] = new SimpleDoc() { Id = "TestDoc2", Name = "State2" };
+
+                    foreach (var doc in docs)
+                    {
+                        session.Store(doc);
+                    }
+
+                    session.SaveChanges();
+
+                    string[] cvsBeforeRefresh = new string[3];
+                    for (int i = 0; i < cvsBeforeRefresh.Length; i++)
+                    {
+                        cvsBeforeRefresh[i] = session.Advanced.GetChangeVectorFor(docs[i]);
+                    }
+                    
+                    foreach (var doc in docs)
+                    {
+                        doc.Name = "Nashorn";
+                        session.Store(doc);
+                    
+                    }
+                    
+                    session.SaveChanges();
+
+                    session.Advanced.Refresh(docs);
+
+                    string[] cvsAfterRefresh = new string[3];
+                    for (int i = 0; i < cvsAfterRefresh.Length; i++)
+                    {
+                        cvsAfterRefresh[i] = session.Advanced.GetChangeVectorFor(docs[i]);
+                    }
+
+                    var cvsBeforeAndAfter = cvsBeforeRefresh.Zip(cvsAfterRefresh, (b, a) => new { cvBefore = b, cvAfter = a });
+                    foreach (var cvs in cvsBeforeAndAfter)
+                    {
+                        Assert.NotEqual(cvs.cvBefore, cvs.cvAfter);
+                    }
+                }
+            }
+        }
+
+        private class SimpleDoc
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Xunit;
@@ -55,6 +56,11 @@ namespace SlowTests.Issues
                     // refresh and assertion
                     session.Advanced.Refresh(new[]{sd,sd1,sd2}.AsEnumerable());
 
+                    /*
+                    session.Advanced.Refresh(new[] { sd, sd, sd }.AsEnumerable());
+                    Assert.Equal("grossesNashorn", sd.Name);
+                    */
+
                     Assert.Equal("grossesNashorn", sd.Name);
                     Assert.Equal("kleinesNashorn", sd1.Name);
                     Assert.Equal("krassesNashorn", sd2.Name);
@@ -101,8 +107,12 @@ namespace SlowTests.Issues
                     sd1.Name = "weisseKraehe";
                     sd2.Name = "gelbeKraehe";
 
-                   
                     await session.Advanced.RefreshAsync(new[] { sd, sd1, sd2 }.AsEnumerable());
+
+                    /*
+                    await session.Advanced.RefreshAsync(new[] { sd, sd, sd }.AsEnumerable());
+                    Assert.Equal("grossesNashorn", sd.Name);
+                    */
 
                     // equality assertion of current names and pre-override names
                     Assert.Equal("grossesNashorn", sd.Name);

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -53,17 +54,89 @@ namespace SlowTests.Issues
                     sd1.Name = "weisseKraehe";
                     sd2.Name = "gelbeKraehe";
 
-                    session.Advanced.Refresh(new[]{sd,sd1,sd2}.AsEnumerable());
+                    session.Advanced.Refresh(new[] { sd, sd1, sd2 }.AsEnumerable());
 
-                    /*
-                    session.Advanced.Refresh(new[] { sd, sd, sd }.AsEnumerable());
-                    Assert.Equal("grossesNashorn", sd.Name);
-                    */
-                  
                     // equality assertion of current names and pre-override names
                     Assert.Equal("grossesNashorn", sd.Name);
                     Assert.Equal("kleinesNashorn", sd1.Name);
                     Assert.Equal("krassesNashorn", sd2.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestRefreshOverloadSameDocs()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    // creating document and store it
+
+                    SimpleDoc doc = new() { Id = "TestDoc0", Name = "State0" };
+
+                    session.Store(doc);
+                    session.SaveChanges();
+
+                    // loading the stored doc and name field equality assertions
+                    SimpleDoc sd = session.Load<SimpleDoc>(doc.Id);
+                    Assert.Equal(doc.Name, sd.Name);
+
+                    // changing the name field and saving the changes
+                    sd.Name = "grossesNashorn";
+                    session.SaveChanges();
+
+                    // overriding locally the name field (without saving)
+                    sd.Name = "schwarzeKraehe";
+
+                    session.Advanced.Refresh(new[] { sd, sd, sd }.AsEnumerable());
+
+                    // equality assertion of current names and pre-override names
+                    Assert.Equal("grossesNashorn", sd.Name);
+
+                }
+            }
+        }
+
+        [Fact]
+        public void TestRefreshOverloadWithDocDeletion()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    // creating document and store it
+
+                    SimpleDoc doc = new() { Id = "TestDoc0", Name = "State0" };
+                    SimpleDoc doc1 = new() { Id = "TestDoc1", Name = "State1" };
+
+                    session.Store(doc);
+                    session.Store(doc1);
+                    session.SaveChanges();
+
+                    // loading the stored doc and name field equality assertions
+                    SimpleDoc sd = session.Load<SimpleDoc>(doc.Id);
+                    Assert.Equal(doc.Name, sd.Name);
+
+                    SimpleDoc sd1 = session.Load<SimpleDoc>(doc1.Id);
+                    Assert.Equal(doc1.Name, sd1.Name);
+
+                    // changing the name field and saving the changes
+                    sd.Name = "grossesNashorn";
+                    sd1.Name = "kleinesNashorn";
+                    session.SaveChanges();
+
+                    // overriding locally the name field (without saving)
+                    sd.Name = "schwarzeKraehe";
+                    sd1.Name = "weisseKraehe";
+
+                    using (var session2 = store.OpenSession())
+                    {
+                        session2.Delete(sd.Id);
+                        session2.SaveChanges();
+                    }
+
+                    Assert.Throws<InvalidOperationException>(() => session.Advanced.Refresh(new[] { sd, sd1 }.AsEnumerable()));
                 }
             }
         }
@@ -74,7 +147,8 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenAsyncSession())
-                {  // creating documents and store them
+                {
+                    // creating documents and store them
                     SimpleDoc[] docs = new SimpleDoc[3];
                     docs[0] = new SimpleDoc() { Id = "TestDoc0", Name = "State0" };
                     docs[1] = new SimpleDoc() { Id = "TestDoc1", Name = "State1" };
@@ -101,7 +175,7 @@ namespace SlowTests.Issues
                     sd1.Name = "kleinesNashorn";
                     sd2.Name = "krassesNashorn";
                     await session.SaveChangesAsync();
-                    
+
                     // overriding locally the name fields (without saving)
                     sd.Name = "schwarzeKraehe";
                     sd1.Name = "weisseKraehe";
@@ -109,15 +183,89 @@ namespace SlowTests.Issues
 
                     await session.Advanced.RefreshAsync(new[] { sd, sd1, sd2 }.AsEnumerable());
 
-                    /*
-                    await session.Advanced.RefreshAsync(new[] { sd, sd, sd }.AsEnumerable());
-                    Assert.Equal("grossesNashorn", sd.Name);
-                    */
-
                     // equality assertion of current names and pre-override names
                     Assert.Equal("grossesNashorn", sd.Name);
                     Assert.Equal("kleinesNashorn", sd1.Name);
                     Assert.Equal("krassesNashorn", sd2.Name);
+                }
+            }
+        }
+
+
+        [Fact]
+        public async Task TestRefreshOverloadSameDocsAsync()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    // creating document and store it
+
+                    SimpleDoc doc = new() { Id = "TestDoc0", Name = "State0" };
+
+                    await session.StoreAsync(doc);
+                    await session.SaveChangesAsync();
+
+                    // loading the stored doc and name field equality assertions
+                    SimpleDoc sd = await session.LoadAsync<SimpleDoc>(doc.Id);
+                    Assert.Equal(doc.Name, sd.Name);
+
+                    // changing the name field and saving the changes
+                    sd.Name = "grossesNashorn";
+                    await session.SaveChangesAsync();
+
+                    // overriding locally the name field (without saving)
+                    sd.Name = "schwarzeKraehe";
+
+                    await session.Advanced.RefreshAsync(new[] { sd, sd, sd }.AsEnumerable());
+
+                    // equality assertion of current names and pre-override names
+                    Assert.Equal("grossesNashorn", sd.Name);
+
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestRefreshOverloadWithDocDeletionAsync()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    // creating document and store it
+
+                    SimpleDoc doc = new() { Id = "TestDoc0", Name = "State0" };
+                    SimpleDoc doc1 = new() { Id = "TestDoc1", Name = "State1" };
+
+                    await session.StoreAsync(doc);
+                    await session.StoreAsync(doc1);
+                    await session.SaveChangesAsync();
+
+                    // loading the stored doc and name field equality assertions
+                    SimpleDoc sd = await session.LoadAsync<SimpleDoc>(doc.Id);
+                    Assert.Equal(doc.Name, sd.Name);
+
+                    SimpleDoc sd1 = await session.LoadAsync<SimpleDoc>(doc1.Id);
+                    Assert.Equal(doc1.Name, sd1.Name);
+
+                    // changing the name field and saving the changes
+                    sd.Name = "grossesNashorn";
+                    sd1.Name = "kleinesNashorn";
+                    await session.SaveChangesAsync();
+
+                    // overriding locally the name field (without saving)
+                    sd.Name = "schwarzeKraehe";
+                    sd1.Name = "weisseKraehe";
+
+                    using (var session2 = store.OpenSession())
+                    {
+                        session2.Delete(sd.Id);
+                        session2.SaveChanges();
+                    }
+
+                    await Assert.ThrowsAsync<InvalidOperationException>(() => session.Advanced.RefreshAsync(new[] { sd, sd1 }.AsEnumerable()));
+
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_19598.cs
+++ b/test/SlowTests/Issues/RavenDB_19598.cs
@@ -53,14 +53,14 @@ namespace SlowTests.Issues
                     sd1.Name = "weisseKraehe";
                     sd2.Name = "gelbeKraehe";
 
-                    // refresh and assertion
                     session.Advanced.Refresh(new[]{sd,sd1,sd2}.AsEnumerable());
 
                     /*
                     session.Advanced.Refresh(new[] { sd, sd, sd }.AsEnumerable());
                     Assert.Equal("grossesNashorn", sd.Name);
                     */
-
+                  
+                    // equality assertion of current names and pre-override names
                     Assert.Equal("grossesNashorn", sd.Name);
                     Assert.Equal("kleinesNashorn", sd1.Name);
                     Assert.Equal("krassesNashorn", sd2.Name);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19598/Add-new-Refresh-overloads

### Additional description

Added new Refresh method overload to handle entities collection

### Type of change
          
- Optimization
-  
### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. version 5.4

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
