### PR TITLE
RavenDB-18419 fixed issue with timings not working when query metadata comes from query metadata cache

### DIFF
--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
@@ -114,23 +114,23 @@ namespace Raven.Server.Documents.Queries
                 if (cache.TryGetMetadata(result, addSpatialProperties, out var metadataHash, out var metadata))
                 {
                     result.Metadata = metadata;
+
+                    SetupTimings(result);
                     SetupPagingFromQueryMetadata();
+                    SetupTracker(result, tracker);
+                    SetupClientVersion(result, httpContext);
+
                     AssertPaging(result);
 
                     return result;
                 }
 
-                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, addSpatialProperties, queryType, database);
-                if (result.Metadata.HasTimings)
-                    result.Timings = new QueryTimingsScope(start: false);
+                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, addSpatialProperties, queryType);
 
+                SetupTimings(result);
                 SetupPagingFromQueryMetadata();
-
-                if (tracker != null)
-                    tracker.Query = result.Query;
-
-                if (result.Metadata.HasFacet && httpContext.Request.Headers.TryGetValue(Constants.Headers.ClientVersion, out var clientVersion))
-                    result.ClientVersion = clientVersion;
+                SetupTracker(result, tracker);
+                SetupClientVersion(result, httpContext);
 
                 AssertPaging(result);
 
@@ -223,26 +223,11 @@ namespace Raven.Server.Documents.Queries
                 }
 
                 result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, 0, addSpatialProperties);
-                
-                if (result.Metadata.HasTimings)
-                    result.Timings = new QueryTimingsScope(start: false);
 
-                if (result.Metadata.Query.Offset != null)
-                {
-                    var offset = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
-                    result.Offset = offset;
-                    result.Start = start + offset;
-                }
-
-                if (result.Metadata.Query.Limit != null)
-                {
-                    pageSize = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
-                    result.Limit = pageSize;
-                    result.PageSize = Math.Min(result.PageSize, pageSize);
-                }
-
-                if (tracker != null)
-                    tracker.Query = result.Query;
+                SetupTimings(result);
+                SetupPagingFromQueryMetadata();
+                SetupTracker(result, tracker);
+                SetupClientVersion(result, httpContext);
 
                 AssertPaging(result);
 
@@ -262,8 +247,47 @@ namespace Raven.Server.Documents.Queries
 
                 throw;
             }
+
+            void SetupPagingFromQueryMetadata()
+            {
+                if (result.Metadata.Query.Offset != null)
+                {
+                    var offset = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    result.Offset = offset;
+                    result.Start = start + offset;
+                }
+
+                if (result.Metadata.Query.Limit != null)
+                {
+                    pageSize = (int)QueryBuilder.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    result.Limit = pageSize;
+                    result.PageSize = Math.Min(result.PageSize, pageSize);
+                }
+            }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SetupTimings(IndexQueryServerSide indexQuery)
+        {
+            if (indexQuery.Metadata.HasTimings)
+                indexQuery.Timings = new QueryTimingsScope(start: false);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SetupTracker(IndexQueryServerSide indexQuery, RequestTimeTracker tracker)
+        {
+            if (tracker != null)
+                tracker.Query = indexQuery.Query;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SetupClientVersion(IndexQueryServerSide indexQuery, HttpContext httpContext)
+        {
+            if (indexQuery.Metadata.HasFacet && httpContext.Request.Headers.TryGetValue(Constants.Headers.ClientVersion, out var clientVersion))
+                indexQuery.ClientVersion = clientVersion;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void AssertPaging(IndexQueryServerSide indexQuery)
         {
             if (indexQuery.Offset < 0)

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -125,7 +125,7 @@ namespace Raven.Server.Documents.Queries
                     return result;
                 }
 
-                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, addSpatialProperties, queryType);
+                result.Metadata = new QueryMetadata(result.Query, result.QueryParameters, metadataHash, addSpatialProperties, queryType, database);
 
                 SetupTimings(result);
                 SetupPagingFromQueryMetadata();

--- a/test/SlowTests/Issues/RavenDB_9587.cs
+++ b/test/SlowTests/Issues/RavenDB_9587.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
 using Orders;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Queries.Timings;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,15 +27,25 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
+                AssertTimings(store);
+                AssertTimings(store); // there was a bug when building IndexQueryServerSide and QueryMetadataCache is used
+            }
+
+            void AssertTimings(IDocumentStore store)
+            {
                 using (var session = store.OpenSession())
                 {
                     QueryTimings timings = null;
                     var companies = session.Query<Company>()
-                        .Customize(x => x.Timings(out timings))
+                        .Customize(x =>
+                        {
+                            x.Timings(out timings);
+                            x.NoCaching();
+                        })
                         .Where(x => x.Name != "HR")
                         .ToList();
 
-                    Assert.True(timings.DurationInMs > 0);
+                    Assert.True(timings.DurationInMs >= 0);
                     Assert.NotNull(timings.Timings);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18419

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
