### PR TITLE
RavenDB-19618 Connection Strings view: Save btn is missing 'dirty' behavior

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStrings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStrings.html
@@ -229,7 +229,7 @@
         <i class="icon-cancel"></i><span>Cancel</span>
     </button>
     <button class="btn btn-success" title="Click to save this connection string"
-            data-bind="click: onSave, visible: !editedRavenEtlConnectionString() || !editedRavenEtlConnectionString().isServerWide()">
+            data-bind="click: onSave, visible: !editedRavenEtlConnectionString() || !editedRavenEtlConnectionString().isServerWide(), disable: !$root.dirtyFlag().isDirty()">
         <i class="icon-check"></i><span>Save</span>
     </button>
 </script>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19618/Connection-Strings-view-Save-btn-is-missing-dirty-behavior

### Additional description

Disable connection string save when not dirty.


### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/218698604-f87040e3-aaa6-4feb-be0f-cd016e4e679e.png)

