### PR TITLE
RavenDB-19932 `CoraxIndexReadOperation` can deal with bigger sets than int32.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19932.cs
+++ b/test/SlowTests/Issues/RavenDB-19932.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19932 : RavenTestBase
+{
+    public RavenDB_19932(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void GrowableHashSetForProjectionInCoraxIndexReadOperation()
+    {
+        var growableHashSet = new CoraxIndexReadOperation.GrowableHashSet<ulong>(maxSizePerCollection: 100);
+        var random = new Random(64352);
+        var hashset = new HashSet<ulong>();
+
+        for (int i = 0; i < 10_000; ++i)
+        {
+            var rand = (ulong)random.NextInt64(0, long.MaxValue);
+            Assert.Equal(hashset.Add(rand), growableHashSet.Add(rand));
+        }
+
+        Assert.True(growableHashSet.HasMultipleHashSets);
+        var shuffledList = hashset.ToList();
+        shuffledList.Shuffle();
+
+        for (int i = 0; i < shuffledList.Count; ++i)
+        {
+            Assert.True(growableHashSet.Contains(shuffledList[i])); //exists
+            Assert.False(growableHashSet.Add(shuffledList[i])); //cannot add again
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19932
### Additional description

When we've to register more than int32 results in hashsets let's change it single HashSet into the bucket of HashSets.

### Type of change


- New feature

### How risky is the change?

- Low 
- Moderate 
- High
- Not relevant

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

It's hard to test it with DB so I provide a test for data structure.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
