### PR TITLE
RavenDB-18166 If query results come from different index defintions on shards then we mark the results as stale

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -532,7 +532,7 @@ namespace Raven.Client.Documents.Indexes
             definition.PatternForOutputReduceToCollectionReferences = PatternForOutputReduceToCollectionReferences;
             definition.PatternReferencesCollectionName = PatternReferencesCollectionName;
             definition.DeploymentMode = DeploymentMode;
-            definition.ClusterState = (ClusterState == null) ? null : new IndexUpdateClusterState(ClusterState);
+            definition.ClusterState = (ClusterState == null) ? null : new IndexDefinitionClusterState(ClusterState);
 
             foreach (var kvp in _configuration)
                 definition.Configuration[kvp.Key] = kvp.Value;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -532,7 +532,7 @@ namespace Raven.Client.Documents.Indexes
             definition.PatternForOutputReduceToCollectionReferences = PatternForOutputReduceToCollectionReferences;
             definition.PatternReferencesCollectionName = PatternReferencesCollectionName;
             definition.DeploymentMode = DeploymentMode;
-            definition.ClusterState = (ClusterState == null) ? null : new ClusterState(ClusterState);
+            definition.ClusterState = (ClusterState == null) ? null : new IndexUpdateClusterState(ClusterState);
 
             foreach (var kvp in _configuration)
                 definition.Configuration[kvp.Key] = kvp.Value;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Indexes
     {
         protected IndexDefinitionBase()
         {
-            ClusterState = new ClusterState();
+            ClusterState = new IndexUpdateClusterState();
         }
 
         /// <summary>
@@ -25,6 +25,6 @@ namespace Raven.Client.Documents.Indexes
         public IndexState? State { get; set; }
 
         [ForceJsonSerialization]
-        internal ClusterState ClusterState;
+        internal IndexUpdateClusterState ClusterState;
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBase.cs
@@ -6,7 +6,7 @@ namespace Raven.Client.Documents.Indexes
     {
         protected IndexDefinitionBase()
         {
-            ClusterState = new IndexUpdateClusterState();
+            ClusterState = new IndexDefinitionClusterState();
         }
 
         /// <summary>
@@ -25,6 +25,6 @@ namespace Raven.Client.Documents.Indexes
         public IndexState? State { get; set; }
 
         [ForceJsonSerialization]
-        internal IndexUpdateClusterState ClusterState;
+        internal IndexDefinitionClusterState ClusterState;
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionClusterState.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionClusterState.cs
@@ -1,15 +1,15 @@
 ﻿namespace Raven.Client.Documents.Indexes
 {
-    public class IndexUpdateClusterState
+    internal class IndexDefinitionClusterState
     {
-        public IndexUpdateClusterState()
+        public IndexDefinitionClusterState()
         {
             LastIndex = 0;
             LastStateIndex = 0;
             LastRollingDeploymentIndex = 0;
         }
 
-        public IndexUpdateClusterState(IndexUpdateClusterState clusterState)
+        public IndexDefinitionClusterState(IndexDefinitionClusterState clusterState)
         {
             LastIndex = clusterState.LastIndex;
             LastStateIndex = clusterState.LastStateIndex;

--- a/src/Raven.Client/Documents/Indexes/IndexUpdateClusterState.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexUpdateClusterState.cs
@@ -1,19 +1,22 @@
 ﻿namespace Raven.Client.Documents.Indexes
 {
-    internal class ClusterState
+    public class IndexUpdateClusterState
     {
-        public ClusterState()
+        public IndexUpdateClusterState()
         {
+            LastIndex = 0;
             LastStateIndex = 0;
             LastRollingDeploymentIndex = 0;
         }
 
-        public ClusterState(ClusterState clusterState)
+        public IndexUpdateClusterState(IndexUpdateClusterState clusterState)
         {
+            LastIndex = clusterState.LastIndex;
             LastStateIndex = clusterState.LastStateIndex;
             LastRollingDeploymentIndex = clusterState.LastRollingDeploymentIndex;
         }
 
+        public long LastIndex;
         public long LastStateIndex;
         public long LastRollingDeploymentIndex;
     }

--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -56,7 +56,7 @@ namespace Raven.Client.Documents.Queries
         public long DurationInMs { get; set; }
 
         [ForceJsonSerialization]
-        internal long? RaftCommandIndex;
+        internal long? IndexDefinitionRaftIndex;
     }
 
     public class QueryResult : QueryResult<BlittableJsonReaderArray, BlittableJsonReaderObject>

--- a/src/Raven.Client/Documents/Queries/QueryResult.cs
+++ b/src/Raven.Client/Documents/Queries/QueryResult.cs
@@ -57,6 +57,9 @@ namespace Raven.Client.Documents.Queries
 
         [ForceJsonSerialization]
         internal long? IndexDefinitionRaftIndex;
+
+        [ForceJsonSerialization]
+        internal long? AutoIndexCreationRaftIndex;
     }
 
     public class QueryResult : QueryResult<BlittableJsonReaderArray, BlittableJsonReaderObject>

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -236,7 +236,7 @@ namespace Raven.Client.ServerWide
             
             AddIndexHistory(definition, source, revisionsToKeep, createdAt);
 
-            definition.ClusterState ??= new IndexUpdateClusterState();
+            definition.ClusterState ??= new IndexDefinitionClusterState();
 
             if (isRolling)
             {
@@ -325,7 +325,7 @@ namespace Raven.Client.ServerWide
                     InitializeRollingDeployment(definition.Name, createdAt, raftIndex);
             }
 
-            definition.ClusterState ??= new IndexUpdateClusterState();
+            definition.ClusterState ??= new IndexDefinitionClusterState();
             definition.ClusterState.LastIndex = raftIndex;
         }
 

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -235,10 +235,12 @@ namespace Raven.Client.ServerWide
             var isRolling = IsRolling(definition.DeploymentMode, globalDeploymentMode);
             
             AddIndexHistory(definition, source, revisionsToKeep, createdAt);
-            
+
+            definition.ClusterState ??= new IndexUpdateClusterState();
+
             if (isRolling)
             {
-                definition.ClusterState ??= new ClusterState();
+                
                 definition.ClusterState.LastRollingDeploymentIndex = raftIndex;
                 if (differences == null || (differences.Value & IndexDefinition.ReIndexRequiredMask) != 0)
                 {
@@ -246,6 +248,8 @@ namespace Raven.Client.ServerWide
                     definition.DeploymentMode = IndexDeploymentMode.Rolling;
                 }
             }
+
+            definition.ClusterState.LastIndex = raftIndex;
         }
 
         internal void AddIndexHistory(IndexDefinition definition, string source, int revisionsToKeep, DateTime createdAt, Dictionary<string, RollingIndexDeployment> rollingIndexDeployment = null, bool isFromCommand = false, bool isRolling = false)
@@ -320,6 +324,9 @@ namespace Raven.Client.ServerWide
                 if (differences == null || (differences.Value & IndexDefinition.ReIndexRequiredMask) != 0)
                     InitializeRollingDeployment(definition.Name, createdAt, raftIndex);
             }
+
+            definition.ClusterState ??= new IndexUpdateClusterState();
+            definition.ClusterState.LastIndex = raftIndex;
         }
 
         internal static bool IsRolling(IndexDeploymentMode? fromDefinition, IndexDeploymentMode fromSetting)

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
@@ -8,8 +8,8 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     public abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
     {
-        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
-            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, clusterState: null)
+        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, IndexUpdateClusterState clusterState, long? indexVersion = null)
+            : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, clusterState)
         {
             if (string.IsNullOrEmpty(collection))
                 throw new ArgumentNullException(nameof(collection));

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
@@ -6,9 +6,9 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
-    public abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
+    internal abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
     {
-        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, IndexUpdateClusterState clusterState, long? indexVersion = null)
+        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState, long? indexVersion = null)
             : base(indexName, new [] { collection }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion, deploymentMode, clusterState)
         {
             if (string.IsNullOrEmpty(collection))

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -8,7 +8,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
-    public class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
+    internal class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
     {
         private AutoMapIndex(AutoMapIndexDefinition definition)
             : base(IndexType.AutoMap, IndexSourceType.Documents, definition)

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -10,10 +10,10 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
-    public class AutoMapIndexDefinition : AutoIndexDefinitionBaseServerSide
+    internal class AutoMapIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
         public AutoMapIndexDefinition(string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
-            IndexUpdateClusterState clusterState, long? indexVersion = null)
+            IndexDefinitionClusterState clusterState, long? indexVersion = null)
             : base(AutoIndexNameFinder.FindMapIndexName(collection, fields), collection, fields, deploymentMode, clusterState, indexVersion)
         {
         }

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -12,14 +12,15 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     public class AutoMapIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
-        public AutoMapIndexDefinition(string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
-            : base(AutoIndexNameFinder.FindMapIndexName(collection, fields), collection, fields, deploymentMode, indexVersion)
+        public AutoMapIndexDefinition(string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
+            IndexUpdateClusterState clusterState, long? indexVersion = null)
+            : base(AutoIndexNameFinder.FindMapIndexName(collection, fields), collection, fields, deploymentMode, clusterState, indexVersion)
         {
         }
 
         // For legacy tests
         public AutoMapIndexDefinition(string collection, AutoIndexField[] fields, long? indexVersion = null)
-            : this(collection, fields, deploymentMode: null, indexVersion)
+            : this(collection, fields, deploymentMode: null, clusterState: null, indexVersion: indexVersion)
         {
         }
 
@@ -156,7 +157,7 @@ namespace Raven.Server.Documents.Indexes.Auto
                 field.Id = idX++;
             }
             
-            return new AutoMapIndexDefinition(collections[0], fields, deploymentMode: null, version)
+            return new AutoMapIndexDefinition(collections[0], fields, deploymentMode: null, indexVersion: version, clusterState: null)
             {
                 LockMode = lockMode,
                 Priority = priority

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyAutoIndexDefinition.cs
@@ -7,7 +7,7 @@ using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Indexes.Errors
 {
-    public class FaultyAutoIndexDefinition : IndexDefinitionBaseServerSide<IndexField>
+    internal class FaultyAutoIndexDefinition : IndexDefinitionBaseServerSide<IndexField>
     {
         public readonly AutoIndexDefinitionBaseServerSide Definition;
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3047,10 +3047,7 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamQuery(HttpResponse response, IStreamQueryResultWriter<Document> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, OperationCancelToken token)
         {
-            var result = new StreamDocumentQueryResult(response, writer, token)
-            {
-                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
-            };
+            var result = new StreamDocumentQueryResult(response, writer, Definition.ClusterState.LastIndex, token);
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: true, token);
             result.Flush();
 
@@ -3060,10 +3057,7 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamIndexEntriesQuery(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, OperationCancelToken token)
         {
-            var result = new StreamDocumentIndexEntriesQueryResult(response, writer, token)
-            {
-                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
-            };
+            var result = new StreamDocumentIndexEntriesQueryResult(response, writer, Definition.ClusterState.LastIndex, token);
             await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             result.Flush();
 
@@ -3077,10 +3071,7 @@ namespace Raven.Server.Documents.Indexes
             Action<DeterminateProgress> onProgress,
             OperationCancelToken token)
         {
-            var result = new DocumentIdQueryResult(progress, onProgress, token)
-            {
-                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
-            };
+            var result = new DocumentIdQueryResult(progress, onProgress, Definition.ClusterState.LastIndex, token);
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: false, token: token);
             return result;
         }
@@ -3090,10 +3081,7 @@ namespace Raven.Server.Documents.Indexes
             QueryOperationContext queryContext,
             OperationCancelToken token)
         {
-            var result = new DocumentQueryResult()
-            {
-                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
-            };
+            var result = new DocumentQueryResult(Definition.ClusterState.LastIndex);
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: false, token: token);
             return result;
         }
@@ -3691,10 +3679,7 @@ namespace Raven.Server.Documents.Indexes
             bool ignoreLimit,
             OperationCancelToken token)
         {
-            var result = new IndexEntriesQueryResult()
-            {
-                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
-            };
+            var result = new IndexEntriesQueryResult(Definition.ClusterState.LastIndex);
             await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             return result;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3047,7 +3047,10 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamQuery(HttpResponse response, IStreamQueryResultWriter<Document> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, OperationCancelToken token)
         {
-            var result = new StreamDocumentQueryResult(response, writer, token);
+            var result = new StreamDocumentQueryResult(response, writer, token)
+            {
+                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
+            };
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: true, token);
             result.Flush();
 
@@ -3057,7 +3060,10 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamIndexEntriesQuery(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, OperationCancelToken token)
         {
-            var result = new StreamDocumentIndexEntriesQueryResult(response, writer, token);
+            var result = new StreamDocumentIndexEntriesQueryResult(response, writer, token)
+            {
+                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
+            };
             await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             result.Flush();
 
@@ -3071,7 +3077,10 @@ namespace Raven.Server.Documents.Indexes
             Action<DeterminateProgress> onProgress,
             OperationCancelToken token)
         {
-            var result = new DocumentIdQueryResult(progress, onProgress, token);
+            var result = new DocumentIdQueryResult(progress, onProgress, token)
+            {
+                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
+            };
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: false, token: token);
             return result;
         }
