### PR TITLE
RavenDB-19931 Cleaner values extraction from Esprima ChildNodes for count(), sum(), key() in JS

### DIFF
--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -124,7 +124,7 @@ namespace Raven.Server.Documents.Patch
 
             if (args[0] is ScriptFunctionInstance sfi)
             {
-                if (sfi.FunctionDeclaration.ChildNodes.ToArray()[1] is StaticMemberExpression sme)
+                if (sfi.FunctionDeclaration.Body is StaticMemberExpression sme)    
                 {
                     if (sme.Property is Identifier identifier)
                     { 

--- a/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/HasSpecialMethodVisitor.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Queries
                         {
                             if (callExpression.Arguments[0] is ArrowFunctionExpression afe)
                             {
-                                if (afe.ChildNodes.ToArray()[1] is StaticMemberExpression sme)
+                                if (afe.Body is StaticMemberExpression sme)
                                 {
                                     if (sme.Property is Identifier identifier)
                                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19931/Proper-handle-of-esprima-ChildNodes

### Additional description

Extracting function body instead of getting it from ChildNodes array

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
