### PR TITLE
RavenDB-19895 Use RFC 3161 to timestamp files

### DIFF
--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -47,12 +47,27 @@ function SignFile( $projectDir, $filePath, $dryRun ) {
     }
 
     Write-Host "Signing the following file: $filePath"
-
-    $timeservers = @("http://tsa.starfieldtech.com", "http://timestamp.globalsign.com/scripts/timstamp.dll", "http://timestamp.comodoca.com/authenticode", "http://www.startssl.com/timestamp", "http://timestamp.verisign.com/scripts/timstamp.dll")
+    $timeservers = @(
+        "http://timestamp.digicert.com",
+        "http://timestamp.globalsign.com/tsa/r6advanced1",
+        "http://rfc3161timestamp.globalsign.com/advanced",
+        "http://timestamp.sectigo.com",
+        "http://timestamp.apple.com/ts01",
+        "http://tsa.mesign.com",
+        "http://time.certum.pl",
+        "https://freetsa.org",
+        "http://tsa.startssl.com/rfc3161",
+        "http://dse200.ncipher.com/TSS/HttpTspServer",
+        "http://zeitstempel.dfn.de",
+        "https://ca.signfiles.com/tsa/get.aspx",
+        "http://services.globaltrustfinder.com/adss/tsa",
+        "https://tsp.iaik.tugraz.at/tsp/TspRequest",
+        "http://timestamp.entrust.net/TSS/RFC3161sha2TS"
+    )
     foreach ($time in $timeservers) {
         try {
             Write-Host "Command: $signTool sign /f `"$installerCert`" /p `"PASSWORD`" /d `"RavenDB`" /du `"https://ravendb.net`" /t `"$time`" /v /debug `"$filePath`""
-            exec { & $signTool sign /f "$installerCert" /p "$certPassword" /d "RavenDB" /du "https://ravendb.net" /t "$time" /v /debug "$filePath" }
+            exec { & $signTool sign /f "$installerCert" /p "$certPassword" /fd SHA256 /d "RavenDB" /du "https://ravendb.net" /tr "$time" /td SHA256 /v /debug "$filePath" }
             CheckLastExitCode
             return
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19895

### Additional description

Updated list of timestamp servers and changed timestamp protocol to RFC 3161.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