@@ -3081,7 +3090,10 @@ namespace Raven.Server.Documents.Indexes
             QueryOperationContext queryContext,
             OperationCancelToken token)
         {
-            var result = new DocumentQueryResult();
+            var result = new DocumentQueryResult()
+            {
+                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
+            };
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: false, token: token);
             return result;
         }
@@ -3679,7 +3691,10 @@ namespace Raven.Server.Documents.Indexes
             bool ignoreLimit,
             OperationCancelToken token)
         {
-            var result = new IndexEntriesQueryResult();
+            var result = new IndexEntriesQueryResult()
+            {
+                IndexDefinitionRaftIndex = Definition.ClusterState.LastIndex
+            };
             await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             return result;
         }

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Indexes
     {
         protected IndexDefinitionBaseServerSide()
         {
-            ClusterState = new ClusterState();
+            ClusterState = new IndexUpdateClusterState();
         }
 
         public string Name { get; protected set; }
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Indexes
 
         public IndexState State { get; set; }
 
-        internal readonly ClusterState ClusterState;
+        internal readonly IndexUpdateClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
 
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Indexes
             T[] mapFields,
             long indexVersion,
             IndexDeploymentMode? deploymentMode,
-            ClusterState clusterState)
+            IndexUpdateClusterState clusterState)
         {
             Name = name;
             DeploymentMode = deploymentMode ?? IndexDeploymentMode.Parallel;
@@ -210,6 +210,7 @@ namespace Raven.Server.Documents.Indexes
             Priority = priority;
             State = state;
             _indexVersion = indexVersion;
+            ClusterState.LastIndex = clusterState?.LastIndex ?? 0;
             ClusterState.LastStateIndex = clusterState?.LastStateIndex ?? 0;
             ClusterState.LastRollingDeploymentIndex = clusterState?.LastRollingDeploymentIndex ?? 0;
         }

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Indexes
     {
         protected IndexDefinitionBaseServerSide()
         {
-            ClusterState = new IndexUpdateClusterState();
+            ClusterState = new IndexDefinitionClusterState();
         }
 
         public string Name { get; protected set; }
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Indexes
 
         public IndexState State { get; set; }
 
-        internal readonly IndexUpdateClusterState ClusterState;
+        internal readonly IndexDefinitionClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
 
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Indexes
             T[] mapFields,
             long indexVersion,
             IndexDeploymentMode? deploymentMode,
-            IndexUpdateClusterState clusterState)
+            IndexDefinitionClusterState clusterState)
         {
             Name = name;
             DeploymentMode = deploymentMode ?? IndexDeploymentMode.Parallel;

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -357,7 +357,7 @@ namespace Raven.Server.Documents.Indexes
 
             if (definition.Type == IndexType.AutoMap)
             {
-                var result = new AutoMapIndexDefinition(definition.Collection, mapFields, indexDeployment, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+                var result = new AutoMapIndexDefinition(definition.Collection, mapFields, indexDeployment, definition.ClusterState, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 if (definition.Priority.HasValue)
                     result.Priority = definition.Priority.Value;
@@ -381,7 +381,7 @@ namespace Raven.Server.Documents.Indexes
                     })
                     .ToArray();
 
-                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, indexDeployment, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, indexDeployment, definition.ClusterState, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 if (definition.Priority.HasValue)
                     result.Priority = definition.Priority.Value;
@@ -1638,7 +1638,8 @@ namespace Raven.Server.Documents.Indexes
                 if (indexDefinition.State != null && index.Definition.State != indexDefinition.State)
                     differences |= IndexDefinitionCompareDifferences.State;
 
-                index.Definition.ClusterState.LastStateIndex = (indexDefinition.ClusterState?.LastStateIndex ?? 0);
+                index.Definition.ClusterState.LastIndex = indexDefinition.ClusterState?.LastIndex ?? 0;
+                index.Definition.ClusterState.LastStateIndex = indexDefinition.ClusterState?.LastStateIndex ?? 0;
 
                 if (differences != IndexDefinitionCompareDifferences.None)
                 {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -18,7 +18,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {
-    public class AutoMapReduceIndex : MapReduceIndexBase<AutoMapReduceIndexDefinition, AutoIndexField>
+    internal class AutoMapReduceIndex : MapReduceIndexBase<AutoMapReduceIndexDefinition, AutoIndexField>
     {
         private ReduceKeyProcessor _reduceKeyProcessor;
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -11,7 +11,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {
-    public class AutoMapReduceIndexDefinition : AutoIndexDefinitionBaseServerSide
+    internal class AutoMapReduceIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
         public readonly Dictionary<string, AutoIndexField> GroupByFields;
 
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public readonly AutoIndexField[] OrderedGroupByFields;
 
-        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, IndexDeploymentMode? deploymentMode, IndexUpdateClusterState clusterState, long? indexVersion = null)
+        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState, long? indexVersion = null)
             : base(AutoIndexNameFinder.FindMapReduceIndexName(collection, mapFields, groupByFields), collection, mapFields, deploymentMode, clusterState, indexVersion)
         {
             OrderedGroupByFields = groupByFields.OrderBy(x => x.Name, StringComparer.Ordinal).ToArray();

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -19,8 +19,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public readonly AutoIndexField[] OrderedGroupByFields;
 
-        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, IndexDeploymentMode? deploymentMode, long? indexVersion = null)
-            : base(AutoIndexNameFinder.FindMapReduceIndexName(collection, mapFields, groupByFields), collection, mapFields, deploymentMode, indexVersion)
+        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, IndexDeploymentMode? deploymentMode, IndexUpdateClusterState clusterState, long? indexVersion = null)
+            : base(AutoIndexNameFinder.FindMapReduceIndexName(collection, mapFields, groupByFields), collection, mapFields, deploymentMode, clusterState, indexVersion)
         {
             OrderedGroupByFields = groupByFields.OrderBy(x => x.Name, StringComparer.Ordinal).ToArray();
 
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         // For Legacy test
         public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, long? indexVersion = null)
-            : this(collection, mapFields, groupByFields, deploymentMode: null, indexVersion)
+            : this(collection, mapFields, groupByFields, deploymentMode: null, clusterState: null, indexVersion)
         {
 
         }
@@ -261,7 +261,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
                 field.Id = fieldId++;
             }
             
-            return new AutoMapReduceIndexDefinition(collection, mapFields, groupByFields, deploymentMode: null, version)
+            return new AutoMapReduceIndexDefinition(collection, mapFields, groupByFields, deploymentMode: null, clusterState: null, version)
             {
                 LockMode = lockMode,
                 Priority = priority,

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto;
 
 public class AutoMapReduceIndexResultsAggregator
 {
-    public AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, TransactionOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
+    internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, TransactionOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
     {
         var aggregatedResultsByReduceKey = new Dictionary<BlittableJsonReaderObject, Dictionary<string, PropertyResult>>(ReduceKeyComparer.Instance);
 
@@ -61,7 +61,7 @@ public class AutoMapReduceIndexResultsAggregator
         return new AggregatedDocuments(resultObjects);
     }
 
-    protected virtual DynamicJsonValue BuildResult(KeyValuePair<BlittableJsonReaderObject, Dictionary<string, PropertyResult>> aggregationResult)
+    internal virtual DynamicJsonValue BuildResult(KeyValuePair<BlittableJsonReaderObject, Dictionary<string, PropertyResult>> aggregationResult)
     {
         var djv = new DynamicJsonValue();
 
@@ -71,7 +71,7 @@ public class AutoMapReduceIndexResultsAggregator
         return djv;
     }
 
-    protected virtual void HandleProperty(AutoMapReduceIndexDefinition indexDefinition, string propertyName, BlittableJsonReaderObject json, Dictionary<string, PropertyResult> aggregatedResult)
+    internal virtual void HandleProperty(AutoMapReduceIndexDefinition indexDefinition, string propertyName, BlittableJsonReaderObject json, Dictionary<string, PropertyResult> aggregatedResult)
     {
         if (indexDefinition.TryGetField(propertyName, out var indexField))
         {
@@ -111,7 +111,7 @@ public class AutoMapReduceIndexResultsAggregator
         }
     }
 
-    protected virtual PropertyResult HandleSumAndCount(object value)
+    internal virtual PropertyResult HandleSumAndCount(object value)
     {
         var numberType = BlittableNumber.Parse(value, out var doubleValue, out var longValue);
 
@@ -132,7 +132,7 @@ public class AutoMapReduceIndexResultsAggregator
         return aggregate;
     }
 
-    protected class PropertyResult
+    internal class PropertyResult
     {
         private NumberParseResult? _numberType;
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
@@ -12,7 +12,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {
-    public class ReduceMapResultsOfAutoIndex : ReduceMapResultsBase<AutoMapReduceIndexDefinition>
+    internal class ReduceMapResultsOfAutoIndex : ReduceMapResultsBase<AutoMapReduceIndexDefinition>
     {
         public static readonly AutoMapReduceIndexResultsAggregator Aggregator = new();
 

--- a/src/Raven.Server/Documents/Queries/DocumentIdQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/DocumentIdQueryResult.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Queries
 
         public readonly Queue<string> DocumentIds = new Queue<string>();
 
-        public DocumentIdQueryResult(DeterminateProgress progress, Action<DeterminateProgress> onProgress, OperationCancelToken token)
+        public DocumentIdQueryResult(DeterminateProgress progress, Action<DeterminateProgress> onProgress, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(indexDefinitionRaftIndex)
         {
             _progress = progress;
             _onProgress = onProgress;

--- a/src/Raven.Server/Documents/Queries/DocumentQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/DocumentQueryResult.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Queries
 {
     public class DocumentQueryResult : QueryResultServerSide<Document>
     {
-        public static readonly DocumentQueryResult NotModifiedResult = new DocumentQueryResult { NotModified = true };
+        public static readonly DocumentQueryResult NotModifiedResult = new DocumentQueryResult(null) { NotModified = true };
 
         public override bool SupportsInclude => true;
 
@@ -31,6 +31,10 @@ namespace Raven.Server.Documents.Queries
         private ITimeSeriesIncludes _timeSeriesIncludes;
 
         private Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>> _compareExchangeValueIncludes;
+
+        public DocumentQueryResult(long? indexDefinitionRaftIndex) : base(indexDefinitionRaftIndex)
+        {
+        }
 
         public override void AddCounterIncludes(ICounterIncludes includeCountersCommand)
         {

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
         {
-            var result = new DocumentQueryResult();
+            var result = new DocumentQueryResult(indexDefinitionRaftIndex: null);
 
             if (queryContext.AreTransactionsOpened() == false)
                 queryContext.OpenReadTransaction();
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
         public override async Task ExecuteStreamQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<Document> writer,
             OperationCancelToken token)
         {
-            var result = new StreamDocumentQueryResult(response, writer, token);
+            var result = new StreamDocumentQueryResult(response, writer, indexDefinitionRaftIndex: null, token);
 
             using (queryContext.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public List<Index> SupersededIndexes;
 
-        public AutoIndexDefinitionBaseServerSide CreateAutoIndexDefinition()
+        internal AutoIndexDefinitionBaseServerSide CreateAutoIndexDefinition()
         {
             int idForFields = 1;
             if (IsGroupBy == false)
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }).ToArray(), deploymentMode: null, clusterState: null);
         }
 
-        public void ExtendMappingBasedOn(AutoIndexDefinitionBaseServerSide definitionOfExistingIndex)
+        internal void ExtendMappingBasedOn(AutoIndexDefinitionBaseServerSide definitionOfExistingIndex)
         {
             Debug.Assert(definitionOfExistingIndex is AutoMapIndexDefinition || definitionOfExistingIndex is AutoMapReduceIndexDefinition, "Dynamic queries are handled only by auto indexes");
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -34,33 +34,33 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 return new AutoMapIndexDefinition(ForCollection, MapFields.Values
                     .OrderBy(x => x.Name.Value, StringComparer.Ordinal)
                     .Select(field =>
-                    {
-                        var indexField = new AutoIndexField
                         {
-                            Id = idForFields++,
-                            Name = field.Name,
-                            Storage = FieldStorage.No,
-                            Indexing = AutoFieldIndexing.Default,
-                            HasQuotedName = field.Name.IsQuoted
-                        };
+                            var indexField = new AutoIndexField
+                            {
+                                Id = idForFields++,
+                                Name = field.Name,
+                                Storage = FieldStorage.No,
+                                Indexing = AutoFieldIndexing.Default,
+                                HasQuotedName = field.Name.IsQuoted
+                            };
 
-                        if (field.IsFullTextSearch)
-                            indexField.Indexing |= AutoFieldIndexing.Search;
+                            if (field.IsFullTextSearch)
+                                indexField.Indexing |= AutoFieldIndexing.Search;
 
-                        if (field.IsExactSearch)
-                            indexField.Indexing |= AutoFieldIndexing.Exact;
+                            if (field.IsExactSearch)
+                                indexField.Indexing |= AutoFieldIndexing.Exact;
 
-                        if (field.HasHighlighting)
-                            indexField.Indexing |= AutoFieldIndexing.Highlighting;
+                            if (field.HasHighlighting)
+                                indexField.Indexing |= AutoFieldIndexing.Highlighting;
 
-                        if (field.Spatial != null)
-                            indexField.Spatial = new AutoSpatialOptions(field.Spatial);
+                            if (field.Spatial != null)
+                                indexField.Spatial = new AutoSpatialOptions(field.Spatial);
 
-                        indexField.HasSuggestions = field.HasSuggestions;
+                            indexField.HasSuggestions = field.HasSuggestions;
 
-                        return indexField;
-                    }
-                ).ToArray(), deploymentMode: null);
+                            return indexField;
+                        }
+                    ).ToArray(), deploymentMode: null, clusterState: null);
             }
 
             if (GroupByFields.Count == 0)
@@ -120,7 +120,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     indexField.HasSuggestions = field.HasSuggestions;
 
                     return indexField;
-                }).ToArray(), deploymentMode: null);
+                }).ToArray(), deploymentMode: null, clusterState: null);
         }
 
         public void ExtendMappingBasedOn(AutoIndexDefinitionBaseServerSide definitionOfExistingIndex)

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -62,7 +62,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
                 var queryResult = await index.Query(query, queryContext, token);
-                queryResult.RaftCommandIndex = result.Index;
 
                 return queryResult;
             }
