### PR TITLE
RavenDB-19421 Will send conflict-resolved document to the other side …

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -300,7 +300,7 @@ namespace Raven.Server.Documents
                         Name = name,
                         DocumentId = documentId,
                         Hash = hash,
-                        Size = stream.Length
+                        Size = stream?.Length ?? -1
                     };
                 }
             }
@@ -451,11 +451,11 @@ namespace Raven.Server.Documents
                 }
             }
         }
-        public void PutAttachmentRevert(DocumentsOperationContext context, Document document, out bool hasAttachments)
+        public void PutAttachmentRevert(DocumentsOperationContext context, LazyStringValue id, BlittableJsonReaderObject document, out bool hasAttachments)
         {
             hasAttachments = false;
 
-            if (document.Data.TryGet(Client.Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+            if (document.TryGet(Client.Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
                 metadata.TryGet(Client.Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
                 return;
 
@@ -471,7 +471,7 @@ namespace Raven.Server.Documents
                 var cv = Slices.Empty;
                 var type = AttachmentType.Document;
 
-                using (DocumentIdWorker.GetSliceFromId(context, document.Id, out Slice lowerDocumentId))
+                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerDocumentId))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, name, out Slice lowerName, out Slice nameSlice))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                 using (Slice.External(context.Allocator, hash, out Slice base64Hash))

--- a/src/Raven.Server/Documents/CompoundKeyHelper.cs
+++ b/src/Raven.Server/Documents/CompoundKeyHelper.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using Sparrow.Server.Utils;
+
+namespace Raven.Server.Documents;
+
+public static class CompoundKeyHelper
+{
+    public static string ExtractDocumentId(ReadOnlySpan<byte> key)
+    {
+        // key structure means doc-id | REC-SEP | ...
+        int endOfDocumentId = key.IndexOf(SpecialChars.RecordSeparator);
+        Debug.Assert(endOfDocumentId != -1);
+        string documentId = Encoding.UTF8.GetString(key[..endOfDocumentId]);// will throw if no separator found
+        return documentId;
+    }
+}

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -571,7 +571,7 @@ namespace Raven.Server.Documents
 
                 if (values.Count == 0)
                 {
-                    if (metadata != null)
+                    if (metadata != null && metadata.TryGetMember(type.MetadataProperty, out _))
                     {
                         metadata.Modifications = new DynamicJsonValue(metadata);
                         metadata.Modifications.Remove(type.MetadataProperty);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1580,19 +1580,20 @@ namespace Raven.Server.Documents
                 DeletedEtag = TableValueToEtag((int)TombstoneTable.DeletedEtag, ref tvr),
                 Type = *(Tombstone.TombstoneType*)tvr.Read((int)TombstoneTable.Type, out int _),
                 TransactionMarker = *(short*)tvr.Read((int)TombstoneTable.TransactionMarker, out int _),
-                ChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr)
+                ChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr),
+                LastModified = TableValueToDateTime((int)TombstoneTable.LastModified, ref tvr)
             };
 
-            if (result.Type == Tombstone.TombstoneType.Document)
+            switch (result.Type)
             {
-                result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
-                result.Flags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr);
-                result.LastModified = TableValueToDateTime((int)TombstoneTable.LastModified, ref tvr);
-                result.LowerId = UnwrapLowerIdIfNeeded(context, result.LowerId);
-            }
-            else if (result.Type == Tombstone.TombstoneType.Revision)
-            {
-                result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
+                case Tombstone.TombstoneType.Document:
+                    result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
+                    result.Flags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr);
+                    result.LowerId = UnwrapLowerIdIfNeeded(context, result.LowerId);
+                    break;
+                case Tombstone.TombstoneType.Revision:
+                    result.Collection = TableValueToId(context, (int)TombstoneTable.Collection, ref tvr);
+                    break;
             }
 
             return result;

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -5,6 +5,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
+using Voron;
 using Voron.Impl;
 
 namespace Raven.Server.Documents
@@ -21,6 +22,8 @@ namespace Raven.Server.Documents
 
         private List<TimeSeriesChange> _timeSeriesNotifications;
 
+        private List<Slice> _attachmentHashesToMaybeDelete;
+
         private bool _replaced;
 
         private Dictionary<string, CollectionName> _collectionCache;
@@ -32,8 +35,17 @@ namespace Raven.Server.Documents
             _changes = changes;
         }
 
