### PR TITLE
RavenDB-19885 Increasing default regex timeout in query | Adding configuration option to change regex timeout value by user.

### DIFF
--- a/src/Raven.Server/Config/Categories/QueryConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/QueryConfiguration.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
 using Raven.Server.Config.Attributes;
+using Raven.Server.Config.Settings;
+using Raven.Server.Documents.Indexes.Configuration;
 
 namespace Raven.Server.Config.Categories
 {
@@ -9,5 +11,12 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(null)]//1024 is Lucene.net default, but we don't set it by default
         [ConfigurationEntry("Query.MaxClauseCount", ConfigurationEntryScope.ServerWideOnly)]
         public int? MaxClauseCount { get; set; }
+        
+        [Description("Timeout for Regex in regex query.")]
+        [TimeUnit(TimeUnit.Milliseconds)]
+        [DefaultValue(100)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Query.RegexTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public TimeSetting RegexTimeout { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -779,7 +779,7 @@ namespace Raven.Server.Documents.Indexes
                 _environment = environment;
                 var safeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(Name);
                 _unmanagedBuffersPool = new UnmanagedBuffersPoolWithLowMemoryHandling($"Indexes//{safeName}");
-
+                _regexCache = new(ConcurrentLruRegexCache.DefaultCapacity, documentDatabase.Configuration.Queries.RegexTimeout.AsTimeSpan);
                 InitializeComponentsUsingEnvironment(documentDatabase, _environment);
 
                 LoadValues();
@@ -3924,7 +3924,7 @@ namespace Raven.Server.Documents.Indexes
 
         internal static readonly TimeSpan DefaultWaitForNonStaleResultsTimeout = TimeSpan.FromSeconds(15); // this matches default timeout from client
 
-        private readonly ConcurrentLruRegexCache _regexCache = new ConcurrentLruRegexCache(1024);
+        private ConcurrentLruRegexCache _regexCache;
 
         internal static bool WillResultBeAcceptable(bool isStale, IndexQueryBase<BlittableJsonReaderObject> query, AsyncWaitForIndexing wait)
         {

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -217,7 +217,7 @@ namespace Raven.Server.Documents.Patch
 
             public string OriginalDocumentId;
             public bool RefreshOriginalDocument;
-            private readonly ConcurrentLruRegexCache _regexCache = new ConcurrentLruRegexCache(1024);
+            private readonly ConcurrentLruRegexCache _regexCache;
             public HashSet<string> DocumentCountersToUpdate;
             public HashSet<string> DocumentTimeSeriesToUpdate;
             public JavaScriptUtils JavaScriptUtils;
@@ -229,6 +229,7 @@ namespace Raven.Server.Documents.Patch
             {
                 _database = database;
                 _configuration = configuration;
+                _regexCache = new(ConcurrentLruRegexCache.DefaultCapacity, configuration.Queries.RegexTimeout.AsTimeSpan);
                 _runner = runner;
                 ScriptEngine = new Engine(options =>
                 {

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -36,7 +36,8 @@ class configurationItem {
         "Indexing.Lucene.IndexInputType",
         "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
         "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
-        "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved"
+        "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
+        "Query.RegexTimeoutInMs"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -79,7 +79,9 @@ namespace FastTests.Issues
                 "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
                 "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
                 "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
-
+                "Query.RegexTimeoutInMs",
+                
+                
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19885
### Additional description

.NET change the internal way of handling timeouts inside Regex:
https://github.com/dotnet/runtime/pull/68146

Sometimes our timeout is not enough to handle those. I've increased the value for timeout and also added a configuration option for a user to change that.

### Type of change

- Bug fix
- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
