### PR TITLE
RavenDB-19751 Read document for map with lazy change vector

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -21,6 +21,7 @@ namespace Raven.Server.Documents
         public LazyStringValue LowerId;
         public BlittableJsonReaderObject Data;
         public string ChangeVector;
+        public LazyStringValue LazyChangeVector;
         public TimeSeriesStream TimeSeriesStream;
         public SpatialResult? Distance;
 
@@ -135,6 +136,9 @@ namespace Raven.Server.Documents
 
             Data?.Dispose();
             Data = null;
+            
+            LazyChangeVector?.Dispose();
+            LazyChangeVector = null;
 
             _disposed = true;
         }
@@ -153,8 +157,10 @@ namespace Raven.Server.Documents
         LowerId = 1 << 1,
         Data = 1 << 4,
         ChangeVector = 1 << 5,
+        LazyChangeVector = 1 << 6,
 
-        All = Id | LowerId | Data | ChangeVector
+        All = Id | LowerId | Data | ChangeVector,
+        AllLazy = Id | LowerId | Data | LazyChangeVector
     }
 
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1548,6 +1548,9 @@ namespace Raven.Server.Documents
 
             if (fields.Contain(DocumentFields.ChangeVector))
                 result.ChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref tvr);
+            
+            if (fields.Contain(DocumentFields.LazyChangeVector))
+                result.LazyChangeVector = TableValueToString(context, (int)DocumentsTable.ChangeVector, ref tvr);
 
             result.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
             result.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicBlittableJson.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicBlittableJson.cs
@@ -143,7 +143,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 if (FastCompare(name, MetadataIdIndex))
                     result = _doc.Id;
                 else if (FastCompare(name, MetadataChangeVectorIndex))
-                    result = _doc.ChangeVector;
+                    result = (object)_doc.LazyChangeVector ?? _doc.ChangeVector;
                 else if (FastCompare(name, MetadataEtagIndex))
                     result = _doc.Etag;
                 else if (FastCompare(name, MetadataLastModifiedIndex))

--- a/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapDocuments.cs
@@ -25,9 +25,10 @@ namespace Raven.Server.Documents.Indexes.Workers
 
         private IEnumerable<Document> GetDocumentsEnumerator(QueryOperationContext queryContext, string collection, long lastEtag, long pageSize)
         {
+            const DocumentFields fields = DocumentFields.AllLazy;
             if (collection == Constants.Documents.Collections.AllDocumentsCollection)
-                return _documentsStorage.GetDocumentsFrom(queryContext.Documents, lastEtag + 1, 0, pageSize);
-            return _documentsStorage.GetDocumentsFrom(queryContext.Documents, collection, lastEtag + 1, 0, pageSize);
+                return _documentsStorage.GetDocumentsFrom(queryContext.Documents, lastEtag + 1, 0, pageSize, fields);
+            return _documentsStorage.GetDocumentsFrom(queryContext.Documents, collection, lastEtag + 1, 0, pageSize, fields);
         }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19751

### Additional description
The first idea was to avoid reading the change vector totally with the assumption that it is not used.
Since we do use it when an index mapping the change vector this cannot be done.
I checked the option to read it lazily.
The improvement is not significant.
But there is some improvement for most cases when you don't use the change vector in mapping.
When the change vector is used in mapping the allocation is worse.

All test results were provided with the issue.

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