+        public override void BeforeCommit()
+        {
+            if (_attachmentHashesToMaybeDelete == null)
+                return;
+
+            _context.DocumentDatabase.DocumentsStorage.AttachmentsStorage.RemoveAttachmentStreamsWithoutReferences(_context, _attachmentHashesToMaybeDelete);
+        }
+
         public DocumentsTransaction BeginAsyncCommitAndStartNewTransaction(DocumentsOperationContext context)
         {
+            BeforeCommit();
             _replaced = true;
             var tx = InnerTransaction.BeginAsyncCommitAndStartNewTransaction(context.PersistentContext);
             return new DocumentsTransaction(context, tx, _changes);
@@ -149,6 +161,13 @@ namespace Raven.Server.Documents
             if (doc == null)
                 return;
             InnerTransaction.ForgetAbout(doc.StorageId);
+        }
+
+        internal void CheckIfShouldDeleteAttachmentStream(Slice hash)
+        {
+            var clone = hash.Clone(InnerTransaction.Allocator);
+            _attachmentHashesToMaybeDelete ??= new();
+            _attachmentHashesToMaybeDelete.Add(clone);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
         
-        [RavenAction("/databases/*/replication/all-items", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        [RavenAction("/databases/*/debug/replication/all-items", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetAllItems()
         {
             var etag = GetLongQueryString("etag", required: false) ?? 0L;

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -5,10 +5,12 @@ using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
+using NuGet.Protocol;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -34,6 +36,60 @@ namespace Raven.Server.Documents.Handlers
                 foreach (var tombstone in tombstones)
                 {
                     array.Add(tombstone.ToJson());
+                }
+                context.Write(writer, new DynamicJsonValue
+                {
+                    ["Results"] = array
+                });
+            }
+        }
+        
+        [RavenAction("/databases/*/replication/all-items", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task GetAllItems()
+        {
+            var etag = GetLongQueryString("etag", required: false) ?? 0L;
+            var pageSize = GetPageSize();
+
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            using (context.OpenReadTransaction())
+            {
+                var runStats = new OutgoingReplicationRunStats();
+                var stats = new ReplicationDocumentSender.ReplicationStats
+                {
+                    Network = new OutgoingReplicationStatsScope(runStats),
+                    Storage = new OutgoingReplicationStatsScope(runStats),
+                    AttachmentRead = new OutgoingReplicationStatsScope(runStats),
+                    CounterRead = new OutgoingReplicationStatsScope(runStats),
+                    DocumentRead = new OutgoingReplicationStatsScope(runStats),
+                    TombstoneRead = new OutgoingReplicationStatsScope(runStats),
+                    TimeSeriesRead = new OutgoingReplicationStatsScope(runStats),
+                };
+                var array = new DynamicJsonArray();
+
+                foreach (ReplicationBatchItem item in ReplicationDocumentSender.GetReplicationItems(Database, context, etag, stats, false).Take(pageSize))
+                {
+                    var djv = new DynamicJsonValue
+                    {
+                        [nameof(item.ChangeVector)] = item.ChangeVector,
+                        [nameof(item.Etag)] = item.Etag,
+                        [nameof(item.Type)] = item.Type,
+                        [nameof(item.TransactionMarker)] = item.TransactionMarker,
+                    };
+                    switch (item)
+                    {
+                        case DocumentReplicationItem i:
+                            djv[nameof(i.Collection)] = i.Collection;
+                            djv[nameof(i.Id)] = i.Id;
+                            djv[nameof(i.Flags)] = i.Flags;
+                            break;
+                        case AttachmentReplicationItem a:
+                            djv[nameof(a.Base64Hash)] = a.Base64Hash.ToString();
+                            djv[nameof(a.Name)] = a.Name.ToString();
+                            djv[nameof(a.ContentType)] = a.ContentType.ToString();
+                            break;
+                    }
+                    array.Add(djv);
                 }
                 context.Write(writer, new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -88,8 +88,8 @@ namespace Raven.Server.Documents.Replication
                             conflicts.Add(local);
 
                         var resolved = _conflictResolver.ResolveToLatest(conflicts);
-                        _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: true, conflictedDoc);
 
+                        _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: true, conflictedDoc);
                         return;
                     }
                 }
@@ -178,8 +178,8 @@ namespace Raven.Server.Documents.Replication
                 conflictedDocs,
                 documentsContext.GetLazyString(collection), out var resolved))
             {
-                _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, conflict);
-                return true;
+                 _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, conflict);
+                 return true;
             }
 
             return false;
@@ -261,7 +261,9 @@ namespace Raven.Server.Documents.Replication
                 if (compareResult.HasFlag(DocumentCompareResult.TimeSeriesNotEqual))
                     nonPersistentFlags |= NonPersistentDocumentFlags.ResolveTimeSeriesConflict;
 
-                _database.DocumentsStorage.Put(context, id, null, incomingDoc, lastModifiedTicks, mergedChangeVector, nonPersistentFlags: nonPersistentFlags);
+                _database.DocumentsStorage.Put(context, id, null, incomingDoc, lastModifiedTicks, mergedChangeVector,
+                    flags: existingDoc.Flags | DocumentFlags.Resolved, 
+                    nonPersistentFlags: nonPersistentFlags);
                 return true;
             }
 

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -178,7 +178,7 @@ namespace Raven.Server.Documents.Replication
                 conflictedDocs,
                 documentsContext.GetLazyString(collection), out var resolved))
             {
-                 _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, conflict);
+                 _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, incoming: conflict);
                  return true;
             }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -774,11 +774,17 @@ namespace Raven.Server.Documents.Replication
                         return true;
                     }
 
