### PR TITLE
RavenDB-19871 - SlowTests.Client.TimeSeries.Issues.RavenDB_14386.TimeSeriesCopyShouldNotThrowForRollupTimeSeries

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_14386.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_14386.cs
@@ -175,8 +175,9 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                 using (var session = store.OpenSession())
                 {
-                    var user2 = session.Load<User>("users/2-A");
-                    var user = session.Load<User>("users/1-A");
+                    var user = session.Load<User>(id);
+                    var user2 = session.Load<User>(id2);
+                    Assert.NotNull(user2);
 
                     foreach (var singleResult in session.Advanced.GetTimeSeriesFor(user))
                     {
@@ -187,14 +188,22 @@ namespace SlowTests.Client.TimeSeries.Issues
                     }
 
                     session.SaveChanges();
-
-                    var ts = session.TimeSeriesFor(user2, tag);
-                    var res = ts.Get();
-                    Assert.NotNull(res);
-                    ts = session.TimeSeriesFor(user2, p1.GetTimeSeriesName(tag));
-                    res = ts.Get();
-                    Assert.NotNull(res);
                 }
+
+                Assert.True(WaitForValue(() =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        var ts = session.TimeSeriesFor(id2, tag);
+                        var res = ts.Get();
+                        if (res == null)
+                            return false;
+
+                        ts = session.TimeSeriesFor(id2, p1.GetTimeSeriesName(tag));
+                        res = ts.Get();
+                        return res != null;
+                    }
+                }, true));
             }
         }
     }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19871/SlowTests.Client.TimeSeries.Issues.RavenDB14386.TimeSeriesCopyShouldNotThrowForRollupTimeSeries

### Additional description

Apply changes also on v5.2. (https://github.com/ravendb/ravendb/pull/15792)


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
