### PR TITLE
RavenDB-18457 Sharding: Added support for sorting query results when using Corax

### DIFF
--- a/src/Corax/Utils/Spatial/SpatialUtils.cs
+++ b/src/Corax/Utils/Spatial/SpatialUtils.cs
@@ -50,7 +50,7 @@ public class SpatialUtils
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    internal static double GetGeoDistance<TComparer>(in (double lat, double lng) fieldCoordinates, in TComparer comparer)
+    public static double GetGeoDistance<TComparer>(in (double lat, double lng) fieldCoordinates, in TComparer comparer)
         where TComparer : ISpatialComparer
     {
         var distance = HaverstineDistanceInInternationalNauticalMiles(comparer.Point.Center.Y, comparer.Point.Center.X, fieldCoordinates.lat, fieldCoordinates.lng);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -50,7 +50,7 @@ public class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
 
         var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1, null);
-        var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out var isBinary);
+        var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out var isBinary, out _);
         var coraxPageSize = CoraxGetPageSize(_indexSearcher, facetQuery.Query.PageSize, query, isBinary);
         var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.Sharding.cs
@@ -1,0 +1,76 @@
+﻿using System.Text;
+using Corax;
+using Corax.Queries;
+using Corax.Utils;
+using Corax.Utils.Spatial;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
+using Raven.Server.Documents.Sharding;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax;
+
+public partial class CoraxIndexReadOperation
+{
+    private SortingMatch.SpatialAscendingMatchComparer? _ascSpatialComparer;
+    private SortingMatch.SpatialDescendingMatchComparer? _descSpatialComparer;
+
+    partial void AddOrderByFields(IndexQueryServerSide query, long indexEntryId, OrderMetadata[] orderByFields, ref Document d)
+    {
+        var documentWithOrderByFields = DocumentWithOrderByFields.From(d);
+
+        for (int i = 0; i < query.Metadata.OrderBy.Length; i++)
+        {
+            var orderByField = query.Metadata.OrderBy[i];
+
+            if (orderByField.OrderingType == OrderByFieldType.Random)
+                break; // we order by random when merging results from shards
+
+            if (orderByField.OrderingType == OrderByFieldType.Score)
+            {
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "RavenDB-13927 Order by score");
+                throw new NotSupportedInShardingException("Ordering by score is not supported in sharding");
+            }
+
+            var orderByFieldMetadata = orderByFields[i];
+
+            IndexEntryReader entryReader = _indexSearcher.GetReaderAndIdentifyFor(indexEntryId, out _);
+            IndexEntryReader.FieldReader reader = entryReader.GetFieldReaderFor(orderByFieldMetadata.Field);
+
+            switch (orderByField.OrderingType)
+            {
+                case OrderByFieldType.Long:
+                    reader.Read<long>(out var longValue);
+                    documentWithOrderByFields.AddLongOrderByField(longValue);
+                    break;
+                case OrderByFieldType.Double:
+                    reader.Read<double>(out var doubleValue);
+                    documentWithOrderByFields.AddDoubleOrderByField(doubleValue);
+                    break;
+                case OrderByFieldType.Distance:
+                {
+                    reader.Read(out (double lat, double lon) coordinates);
+
+                    ISpatialComparer comparer = orderByField.Ascending
+                        ? _ascSpatialComparer ??= new SortingMatch.SpatialAscendingMatchComparer(_indexSearcher, orderByFieldMetadata)
+                        : _descSpatialComparer ??= new SortingMatch.SpatialDescendingMatchComparer(_indexSearcher, orderByFieldMetadata);
+
+                    var distance = SpatialUtils.GetGeoDistance(in coordinates, in comparer);
+                    documentWithOrderByFields.AddDoubleOrderByField(distance);
+                    break;
+                }
+                default:
+                {
+                    reader.Read(out var sv);
+                    var stringValue = Encoding.UTF8.GetString(sv);
+                    documentWithOrderByFields.AddStringOrderByField(stringValue);
+                    break;
+                }
+            }
+
+            d = documentWithOrderByFields;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -91,7 +91,7 @@ internal static class CoraxQueryBuilder
         return source;
     }
 
-    internal static IQueryMatch BuildQuery(Parameters builderParameters, out bool isBinary)
+    internal static IQueryMatch BuildQuery(Parameters builderParameters, out bool isBinary, out OrderMetadata[] sortMetadata)
     {
         using (CultureHelper.EnsureInvariantCulture())
         {
@@ -115,9 +115,11 @@ internal static class CoraxQueryBuilder
 
             if (metadata.Query.OrderBy is not null)
             {
-                var sortMetadata = GetSortMetadata(builderParameters);
+                sortMetadata = GetSortMetadata(builderParameters);
                 coraxQuery = OrderBy(builderParameters, coraxQuery, sortMetadata);
             }
+            else
+                sortMetadata = null;
 
             // The parser already throws parse exception if there is a syntax error.
             // We now return null in the case of a term query that has been fully analyzed, so we need to return a valid query.
@@ -451,7 +453,7 @@ internal static class CoraxQueryBuilder
     {
         using (CultureHelper.EnsureInvariantCulture())
         {
-            var filterQuery = BuildQuery(builderParameters, out isBinary);
+            var filterQuery = BuildQuery(builderParameters, out isBinary, out _);
             filterQuery = MaterializeWhenNeeded(filterQuery, ref isBinary);
 
             var moreLikeThisQuery = ToMoreLikeThisQuery(builderParameters, whereExpression, out isBinary, out var baseDocument, out var options);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.Sharding.cs
@@ -1,28 +1,17 @@
 ﻿using Lucene.Net.Search;
-using Raven.Client;
-using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
-using Raven.Server.Documents.Sharding;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Lucene;
 
 public partial class LuceneIndexReadOperation
 {
-    partial void AddOrderByFields(IndexQueryServerSide query, global::Lucene.Net.Documents.Document document, int doc, ref Document d)
+    partial void AddOrderByFields(IndexQueryServerSide query, int doc, ref Document d)
     {
-        // * for sharded queries, we'll send the order by fields separately
-        // * for a map-reduce index, it's fields are the ones that are used for sorting
-        if (_index.DocumentDatabase is ShardedDocumentDatabase == false || query.Metadata.OrderBy?.Length > 0 == false || _indexType.IsMapReduce())
-            return;
-
-        //https://issues.hibernatingrhinos.com/issue/RavenDB-18457
-        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "review after Corax is merged");
-
         var documentWithOrderByFields = DocumentWithOrderByFields.From(d);
-
+        
         foreach (var field in query.Metadata.OrderBy)
         {
             switch (field.OrderingType)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -253,7 +253,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                                         explanation = GetQueryExplanations(explanationOptions, luceneQuery, _searcher, scoreDoc, d, document);
                                     }
                                 }
-                                AddOrderByFields(query, document, scoreDoc.Doc, ref d);
+
+                                if (ShouldAddOrderByFieldValues(query))
+                                    AddOrderByFields(query, scoreDoc.Doc, ref d);
+                                
                                 // We return the document to the caller. 
                                 return new QueryResult { Result = d, Highlightings = highlightings, Explanation = explanation };
                             }
@@ -370,7 +373,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             return results;
         }
 
-        partial void AddOrderByFields(IndexQueryServerSide query, global::Lucene.Net.Documents.Document document, int doc, ref Document d);
+        partial void AddOrderByFields(IndexQueryServerSide query, int doc, ref Document d);
 
         private void SetupHighlighter(IndexQueryServerSide query, Query luceneQuery, JsonOperationContext context)
         {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedDocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedDocumentsComparer.cs
@@ -155,6 +155,12 @@ public class ShardedDocumentsComparer : IComparer<BlittableJsonReaderObject>
             return true;
         }
 
+        if (arrayValue is long)
+        {
+            value = Convert.ToDouble(arrayValue);
+            return true;
+        }
+
         ThrowIfNotExpectedType(nameof(LazyNumberValue), arrayValue);
         value = 0;
         return false;

--- a/test/FastTests/Client/Queries/DictionaryQueriesWithLinq.cs
+++ b/test/FastTests/Client/Queries/DictionaryQueriesWithLinq.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,10 +35,11 @@ public class DictionaryQueriesWithLinq : RavenTestBase
         }
     }
 
-    [Fact]
-    public void QueryCustomDictionaryWithOrderEqualityClause()
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueryCustomDictionaryWithOrderEqualityClause(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var newSession = store.OpenSession())
             {

--- a/test/FastTests/Sharding/Queries/BasicShardedQueryTests.cs
+++ b/test/FastTests/Sharding/Queries/BasicShardedQueryTests.cs
@@ -135,10 +135,11 @@ namespace FastTests.Sharding.Queries
             }
         }
 