+                    if (doc.Flags.Contain(DocumentFlags.Resolved))
+                    {
+                        // we let all resolved documents to pass to the other side, since we might resolved them to a merged change vector, and we want to ensure
+                        // that this is properly synced between the nodes
+                        return false;
+                    }
+
                     if (doc.Flags.Contain(DocumentFlags.Revision) || doc.Flags.Contain(DocumentFlags.DeleteRevision))
                     {
-                        // we let pass all the conflicted/resolved revisions, since we keep them with their original change vector which might be `AlreadyMerged` at the destination.
+                        // we let pass all the conflicted revisions, since we keep them with their original change vector which might be `AlreadyMerged` at the destination.
                         if (doc.Flags.Contain(DocumentFlags.Conflicted) ||
-                            doc.Flags.Contain(DocumentFlags.Resolved) ||
                             doc.Flags.Contain(DocumentFlags.FromClusterTransaction) ||
                             doc.Flags.Contain(DocumentFlags.FromOldDocumentRevision))
                         {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using Raven.Client.Util;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -17,6 +19,16 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public Slice Key;
         public Slice Base64Hash;
         public Stream Stream;
+
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Name)] = Name.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(ContentType)] = ContentType.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Base64Hash)] = Base64Hash.ToString();
+            djv[nameof(Key)] = CompoundKeyHelper.ExtractDocumentId(Key);
+            return djv;
+        }
 
         public static unsafe AttachmentReplicationItem From(DocumentsOperationContext context, Attachment attachment)
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentTombstoneReplicationItem.cs
@@ -3,6 +3,7 @@ using Raven.Client.Util;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -12,6 +13,13 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
     public class AttachmentTombstoneReplicationItem : ReplicationBatchItem
     {
         public Slice Key;
+
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Key)] = CompoundKeyHelper.ExtractDocumentId(Key);
+            return djv;
+        }
 
         public override long AssertChangeVectorSize()
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 
@@ -14,6 +16,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Id;
 
         public BlittableJsonReaderObject Values;
+
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Collection)] = Collection.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Id)] = Id.ToString(CultureInfo.InvariantCulture);
+            return djv;
+        }
+
         public override long AssertChangeVectorSize()
         {
             return sizeof(byte) + // type

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 
@@ -14,6 +16,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Collection;
         public LazyStringValue Id;
         public DocumentFlags Flags;
+
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Collection)] = Collection.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Id)] = Id.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Flags)] = Flags;
+            return djv;
+        }
 
         public static DocumentReplicationItem From(Document doc)
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -7,6 +7,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 
@@ -83,6 +84,19 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 ChangeVector = Encoding.UTF8.GetString(Reader.ReadExactly(changeVectorSize), changeVectorSize);
 
             TransactionMarker = *(short*)Reader.ReadExactly(sizeof(short));
+        }
+
+        public virtual DynamicJsonValue ToDebugJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Type)] = Type,
+                [nameof(Size)] = Size,
+                [nameof(TransactionMarker)] = TransactionMarker,
+                [nameof(ChangeVector)] = ChangeVector,
+                [nameof(Etag)] = Etag,
+                ["LastModified"] = new DateTime(LastModifiedTicks).ToString("O")
+            };
         }
 
         protected unsafe int WriteCommon(Slice changeVector, byte* tempBuffer)

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 
@@ -13,6 +15,14 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Collection;
         public LazyStringValue Id;
 
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Collection)] = Collection.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Id)] = Id.ToString(CultureInfo.InvariantCulture);
+            return djv;
+        }
+        
         public override long AssertChangeVectorSize()
         {
             return sizeof(byte) + // type

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using Nest;
 using Raven.Client.Util;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 
@@ -18,6 +21,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public DateTime From;
         public DateTime To;
 
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Collection)] = Collection.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Key)] = CompoundKeyHelper.ExtractDocumentId(Key);
+            djv[nameof(From)] = From.ToString("O");
+            djv[nameof(To)] = To.ToString("O");
+            return djv;
+        }
         public override long AssertChangeVectorSize()
         {
             return sizeof(byte) + // type
@@ -100,6 +112,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Name; // original casing
         public LazyStringValue Collection;
         public TimeSeriesValuesSegment Segment;
+        
+        public override DynamicJsonValue ToDebugJson()
+        {
+            var djv = base.ToDebugJson();
+            djv[nameof(Collection)] = Collection.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Name)] = Name.ToString(CultureInfo.InvariantCulture);
+            djv[nameof(Key)] = CompoundKeyHelper.ExtractDocumentId(Key);
+            return djv;
+        }
 
         public override long AssertChangeVectorSize()
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TombstoneReplicationItem.cs
@@ -30,7 +30,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                         Type = ReplicationBatchItem.ReplicationItemType.AttachmentTombstone,
                         Etag = doc.Etag,
                         TransactionMarker = doc.TransactionMarker,
-                        ChangeVector = doc.ChangeVector
+                        ChangeVector = doc.ChangeVector,
+                        LastModifiedTicks = doc.LastModified.Ticks,
                     };
 
                     item.ToDispose(Slice.From(context.Allocator, doc.LowerId.Buffer, doc.LowerId.Size, ByteStringType.Immutable, out item.Key));

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1696,7 +1696,7 @@ namespace Raven.Server.Documents.Revisions
 
             private static void InsertNewMetadataInfo(DocumentsOperationContext context, DocumentsStorage documentsStorage, Document document, CollectionName collectionName)
             {
-                documentsStorage.AttachmentsStorage.PutAttachmentRevert(context, document, out bool has);
+                documentsStorage.AttachmentsStorage.PutAttachmentRevert(context, document.Id,  document.Data, out bool has);
                 RevertCounters(context, documentsStorage, document, collectionName);
 
                 document.Data = RevertSnapshotFlags(context, document.Data, document.Id);

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -16,8 +16,14 @@ namespace Raven.Server.ServerWide
             InnerTransaction = transaction;
         }
 