@@ -133,7 +132,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
                 var queryResult = await ExecuteSuggestion(query, index, queryContext, existingResultEtag, token);
-                queryResult.RaftCommandIndex = result.Index;
 
                 return queryResult;
             }

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
                 var queryResult = await index.Query(query, queryContext, token);
+                queryResult.AutoIndexCreationRaftIndex = result.Index;
 
                 return queryResult;
             }
@@ -86,7 +87,10 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
-                return await index.IndexEntries(query, queryContext, ignoreLimit, token);
+                var queryResult = await index.IndexEntries(query, queryContext, ignoreLimit, token);
+                queryResult.AutoIndexCreationRaftIndex = result.Index;
+
+                return queryResult;
             }
         }
 
@@ -132,6 +136,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             using (QueryRunner.MarkQueryAsRunning(index.Name, query, token))
             {
                 var queryResult = await ExecuteSuggestion(query, index, queryContext, existingResultEtag, token);
+                queryResult.AutoIndexCreationRaftIndex = result.Index;
 
                 return queryResult;
             }

--- a/src/Raven.Server/Documents/Queries/IndexEntriesQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/IndexEntriesQueryResult.cs
@@ -11,7 +11,11 @@ namespace Raven.Server.Documents.Queries
 {
     public class IndexEntriesQueryResult : QueryResultServerSide<BlittableJsonReaderObject>
     {
-        public static readonly IndexEntriesQueryResult NotModifiedResult = new IndexEntriesQueryResult { NotModified = true };
+        public static readonly IndexEntriesQueryResult NotModifiedResult = new IndexEntriesQueryResult(null) { NotModified = true };
+
+        public IndexEntriesQueryResult(long? indexDefinitionRaftIndex) : base(indexDefinitionRaftIndex)
+        {
+        }
 
         public override ValueTask AddResultAsync(BlittableJsonReaderObject result, CancellationToken token)
         {

--- a/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.CompareExchange;
-using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Documents.Session.Loaders;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Spatial;
 using Raven.Server.Documents.Queries.Explanation;
@@ -15,10 +13,12 @@ namespace Raven.Server.Documents.Queries
 {
     public abstract class QueryResultServerSide<T> : QueryResult<List<T>, List<T>>
     {
-        protected QueryResultServerSide()
+        protected QueryResultServerSide(long? indexDefinitionRaftIndex)
         {
             Results = new List<T>();
             Includes = new List<T>();
+
+            IndexDefinitionRaftIndex = indexDefinitionRaftIndex;
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Queries/Sharding/ShardedIndexEntriesQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/Sharding/ShardedIndexEntriesQueryResult.cs
@@ -2,4 +2,8 @@
 
 public class ShardedIndexEntriesQueryResult : IndexEntriesQueryResult
 {
+
+    public ShardedIndexEntriesQueryResult() : base(indexDefinitionRaftIndex: null)
+    {
+    }
 }

--- a/src/Raven.Server/Documents/Queries/Sharding/ShardedQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/Sharding/ShardedQueryResult.cs
@@ -16,6 +16,11 @@ public class ShardedQueryResult : QueryResultServerSide<BlittableJsonReaderObjec
     private ITimeSeriesIncludes _includeTimeSeries;
     private ICompareExchangeValueIncludes _includeCompareExchangeValues;
 
+    public ShardedQueryResult() : base(indexDefinitionRaftIndex: null)
+    {
+        
+    }
+
     public override ValueTask AddResultAsync(BlittableJsonReaderObject result, CancellationToken token)
     {
         throw new NotSupportedException();

--- a/src/Raven.Server/Documents/Queries/StreamDocumentIndexEntriesQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamDocumentIndexEntriesQueryResult.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Queries
             GetToken().Delay();
         }
 
-        public StreamDocumentIndexEntriesQueryResult(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, OperationCancelToken token) : base(response, writer, token)
+        public StreamDocumentIndexEntriesQueryResult(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(response, writer, indexDefinitionRaftIndex, token)
         {
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");

--- a/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Queries
             GetToken().Delay();
         }
 
-        public StreamDocumentQueryResult(HttpResponse response, IStreamQueryResultWriter<Document> writer, OperationCancelToken token) : base(response, writer, token)
+        public StreamDocumentQueryResult(HttpResponse response, IStreamQueryResultWriter<Document> writer, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(response, writer, indexDefinitionRaftIndex, token)
         {
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");

--- a/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
@@ -4,9 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations.CompareExchange;
-using Raven.Client.Documents.Operations.Counters;
-using Raven.Client.Documents.Operations.TimeSeries;
-using Raven.Client.Documents.Session.Loaders;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Queries.Explanation;
 using Raven.Server.ServerWide;
@@ -21,7 +18,7 @@ namespace Raven.Server.Documents.Queries
         private bool _anyWrites;
         private bool _anyExceptions;
 
-        protected StreamQueryResult(HttpResponse response, IStreamQueryResultWriter<T> writer, OperationCancelToken token)
+        protected StreamQueryResult(HttpResponse response, IStreamQueryResultWriter<T> writer, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(indexDefinitionRaftIndex)
         {
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -102,7 +102,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
                 {
                     var (results, queryStatistics) = await ExecuteQueryAsync(context, query, null, ignoreLimit, token);
 
-                    var queryResult = new StreamDocumentIndexEntriesQueryResult(HttpContext.Response, writer, token); // writes blittable docs as blittable docs
+                    var queryResult = new StreamDocumentIndexEntriesQueryResult(HttpContext.Response, writer, indexDefinitionRaftIndex: null, token); // writes blittable docs as blittable docs
                     queryResult.TotalResults = queryStatistics.TotalResults;
                     queryResult.IndexName = queryStatistics.IndexName;
                     queryResult.IndexTimestamp = queryStatistics.IndexTimestamp;
@@ -136,7 +136,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
                 {
                     var (results, _) = await ExecuteQueryAsync(context, query, debug, ignoreLimit, token);
 
-                    var queryResult = new StreamDocumentIndexEntriesQueryResult(HttpContext.Response, writer, token);
+                    var queryResult = new StreamDocumentIndexEntriesQueryResult(HttpContext.Response, writer, indexDefinitionRaftIndex: null, token);
 
                     foreach (BlittableJsonReaderObject doc in results)
                     {

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -74,6 +74,12 @@ public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TI
             if (combinedResult.IndexDefinitionRaftIndex == null || singleShardResult.IndexDefinitionRaftIndex > combinedResult.IndexDefinitionRaftIndex)
                 combinedResult.IndexDefinitionRaftIndex = singleShardResult.IndexDefinitionRaftIndex;
         }
+
+        if (singleShardResult.AutoIndexCreationRaftIndex.HasValue)
+        {
+            if (combinedResult.AutoIndexCreationRaftIndex == null || singleShardResult.AutoIndexCreationRaftIndex > combinedResult.AutoIndexCreationRaftIndex)
+                combinedResult.AutoIndexCreationRaftIndex = singleShardResult.AutoIndexCreationRaftIndex;
+        }
     }
 
     protected void HandleDocumentIncludes(QueryResult cmdResult, QueryResult<List<TResult>, List<TIncludes>> result)

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -66,10 +66,13 @@ public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TI
         if (combinedResult.LastQueryTime < singleShardResult.LastQueryTime)
             combinedResult.LastQueryTime = singleShardResult.LastQueryTime;
 
-        if (singleShardResult.RaftCommandIndex.HasValue)
+        if (singleShardResult.IndexDefinitionRaftIndex.HasValue)
         {
-            if (combinedResult.RaftCommandIndex == null || singleShardResult.RaftCommandIndex > combinedResult.RaftCommandIndex)
-                combinedResult.RaftCommandIndex = singleShardResult.RaftCommandIndex;
+            if (combinedResult.IndexDefinitionRaftIndex != null && combinedResult.IndexDefinitionRaftIndex != singleShardResult.IndexDefinitionRaftIndex)
+                combinedResult.IsStale = true;
+
+            if (combinedResult.IndexDefinitionRaftIndex == null || singleShardResult.IndexDefinitionRaftIndex > combinedResult.IndexDefinitionRaftIndex)
+                combinedResult.IndexDefinitionRaftIndex = singleShardResult.IndexDefinitionRaftIndex;
         }
     }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -451,15 +451,15 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         }
     }
 
-    protected async Task WaitForRaftIndexIfNeededAsync(long? raftCommandIndex, QueryTimingsScope scope)
+    protected async Task WaitForRaftIndexIfNeededAsync(long? autoIndexCreationRaftCommandIndex, QueryTimingsScope scope)
     {
-        if (IsAutoMapReduceQuery && raftCommandIndex.HasValue)
+        if (IsAutoMapReduceQuery && autoIndexCreationRaftCommandIndex.HasValue)
         {
             using (scope?.For(nameof(QueryTimingsScope.Names.Cluster)))
             {
                 // we are waiting here for all nodes, we should wait for all of the orchestrators at least to apply that
                 // so further queries would not throw index does not exist in case of a failover
-                await RequestHandler.DatabaseContext.Cluster.WaitForExecutionOnAllNodesAsync(raftCommandIndex.Value, Token);
+                await RequestHandler.DatabaseContext.Cluster.WaitForExecutionOnAllNodesAsync(autoIndexCreationRaftCommandIndex.Value, Token);
             }
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -125,7 +125,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope);
+            await WaitForRaftIndexIfNeededAsync(result.AutoIndexCreationRaftIndex, scope);
 
             using (Query.Metadata.HasIncludeOrLoad ? queryScope?.For(nameof(QueryTimingsScope.Names.Includes)) : null)
             {

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -125,7 +125,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex, scope);
+            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope);
 
             using (Query.Metadata.HasIncludeOrLoad ? queryScope?.For(nameof(QueryTimingsScope.Names.Includes)) : null)
             {

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
@@ -44,7 +44,7 @@ public class ShardedIndexEntriesQueryProcessor : ShardedQueryProcessorBase<Shard
 
         var result = shardedReadResult.Result;
 
-        await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex, scope: null);
+        await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope: null);
 
         // For map/reduce - we need to re-run the reduce portion of the index again on the results
         ReduceResults(ref result, scope: null);

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
@@ -44,7 +44,7 @@ public class ShardedIndexEntriesQueryProcessor : ShardedQueryProcessorBase<Shard
 
         var result = shardedReadResult.Result;
 
-        await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope: null);
+        await WaitForRaftIndexIfNeededAsync(result.AutoIndexCreationRaftIndex, scope: null);
 
         // For map/reduce - we need to re-run the reduce portion of the index again on the results
         ReduceResults(ref result, scope: null);

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedMapReduceIndexEntriesQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedMapReduceIndexEntriesQueryResultsMerger.cs
@@ -29,7 +29,7 @@ public class ShardedMapReduceIndexEntriesQueryResultsMerger : ShardedMapReduceQu
     {
     }
 
-    protected override AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
+    internal override AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
     {
         BlittableJsonReaderObject currentlyProcessedResult = null;
         return Aggregator.AggregateOn(CurrentResults, indexDefinition, Context, null, ref currentlyProcessedResult, Token);

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -87,7 +87,7 @@ public class ShardedMapReduceQueryResultsMerger
     protected virtual AggregatedAnonymousObjects CreateShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor)
         => new ShardedAggregatedAnonymousObjects(results, propertyAccessor, Context);
 
-    protected virtual AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
+    internal virtual AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
     {
         BlittableJsonReaderObject currentlyProcessedResult = null;
         return ReduceMapResultsOfAutoIndex.Aggregator.AggregateOn(CurrentResults, indexDefinition, Context, null, ref currentlyProcessedResult, Token);

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -70,7 +70,7 @@ public class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQueryResul
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex, queryScope);
+            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, queryScope);
 
             using (Query.Metadata.HasIncludeOrLoad ? queryScope?.For(nameof(QueryTimingsScope.Names.Includes)) : null)
             {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -70,7 +70,7 @@ public class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQueryResul
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, queryScope);
+            await WaitForRaftIndexIfNeededAsync(result.AutoIndexCreationRaftIndex, queryScope);
 
             using (Query.Metadata.HasIncludeOrLoad ? queryScope?.For(nameof(QueryTimingsScope.Names.Includes)) : null)
             {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedReduceMapResultsOfAutoIndex.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedReduceMapResultsOfAutoIndex.cs
@@ -10,7 +10,7 @@ public class ShardedAutoMapReduceIndexResultsAggregatorForIndexEntries : AutoMap
 {
     private string _reduceKeyHash;
 
-    protected override void HandleProperty(AutoMapReduceIndexDefinition indexDefinition, string propertyName, BlittableJsonReaderObject json, Dictionary<string, PropertyResult> aggregatedResult)
+    internal override void HandleProperty(AutoMapReduceIndexDefinition indexDefinition, string propertyName, BlittableJsonReaderObject json, Dictionary<string, PropertyResult> aggregatedResult)
     {
         if (_reduceKeyHash == null && propertyName == Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName)
             json.TryGet(propertyName, out _reduceKeyHash);
@@ -18,7 +18,7 @@ public class ShardedAutoMapReduceIndexResultsAggregatorForIndexEntries : AutoMap
         base.HandleProperty(indexDefinition, propertyName, json, aggregatedResult);
     }
 
-    protected override DynamicJsonValue BuildResult(KeyValuePair<BlittableJsonReaderObject, Dictionary<string, PropertyResult>> aggregationResult)
+    internal override DynamicJsonValue BuildResult(KeyValuePair<BlittableJsonReaderObject, Dictionary<string, PropertyResult>> aggregationResult)
     {
         var djv = base.BuildResult(aggregationResult);
 
@@ -28,7 +28,7 @@ public class ShardedAutoMapReduceIndexResultsAggregatorForIndexEntries : AutoMap
         return djv;
     }
 
-    protected override PropertyResult HandleSumAndCount(object value)
+    internal override PropertyResult HandleSumAndCount(object value)
     {
         if (value is LazyStringValue or LazyCompressedStringValue)
         {

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
@@ -64,7 +64,7 @@ public class ShardedSuggestionQueryProcessor : AbstractShardedQueryProcessor<Sha
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope);
+            await WaitForRaftIndexIfNeededAsync(result.AutoIndexCreationRaftIndex, scope);
 
             return result;
         }

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
@@ -64,7 +64,7 @@ public class ShardedSuggestionQueryProcessor : AbstractShardedQueryProcessor<Sha
 
             var result = shardedReadResult.Result;
 
-            await WaitForRaftIndexIfNeededAsync(result.RaftCommandIndex, scope);
+            await WaitForRaftIndexIfNeededAsync(result.IndexDefinitionRaftIndex, scope);
 
             return result;
         }

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -49,7 +49,9 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.Maps)] = new DynamicJsonArray(definition.Maps);
             result[nameof(IndexDefinition.ClusterState)] = new DynamicJsonValue()
             {
-                [nameof(IndexDefinition.ClusterState.LastStateIndex)] = definition.ClusterState?.LastStateIndex ?? 0
+                [nameof(IndexDefinition.ClusterState.LastIndex)] = definition.ClusterState?.LastIndex ?? 0,
+                [nameof(IndexDefinition.ClusterState.LastStateIndex)] = definition.ClusterState?.LastStateIndex ?? 0,
+                [nameof(IndexDefinition.ClusterState.LastRollingDeploymentIndex)] = definition.ClusterState?.LastRollingDeploymentIndex ?? 0
             };
 
             var fields = new DynamicJsonValue();

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -257,6 +257,13 @@ namespace Raven.Server.Json
                 writer.WriteComma();
             }
 
+            if (result.AutoIndexCreationRaftIndex.HasValue)
+            {
+                writer.WritePropertyName(nameof(result.AutoIndexCreationRaftIndex));
+                writer.WriteInteger(result.AutoIndexCreationRaftIndex.Value);
+                writer.WriteComma();
+            }
+
             var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
 
             writer.WriteEndObject();
@@ -694,6 +701,13 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.IndexDefinitionRaftIndex));
                 writer.WriteInteger(result.IndexDefinitionRaftIndex.Value);
+            }
+
+            if (result.AutoIndexCreationRaftIndex.HasValue)
+            {
+                writer.WriteComma();
+                writer.WritePropertyName(nameof(result.AutoIndexCreationRaftIndex));
+                writer.WriteInteger(result.AutoIndexCreationRaftIndex.Value);
             }
 
             writeAdditionalData?.Invoke(writer);

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -250,10 +250,10 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            if (result.RaftCommandIndex.HasValue)
+            if (result.IndexDefinitionRaftIndex.HasValue)
             {
-                writer.WritePropertyName(nameof(result.RaftCommandIndex));
-                writer.WriteInteger(result.RaftCommandIndex.Value);
+                writer.WritePropertyName(nameof(result.IndexDefinitionRaftIndex));
+                writer.WriteInteger(result.IndexDefinitionRaftIndex.Value);
                 writer.WriteComma();
             }
 
@@ -689,11 +689,11 @@ namespace Raven.Server.Json
                     (w, c, spatialShape) => w.WriteSpatialShapeResult(c, spatialShape));
             }
 
