### PR TITLE
RavenDB-16500 Cannot start SinkToHub replication (studio)

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
@@ -94,8 +94,10 @@
                                         <label for="allowHubToSink">Allow replication from Hub to Sink</label>
                                     </div>
                                     <div class="toggle">
-                                        <input id="allowSinkToHub" type="checkbox" data-bind="checked: allowReplicationFromSinkToHub" />
-                                        <label for="allowSinkToHub">Allow replication from Sink to Hub</label>
+                                        <div data-placement="right" data-toggle="tooltip" title="Server must be secured in order to use Sink to Hub mode" data-animation="true" data-bind="visible: !$root.canDefineCertificates">
+                                            <input id="allowSinkToHub" type="checkbox" data-bind="checked: allowReplicationFromSinkToHub, disable: !$root.canDefineCertificates" />
+                                            <label for="allowSinkToHub">Allow replication from Sink to Hub</label>
+                                        </div>
                                     </div>
                                     <div class="help-block" data-bind="validationMessage: replicationMode"></div>
                                 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16500/Cannot-start-SinkToHub-replication

### Additional description

Disable Sink to Hub when server is unsecured

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/219031425-b3c3851c-38ad-4b77-bc0c-3b0e6fdcb2c6.png)