+        public virtual void BeforeCommit()
+        {
+
+        }
+
         public void Commit()
         {
+            BeforeCommit();
             InnerTransaction.Commit();
         }
 

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Server.Replication;
@@ -16,12 +15,12 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Documents;
-using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
@@ -2552,7 +2551,7 @@ namespace SlowTests.Client.Attachments
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store1, store3);
-                
+
                 using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
                 {
                     var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
@@ -2561,7 +2560,7 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal("image/png", result.ContentType);
                     Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
                 }
-                
+
                 using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50, 60 }))
                 {
                     var result = store3.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
@@ -2570,10 +2569,11 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal("image/png", result.ContentType);
                     Assert.Equal("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=", result.Hash);
                 }
-                
-                await WriteStatus(store1, store2, store3, "Stage 1");
 
-                
+                var stores = new DocumentStore[] { store1, store2, store3 };
+                await WriteStatus(stores, "Stage 1");
+
+
                 using (var session = store1.OpenAsyncSession())
                 {
                     var u = await session.LoadAsync<User>("users/1");
@@ -2584,45 +2584,21 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store1, store3);
 
-                await WriteStatus(store1, store2, store3, "Stage 2");
+                await WriteStatus(stores, "Stage 2");
 
                 await SetupReplicationAsync(store2, store1);
                 await SetupReplicationAsync(store2, store3);
                 await EnsureReplicatingAsync(store2, store1);
                 await EnsureReplicatingAsync(store2, store3);
-                
-                await WriteStatus(store1, store2, store3, "Stage 3");
-                
+
+                await WriteStatus(stores, "Stage 3");
+
                 await SetupReplicationAsync(store3, store2);
                 await EnsureReplicatingAsync(store3, store2);
-                
-                await WriteStatus(store1, store2, store3, "Stage 4");
-                
-                var res2 =  await WaitForValueAsync(async () =>
-                {
-                    var cvs = new List<string>();
-                
-                        var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
-                        using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                        using (context.OpenReadTransaction())
-                        {
-                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                        }
-                        var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
-                        using (storage2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                        using (context.OpenReadTransaction())
-                        {
-                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                        }
-                        var storage3 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database);
-                        using (storage3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                        using (context.OpenReadTransaction())
-                        {
-                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                        }
 
-                    return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
-                }, true, timeout: 30_000, interval: 333);
+                await WriteStatus(stores, "Stage 4");
+
+                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
                 Assert.True(res2);
 
                 var res = await WaitForValueAsync(async () =>
@@ -2646,9 +2622,9 @@ namespace SlowTests.Client.Attachments
                         return false;
                     }
                 }, true, 30_000, interval: 333);
-             
 
-                await WriteStatus(store1, store2, store3, "Stage 5");
+
+                await WriteStatus(stores, "Stage 5");
 
                 using (var session = store1.OpenAsyncSession())
                 using (var session2 = store2.OpenAsyncSession())
@@ -2665,7 +2641,7 @@ namespace SlowTests.Client.Attachments
                     Console.WriteLine($"\ncv1: {cv1}");
                     Console.WriteLine($"cv2: {cv2}");
                     Console.WriteLine($"cv3: {cv3}\n");
-                   
+
                     Assert.True(cv1.Equals(cv2));
                     Assert.True(cv1.Equals(cv3));
 
@@ -2689,30 +2665,498 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                 }
             }
+        }
 
