### PR TITLE
RavenDB-18784 Fixing dynamic map-reduce queries with aliases against a sharded database

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
@@ -12,8 +12,8 @@ namespace Raven.Server.Documents.Queries.Results.Sharding;
 
 public class ShardedMapReduceResultRetriever : QueryResultRetrieverBase
 {
-    public ShardedMapReduceResultRetriever(ScriptRunnerCache scriptRunnerCache, IndexQueryServerSide query, QueryTimingsScope queryTimings, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, DocumentsStorage documentsStorage, JsonOperationContext context, bool reduceResults, IncludeDocumentsCommand includeDocumentsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, IncludeRevisionsCommand includeRevisionsCommand, char identitySeparator)
-        : base(scriptRunnerCache, query, queryTimings, searchEngineType, fieldsToFetch, documentsStorage, context, reduceResults, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand, identitySeparator)
+    public ShardedMapReduceResultRetriever(ScriptRunnerCache scriptRunnerCache, IndexQueryServerSide query, QueryTimingsScope queryTimings, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, DocumentsStorage documentsStorage, JsonOperationContext context, IncludeDocumentsCommand includeDocumentsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, IncludeRevisionsCommand includeRevisionsCommand, char identitySeparator)
+        : base(scriptRunnerCache, query, queryTimings, searchEngineType, fieldsToFetch, documentsStorage, context, reduceResults: true, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand, identitySeparator)
     {
     }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -277,7 +277,7 @@ public class ShardedQueryProcessor : AbstractShardedQueryProcessor<ShardedQueryC
         using (scope?.For(nameof(QueryTimingsScope.Names.Projection)))
         {
             var fieldsToFetch = new FieldsToFetch(Query, null);
-            var retriever = new ShardedMapReduceResultRetriever(RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Query, null, SearchEngineType.Lucene, fieldsToFetch, null, Context, false, null, null, null,
+            var retriever = new ShardedMapReduceResultRetriever(RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Query, null, SearchEngineType.Lucene, fieldsToFetch, null, Context, null, null, null,
                 RequestHandler.DatabaseContext.IdentityPartsSeparator);
 
             var currentResults = result.Results;

--- a/test/SlowTests/Sharding/Issues/RavenDB_18784.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18784.cs
@@ -1,0 +1,84 @@
+﻿using FastTests;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_18784 : RavenTestBase
+{
+    public RavenDB_18784(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void DynamicMapReduceQueryProjectionsOnShardedDatabase()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Order {ShipTo = new Address {City = "Torun"}, Employee = "employees/1"});
+                session.Store(new Order {ShipTo = new Address {City = "Gdansk"}, Employee = "employees/1"});
+                session.Store(new Order {ShipTo = new Address {City = "Torun"}, Employee = "employees/2"});
+                session.Store(new Order {ShipTo = new Address {City = "Warszawa"}, Employee = "employees/2"});
+                session.Store(new Order {ShipTo = new Address {City = "Gdansk"}, Employee = "employees/1"});
+
+                session.Store(new Employee { FirstName = "Jan"}, "employees/1");
+                session.Store(new Employee { FirstName = "Adam"}, "employees/2");
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var orders = session.Advanced.RawQuery<dynamic>("from Orders group by ShipTo.City select count(), ShipTo.City").WaitForNonStaleResults().ToList();
+
+                Assert.Equal(3, orders.Count);
+
+                foreach (dynamic order in orders)
+                {
+                    Assert.NotNull(order["Count"].Value);
+                    Assert.NotNull(order["ShipTo.City"].Value);
+                }
+
+                var orders2 = session.Advanced.RawQuery<dynamic>("from Orders group by ShipTo.City select count(), ShipTo.City as c").WaitForNonStaleResults().ToList();
+
+                Assert.Equal(3, orders2.Count);
+
+                foreach (dynamic order in orders2)
+                {
+                    Assert.NotNull(order["Count"].Value);
+                    Assert.NotNull(order["c"].Value);
+                }
+
+                var orders3 = session.Advanced.RawQuery<dynamic>("from Orders group by ShipTo.City select count() as MyCount, ShipTo.City as c").WaitForNonStaleResults().ToList();
+
+                Assert.Equal(3, orders3.Count);
+
+                foreach (dynamic order in orders3)
+                {
+                    Assert.NotNull(order["MyCount"].Value);
+                    Assert.NotNull(order["c"].Value);
+                }
+
+                var ordersWithEmployeesIncluded = session.Advanced.RawQuery<dynamic>("from Orders group by Employee select Employee, count() include Employee").WaitForNonStaleResults().ToList();
+
+                Assert.Equal(2, ordersWithEmployeesIncluded.Count);
+
+                int requestsCount = session.Advanced.NumberOfRequests;
+
+                foreach (dynamic order in ordersWithEmployeesIncluded)
+                {
+                    Assert.NotNull(order["Count"].Value);
+                    Assert.NotNull(order["Employee"].Value);
+                    Assert.NotNull(session.Load<Employee>(order["Employee"].Value));
+                }
+
+                Assert.Equal(requestsCount, session.Advanced.NumberOfRequests);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18784/Sharding-auto-map-reduce-queries-with-count-in-the-select-field-do-not-work

### Additional description

1. When creating `ShardedMapReduceResultRetriever` we must set `reduceResults: true` so we'll use `BlittableJsonTraverser.FlatMapReduceResults` under the covers that will work well with projection fields like `'ShipTo.City'`
2. When we send a projection query against an auto map-reduce index to shards then we need to drop aliases. This way we're able to re-reduce the results on the orchestrator. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
