### PR TITLE
RavenDB-19237 Add the ability to import just one collection (studio)

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -27,6 +27,9 @@ class importDatabaseModel {
     includeExpiredDocuments = ko.observable(true);
     includeArtificialDocuments = ko.observable(false);
     removeAnalyzers = ko.observable(false);
+
+    includeAllCollections = ko.observable<boolean>(true);
+    includedCollections = ko.observableArray<string>([]);
     
     transformScript = ko.observable<string>();
 
@@ -179,7 +182,8 @@ class importDatabaseModel {
             RemoveAnalyzers: this.removeAnalyzers(),
             EncryptionKey: this.encryptedInput() ? this.encryptionKey() : undefined,
             OperateOnTypes: operateOnTypes.join(",") as Raven.Client.Documents.Smuggler.DatabaseItemType,
-            OperateOnDatabaseRecordTypes: recordTypes
+            OperateOnDatabaseRecordTypes: recordTypes,
+            Collections: this.includeAllCollections() ? null : this.includedCollections(),
         } as Raven.Client.Documents.Smuggler.DatabaseSmugglerImportOptions;
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromFile.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromFile.ts
@@ -34,6 +34,8 @@ class importDatabaseFromFile extends viewModelBase {
 
     showAdvancedOptions = ko.observable(false);
     showTransformScript = ko.observable(false);
+    
+    inputCollection = ko.observable<string>("");
 
     hasFileSelected = ko.observable(false);
     importedFileName = ko.observable<string>();
@@ -55,7 +57,7 @@ class importDatabaseFromFile extends viewModelBase {
     constructor() {
         super();
 
-        this.bindToCurrentInstance("copyCommandToClipboard", "fileSelected", "customizeConfigurationClicked");
+        this.bindToCurrentInstance("copyCommandToClipboard", "fileSelected", "customizeConfigurationClicked", "addCollection", "removeCollection");
 
         aceEditorBindingHandler.install();
         this.isUploading.subscribe(v => {
@@ -291,6 +293,15 @@ class importDatabaseFromFile extends viewModelBase {
             case "Bash":
                 return `curl -F 'importOptions=${json}' -F 'file=@${fileName}' ${commandEndpointUrl(db)}`;
         }
+    }
+
+    addCollection() {
+        this.model.includedCollections.push(this.inputCollection());
+        this.inputCollection("");
+    }
+
+    removeCollection(collection: string) {
+        this.model.includedCollections.remove(collection);
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
@@ -172,6 +172,37 @@
                 <div class="margin-left margin-left-lg">
                     <div class="margin-bottom">
                         <div class="toggle">
+                            <input id="collections" type="checkbox" data-bind="checked: includeAllCollections" />
+                            <label for="collections">Import all collections</label>
+                        </div>
+                        <div data-bind="collapse: !includeAllCollections()">
+                            <div class="row margin-bottom">
+                                <div class="flex-horizontal col-lg-3">
+                                    <input class="form-control" placeholder="Enter a collection" autocomplete="off" data-bind="textInput: $root.inputCollection" />
+                                    <button class="btn btn-info" data-bind="click: $root.addCollection, disable: !$root.inputCollection()">
+                                        <i class="icon-plus"></i><span>Add Collection</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="margin-top margin-bottom" data-bind="visible: includedCollections().length">
+                                <label>
+                                    <strong>Collections Selected:</strong>
+                                </label>
+                                <div class="row">
+                                    <div class="col-lg-3">
+                                        <ul class="well collection-list" data-bind="foreach: includedCollections">
+                                            <li>
+                                                <div class="name" data-bind="text: $data"></div>
+                                                <a title="Remove collection" href="#" data-bind="click: $root.removeCollection">
+                                                    <i class="icon-trash"></i>
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="toggle">
                             <input id="useTransformScript" type="checkbox" data-bind="checked: $root.showTransformScript" />
                             <label for="useTransformScript" class="use-transform-script margin-right margin-right-sm">Use Transform script </label>
                             <small id="scriptPopover"><i class="icon-info text-info"></i></small>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19237/Add-the-ability-to-import-just-one-collection

### Additional description

Allow to import selected collections.

### Type of change

- New feature

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/219611123-12b3a431-7276-413b-931d-1ae82965f65a.png)