-            async Task WriteStatus(DocumentStore store1, DocumentStore store2, DocumentStore store3, string s)
+        [Fact]
+        public async Task ConflictOfAttachmentAndDocument_SameMetadataDifferentAttachmentChangeVectors_RevisionsDisabled()
+        {
+            var options = new Options
             {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                var revisionCollectionConfiguration = new RevisionsCollectionConfiguration { Disabled = true };
+                await store1.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store1.Database, revisionCollectionConfiguration));
+                await store2.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store2.Database, revisionCollectionConfiguration));
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store1);
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store2, store1);
+
+                var stores = new DocumentStore[] { store1, store2 };
+
+                await WriteStatus(stores, "Stage 1");
+
+                var b1 = await BreakReplication(Server.ServerStore, store1.Database);
+                var b2 = await BreakReplication(Server.ServerStore, store2.Database);
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                await WriteStatus(stores, "Stage 2");
+
+                b1.Mend();
+                b2.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store2, store1);
+
+                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
+                Assert.True(res2);
+
+                await WriteStatus(stores, "Stage 3");
+
+                var res = await WaitForValueAsync(async () =>
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    using (var session2 = store2.OpenAsyncSession())
+                    {
+
+                        var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null &&
+                            attachment.Details.Hash == "igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=" &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details))
+                        {
+                            return true;
+                        }
+                        return false;
+                    }
+                }, true, 15_000, 500);
+
+                using (var session = store1.OpenAsyncSession())
+                using (var session2 = store2.OpenAsyncSession())
+                {
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
+
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment.Details.Hash);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ConflictOfAttachmentAndDocument()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                await SetupReplicationAsync(store2, store1);
+                await SetupReplicationAsync(store1, store2);
+
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var stores = new DocumentStore[] { store1, store2 };
+                await WriteStatus(stores, "Stage 1");
+
+                var b1 = await BreakReplication(Server.ServerStore, store1.Database);
+                var b2 = await BreakReplication(Server.ServerStore, store2.Database);
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 30;
+                    await session.SaveChangesAsync();
+                }
+
+                await WriteStatus(stores, "Stage 2");
+
+                b1.Mend();
+                b2.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store2, store1);
+
+                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
+                Assert.True(res2);
+
+                await WriteStatus(stores, "Stage 3");
+
+                using (var session = store1.OpenAsyncSession())
+                using (var session2 = store2.OpenAsyncSession())
+                {
+                    await WaitForValueAsync(async () =>
+                    {
+                        var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null &&
+                            attachment.Details.Hash == "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }, true, 10000, 500);
+
+                    var user = await session.LoadAsync<User>("users/1");
+                    Assert.Equal(30, user.Age);
+                    var user2 = await session2.LoadAsync<User>("users/1");
+                    Assert.Equal(30, user2.Age);
+
+                    await WriteAttachmentDetails(stores);
+
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
+
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
+                    Assert.Equal("foo/bar", attachment.Details.Name);
+
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ConflictOfAttachmentAndDocument3Stores()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            using (var store3 = GetDocumentStore())
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store1, store3);
+
+                await SetupReplicationAsync(store2, store1);
+                await SetupReplicationAsync(store2, store3);
+
+                await SetupReplicationAsync(store3, store1);
+                await SetupReplicationAsync(store3, store2);
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+
+                await EnsureReplicatingAsync(store3, store1);
+                await EnsureReplicatingAsync(store3, store2);
+
+                var b1 = await BreakReplication(Server.ServerStore, store1.Database);
+                var b2 = await BreakReplication(Server.ServerStore, store2.Database);
+                var b3 = await BreakReplication(Server.ServerStore, store3.Database);
+
+                var stores = new DocumentStore[] { store1, store2, store3 };
+
+                await WriteAttachmentDetails(stores);
+                await WriteStatus(stores, "Stage 1");
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50, 60 }))
+                {
+                    var result = store3.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=", result.Hash);
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 30;
+                    await session.SaveChangesAsync();
+                }
+
+                await WriteStatus(stores, "Stage 2");
+
+                b1.Mend();
+                b2.Mend();
+                b3.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+
+                await EnsureReplicatingAsync(store3, store1);
+                await EnsureReplicatingAsync(store3, store2);
+
+                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
+                Assert.True(res2);
+
+                await WriteStatus(stores, "Stage 3");
+
+                await WaitForValueAsync(async () =>
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    using (var session2 = store2.OpenAsyncSession())
+                    using (var session3 = store3.OpenAsyncSession())
+                    {
+                        var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null && attachment3 != null &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                }, true, 10000, 500);
+
+                await WriteAttachmentDetails(stores);
+
                 using (var session = store1.OpenAsyncSession())
                 using (var session2 = store2.OpenAsyncSession())
                 using (var session3 = store3.OpenAsyncSession())
                 {
-                    var u1 = await session.LoadAsync<User>("users/1");
-                    var u2 = await session2.LoadAsync<User>("users/1");
-                    var u3 = await session3.LoadAsync<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
 
-                    var cv1 = session.Advanced.GetChangeVectorFor(u1);
-                    var cv2 = session2.Advanced.GetChangeVectorFor(u2);
-                    var cv3 = session3.Advanced.GetChangeVectorFor(u3);
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                    Console.WriteLine(s);
-                    Console.WriteLine($"\ncv1: {cv1}");
-                    Console.WriteLine($"cv2: {cv2}");
-                    Console.WriteLine($"cv3: {cv3}\n");
-                    Console.WriteLine("-----");
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
+                    Assert.NotNull(attachment3);
+
+                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
+                    Assert.Equal("foo/bar", attachment.Details.Name);
+
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+
+                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                 }
             }
         }
