### PR TITLE
RavenDB-18415 Move `requestTime` inside the relevant subfolder

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -358,7 +358,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 }
             }
 
-            await DebugInfoPackageUtils.WriteDebugInfoTimesAsZipEntryAsync(debugInfoDict, archive, databaseName);
+            await DebugInfoPackageUtils.WriteDebugInfoTimesAsZipEntryAsync(debugInfoDict, archive, path);
         }
 
         internal static async Task InvokeAndWriteToArchive(ZipArchive archive, JsonOperationContext jsonOperationContext, LocalEndpointClient localEndpointClient, RouteInformation route, string path, Dictionary<string, Microsoft.Extensions.Primitives.StringValues> endpointParameters = null, CancellationToken token = default)

--- a/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
+++ b/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
@@ -78,10 +78,10 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public static async Task WriteDebugInfoTimesAsZipEntryAsync(Dictionary<string, TimeSpan> debugInfoTimeSpans, ZipArchive archive, string databaseName)
+        public static async Task WriteDebugInfoTimesAsZipEntryAsync(Dictionary<string, TimeSpan> debugInfoTimeSpans, ZipArchive archive, string prefix)
         {
-            var entryName = databaseName == null ? "server-wide-requestTimes" : $"{databaseName}-requestTimes";
-            var entry = archive.CreateEntry($"{entryName}.txt");
+            var entryName = GetOutputPathFromRouteInformation("requestTimes", prefix, "txt");
+            var entry = archive.CreateEntry(entryName);
             entry.ExternalAttributes = ((int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR)) << 16;
 
             var sorted = debugInfoTimeSpans.OrderByDescending(o => o.Value);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18415

### Additional description
Moving the requestTImes file to the server-wide or database subfolder.

_Please delete below the options that are not relevant_

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