-            if (result.RaftCommandIndex.HasValue)
+            if (result.IndexDefinitionRaftIndex.HasValue)
             {
                 writer.WriteComma();
-                writer.WritePropertyName(nameof(result.RaftCommandIndex));
-                writer.WriteInteger(result.RaftCommandIndex.Value);
+                writer.WritePropertyName(nameof(result.IndexDefinitionRaftIndex));
+                writer.WriteInteger(result.IndexDefinitionRaftIndex.Value);
             }
 
             writeAdditionalData?.Invoke(writer);

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
@@ -51,14 +51,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             json[nameof(DefaultStaticDeploymentMode)] = TypeConverter.ToBlittableSupportedType(DefaultStaticDeploymentMode);
         }
 
-        public static PutAutoIndexCommand Create(AutoIndexDefinitionBaseServerSide definition, string databaseName, string raftRequestId, IndexDeploymentMode mode)
+        internal static PutAutoIndexCommand Create(AutoIndexDefinitionBaseServerSide definition, string databaseName, string raftRequestId, IndexDeploymentMode mode)
         {
             var indexType = GetAutoIndexType(definition);
 
             return new PutAutoIndexCommand(GetAutoIndexDefinition(definition, indexType), databaseName, raftRequestId, mode, SystemTime.UtcNow);
         }
 