-        
+
+        // the original issue RavenDB-19421
+        [Fact]
+        public async Task ReplicationShouldSendMissingAttachments()
+        {
+            using (var source = GetDocumentStore())
+            using (var destination = GetDocumentStore())
+            {
+                await SetupReplicationAsync(source, destination);
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        fooStream.Position = 0;
+                        await session.StoreAsync(new User { Name = "Foo" }, $"FoObAr/{i}");
+                        session.Advanced.Attachments.Store($"FoObAr/{i}", "foo.png", fooStream, "image/png");
+                        await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentToReplicate<User>(destination, $"FoObAr/{i}", 15 * 1000));
+                    }
+                }
+
+                using (var session = destination.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        session.Delete($"FoObAr/{i}");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream2 = new MemoryStream(new byte[] { 4, 5, 6 }))
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        fooStream2.Position = 0;
+                        session.Advanced.Attachments.Store($"FoObAr/{i}", "foo2.png", fooStream2, "image/png");
+                        await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, $"FoObAr/{i}", "foo2.png", 30 * 1000));
+                    }
+                }
+
+                var buffer = new byte[3];
+                using (var session = destination.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        var user = await session.LoadAsync<User>($"FoObAr/{i}");
+                        var attachments = session.Advanced.Attachments.GetNames(user);
+                        Assert.Equal(2, attachments.Length);
+
+                        foreach (var name in attachments)
+                        {
+                            using (var attachment = await session.Advanced.Attachments.GetAsync(user, name.Name))
+                            {
+                                Assert.NotNull(attachment);
+                                Assert.Equal(3, await attachment.Stream.ReadAsync(buffer, 0, 3));
+                                if (attachment.Details.Name == "foo.png")
+                                {
+                                    Assert.Equal(1, buffer[0]);
+                                    Assert.Equal(2, buffer[1]);
+                                    Assert.Equal(3, buffer[2]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task WriteStatus(DocumentStore[] stores, string s)
+        {
+            Console.WriteLine(s + "\n");
+            for (int i = 0; i < stores.Length; i++)
+            {
+                using (var session = stores[i].OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    var cv = session.Advanced.GetChangeVectorFor(u);
+                    Console.WriteLine($"cv{i}: {cv}");
+                }
+            }
+            Console.WriteLine();
+            Console.WriteLine("-----");
+        }
+
+        private async Task WriteAttachmentDetails(DocumentStore[] stores)
+        {
+            Console.WriteLine();
+            for (int i = 0; i < stores.Length; i++)
+            {
+                using (var session = stores[i].OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    var names = session.Advanced.Attachments.GetNames(u);
+                    Console.WriteLine($"Attachments {i}: {string.Join(", ", names.Select(x => new string($"{x.Name}; Hash: {x.Hash}; ContentType: {x.ContentType}")))}");
+                }
+            }
+            Console.WriteLine();
+            Console.WriteLine("-----");
+        }
+
+        private async Task<bool> WaitForChangeVectorInReplicationAsync(DocumentStore[] stores)
+        {
+            var val = await WaitForValueAsync(async () =>
+            {
+                var cvs = new List<string>();
+                foreach (var store in stores)
+                {
+                    var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                    }
+                }
+                return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
+            }, true, timeout: 30_000, interval: 333);
+            return val;
+        }
+
         private bool AreAttachmentDetailsEqual(AttachmentDetails attachment1, AttachmentDetails attachment2)
         {
             if (attachment1.DocumentId == attachment2.DocumentId &&

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -3113,6 +3113,194 @@ namespace SlowTests.Client.Attachments
                 }
             }
         }
+        
+            [Fact]
+        public async Task ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder_RevisionsDisabled_MissingAttachmentLoop()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            using (var store3 = GetDocumentStore(options))
+            {
+                await store1.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store1.Database, new RevisionsCollectionConfiguration
+                {
+                    Disabled = true
+                }));
+                await store2.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store2.Database, new RevisionsCollectionConfiguration
+                {
+                    Disabled = true
+                }));
+                await store3.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store3.Database, new RevisionsCollectionConfiguration
+                {
+                    Disabled = true
+                }));
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                await SetupReplicationAsync(store2, store1);
+                await SetupReplicationAsync(store2, store3);
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store1, store3);
+                await SetupReplicationAsync(store3, store1);
+                await SetupReplicationAsync(store3, store2);
+
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+                await EnsureReplicatingAsync(store3, store1);
+                await EnsureReplicatingAsync(store3, store2);
+
+                var b1 = await BreakReplication(Server.ServerStore, store1.Database);
+                var b2 = await BreakReplication(Server.ServerStore, store2.Database);
+                var b3 = await BreakReplication(Server.ServerStore, store3.Database);
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var session = store2.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 20;
+                    await session.SaveChangesAsync();
+                }
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50, 60 }))
+                {
+                    var result = store3.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=", result.Hash);
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 30;
+                    await session.SaveChangesAsync();
+                }
+
+                b2.Mend();
+
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+                
+                b3.Mend();
+
+                await EnsureReplicatingAsync(store3, store2);
+                await EnsureReplicatingAsync(store3, store1);
+
+                b1.Mend();
+WaitForUserToContinueTheTest(store1);
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+
+                var res2 = await WaitForValueAsync(async () =>
+                {
+                    var cvs = new List<string>();
+
+                    var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                    using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                    }
+                    var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                    using (storage2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                    }
+                    var storage3 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database);
+                    using (storage3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                    }
+
+                    return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
+                }, true, timeout: 30_000, interval: 333);
+
+                WaitForUserToContinueTheTest(store1);
+                Assert.True(res2);
+
+                var res = await WaitForValueAsync(async () =>
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    using (var session2 = store2.OpenAsyncSession())
+                    using (var session3 = store3.OpenAsyncSession())
+                    {
+                        var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null && attachment3 != null &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                }, true, 10_000, 500);
+
+                if (res == false)
+                    WaitForUserToContinueTheTest(store1);
+
+                using (var session = store1.OpenAsyncSession())
+                using (var session2 = store2.OpenAsyncSession())
+                using (var session3 = store3.OpenAsyncSession())
+                {
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
+                    Assert.NotNull(attachment3);
+
+                    var user = await session.LoadAsync<User>("users/1");
+                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0), $"age: {user.Age}, hash: {attachment.Details.Hash}");
+                    Assert.Equal("foo/bar", attachment.Details.Name);
+
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+
+                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
+                }
+            }
+        }
 
         private async Task WriteStatus(DocumentStore[] stores, string s)
         {

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -2516,5 +2516,213 @@ namespace SlowTests.Client.Attachments
                 }
             }
         }
