### PR TITLE
RavenDB-19934 Using the right database backup task id to reschedule wakeup.

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1108,7 +1108,7 @@ namespace Raven.Server.Documents
                 return true;
 
             // if we have a small value or even a negative one, simply don't dispose the database.
-            dueTime = (int)(wakeupUtc - DateTime.UtcNow).Value.TotalMilliseconds;
+            dueTime = (int)Math.Min(int.MaxValue, (wakeupUtc - DateTime.UtcNow).Value.TotalMilliseconds);
 
             if (SkipShouldContinueDisposeCheck)
                 return true;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1221,16 +1221,13 @@ namespace Raven.Server.ServerWide
             if (IdleDatabases.ContainsKey(db) == false)
                 return;
 
-            if (state is Dictionary<string, long> indexPerDatabase == false)
+            if (state is long taskId == false)
             {
-                Debug.Assert(state is Dictionary<string, long>, 
-                    $"This is probably a bug. This method should be called only for {nameof(PutServerWideBackupConfigurationCommand)} and the state should be dictionary of task id per database - {nameof(Dictionary<string, long>)}.");
+                Debug.Assert(state == null, 
+                    $"This is probably a bug. This method should be called only for {nameof(PutServerWideBackupConfigurationCommand)} and the state should be the database periodic backup task id.");
+                //The database is excluded from the server-wide backup.
                 return;
             }
-            
-            if (indexPerDatabase.TryGetValue(db, out var taskId) == false)
-                //The database was excluded from the server wide backup
-                return;
             
             PeriodicBackupConfiguration backupConfig;
             DatabaseTopology topology;

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Smuggler;
@@ -986,34 +987,35 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             {
                 CustomSettings = new Dictionary<string, string>
                 {
-                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "3",
                     [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
                     [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
                 }
             });
-            using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
+            using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false}))
+            using (var excludedStore = GetDocumentStore(new Options { Server = server, RunInMemory = false}))
             {
+                await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000);
+
                 var fullFreq = "0 2 1 1 *";
                 var incFreq = "0 2 * * 0";
                 var putConfiguration = new ServerWideBackupConfiguration
                 {
                     FullBackupFrequency = fullFreq,
                     IncrementalBackupFrequency = incFreq,
-                    LocalSettings = new LocalSettings
-                    {
-                        FolderPath = "test/folder"
-                    }
+                    LocalSettings = new LocalSettings {FolderPath = "test/folder"},
+                    ExcludedDatabases = new []{excludedStore.Database}
                 };
-
-                Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000));
-
                 var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
                 var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
                 Assert.NotNull(serverWideConfiguration);
                 Assert.Equal(fullFreq, serverWideConfiguration.FullBackupFrequency);
                 Assert.Equal(incFreq, serverWideConfiguration.IncrementalBackupFrequency);
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
 
+                await BackupNow(store, serverWideConfiguration.Name);
+
+                await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000);
+                
                 // update the backup configuration
                 putConfiguration.Name = serverWideConfiguration.Name;
                 putConfiguration.TaskId = serverWideConfiguration.TaskId;
@@ -1021,25 +1023,12 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var oldName = result.Name;
                 result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+                await server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex, TimeSpan.FromMinutes(1));
 
-                Exception ex = null;
-                try
-                {
-                    await server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex, TimeSpan.FromMinutes(1));
-                }
-                catch (Exception e)
-                {
-                    ex = e;
-                }
-                finally
-                {
-                    Assert.Null(ex);
-                }
-                
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(1, record.PeriodicBackups.Count);
-                PeriodicBackupConfiguration periodicBackupConfiguration = record.PeriodicBackups.First();
-
+                var periodicBackupConfiguration = record.PeriodicBackups.First();
+                
                 var newServerWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
 
                 // compare with periodic backup task 
@@ -1055,7 +1044,24 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Equal(incFreq, newServerWideConfiguration.FullBackupFrequency);
                 Assert.Equal(incFreq, newServerWideConfiguration.IncrementalBackupFrequency);
                 Assert.NotEqual(serverWideConfiguration.FullBackupFrequency, newServerWideConfiguration.FullBackupFrequency);
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
+                
+                using (var createdAfter = GetDocumentStore(new Options {Server = server, RunInMemory = false}))
+                {
+                    await BackupNow(createdAfter, serverWideConfiguration.Name);
+                
+                    await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 2, timeout: 60000, interval: 1000);
+                
+                    putConfiguration.TaskId = result.RaftCommandIndex;
+                    putConfiguration.RetentionPolicy = new RetentionPolicy {MinimumBackupAgeToKeep = TimeSpan.FromDays(10)};
+                    result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+                    await server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex, TimeSpan.FromMinutes(1));
+                }
+            }
+
+            async Task BackupNow(DocumentStore store, string backupName)
+            {
+                var res = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation($"Server Wide Backup, {backupName}", OngoingTaskType.Backup));
+                await store.Maintenance.SendAsync(new StartBackupOperation(false, res.TaskId));
             }
         }
 
@@ -1172,6 +1178,12 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             {
                 await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(configuration));
             });
+        }
+        
+        [Fact, Trait("Category", "Smuggler")]
+        public async Task ServerWideBackup_WhenSaveAndADatabaseIsIdle_ShouldNotFails()
+        {
+            using var store = GetDocumentStore();
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -1179,11 +1179,5 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(configuration));
             });
         }
-        
-        [Fact, Trait("Category", "Smuggler")]
-        public async Task ServerWideBackup_WhenSaveAndADatabaseIsIdle_ShouldNotFails()
-        {
-            using var store = GetDocumentStore();
-        }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -387,12 +387,12 @@ namespace FastTests
             Assert.Equal(expectedVal, val);
         }
 
-        protected static async Task<T> AssertWaitFoGreaterAsync<T>(Func<T> act, T value, int timeout = 15000, int interval = 100) where T : IComparable
+        protected static async Task<T> AssertWaitForGreaterAsync<T>(Func<T> act, T value, int timeout = 15000, int interval = 100) where T : IComparable
         {
-            return await AssertWaitFoGreaterAsync(() => Task.FromResult(act()), value, timeout, interval);
+            return await AssertWaitForGreaterAsync(() => Task.FromResult(act()), value, timeout, interval);
         }
 
-        protected static async Task<T> AssertWaitFoGreaterAsync<T>(Func<Task<T>> act, T value, int timeout = 15000, int interval = 100) where T : IComparable
+        protected static async Task<T> AssertWaitForGreaterAsync<T>(Func<Task<T>> act, T value, int timeout = 15000, int interval = 100) where T : IComparable
         {
             var ret = await WaitForPredicateAsync(r => r.CompareTo(value) > 0, act, timeout, interval);
             Assert.NotNull(ret);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19934

### Additional description
Since the identification of a backup task is due to its id the id cannot be changed.
The server-wide backup id is the raft index and it changes every time it has been modified.
The database backup created from server-wide backup gets its id from the id of the server-wide backup at the time it was created.
When the server modifies a server-wide backup it also reschedules the wakeup of the relevant databases.
Previously, the task ID to find the backup task in the database was the same for all databases.
Since different database backup tasks of the same server-wide backup can have different task IDs, the logic is wrong. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