-        public static IndexType GetAutoIndexType(AutoIndexDefinitionBaseServerSide definition)
+        internal static IndexType GetAutoIndexType(AutoIndexDefinitionBaseServerSide definition)
         {
             var indexType = IndexType.None;
             if (definition is AutoMapIndexDefinition)
@@ -73,7 +73,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             return indexType;
         }
 
-        public static AutoIndexDefinition GetAutoIndexDefinition(AutoIndexDefinitionBaseServerSide definition, IndexType indexType)
+        internal static AutoIndexDefinition GetAutoIndexDefinition(AutoIndexDefinitionBaseServerSide definition, IndexType indexType)
         {
             Debug.Assert(indexType == IndexType.AutoMap || indexType == IndexType.AutoMapReduce);
 

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             : base(databaseName, uniqueRequestId)
         {
             Definition = definition;
-            Definition.ClusterState ??= new IndexUpdateClusterState();
+            Definition.ClusterState ??= new IndexDefinitionClusterState();
             Source = source;
             CreatedAt = createdAt;
             RevisionsToKeep = revisionsToKeep;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             : base(databaseName, uniqueRequestId)
         {
             Definition = definition;
-            Definition.ClusterState ??= new ClusterState();
+            Definition.ClusterState ??= new IndexUpdateClusterState();
             Source = source;
             CreatedAt = createdAt;
             RevisionsToKeep = revisionsToKeep;

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
@@ -28,6 +28,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.Indexes.TryGetValue(IndexName, out IndexDefinition staticIndex))
             {
                 staticIndex.LockMode = LockMode;
+                staticIndex.ClusterState.LastIndex = etag;
             }
 
             if (record.AutoIndexes.ContainsKey(IndexName))

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
@@ -27,13 +27,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.Indexes.TryGetValue(IndexName, out IndexDefinition staticIndex))
             {
                 staticIndex.Priority = Priority;
+                staticIndex.ClusterState.LastIndex = etag;
             }
 
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.Priority = Priority;
+                autoIndex.ClusterState.LastIndex = etag;
             }