+        
+        
+        [Fact]
+        public async Task ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            using (var store3 = GetDocumentStore(options))
+            {
+                var user = new User {Name = "Karmel", Id = "users/1"};
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(user, user.Id);
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store1, store3);
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+                
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+                
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50, 60 }))
+                {
+                    var result = store3.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=", result.Hash);
+                }
+                
+                await WriteStatus(store1, store2, store3, "Stage 1");
+
+                
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 30;
+                    await session.SaveChangesAsync();
+                }
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+
+                await WriteStatus(store1, store2, store3, "Stage 2");
+
+                await SetupReplicationAsync(store2, store1);
+                await SetupReplicationAsync(store2, store3);
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+                
+                await WriteStatus(store1, store2, store3, "Stage 3");
+                
+                await SetupReplicationAsync(store3, store2);
+                await EnsureReplicatingAsync(store3, store2);
+                
+                await WriteStatus(store1, store2, store3, "Stage 4");
+                
+                var res2 =  await WaitForValueAsync(async () =>
+                {
+                    var cvs = new List<string>();
+                
+                        var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                        using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                        }
+                        var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                        using (storage2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                        }
+                        var storage3 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store3.Database);
+                        using (storage3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
+                        }
+
+                    return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
+                }, true, timeout: 30_000, interval: 333);
+                Assert.True(res2);
+
+                var res = await WaitForValueAsync(async () =>
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    using (var session2 = store2.OpenAsyncSession())
+                    using (var session3 = store3.OpenAsyncSession())
+                    {
+                        var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null && attachment3 != null &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                }, true, 30_000, interval: 333);
+             
+
+                await WriteStatus(store1, store2, store3, "Stage 5");
+
+                using (var session = store1.OpenAsyncSession())
+                using (var session2 = store2.OpenAsyncSession())
+                using (var session3 = store3.OpenAsyncSession())
+                {
+                    var u1 = await session.LoadAsync<User>("users/1");
+                    var u2 = await session2.LoadAsync<User>("users/1");
+                    var u3 = await session3.LoadAsync<User>("users/1");
+
+                    var cv1 = session.Advanced.GetChangeVectorFor(u1);
+                    var cv2 = session2.Advanced.GetChangeVectorFor(u2);
+                    var cv3 = session3.Advanced.GetChangeVectorFor(u3);
+
+                    Console.WriteLine($"\ncv1: {cv1}");
+                    Console.WriteLine($"cv2: {cv2}");
+                    Console.WriteLine($"cv3: {cv3}\n");
+                   
+                    Assert.True(cv1.Equals(cv2));
+                    Assert.True(cv1.Equals(cv3));
+
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
+                    Assert.NotNull(attachment3);
+
+                    user = await session.LoadAsync<User>("users/1");
+                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
+                    Assert.Equal("foo/bar", attachment.Details.Name);
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
+                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
+                }
+            }
+
+            async Task WriteStatus(DocumentStore store1, DocumentStore store2, DocumentStore store3, string s)
+            {
+                using (var session = store1.OpenAsyncSession())
+                using (var session2 = store2.OpenAsyncSession())
+                using (var session3 = store3.OpenAsyncSession())
+                {
+                    var u1 = await session.LoadAsync<User>("users/1");
+                    var u2 = await session2.LoadAsync<User>("users/1");
+                    var u3 = await session3.LoadAsync<User>("users/1");
+
+                    var cv1 = session.Advanced.GetChangeVectorFor(u1);
+                    var cv2 = session2.Advanced.GetChangeVectorFor(u2);
+                    var cv3 = session3.Advanced.GetChangeVectorFor(u3);
+
+                    Console.WriteLine(s);
+                    Console.WriteLine($"\ncv1: {cv1}");
+                    Console.WriteLine($"cv2: {cv2}");
+                    Console.WriteLine($"cv3: {cv3}\n");
+                    Console.WriteLine("-----");
+                }
+            }
+        }
+        
+        private bool AreAttachmentDetailsEqual(AttachmentDetails attachment1, AttachmentDetails attachment2)
+        {
+            if (attachment1.DocumentId == attachment2.DocumentId &&
+                attachment1.ChangeVector == attachment2.ChangeVector &&
+                attachment1.Hash == attachment2.Hash &&
+                attachment1.Name == attachment2.Name &&
+                attachment1.ContentType == attachment2.ContentType)
+                return true;
+            return false;
+        }
+
     }
 }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -3216,7 +3216,7 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store3, store1);
 
                 b1.Mend();
-WaitForUserToContinueTheTest(store1);
+
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store1, store3);
 

--- a/test/SlowTests/Client/Counters/CountersReplication.cs
+++ b/test/SlowTests/Client/Counters/CountersReplication.cs
@@ -252,7 +252,7 @@ namespace SlowTests.Client.Counters
                     var user = await session.LoadAsync<User>("users/1");
 
                     var flags = session.Advanced.GetMetadataFor(user)[Constants.Documents.Metadata.Flags];
-                    Assert.Equal((DocumentFlags.HasCounters).ToString(), flags);
+                    Assert.Equal((DocumentFlags.HasCounters|DocumentFlags.Resolved).ToString(), flags);
                     var list = session.Advanced.GetCountersFor(user);
                     Assert.Equal(2, list.Count);
                 }

