### PR TITLE
RavenDB-19951 Introduce TOTP support for browser generated requests

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
@@ -26,6 +26,8 @@ public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation
     {
         private readonly string _validationCode;
 
+        public override bool IsReadRequest => false;
+
         public ValidateTwoFactorAuthenticationTokenCommand(string validationCode)
         {
             _validationCode = validationCode;

--- a/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Operations.Certificates;
+
+public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation
+{
+    private readonly string _validationCode;
+
+    public ValidateTwoFactorAuthenticationTokenOperation(string validationCode)
+    {
+        _validationCode = validationCode;
+    }
+    
+    public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new ValidateTwoFactorAuthenticationTokenCommand(_validationCode);
+    }
+    
+    private class ValidateTwoFactorAuthenticationTokenCommand : RavenCommand
+    {
+        private readonly string _validationCode;
+
+        public ValidateTwoFactorAuthenticationTokenCommand(string validationCode)
+        {
+            _validationCode = validationCode;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/authentication/2fa";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    {
+                        writer.WriteStartObject();
+                        writer.WritePropertyName("Token");
+                        writer.WriteString(_validationCode);
+                        writer.WriteEndObject();
+                    }
+                })
+            };
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/ValidateTwoFactorAuthenticationTokenOperation.cs
@@ -8,7 +8,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Operations.Certificates;
 
-public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation
+public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation<string>
 {
     private readonly string _validationCode;
 
@@ -17,12 +17,12 @@ public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation
         _validationCode = validationCode;
     }
     
-    public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    public RavenCommand<string> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
         return new ValidateTwoFactorAuthenticationTokenCommand(_validationCode);
     }
     
-    private class ValidateTwoFactorAuthenticationTokenCommand : RavenCommand
+    private class ValidateTwoFactorAuthenticationTokenCommand : RavenCommand<string>
     {
         private readonly string _validationCode;
 
@@ -31,6 +31,11 @@ public class ValidateTwoFactorAuthenticationTokenOperation : IServerOperation
         public ValidateTwoFactorAuthenticationTokenCommand(string validationCode)
         {
             _validationCode = validationCode;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            response.TryGet("Token", out Result);
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)

--- a/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
+++ b/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -81,7 +82,7 @@ namespace Raven.Server.Https
                 certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed);
 
             var httpConnectionFeature = context.Features.Get<IHttpConnectionFeature>();
