### PR TITLE
RavenDB-19730 - Sharding - Query - Further Performance Optimizations

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -267,6 +267,8 @@ namespace Raven.Client.Documents.Conventions
             _firstBroadcastAttemptTimeout = TimeSpan.FromSeconds(5);
             _secondBroadcastAttemptTimeout = TimeSpan.FromSeconds(30);
 
+            _globalHttpClientTimeout = TimeSpan.FromHours(12);
+
             _waitForIndexesAfterSaveChangesTimeout = TimeSpan.FromSeconds(15);
             _waitForReplicationAfterSaveChangesTimeout = TimeSpan.FromSeconds(15);
             _waitForNonStaleResultsTimeout = TimeSpan.FromSeconds(15);
@@ -318,6 +320,7 @@ namespace Raven.Client.Documents.Conventions
         private TimeSpan _waitForIndexesAfterSaveChangesTimeout;
         private TimeSpan _waitForReplicationAfterSaveChangesTimeout;
         private TimeSpan _waitForNonStaleResultsTimeout;
+        private TimeSpan _globalHttpClientTimeout;
 
         private int _loadBalancerContextSeed;
         private LoadBalanceBehavior _loadBalanceBehavior;
@@ -478,6 +481,16 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _requestTimeout = value;
+            }
+        }
+
+        public TimeSpan GlobalHttpClientTimeout
+        {
+            get => _globalHttpClientTimeout;
+            set
+            {
+                AssertNotFrozen();
+                _globalHttpClientTimeout = value;
             }
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2285,6 +2285,7 @@ namespace Raven.Client.Http
             private readonly bool _useCompression;
             private readonly TimeSpan? _pooledConnectionLifetime;
             private readonly TimeSpan? _pooledConnectionIdleTimeout;
+            private readonly TimeSpan _globalHttpClientTimeout;
             private readonly Type _httpClientType;
 
             public HttpClientCacheKey(string certificateThumbprint, bool useCompression, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout, TimeSpan globalHttpClientTimeout, Type httpClientType)
@@ -2293,6 +2294,7 @@ namespace Raven.Client.Http
                 _useCompression = useCompression;
                 _pooledConnectionLifetime = pooledConnectionLifetime;
                 _pooledConnectionIdleTimeout = pooledConnectionIdleTimeout;
+                _globalHttpClientTimeout = globalHttpClientTimeout;
                 _globalHttpClientTimeout = globalHttpClientTimeout;
                 _httpClientType = httpClientType;
             }
@@ -2303,7 +2305,7 @@ namespace Raven.Client.Http
                        && _useCompression == other._useCompression 
                        && Nullable.Equals(_pooledConnectionLifetime, other._pooledConnectionLifetime) 
                        && Nullable.Equals(_pooledConnectionIdleTimeout, other._pooledConnectionIdleTimeout)
-                       && Nullable.Equals(_globalHttpClientTimeout, other._globalHttpClientTimeout
+                       && Nullable.Equals(_globalHttpClientTimeout, other._globalHttpClientTimeout)
                        && _httpClientType == other._httpClientType;
             }
 

--- a/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
@@ -1,15 +1,34 @@
+using System;
 using System.ComponentModel;
 using System.IO.Compression;
+using System.Threading;
 using Raven.Server.Config.Attributes;