--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -1132,7 +1132,7 @@ namespace SlowTests.Client.TimeSeries.Replication
                     var user = await session.LoadAsync<User>("users/1");
 
                     var flags = session.Advanced.GetMetadataFor(user)[Constants.Documents.Metadata.Flags];
-                    Assert.Equal((DocumentFlags.HasTimeSeries).ToString(), flags);
+                    Assert.Equal((DocumentFlags.HasTimeSeries | DocumentFlags.Resolved).ToString(), flags);
                     var list = session.Advanced.GetTimeSeriesFor(user);
                     Assert.Equal(2, list.Count);
                 }
@@ -1166,7 +1166,7 @@ namespace SlowTests.Client.TimeSeries.Replication
                     var user = await session.LoadAsync<User>("users/1");
 
                     var flags = session.Advanced.GetMetadataFor(user)[Constants.Documents.Metadata.Flags];
-                    Assert.Equal((DocumentFlags.HasTimeSeries | DocumentFlags.HasCounters).ToString(), flags);
+                    Assert.Equal((DocumentFlags.HasTimeSeries | DocumentFlags.HasCounters | DocumentFlags.Resolved).ToString(), flags);
 
                     var ts = session.Advanced.GetTimeSeriesFor(user);
                     Assert.Equal(1, ts.Count);

--- a/test/SlowTests/Issues/RavenDB_19421_2.cs
+++ b/test/SlowTests/Issues/RavenDB_19421_2.cs
@@ -1,0 +1,80 @@
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19421_2 : ReplicationTestBase
+{
+    public RavenDB_19421_2(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task ConflictsOnIdenticalDocument()
+    {
+        using var store1 = GetDocumentStore();
+        using var store2 = GetDocumentStore();
+        using var store3 = GetDocumentStore();
+
+        using (var s1 = store1.OpenAsyncSession())
+        {
+            await s1.StoreAsync(new { Val = 1 }, "users/1");
+            await s1.SaveChangesAsync();
+        }
+
+        await SetupReplicationAsync(store1, store3);
+        await EnsureReplicatingAsync(store1, store3);
+          
+        using (var s3 = store3.OpenAsyncSession())
+        {
+            await s3.StoreAsync(new { Val = 3 }, "users/1");
+            await s3.SaveChangesAsync();
+        }
+
+        // will be replicated to 3 and resolved to latest
+        using (var s1 = store1.OpenAsyncSession())
+        {
+            await s1.StoreAsync(new { Val = 4 }, "users/1");
+            await s1.SaveChangesAsync();
+        }
+        await EnsureReplicatingAsync(store1, store3);
+
+        using (var s3 = store3.OpenAsyncSession())
+        {
+            await s3.StoreAsync(new { Val = 5 }, "users/1");
+            await s3.StoreAsync(new { Val = 4 }, "users/4");
+            await s3.SaveChangesAsync();
+        }
+        
+        // here we resolve identical value, merging the change vectors
+        using (var s1 = store1.OpenAsyncSession())
+        {
+            await s1.StoreAsync(new { Val = 5 }, "users/1");
+            await s1.SaveChangesAsync();
+        }
+        await EnsureReplicatingAsync(store1, store3);
+        
+        await SetupReplicationAsync(store3, store1);
+        await EnsureReplicatingAsync(store3, store1);
+        
+        await SetupReplicationAsync(store3, store2);
+        await SetupReplicationAsync(store1, store2);
+
+        await EnsureReplicatingAsync(store3, store2);
+        await EnsureReplicatingAsync(store1, store2);
+
+        using (var s1 = store1.OpenAsyncSession())
+        using (var s2 = store2.OpenAsyncSession())
+        using (var s3 = store3.OpenAsyncSession())
+        {
+            var u1 = await s1.LoadAsync<object>("users/1");
+            var u2 = await s2.LoadAsync<object>("users/1");
+            var u3 = await s3.LoadAsync<object>("users/1");
+            
+            Assert.Equal(s1.Advanced.GetChangeVectorFor(u1), s2.Advanced.GetChangeVectorFor(u2));
+            Assert.Equal(s2.Advanced.GetChangeVectorFor(u2), s3.Advanced.GetChangeVectorFor(u3));
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -32,7 +32,7 @@ namespace Tryouts
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
                     using (var test = new AttachmentsReplication(testOutputHelper))
                     {
-                        await test.ConflictOfAttachmentAndDocument3Stores();
+                        await test.ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder_RevisionsDisabled_MissingAttachmentLoop();
                     }
                 }
                 catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FastTests.Blittable;
 using FastTests.Client;
 using RachisTests;
+using SlowTests.Client.Attachments;
 using SlowTests.Client.TimeSeries.Replication;
 using SlowTests.Issues;
 using SlowTests.MailingList;
@@ -29,9 +30,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new SubscriptionsFailover(testOutputHelper))
+                    using (var test = new AttachmentsReplication(testOutputHelper))
                     {
-                        await test.ContinueFromThePointIStoppedConcurrentSubscription(1, 20);
+                        await test.ConflictOfAttachmentAndDocument3Stores();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
…to ensure that all nodes in the cluster will have the same change vector for the documents

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19421 

### Additional description

When we resolve a conflict using "it's the same thing" model, we need to send it to the other side anyway, to ensure that the change vectors would be the same afterward.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
