### PR TITLE
Indicate that document is new by providing an empty change vector fallback in ConcurrencyCheckMode.Forced scenario

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1124,13 +1124,14 @@ more responsive application.
                     if (UseOptimisticConcurrency)
                     {
                         if (entity.Value.ConcurrencyCheckMode != ConcurrencyCheckMode.Disabled)
-                            // if the user didn't provide a change vector, we'll test for an empty one
+                            // if the user didn't provide a change vector, we'll test for an empty one indicating it is a new document
                             changeVector = entity.Value.ChangeVector ?? string.Empty;
                         else
                             changeVector = null;
                     }
                     else if (entity.Value.ConcurrencyCheckMode == ConcurrencyCheckMode.Forced)
-                        changeVector = entity.Value.ChangeVector;
+                        // if the user didn't provide a change vector, we'll test for an empty one indicating it is a new document
+                        changeVector = entity.Value.ChangeVector ?? string.Empty;
                     else
                         changeVector = null;
 


### PR DESCRIPTION
This has no functional impact as DocumentPutAction.PutAction method doesn't differentiate at the moment between null or empty change vector when there was no such document before on the server side. If in the future there was a need to differentiate then this change would be needed anyway. But for now the only point of this change is to bring consistency with ConcurrencyCheckMode.Auto scenario to avoid confusion of why ConcurrencyCheckMode.Auto fallbacks to empty change vector and ConcurrencyCheckMode.Forced does not.

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