-        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
-        public void Simple_Projection_With_Order_By()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Simple_Projection_With_Order_By(Options options)
         {
-            using (var store = Sharding.GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new UserMapIndex());
 
@@ -351,10 +352,11 @@ select project(o)")
             }
         }
 
-        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
-        public void Auto_Map_Reduce_With_Order_By()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Auto_Map_Reduce_With_Order_By(Options options)
         {
-            using (var store = Sharding.GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -408,11 +410,11 @@ select {{
         }
 
         [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
-        [InlineData("long")]
-        [InlineData("double")]
-        public void Map_Index_With_Order_By_Multiple_Results(string sortType)
+        [RavenData("long", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData("double", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Map_Index_With_Order_By_Multiple_Results(Options options, string sortType)
         {
-            using (var store = Sharding.GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new OrderMapIndex());
 
@@ -473,11 +475,11 @@ order by o.Freight as {sortType}
         }
 
         [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
-        [InlineData("long")]
-        [InlineData("double")]
-        public void Map_Reduce_Index_With_Order_By_Multiple_Results(string sortType)
+        [RavenData("long", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData("double", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Map_Reduce_Index_With_Order_By_Multiple_Results(Options options, string sortType)
         {
-            using (var store = Sharding.GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new OrderMapReduceIndex());
 

--- a/test/SlowTests/Issues/RavenDB-11385.cs
+++ b/test/SlowTests/Issues/RavenDB-11385.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task OrderByIdTest()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task OrderByIdTest(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new DocsIndex().Execute(store);
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Issues/RavenDB_11879.cs
+++ b/test/SlowTests/Issues/RavenDB_11879.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -63,10 +64,11 @@ namespace SlowTests.Issues
             public string Id { get; set; }
         }
 
-        [Fact]
-        public void SortOnlyQueriesShouldWorkForMultiMapIndexes()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SortOnlyQueriesShouldWorkForMultiMapIndexes(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new MultiMap().Execute(store);
 
@@ -132,10 +134,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void SortOnlyQueriesShouldWorkForAutoIndexes()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SortOnlyQueriesShouldWorkForAutoIndexes(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 for (var i = 0; i < 50; i++)
                 {

--- a/test/SlowTests/MailingList/Jabber/Games.cs
+++ b/test/SlowTests/MailingList/Jabber/Games.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -64,10 +65,11 @@ namespace SlowTests.MailingList.Jabber
             #endregion
         }
 
-        [Fact]
-        public void CanUseTransformResults()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanUseTransformResults(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 SetupTestGameData(store);
                 new GameServers_ConnectedPlayers().Execute(store);

--- a/test/SlowTests/MailingList/Vlad.cs
+++ b/test/SlowTests/MailingList/Vlad.cs
@@ -106,10 +106,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void WillOnlyGetPost2Once()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void WillOnlyGetPost2Once(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new Post_ByTag().Execute(store);
                 using (IDocumentSession session = store.OpenSession())

--- a/test/SlowTests/Tests/Linq/UsingRavenQueryProvider.cs
+++ b/test/SlowTests/Tests/Linq/UsingRavenQueryProvider.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.Util;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -42,10 +43,11 @@ namespace SlowTests.Tests.Linq
             }
         }
 
-        [Fact]
-        public void Can_perform_Skip_Take_Query()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_perform_Skip_Take_Query(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Initialize();
 

--- a/test/SlowTests/Tests/Spatial/SpatialSearch.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialSearch.cs
@@ -207,19 +207,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void PolandTestOrderByDistanceLucene(Options options)
-        {
-            PolandTestOrderByDistance(options);
-        }
-
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void PolandTestOrderByDistanceCorax(Options options)
-        {
-            PolandTestOrderByDistance(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void PolandTestOrderByDistance(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -261,20 +249,9 @@ namespace SlowTests.Tests.Spatial
             }
         }
 
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_do_spatial_search_with_client_api_addorderLucene(Options options)
-        {
-            Can_do_spatial_search_with_client_api_addorder(options);
-        }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void Can_do_spatial_search_with_client_api_addorderCorax(Options options)
-        {
-            Can_do_spatial_search_with_client_api_addorder(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_do_spatial_search_with_client_api_addorder(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialSorting.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialSorting.cs
@@ -115,19 +115,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQueryLucene(Options options)
-        {
-            CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(options);
-        }
-
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQueryCorax(Options options)
-        {
-            CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanFilterByLocationAndSortByDistanceFromDifferentPointWDocQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -147,19 +135,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanSortByDistanceWOFilteringWDocQueryLucene(Options options)
-        {
-            CanSortByDistanceWOFilteringWDocQuery(options);
-        }
-
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanSortByDistanceWOFilteringWDocQueryCorax(Options options)
-        {
-            CanSortByDistanceWOFilteringWDocQuery(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         private void CanSortByDistanceWOFilteringWDocQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -198,19 +174,7 @@ namespace SlowTests.Tests.Spatial
 
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanSortByDistanceWOFilteringLucene(Options options)
-        {
-            CanSortByDistanceWOFiltering(options);
-        }
-
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanSortByDistanceWOFilteringCorax(Options options)
-        {
-            CanSortByDistanceWOFiltering(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanSortByDistanceWOFiltering(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -229,19 +193,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanSortByDistanceWOFilteringBySpecifiedFieldLucene(Options options)
-        {
-            CanSortByDistanceWOFilteringBySpecifiedField(options);
-        }
-
-        [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanSortByDistanceWOFilteringBySpecifiedFieldCorax(Options options)
-        {
-            CanSortByDistanceWOFilteringBySpecifiedField(options);
-        }
-
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanSortByDistanceWOFilteringBySpecifiedField(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18457/Sharding-Querying-Review-Order-By-fields-after-Corax-is-merged

### Additional description

We didn't send `@order-by-fields` in the metadata of query results when using Corax. Switching multiple tests to be run on Corax in sharded environment.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests switched to Corax will verify that

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
