### PR TITLE
RavenDB-19650 RQL projection using document loaded from index stored reference

### DIFF
--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -205,8 +205,7 @@ namespace Raven.Server.Documents.Queries
 
         private static bool ShouldTryToExtractBySourceAliasName(string selectFieldName, SelectField selectField)
         {
-            return selectFieldName.Length == 0 &&
-                   selectField.HasSourceAlias &&
+            return selectField.HasSourceAlias &&
                    selectField.SourceAlias != null;
         }
 

--- a/test/SlowTests/Issues/RavenDB-19650.cs
+++ b/test/SlowTests/Issues/RavenDB-19650.cs
@@ -157,7 +157,7 @@ namespace SlowTests.Issues
                     var e1 = new Employee() { ManId = m1.Id, Salary = 37};
                     session.Store(e1);
 
-                    var o1 = new Order() { EmpId = e1.Id, Price = 44};
+                    var o1 = new Order() { EmpId = e1.Id, Price = 44, Name = "OrderName"};
                     session.Store(o1);
                     
                     session.SaveChanges();
@@ -170,16 +170,11 @@ namespace SlowTests.Issues
 
                     var query = from res in session.Query<DummyIndex.Result>(index.IndexName)
                         let manager = RavenQuery.Load<Manager>(res.ManRef)
-                        select new
-                        {
-                            Name = manager.Name,
-                            Age = manager.Age
-                        };
+                        select manager.Name;
 
                     var result = query.ToList();
-                    
-                    Assert.Equal("CoolName", result[0].Name);
-                    Assert.Equal(21, result[0].Age);
+
+                    Assert.Equal("CoolName", result[0]);
                 }
             }
         }
@@ -206,6 +201,8 @@ namespace SlowTests.Issues
             public string EmpId { get; set; }
             
             public int Price { get; set; }
+            
+            public string Name { get; set; }
         }
 
         private class DummyIndex : AbstractJavaScriptIndexCreationTask


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19650/Query-index-with-projection-and-let

### Additional description

When projecting fields from a document loaded from reference existing only in the index, only identity projection would work (doc => doc). This case was tested (https://github.com/ravendb/ravendb/pull/7013/files#diff-cebaf16672f43d77cb77bed767abd97f600e8c3aada3901eb23c704ab0fada97R60), but projecting any fields (doc => doc.FieldName) wouldn't work. 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