-            var authenticationStatus = _server.AuthenticateConnectionCertificate(certificate, httpConnectionFeature);
+            var authenticationStatus = _server.AuthenticateConnectionCertificate(certificate, httpConnectionFeature, ((IPEndPoint)context.RemoteEndPoint)?.Address);
 
             // build the token
             context.Features.Set<IHttpAuthenticationFeature>(authenticationStatus);

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -19,6 +19,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Cli;
+using Raven.Server.Web.Authentication;
 using Sparrow;
 using Sparrow.Logging;
 using Sparrow.Platform;

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Routing
         {
             if (context.Request.Cookies.TryGetValue(TwoFactorAuthentication.CookieName, out var cookieStr) == false)
             {
-                msg = "Missing the csrf-cookie in the request";
+                msg = $"Missing the '{TwoFactorAuthentication.CookieName}' in the request";
                 return false;
             }
 
@@ -187,7 +187,7 @@ namespace Raven.Server.Routing
             {
                 if (context.Request.Headers.TryGetValue(TwoFactorAuthentication.HeaderName, out var headerStr) == false || headerStr.Count == 0)
                 {
-                    msg = "Missing Csrf-Token header";
+                    msg = $"Missing '{TwoFactorAuthentication.HeaderName}' header";
                     return false;
                 }
                 var header = MemoryMarshal.Cast<char, byte>(headerStr[0]);

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -180,6 +180,7 @@ namespace Raven.Server.Routing
                     switch (authenticationStatus)
                     {
                         case RavenServer.AuthenticationStatus.TwoFactorAuthNotProvided:
+                        case RavenServer.AuthenticationStatus.TwoFactorAuthFromInvalidIp:
                         case RavenServer.AuthenticationStatus.NoCertificateProvided:
                         case RavenServer.AuthenticationStatus.Expired:
                         case RavenServer.AuthenticationStatus.NotYetValid:
@@ -333,6 +334,7 @@ namespace Raven.Server.Routing
                                 case RavenServer.AuthenticationStatus.Expired:
                                 case RavenServer.AuthenticationStatus.NotYetValid:
                                 case RavenServer.AuthenticationStatus.TwoFactorAuthNotProvided:
+                                case RavenServer.AuthenticationStatus.TwoFactorAuthFromInvalidIp:
                                     break;
 
                                 default:
@@ -457,6 +459,10 @@ namespace Raven.Server.Routing
                 else if (feature.Status == RavenServer.AuthenticationStatus.TwoFactorAuthNotProvided)
                 {
                     message = $"The supplied client certificate '{name}' requires two factor authorization to be valid. Please POST the relevant TOTP value to /authentication/2fa";
+                }
+                else if (feature.Status == RavenServer.AuthenticationStatus.TwoFactorAuthFromInvalidIp)
+                {
+                    message = $"The supplied client certificate '{name}' requires two factor authorization and is limited to a specified IP address, but this request came from a different IP address. Please POST the relevant TOTP value to /authentication/2fa to register this IP address";
                 }
                 else
                 {

--- a/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
+++ b/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
@@ -44,14 +44,13 @@ namespace Raven.Server.ServerWide
         public static IEnumerable<RouteInformation> GetAuthorizedRoutes(RavenServer server, HttpContext httpContext, string databaseName = null)
         {
             var routes = Routes.Where(x => server._forTestingPurposes == null || server._forTestingPurposes.DebugPackage.RoutesToSkip.Contains(x.Path) == false);
-            var feature = httpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
+            var feature = (RavenServer.AuthenticateConnection)httpContext.Features.Get<IHttpAuthenticationFeature>();
 
             foreach (var route in routes)
             {
                 if (server.Certificate.Certificate != null)
                 {
-                    Debug.Assert(feature != null);
-                    if (server.Router.CanAccessRoute(route, httpContext, databaseName, feature, out _))
+                    if (server.Router.CanAccessRoute(route, httpContext, databaseName, feature))
                     {
                         yield return route;
                     }

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -784,7 +784,7 @@ namespace Raven.Server.Utils.Cli
 
                 try
                 {
-                    AdminCertificatesHandler.PutCertificateCollectionInCluster(certDef, certBytes, password, cli._server.ServerStore, ctx, RaftIdGenerator.NewId()).Wait();
+                    AdminCertificatesHandler.PutCertificateCollectionInCluster(certDef, certBytes, password, cli._server.ServerStore, ctx, RaftIdGenerator.NewId(), null).Wait();
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthentication.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthentication.cs
@@ -113,7 +113,9 @@ public static class TwoFactorAuthentication
     // base 32 taken from:
     // https://github.com/dotnet/aspnetcore/blob/74389644ecb9f7abc63b2d54bf615e1c3887ffd5/src/Identity/Extensions.Core/src/Base32.cs
     private const string _base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-    
+    public const string CookieName = "csrf-cookie";
+    public const string HeaderName = "Csrf-Token";
+
     private static string GenerateBase32()
     {
         const int length = 20;

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthentication.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthentication.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using JetBrains.Annotations;
+
+namespace Raven.Server.Web.Authentication;
+
+public static class TwoFactorAuthentication
+{
+    public static string CreateValidationCode(string twoFactorAuthenticationKey)
+    {
+        byte[] bytes = FromBase32(twoFactorAuthenticationKey);
+        return Rfc6238AuthenticationService.Generate(bytes);
+    }
+    
+    public static bool ValidateCode(string twoFactorAuthenticationKey, int token)
+    {
+        byte[] bytes = FromBase32(twoFactorAuthenticationKey);
+        return Rfc6238AuthenticationService.ValidateCode(bytes, token);
+    }
+    
+    public static string GenerateQrCodeUri(string secret, string host, string name)
+    {
+        string environmentName = host;
+        int dotIdx = environmentName.IndexOf('.');
+        if (dotIdx != -1)
+        {
+            var withoutNodePrefix = environmentName[(dotIdx + 1)..];
+            if (string.IsNullOrEmpty(withoutNodePrefix) == false) // strip the a., etc
+                environmentName = withoutNodePrefix;
+        }
+
+        string encodedIssuer = UrlEncoder.Default.Encode(environmentName);
+        string encodedName = UrlEncoder.Default.Encode(name);
+        return $"otpauth://totp/{encodedIssuer}:{encodedName}?secret={secret}&issuer={encodedIssuer}";
+    }
+    
+    public static string GenerateSecret() => GenerateBase32();
+    // Rfc6238Authentication taken from:
+    // https://github.com/dotnet/aspnetcore/blob/6a7bcda42de7b98196b38924cc354216eba57c9b/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs#L15
+    public static class Rfc6238AuthenticationService
+    {
+        private static readonly TimeSpan _timestep = TimeSpan.FromMinutes(3);
+        private static readonly Encoding _encoding = new UTF8Encoding(false, true);
+
+        
+        internal static int ComputeTotp(byte[] key, ulong timestepNumber)
+        {
+            // # of 0's = length of pin
+            const int Mod = 1000000;
+
+            // See https://tools.ietf.org/html/rfc4226
+            Span<byte> timestepAsBytes = stackalloc byte[sizeof(long)];
+            var res = BitConverter.TryWriteBytes(timestepAsBytes, IPAddress.HostToNetworkOrder((long)timestepNumber));
+            Debug.Assert(res);
+
+            Span<byte> modifierCombinedBytes = timestepAsBytes;
+  
+            Span<byte> hash = stackalloc byte[HMACSHA1.HashSizeInBytes];
+            res = HMACSHA1.TryHashData(key, modifierCombinedBytes, hash, out var written);
+            Debug.Assert(res);
+            Debug.Assert(written == hash.Length);
+
+            // Generate DT string
+            var offset = hash[^1] & 0xf;
+            Debug.Assert(offset + 4 < hash.Length);
+            var binaryCode = (hash[offset] & 0x7f) << 24
+                             | (hash[offset + 1] & 0xff) << 16
+                             | (hash[offset + 2] & 0xff) << 8
+                             | (hash[offset + 3] & 0xff);
+
+            return binaryCode % Mod;
+        }
+        
+        // More info: https://tools.ietf.org/html/rfc6238#section-4
+        private static ulong GetCurrentTimeStepNumber()
+        {
+            var delta = DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch;
+            return (ulong)(delta.Ticks / _timestep.Ticks);
+        }
+        
+        public static bool ValidateCode([NotNull] byte[] securityToken, int code)
+        {
+            if (securityToken == null) throw new ArgumentNullException(nameof(securityToken));
+
+            // Allow a variance of no greater than 9 minutes in either direction
+            var currentTimeStep = GetCurrentTimeStepNumber();
+
+            for (var i = -2; i <= 2; i++)
+            {
+                var computedTotp = ComputeTotp(securityToken, (ulong)((long)currentTimeStep + i));
+                if (computedTotp == code)
+                    return true;
+            }
+            return false;
+        }
+        
+                
+        public static string Generate([NotNull] byte[] securityToken)
+        {
+            if (securityToken == null) throw new ArgumentNullException(nameof(securityToken));
+
+            var currentTimeStep = GetCurrentTimeStepNumber();
+            return ComputeTotp(securityToken, (ulong)((long)currentTimeStep)).ToString("D6", CultureInfo.InvariantCulture);
+        }
+    }
+    
+    
+    // base 32 taken from:
+    // https://github.com/dotnet/aspnetcore/blob/74389644ecb9f7abc63b2d54bf615e1c3887ffd5/src/Identity/Extensions.Core/src/Base32.cs
+    private const string _base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    
+    private static string GenerateBase32()
+    {
+        const int length = 20;
+        // base32 takes 5 bytes and converts them into 8 characters, which would be (byte length / 5) * 8
+        // except that it also pads ('=') for the last processed chunk if it's less than 5 bytes.
+        // So in order to handle the padding we add 1 less than the chunk size to our byte length
+        // which will either be removed due to integer division truncation if the length was already a multiple of 5
+        // or it will increase the divided length by 1 meaning that a 1-4 byte length chunk will be 1 instead of 0
+        // so the padding is now included in our string length calculation
+        return string.Create(((length + 4) / 5) * 8, 0, static (buffer, _) =>
+        {
+            Span<byte> bytes = stackalloc byte[length];
+            RandomNumberGenerator.Fill(bytes);
+
+            var index = 0;
+            for (int offset = 0; offset < bytes.Length;)
+            {
+                byte a, b, c, d, e, f, g, h;
+                int numCharsToOutput = GetNextGroup(bytes, ref offset, out a, out b, out c, out d, out e, out f, out g, out h);
+
+                buffer[index + 7] = ((numCharsToOutput >= 8) ? _base32Chars[h] : '=');
+                buffer[index + 6] = ((numCharsToOutput >= 7) ? _base32Chars[g] : '=');
+                buffer[index + 5] = ((numCharsToOutput >= 6) ? _base32Chars[f] : '=');
+                buffer[index + 4] = ((numCharsToOutput >= 5) ? _base32Chars[e] : '=');
+                buffer[index + 3] = ((numCharsToOutput >= 4) ? _base32Chars[d] : '=');
+                buffer[index + 2] = (numCharsToOutput >= 3) ? _base32Chars[c] : '=';
+                buffer[index + 1] = (numCharsToOutput >= 2) ? _base32Chars[b] : '=';
+                buffer[index] = (numCharsToOutput >= 1) ? _base32Chars[a] : '=';
+                index += 8;
+            }
+        });
+    }
+
+    // returns the number of bytes that were output
+    private static int GetNextGroup(Span<byte> input, ref int offset, out byte a, out byte b, out byte c, out byte d, out byte e, out byte f, out byte g, out byte h)
+    {
+        uint b1, b2, b3, b4, b5;
+
+        int retVal;
+        switch (input.Length - offset)
+        {
+            case 1: retVal = 2; break;
+            case 2: retVal = 4; break;
+            case 3: retVal = 5; break;
+            case 4: retVal = 7; break;
+            default: retVal = 8; break;
+        }
+
+        b1 = (offset < input.Length) ? input[offset++] : 0U;
+        b2 = (offset < input.Length) ? input[offset++] : 0U;
+        b3 = (offset < input.Length) ? input[offset++] : 0U;
+        b4 = (offset < input.Length) ? input[offset++] : 0U;
+        b5 = (offset < input.Length) ? input[offset++] : 0U;
+
+        a = (byte)(b1 >> 3);
+        b = (byte)(((b1 & 0x07) << 2) | (b2 >> 6));
+        c = (byte)((b2 >> 1) & 0x1f);
+        d = (byte)(((b2 & 0x01) << 4) | (b3 >> 4));
+        e = (byte)(((b3 & 0x0f) << 1) | (b4 >> 7));
+        f = (byte)((b4 >> 2) & 0x1f);
+        g = (byte)(((b4 & 0x3) << 3) | (b5 >> 5));
+        h = (byte)(b5 & 0x1f);
+
+        return retVal;
+    }
+    
+    public static byte[] FromBase32([NotNull] string input)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        var trimmedInput = input.AsSpan().TrimEnd('=');
+        if (trimmedInput.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        var output = new byte[trimmedInput.Length * 5 / 8];
+        var bitIndex = 0;
+        var inputIndex = 0;
+        var outputBits = 0;
+        var outputIndex = 0;
+        while (outputIndex < output.Length)
+        {
+            var byteIndex = _base32Chars.IndexOf(char.ToUpperInvariant(trimmedInput[inputIndex]));
+            if (byteIndex < 0)
+            {
+                throw new FormatException();
+            }
+
+            var bits = Math.Min(5 - bitIndex, 8 - outputBits);
+            output[outputIndex] <<= bits;
+            output[outputIndex] |= (byte)(byteIndex >> (5 - (bitIndex + bits)));
+
+            bitIndex += bits;
+            if (bitIndex >= 5)
+            {
+                inputIndex++;
+                bitIndex = 0;
+            }
+
+            outputBits += bits;
+            if (outputBits >= 8)
+            {
+                outputIndex++;
+                outputBits = 0;
+            }
+        }
+        return output;
+    }
+}

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using Raven.Server.Json;
+using Raven.Server.Routing;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Json.Sync;
+
+namespace Raven.Server.Web.Authentication;
+
+public class TwoFactorAuthenticationHandler : ServerRequestHandler
+{
+    [RavenAction("/authentication/2fa", "POST", AuthorizationStatus.UnauthenticatedClients)]
+    public async Task ValidateTotp()
+    {
+        using var _ = ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx);
+        ctx.OpenReadTransaction();
+
+        var clientCert = GetCurrentCertificate();
+
+        if (clientCert == null)
+        {
+            ReplyWith(ctx, "Two factor authentication requires that you'll use a client certificate, but none was provided.", HttpStatusCode.BadRequest);
+            return;
+        }
+
+        using var input = await ctx.ReadForMemoryAsync(RequestBodyStream(), "2fa-auth");
+        
+        var certificate = ServerStore.Cluster.GetCertificateByThumbprint(ctx, clientCert.Thumbprint);
+        if (certificate == null)
+        {
+            ReplyWith(ctx, $"The certificate {clientCert.Thumbprint} ({clientCert.FriendlyName}) is not known to the server", HttpStatusCode.BadRequest);
+            return;
+        }
+
+        if (certificate.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out string key) == false)
+        {
+            ReplyWith(ctx, $"The certificate {clientCert.Thumbprint} ({clientCert.FriendlyName}) is not set up for two factor authentication", HttpStatusCode.BadRequest);
+            return;
+        }
+
+
+        input.TryGet("Token", out int token);
+
+        if (TwoFactorAuthentication.ValidateCode(key, token))
+        {
+            if (certificate.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationValidityPeriod), out TimeSpan period) == false)
+            {
+                period = TimeSpan.FromHours(2);
+            }
+            var feature = (RavenServer.AuthenticateConnection)HttpContext.Features.Get<IHttpAuthenticationFeature>();
+            feature.SuccessfulTwoFactorAuthentication(); // enable access for the current connection 
+            Server.RegisterTwoFactorAuthSuccess(clientCert.Thumbprint, period);
+            HttpContext.Response.StatusCode = (int)HttpStatusCode.Accepted;
+        }
+        else
+        {
+            ReplyWith(ctx, $"Wrong token provided for {clientCert.Thumbprint} ({clientCert.FriendlyName})", HttpStatusCode.NotAcceptable);
+        }
+    }
+
+    private void ReplyWith(TransactionOperationContext ctx, string err, HttpStatusCode httpStatusCode)
+    {
+        HttpContext.Response.StatusCode = (int)httpStatusCode;
+        using (var writer = new BlittableJsonTextWriter(ctx, ResponseBodyStream()))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("Error");
+            writer.WriteString(err);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -61,7 +61,7 @@ namespace FastTests.Client
                 "DeleteServerWideAnalyzerCommand", "PutServerWideAnalyzersCommand",
                 "DeleteServerWideSorterCommand", "PutServerWideSortersCommand",
                 "SetDatabasesLockCommand",
-                "GetDatabaseSettingsCommand", "PutDatabaseConfigurationSettingsCommand", "ConfigurePostgreSqlCommand",
+                "GetDatabaseSettingsCommand", "PutDatabaseConfigurationSettingsCommand", "ConfigurePostgreSqlCommand", "ValidateTwoFactorAuthenticationTokenCommand",
                 "GetTrafficWatchConfigurationCommand", "SetTrafficWatchConfigurationCommand",
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand", "DelayBackupCommand",
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand", "GetTcpInfoForReplicationCommand"

--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -515,7 +515,7 @@ namespace SlowTests.Authentication
                 {
                     var certBytes = certificate.Export(X509ContentType.Cert);
                     var certDef = new CertificateDefinition { Name = name, Permissions = permissions, SecurityClearance = clearance };
-                    await AdminCertificatesHandler.PutCertificateCollectionInCluster(certDef, certBytes, string.Empty, Server.ServerStore, ctx, RaftIdGenerator.NewId());
+                    await AdminCertificatesHandler.PutCertificateCollectionInCluster(certDef, certBytes, string.Empty, Server.ServerStore, ctx, RaftIdGenerator.NewId(), null);
                 }
             }
             {

--- a/test/SlowTests/Issues/RavenDB-19951.cs
+++ b/test/SlowTests/Issues/RavenDB-19951.cs
@@ -1,0 +1,87 @@
+using System;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Web.Authentication;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19951 : RavenTestBase
+{
+    public RavenDB_19951(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanSetupTOTP()
+    {
+        var certificates = Certificates.SetupServerAuthentication();
+        using var store = GetDocumentStore(new Options
+        {
+            ClientCertificate = certificates.ServerCertificate.Value,
+        });
+        Assert.NotNull(store.Certificate);
+        string key = TwoFactorAuthentication.GenerateSecret();
+        store.Maintenance.Server.Send(
+            new PutClientCertificateOperation("test", 
+                certificates.ClientCertificate1.Value, 
+                new(),
+                SecurityClearance.Operator)
+        {
+            TwoFactorAuthenticationKey = key,
+            TwoFactorAuthenticationValidityPeriod = TimeSpan.FromMinutes(5)
+        });
+        {
+              
+            using var withoutTotp = new DocumentStore
+            {
+                Certificate = certificates.ClientCertificate1.Value,
+                Database = store.Database,
+                Urls = store.Urls,
+            }.Initialize();
+            
+            
+            using (var s = withoutTotp.OpenSession())
+            {
+                var e = Assert.Throws<AuthorizationException>(() => s.Load<object>("item/1"));
+                Assert.Contains("requires two factor authorization to be valid", e.Message);
+            }
+
+        }
+        using var storeTotp = new DocumentStore
+        {
+            Certificate = certificates.ClientCertificate1.Value,
+            Database = store.Database,
+            Urls = store.Urls,
+            Conventions =
+            {
+                // have to do that to avoid /cluster/topology failure
+                DisableTopologyUpdates = true 
+            }
+        }.Initialize();
+
+        string validationCode = TwoFactorAuthentication.CreateValidationCode(key);
+
+        storeTotp.Maintenance.Server.Send(new ValidateTwoFactorAuthenticationTokenOperation(validationCode));
+
+        using (var s = storeTotp.OpenSession())
+        {
+            s.Load<object>("item/1");
+        }
+        
+        using var anotherStore = new DocumentStore // now we try another connection
+        {
+            Certificate = certificates.ClientCertificate1.Value,
+            Database = store.Database,
+            Urls = store.Urls,
+        }.Initialize();
+        using (var s = anotherStore.OpenSession())
+        {
+            s.Load<object>("item/1");
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19951 

### Additional description

This allows an administrator to define a TOTP key for a certificate. A certificate with such a key will _not_ work unless the user will utilize a dedicated endpoint to provide a TOTP code. At which point, the certificate will be valid for a set duration. Afterward, a new TOTP key would be required.

This is meant for administrators certificates, not for applications to use.

The current version is a draft, to show the overall solution. Some notes about how this works:

* The TOTP provided is stored globally, but needs to be provided separately for each node in the cluster. We can make is cluster wide configuration, but I'm not sure if that matters or is even desirable.
* The limit happens when the actual connection is established. If we have a 1 minute validity period, but the connection is still being used, it'll keep on working.

UX concerns:

* We need some Studio work to generate the key, render it, etc.
* I didn't provide a way to extract the key out of the system. Not sure how important that is. 
* Need to provide a way to *update* this? What about updating just the validity period? 

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio
