### PR TITLE
RavenDB-17153 Generating correct projection when using Load<>() with enumerable argument

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2998,7 +2998,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     AppendLineToOutputFunction(name, ToJs(expression), wrapper);
                     return;
                 }
-                arg = ToJs(loadSupport.Arg, true);
+                
+                arg = ToJs(loadSupport.Arg, true, loadSupport);
+                if (loadSupport.IsEnumerable)
+                {
+                    AppendLineToOutputFunction(name, arg, wrapper);
+                    return;
+                }
             }
             else
             {

--- a/test/SlowTests/Issues/RavenDB-17153.cs
+++ b/test/SlowTests/Issues/RavenDB-17153.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17153: RavenTestBase
+{
+    public RavenDB_17153(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void CanLoadMultipleDocumentsUsingEnumerableArgument()
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Document { Id = "documents/1", OtherIds = new Dictionary<string, string> { ["other"] = "documents/2" } });
+            session.Store(new Document { Id = "documents/2", OtherIds = new Dictionary<string, string>() });
+            session.Store(new Document { Id = "documents/3", OtherIds = new Dictionary<string, string>() { ["other1"] = "documents/1", ["other2"] = "documents/2"}});
+
+            session.SaveChanges();
+            
+            var query = session.Query<Document>();
+            
+            var projectionWithValues = from doc in query
+                let related = RavenQuery.Load<Document>(doc.OtherIds.Values)
+                select new
+                {
+                    Id = doc.Id,
+                    Others = doc.OtherIds.ToDictionary(x => x.Key, x => x.Value)
+                };
+            
+            
+            var resultsWithValues = projectionWithValues.ToArray();
+            
+            Assert.Equal(resultsWithValues[0].Others["other"], "documents/2");
+            Assert.Equal(resultsWithValues[2].Others["other1"], "documents/1");
+            Assert.Equal(resultsWithValues[2].Others["other2"], "documents/2");
+            
+            var projectionWithSelect = from doc in query
+                let related = RavenQuery.Load<Document>(doc.OtherIds.Select(x => x.Value))
+                select new
+                {
+                    Id = doc.Id,
+                    Others = doc.OtherIds
+                };
+            
+            var resultsWithSelect = projectionWithSelect.ToArray();
+            
+            Assert.Equal(resultsWithSelect[0].Others["other"], "documents/2");
+            Assert.Equal(resultsWithSelect[2].Others["other1"], "documents/1");
+            Assert.Equal(resultsWithSelect[2].Others["other2"], "documents/2");
+        }
+    }
+
+    private class Document
+    { 
+        public string Id { get; set;}
+        public Dictionary<string, string> OtherIds { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17153/Trying-to-load-DictionaryX-Y.Values-from-a-projection-fails-to-generate-valid-projection-JS

### Additional description

The issue was that when using Load<>() with enumerable argument, LINQ would generate a correct JS code, but it was placed in load() clause instead of JS declared function.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