-
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
@@ -32,13 +32,13 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.State = State;
-                autoIndex.ClusterState ??= new ClusterState();
+                autoIndex.ClusterState.LastIndex = etag;
                 autoIndex.ClusterState.LastStateIndex = etag;
             }
             else if (record.Indexes.TryGetValue(IndexName, out IndexDefinition indexDefinition))
             {
                 indexDefinition.State = State;
-                indexDefinition.ClusterState ??= new ClusterState();
+                indexDefinition.ClusterState.LastIndex = etag;
                 indexDefinition.ClusterState.LastStateIndex = etag;
             }
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_18166.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18166.cs
@@ -1,0 +1,118 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_18166 : RavenTestBase
+{
+    public RavenDB_18166(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task ShouldMarkQueryResultsAsStaleIfShardsHaveDifferentAutoIndexes()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    session.Store(new User { Name = "Joe" });
+                    session.Store(new User { Name = "Doe" });
+                }
+
+                session.SaveChanges();
+
+                var results = session.Query<User>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(x => x.Name == "Joe")
+                    .ToList();
+
+
+                Assert.Equal(100, results.Count);
+            }
+
+            var shardedDb = await Sharding.GetShardsDocumentDatabaseInstancesFor(store).FirstAsync();
+
+            Index index = shardedDb.IndexStore.GetIndex("Auto/Users/ByName");
+            
+            Assert.NotEqual(0, index.Definition.ClusterState.LastIndex); // precaution - to make sure we have real value here
+            
+            // let's pretend that on one shard the definition is different
+            index.Definition.ClusterState.LastIndex++;
+            
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<User>()
+                    .Statistics(out var stats)
+                    .Where(x => x.Name == "Joe")
+                    .ToList();
+
+                Assert.True(stats.IsStale);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task ShouldMarkQueryResultsAsStaleIfShardsHaveDifferentStaticIndexes()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            await new Users_ByName().ExecuteAsync(store);
+
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    session.Store(new User { Name = "Joe" });
+                    session.Store(new User { Name = "Doe" });
+                }
+
+                session.SaveChanges();
+
+                var results = session.Query<User, Users_ByName>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(x => x.Name == "Joe")
+                    .ToList();
+
+
+                Assert.Equal(100, results.Count);
+            }
+
+            var shardedDb = await Sharding.GetShardsDocumentDatabaseInstancesFor(store).FirstAsync();
+
+            Index index = shardedDb.IndexStore.GetIndex("Users/ByName");
+
+            Assert.NotEqual(0, index.Definition.ClusterState.LastIndex); // precaution - to make sure we have real value here
+
+            // let's pretend that on one shard the definition is different
+            index.Definition.ClusterState.LastIndex++;
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<User, Users_ByName>()
+                    .Statistics(out var stats)
+                    .Where(x => x.Name == "Joe")
+                    .ToList();
+
+                Assert.True(stats.IsStale);
+            }
+        }
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from u in users select new {u.Name};
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18166/Different-index-defintions-after-a-query

### Additional description

Storing raft index on any modification of an index definition so we're able to detect on the orchestrator that query results returned by indexes having different definitions. In that case we mark the results as stale.

### Type of change

- Sharding feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
