### PR TITLE
RavenDB-19733 - SlowTests.Server.Documents.ETL.EtlTimeSeriesTests.RavenEtlWithTimeSeries_WhenStoreDocumentAndMultipleSegmentOfTimeSeriesInSameSession_ShouldDestBeAsSrc(justForXUint: "A0", collections: [], script: null)

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -1713,9 +1713,10 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
                 var entity = new User { Name = "Joe Doe" };
                 await session.StoreAsync(entity, documentId);
 
+                var ts = session.TimeSeriesFor(documentId, timeSeriesName);
                 foreach (var entry in randomOrder)
                 {
-                    session.TimeSeriesFor(documentId, timeSeriesName).Append(entry.Timestamp, entry.Values, entry.Tag);
+                    ts.Append(entry.Timestamp, entry.Values, entry.Tag);
                 }
 
                 await session.SaveChangesAsync();


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19733/SlowTests.Server.Documents.ETL.EtlTimeSeriesTests.RavenEtlWithTimeSeriesWhenStoreDocumentAndMultipleSegmentOfTimeSeriesInSameSes

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