+using Raven.Server.Config.Settings;
 
 namespace Raven.Server.Config.Categories
 {
     [ConfigurationCategory(ConfigurationCategoryType.Sharding)]
     public class ShardingConfiguration : ConfigurationCategory
     {
+        public ShardingConfiguration()
+        {
+            OrchestratorTimeoutInMinutes = new TimeSetting(Timeout.InfiniteTimeSpan);
+        }
+
         [Description("The compression level to use when sending import streams to shards during smuggler import")]
         [DefaultValue(CompressionLevel.NoCompression)]
         [ConfigurationEntry("Sharding.Import.CompressionLevel", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public CompressionLevel CompressionLevel { get; set; }
+
+        [Description("The compression to use when distributing requests from the orchestrator to the shards")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Sharding.ShardExecutorUseCompression", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ShardExecutorUseCompression { get; set; }
+
+        [Description("Enable the timeout of the orchestrator's requests to the shards")]
+        [DefaultValue(DefaultValueSetInConstructor)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [ConfigurationEntry("Sharding.OrchestratorTimeoutInMinutes", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting OrchestratorTimeoutInMinutes { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Settings/TimeSetting.cs
+++ b/src/Raven.Server/Config/Settings/TimeSetting.cs
@@ -45,6 +45,11 @@ namespace Raven.Server.Config.Settings
             }
         }
 
+        public TimeSetting(TimeSpan timeSpan)
+        {
+            AsTimeSpan = timeSpan;
+        }
+
         internal long GetValue(TimeUnit requestedUnit)
         {
             switch (requestedUnit)

--- a/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Http;
-using Raven.Client.Json;
 using Raven.Client.Util;
 using Sparrow.Json;
 using Sparrow.Utils;
@@ -13,13 +12,13 @@ namespace Raven.Server.Documents.Commands.Streaming
 {
     public class PostQueryStreamCommand : RavenCommand<StreamResult>
     {
-        private readonly BlittableJsonReaderObject _indexQueryServerSide;
+        private readonly string _query;
         private readonly string _debug;
         private readonly bool _ignoreLimit;
 
-        public PostQueryStreamCommand(BlittableJsonReaderObject indexQueryServerSide, string debug, bool ignoreLimit)
+        public PostQueryStreamCommand(string query, string debug, bool ignoreLimit)
         {
-            _indexQueryServerSide = indexQueryServerSide;
+            _query = query;
             _debug = debug;
             _ignoreLimit = ignoreLimit;
             ResponseType = RavenCommandResponseType.Empty;
@@ -31,8 +30,8 @@ namespace Raven.Server.Documents.Commands.Streaming
         {
             var request = new HttpRequestMessage
             {
-                Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async (stream) => await _indexQueryServerSide.WriteJsonToAsync(stream))
+                Method = HttpMethod.Post, 
+                Content = new StringContent(_query, Encoding.UTF8, "application/json")
             };
 
             var sb = new StringBuilder($"{node.Url}/databases/{node.Database}/streams/queries?");

--- a/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
@@ -11,7 +11,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Queries
 {
-    public abstract class QueryResultServerSide<T> : QueryResult<List<T>, List<T>>
+    public abstract class QueryResultServerSide<T> : QueryResult<List<T>, List<T>>, IDisposable
     {
         protected QueryResultServerSide(long? indexDefinitionRaftIndex)
         {
@@ -106,5 +106,9 @@ namespace Raven.Server.Documents.Queries
         public abstract void AddRevisionIncludes(IRevisionIncludes revisions);
        
         public abstract IRevisionIncludes GetRevisionIncludes();
+
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/src/Raven.Server/Documents/Queries/Sharding/ShardedQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/Sharding/ShardedQueryResult.cs
@@ -15,6 +15,7 @@ public class ShardedQueryResult : QueryResultServerSide<BlittableJsonReaderObjec
     private ICounterIncludes _counterIncludes;
     private ITimeSeriesIncludes _includeTimeSeries;
     private ICompareExchangeValueIncludes _includeCompareExchangeValues;
+    private List<IDisposable> _shardContextsToDispose;
 
     public ShardedQueryResult() : base(indexDefinitionRaftIndex: null)
     {
@@ -82,5 +83,22 @@ public class ShardedQueryResult : QueryResultServerSide<BlittableJsonReaderObjec
     public override IRevisionIncludes GetRevisionIncludes()
     {
         return _includeRevisions;
+    }
+
+    public void AddToDispose(IDisposable disposable)
+    {
+        _shardContextsToDispose ??= new List<IDisposable>();
+        _shardContextsToDispose.Add(disposable);
+    }
+
+    public override void Dispose()
+    {
+        if (_shardContextsToDispose == null)
+            return;
+
+        foreach (var disposable in _shardContextsToDispose)
+        {
+            disposable.Dispose();
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Commands/Querying/AbstractShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/Querying/AbstractShardedQueryCommand.cs
@@ -12,13 +12,13 @@ namespace Raven.Server.Documents.Sharding.Commands.Querying;
 
 public abstract class AbstractShardedQueryCommand<TResult, TParameters> : AbstractQueryCommand<TResult, TParameters>, IRaftCommand
 {
-    private readonly BlittableJsonReaderObject _query;
+    private readonly string _query;
 
     public readonly QueryTimingsScope Scope;
 
     protected readonly string IndexName;
     protected AbstractShardedQueryCommand(
-        BlittableJsonReaderObject query,
+        string query,
         IndexQueryBase<TParameters> indexQuery,
         QueryTimingsScope scope,
         bool metadataOnly,

--- a/src/Raven.Server/Documents/Sharding/Commands/Querying/AbstractShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/Querying/AbstractShardedQueryCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Text;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Queries;
@@ -25,8 +26,9 @@ public abstract class AbstractShardedQueryCommand<TResult, TParameters> : Abstra
         bool ignoreLimit,
         string indexName,
         bool canReadFromCache,
-        string raftUniqueRequestId)
-        : base(indexQuery, true, metadataOnly, indexEntriesOnly, ignoreLimit)
+        string raftUniqueRequestId,
+        TimeSpan globalHttpClientTimeout)
+        : base(indexQuery, true, metadataOnly, indexEntriesOnly, ignoreLimit, globalHttpClientTimeout)
     {
         _query = query;
         Scope = scope;
@@ -51,6 +53,6 @@ public abstract class AbstractShardedQueryCommand<TResult, TParameters> : Abstra
     {
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "let's create a server-side query class here and use same code as for QueryCommand");
 
-        return new StringContent(_query.ToString(), Encoding.UTF8, "application/json");
+        return new StringContent(_query, Encoding.UTF8, "application/json");
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Queries;
+﻿using System;
+using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Queries;
@@ -18,8 +19,9 @@ public class ShardedQueryCommand : AbstractShardedQueryCommand<QueryResult, Blit
         bool ignoreLimit,
         string indexName,
         bool canReadFromCache,
-        string raftUniqueRequestId)
-        : base(query, indexQuery, scope, metadataOnly, indexEntriesOnly, ignoreLimit, indexName, canReadFromCache, raftUniqueRequestId)
+        string raftUniqueRequestId,
+        TimeSpan globalHttpClientTimeout)
+        : base(query, indexQuery, scope, metadataOnly, indexEntriesOnly, ignoreLimit, indexName, canReadFromCache, raftUniqueRequestId, globalHttpClientTimeout)
     {
     }
 

--- a/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Sharding.Commands.Querying;
 public class ShardedQueryCommand : AbstractShardedQueryCommand<QueryResult, BlittableJsonReaderObject>
 {
     public ShardedQueryCommand(
-        BlittableJsonReaderObject query,
+        string query,
         IndexQueryServerSide indexQuery,
         QueryTimingsScope scope,
         bool metadataOnly,

--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -109,8 +109,6 @@ public abstract class AbstractExecutor : IDisposable
         foreach (var holder in commands.Values)
         {
             holder.Result = holder.Command.Result;
-
-
         }
 
         var result = operation.CombineCommands(commands);
@@ -120,7 +118,7 @@ public abstract class AbstractExecutor : IDisposable
             if (result == null)
                 return default;
 
-            var blittable = result as BlittableJsonReaderObject;
+            var blittable = result as BlittableJsonReaderObject; //TODO stav: dispose?
             return (TCombinedResult)(object)blittable.Clone(operation.CreateOperationContext());
         }
 
@@ -153,7 +151,7 @@ public abstract class AbstractExecutor : IDisposable
             {
                 ShardNumber = shardNumber,
                 Command = cmd,
-                Task = t,
+                CommandTask = t,
                 ContextReleaser = release
             });
 
@@ -175,7 +173,7 @@ public abstract class AbstractExecutor : IDisposable
         {
             try
             {
-                await command.Task;
+                await command.CommandTask;
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/IShardedOperation.cs
@@ -63,7 +63,8 @@ namespace Raven.Server.Documents.Sharding.Operations
 
     public interface IShardedStreamableOperation : IShardedReadOperation<StreamResult, CombinedStreamResult>
     {
-        ShardedReadResult<CombinedStreamResult> IShardedOperation<StreamResult, ShardedReadResult<CombinedStreamResult>>.Combine(Dictionary<int, ShardExecutionResult<StreamResult>> results) =>
+        ShardedReadResult<CombinedStreamResult> IShardedOperation<StreamResult, ShardedReadResult<CombinedStreamResult>>.Combine(
+            Dictionary<int, ShardExecutionResult<StreamResult>> results) =>
             new() {Result = new CombinedStreamResult {Results = results}};
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries;
@@ -136,7 +137,9 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
         {
             foreach (var (shardNumber, cmdResult) in results)
             {
-                mergedEnumerator.AddEnumerator(GetEnumerator(cmdResult.Result.Results.Clone(Context), shardNumber));
+                mergedEnumerator.AddEnumerator(GetEnumerator(cmdResult.Result.Results, shardNumber));
+                result.AddToDispose(cmdResult.ContextReleaser);
+                cmdResult.ContextReleaser = null;
             }
 
             while (mergedEnumerator.MoveNext())

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -174,12 +174,12 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         return _commands ??= CreateQueryCommands(_queryTemplates, scope);
     }
 
-    protected abstract TCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope);
+    protected abstract TCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope);
 
-    protected ShardedQueryCommand CreateShardedQueryCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope)
+    protected ShardedQueryCommand CreateShardedQueryCommand(int shardNumber, string query, QueryTimingsScope scope)
     {
         return new ShardedQueryCommand(
-            Context.ReadObject(query, "query"),
+            query,
             Query,
             scope?.For($"Shard_{shardNumber}"),
             _metadataOnly,

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -139,5 +139,5 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
         }
     }
 
-    protected override ShardedQueryCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
+    protected override ShardedQueryCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
@@ -56,5 +56,5 @@ public class ShardedIndexEntriesQueryProcessor : ShardedQueryProcessorBase<Shard
 
     protected override ShardedMapReduceQueryResultsMerger CreateMapReduceQueryResultsMerger(ShardedIndexEntriesQueryResult result) => new ShardedMapReduceIndexEntriesQueryResultsMerger(result.Results, RequestHandler.DatabaseContext.Indexes, result.IndexName, IsAutoMapReduceQuery, Context, Token);
 
-    protected override ShardedQueryCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
+    protected override ShardedQueryCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -31,7 +31,7 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
 
     }
 
-    protected override ShardedQueryCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
+    protected override ShardedQueryCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
 
     protected void ApplyPaging(ref TCombinedResult result, QueryTimingsScope scope)
     {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents.Sharding.Queries
             return RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shards, op, Token);
         }
 
-        protected override PostQueryStreamCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope)
+        protected override PostQueryStreamCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope)
         {
             return new PostQueryStreamCommand(query, _debug, _ignoreLimit);
         }

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionQueryProcessor.cs
@@ -70,5 +70,5 @@ public class ShardedSuggestionQueryProcessor : AbstractShardedQueryProcessor<Sha
         }
     }
 
-    protected override ShardedQueryCommand CreateCommand(int shardNumber, BlittableJsonReaderObject query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
+    protected override ShardedQueryCommand CreateCommand(int shardNumber, string query, QueryTimingsScope scope) => CreateShardedQueryCommand(shardNumber, query, scope);
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19730

### Additional description

Improvements made:

- Configurable `GZip` compression between orchestrator and shards - enable/disable. Spent a lot of time on compressing and decompressing. default is no compression;

- Configurable `GlobalHttpClientTimeout` for orchestrator - spent a long time in Microsoft's `HttpClient`'s `CancelAfter()` because there was contention on a lock inside. This function was only called when there was a timeout set for the `HttpClient`.  In order to avoid this path, the timeout configuration's default is set to infinite (-1 ms).
(see here https://github.com/dotnet/runtime/blob/54972b75762f800fddbe1abfe5fce544ae671033/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs#L806").

- Avoid cloning the blittable results that exist on each shard's context to the local orchestrator context. Now keeping them alive until they are written to the stream and only then disposing.

- Now converting the query into a string (`Blittable.ToString()` function) so it will happen once if possible instead of per shard. When the request is not load by id, it is the same for all shards.

Results:

Running the following queries:
Search: `from "Questions" where search("Title",$p0) select Title limit 128`
Load: `session.LoadAsync<dynamic>(someId)`

Client keeps sending requests to maintain a set number of concurrent requests during the entire run.
Run length is ~30 seconds.

**Search Queries**
All queries are for searching on terms that return the most results.
Concurrency: 10

Before Optimizations:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 117 | 83.52 | 154 | 184 | 1421 | 15 | 1447 | 3540
NonSharded | 246 | 39 | 83 | 106 | 1311 | 16 | 1381 | 7412
Orch seperated | 209 | 46.3 | 103 | 134 | 1350 | 17 | 1413 | 6302

<!--EndFragment-->
</body>
</html>

After Optimizations:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 163 | 59.78 | 143 | 184 | 1189 | 20 | 1261 | 4908
NonSharded | 227 | 42.35 | 101 | 122 | 1510 | 13 | 1562 | 6841
Orch seperated | 221 | 43.66 | 101 | 132 | 1592 | 20 | 1635 | 6653

<!--EndFragment-->
</body>
</html>

After Rebase:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 173 | 56.13 | 108 | 123 | 1286 | 15 | 1320 | 5229
NonSharded | 245 | 39.31 | 97 | 109 | 1330 | 10 | 1409 | 7369
Orch seperated | 235 | 40.98 | 91 | 128 | 1208 | 21 | 1266 | 7066

<!--EndFragment-->
</body>
</html>

**Load Queries**
All queries are for Ids that exist in the database
Concurrency: 50
(numbers are a bit unstable)

Before optimizations:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 1971 | 23.53 | 48 | 61 | 105 | 50 | 2689 | 59186
NonSharded | 3436 | 10.15 | 29 | 36 | 60 | 51 | 2748 | 103120
Orch seperated | 2237 | 19.77 | 46 | 69 | 109 | 53 | 2582 | 67160

<!--EndFragment-->
</body>
</html>

After optimizations:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 2777 | 15.11 | 38 | 51 | 175 | 52 | 2624 | 83375
NonSharded | 3267 | 11.51 | 32 | 36 | 63 | 52 | 2436 | 98031
Orch seperated | 2755 | 15.37 | 42 | 52 | 501 | 111 | 1978 | 82687

<!--EndFragment-->
</body>
</html>

After Rebase:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin>

  | req /s | avg | p99 | p995 | p999 | >200ms | max | total reqs
-- | -- | -- | -- | -- | -- | -- | -- | --
Sharding | 2100 | 21.96 | 48 | 68 | 176 | 51 | 2514 | 63056
NonSharded | 3305 | 10.83 | 31 | 39 | 67 | 58 | 2100 | 99185
Orch seperated | 2448 | 18.62 | 55 | 66 | 100 | 52 | 1787 | 73472

<!--EndFragment-->
</body>
</html>

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### UI work

- It requires further work in the Studio - changing timeout configuration to infinite should be possible through studio

