### PR TITLE
RavenDB-19923 Configuration and Ongoing Tasks not exported/imported when toggle is on

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -96,15 +96,11 @@ class exportDatabaseModel {
         });
 
         this.includeDatabaseRecord.subscribe(dbRecord => {
-            if (!dbRecord) {
-                this.databaseModel.customizeDatabaseRecordTypes(false);
-            }
+            this.databaseModel.customizeDatabaseRecordTypes(dbRecord);
         });
 
         this.databaseModel.customizeDatabaseRecordTypes.subscribe(customize => {
-            if (customize) {
-                this.includeDatabaseRecord(true);
-            }
+            this.includeDatabaseRecord(customize);
         })
 
         this.itemsToWarnAbout = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -90,15 +90,11 @@ class importDatabaseModel {
         });
 
         this.includeDatabaseRecord.subscribe(dbRecord => {
-            if (!dbRecord) {
-                this.databaseModel.customizeDatabaseRecordTypes(false);
-            }
+            this.databaseModel.customizeDatabaseRecordTypes(dbRecord);
         });
 
         this.databaseModel.customizeDatabaseRecordTypes.subscribe(customize => {
-            if (customize) {
-                this.includeDatabaseRecord(true);
-            }
+            this.includeDatabaseRecord(customize);
         });
 
         this.itemsToWarnAbout = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/migrateRavenDbDatabaseModel.ts
@@ -82,15 +82,11 @@ class migrateRavenDbDatabaseModel {
         });
 
         this.includeDatabaseRecord.subscribe(dbRecord => {
-            if (!dbRecord) {
-                this.databaseModel.customizeDatabaseRecordTypes(false);
-            }
+            this.databaseModel.customizeDatabaseRecordTypes(dbRecord);
         });
 
         this.databaseModel.customizeDatabaseRecordTypes.subscribe(customize => {
-            if (customize) {
-                this.includeDatabaseRecord(true);
-            }
+            this.includeDatabaseRecord(customize);
         })
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
@@ -8,7 +8,7 @@ class smugglerDatabaseRecord {
     
     instanceCounter: number;
 
-    customizeDatabaseRecordTypes = ko.observable<boolean>(false);
+    customizeDatabaseRecordTypes = ko.observable<boolean>(true);
     
     includeConflictSolverConfig = ko.observable<boolean>(true);
     includeDocumentsCompression = ko.observable<boolean>(true);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19923/Configuration-and-Ongoing-Tasks-not-exported-imported-when-toggle-is-on

### Additional description

Sync "Include Configuration" toggle with "Customize Configuration" toggle.

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
