### PR TITLE
RavenDB-17068 Sending notification to studio when there is a LoadDocument with missmatch collection in index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2394,14 +2394,14 @@ namespace Raven.Server.Documents.Indexes
 
         private void HandleMismatchedReferences()
         {
-            if (CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.IsEmpty) 
+            if (CurrentIndexingScope.Current.MismatchedReferencesWarningHandler == null || CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.IsEmpty)
                 return;
             
             MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.GetLoadFailures());
 
             DocumentDatabase.NotificationCenter.Indexing.AddWarning(warning);
                 
-            CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.Clear();
+            CurrentIndexingScope.Current.MismatchedReferencesWarningHandler = null;
         }
 
         private void DisposeIndexWriterOnError(Lazy<IndexWriteOperationBase> writeOperation)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2394,14 +2394,14 @@ namespace Raven.Server.Documents.Indexes
 
         private void HandleMismatchedReferences()
         {
-            if (CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences.Count == 0) 
+            if (CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.IsEmpty) 
                 return;
             
-            MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences);
+            MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.GetLoadFailures());
 
             DocumentDatabase.NotificationCenter.Indexing.AddWarning(warning);
                 
-            CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences = null;
+            CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.Clear();
         }
 
         private void DisposeIndexWriterOnError(Lazy<IndexWriteOperationBase> writeOperation)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2328,6 +2328,8 @@ namespace Raven.Server.Documents.Indexes
 
                             IndexFieldsPersistence.Persist(indexContext);
                             HandleReferences(tx);
+
+                            HandleMismatchedReferences();
                         }
 
                         using (stats.For(IndexingOperation.Storage.Commit))
@@ -2388,6 +2390,18 @@ namespace Raven.Server.Documents.Indexes
             DocumentDatabase.NotificationCenter.Indexing.AddWarning(Name, _referenceLoadWarning);
 
             _updateReferenceLoadWarning = false;
+        }
+
+        private void HandleMismatchedReferences()
+        {
+            if (CurrentIndexingScope.Current.MismatchedReferences == null) 
+                return;
+            
+            MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current.MismatchedReferences);
+                
+            DocumentDatabase.NotificationCenter.Indexing.AddWarning(warning);
+                
+            CurrentIndexingScope.Current.MismatchedReferences = null;
         }
 
         private void DisposeIndexWriterOnError(Lazy<IndexWriteOperationBase> writeOperation)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2394,14 +2394,14 @@ namespace Raven.Server.Documents.Indexes
 
         private void HandleMismatchedReferences()
         {
-            if (CurrentIndexingScope.Current.MismatchedReferences == null) 
+            if (CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences.Count == 0) 
                 return;
             
-            MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current.MismatchedReferences);
-                
+            MismatchedReferencesLoadWarning warning = new (Name, CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences);
+
             DocumentDatabase.NotificationCenter.Indexing.AddWarning(warning);
                 
-            CurrentIndexingScope.Current.MismatchedReferences = null;
+            CurrentIndexingScope.Current._mismatchedReferencesHandler.MismatchedReferences = null;
         }
 
         private void DisposeIndexWriterOnError(Lazy<IndexWriteOperationBase> writeOperation)

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -36,15 +36,7 @@ namespace Raven.Server.Documents.Indexes.Static
         /// [collection: [key: [referenceKeys]]]
         public Dictionary<string, Dictionary<Slice, HashSet<Slice>>> ReferencesByCollectionForCompareExchange;
 
-        /*
-        public Dictionary<string, Dictionary<string, LoadFailure>> MismatchedReferences;
-
-        private const int MaxMismatchedReferencesPerSource = 10;
-        private const int MaxMismatchedDocumentLoadsPerIndex = 10;
-        
-        private bool _lastLoadMismatched = false;
-        */
-        internal MismatchedReferencesHandler _mismatchedReferencesHandler = new MismatchedReferencesHandler();
+        public MismatchedReferencesWarningHandler MismatchedReferencesWarningHandler;
 
         [ThreadStatic]
         public static CurrentIndexingScope Current;
@@ -233,19 +225,19 @@ namespace Raven.Server.Documents.Indexes.Static
                 {
                     if (string.Equals(collection, collectionName, StringComparison.OrdinalIgnoreCase) == false)
                     {
-                        if (_mismatchedReferencesHandler.MismatchedReferences.Count < MismatchedReferencesHandler.MaxMismatchedDocumentLoadsPerIndex)
+                        MismatchedReferencesWarningHandler ??= new MismatchedReferencesWarningHandler();
+                        
+                        if (MismatchedReferencesWarningHandler.IsFull == false)
                         {
-                            _mismatchedReferencesHandler._lastLoadMismatched = true;
-                            _mismatchedReferencesHandler.HandleMismatchedReference(document, collectionName, id, collection);
+                            MismatchedReferencesWarningHandler.HandleMismatchedReference(document, collectionName, id, collection);
                         }
 
                         return DynamicNullObject.Null;
                     }
 
-                    if (_mismatchedReferencesHandler._lastLoadMismatched)
+                    if (MismatchedReferencesWarningHandler?.LastLoadMismatched == true)
                     {
-                        _mismatchedReferencesHandler.RemoveMismatchedReferenceOnMatchingLoad(document, id);
-                        _mismatchedReferencesHandler._lastLoadMismatched = false;
+                        MismatchedReferencesWarningHandler.RemoveMismatchedReferenceOnMatchingLoad(document, id);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -262,13 +262,12 @@ namespace Raven.Server.Documents.Indexes.Static
 
         private void HandleMismatchedReference(Document referencedDocument, string referencedCollectionName, LazyStringValue sourceId)
         {
-            //another mismatch for source document
+            // another mismatch for source document
             if(MismatchedReferences.TryGetValue(sourceId, out Dictionary<string, LoadFailure> mismatchesForDocument) && mismatchesForDocument.Count < MaxMismatchedReferencesPerSource)
             {
-                //another mismatch referencing the same document
-                if(mismatchesForDocument.TryGetValue(referencedDocument.Id, out LoadFailure loadFailure))
+                // another mismatch referencing the same document
+                if (mismatchesForDocument.TryGetValue(referencedDocument.Id, out LoadFailure loadFailure))
                     loadFailure.MismatchedCollections.Add(referencedCollectionName);
-
                 else
                 {
                     mismatchesForDocument.Add(
@@ -283,10 +282,9 @@ namespace Raven.Server.Documents.Indexes.Static
                         });
                 }
             }
-
-            //first mismatch for source document
             else
             {
+                // first mismatch for source document
                 LoadFailure failure = new ()
                 {
                     SourceId = sourceId, 

--- a/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesHandler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesHandler.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Indexes.Static;
+
+public class MismatchedReferencesHandler
+{
+    public Dictionary<string, Dictionary<string, LoadFailure>> MismatchedReferences;
+
+    internal const int MaxMismatchedReferencesPerSource = 10;
+    internal const int MaxMismatchedDocumentLoadsPerIndex = 10;
+        
+    internal bool _lastLoadMismatched = false;
+    
+    public class LoadFailure
+    {
+        public string SourceId;
+        public string ReferenceId;
+        public string ActualCollection;
+        public HashSet<string> MismatchedCollections;
+    }
+
+    public MismatchedReferencesHandler()
+    {
+        MismatchedReferences = new Dictionary<string, Dictionary<string, LoadFailure>>();
+    }
+    
+    public void HandleMismatchedReference(Document referencedDocument, string referencedCollectionName, LazyStringValue sourceId, string actualCollection)
+    {
+        // another mismatch for source document
+        if(MismatchedReferences.TryGetValue(sourceId, out Dictionary<string, LoadFailure> mismatchesForDocument) && mismatchesForDocument.Count < MaxMismatchedReferencesPerSource)
+        {
+            // another mismatch referencing the same document
+            if (mismatchesForDocument.TryGetValue(referencedDocument.Id, out LoadFailure loadFailure))
+                loadFailure.MismatchedCollections.Add(referencedCollectionName);
+            else
+            {
+                mismatchesForDocument.Add(
+                    referencedDocument.Id, new LoadFailure()
+                    {
+                        SourceId = sourceId, 
+                        ReferenceId = referencedDocument.Id,
+                        ActualCollection = actualCollection,
+                        MismatchedCollections = new HashSet<string>()
+                        {
+                            referencedCollectionName
+                        } 
+                    });
+            }
+        }
+        else
+        {
+            // first mismatch for source document
+            LoadFailure failure = new ()
+            {
+                SourceId = sourceId, 
+                ReferenceId = referencedDocument.Id,
+                ActualCollection = actualCollection,
+                MismatchedCollections = new HashSet<string>()
+                {
+                    referencedCollectionName
+                }
+            };
+                            
+            MismatchedReferences.Add(sourceId, new Dictionary<string, LoadFailure>(){ {referencedDocument.Id, failure} });
+        }
+    }
+    
+    public void RemoveMismatchedReferenceOnMatchingLoad(Document document, string sourceId)
+    {
+        if (MismatchedReferences.TryGetValue(sourceId, out var failing) == false) 
+            return;
+            
+        failing.Remove(document.Id);
+
+        if (failing.Count == 0)
+            MismatchedReferences.Remove(sourceId);
+
+        if (MismatchedReferences.Count == 0)
+            MismatchedReferences = new Dictionary<string, Dictionary<string, LoadFailure>>();
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesWarningHandler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesWarningHandler.cs
@@ -85,14 +85,6 @@ public class MismatchedReferencesWarningHandler
         if (failing.Count == 0)
             _mismatchedReferences.Remove(sourceId);
 
-        if (_mismatchedReferences.Count == 0)
-            Clear();
-        
         LastLoadMismatched = false;
-    }
-
-    public void Clear()
-    {
-        _mismatchedReferences = new Dictionary<string, Dictionary<string, LoadFailure>>();
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesWarningHandler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MismatchedReferencesWarningHandler.cs
@@ -35,8 +35,11 @@ public class MismatchedReferencesWarningHandler
     public void HandleMismatchedReference(Document referencedDocument, string referencedCollectionName, LazyStringValue sourceId, string actualCollection)
     {
         // another mismatch for source document
-        if(_mismatchedReferences.TryGetValue(sourceId, out Dictionary<string, LoadFailure> mismatchesForDocument) && mismatchesForDocument.Count < MaxMismatchedReferencesPerSource)
+        if(_mismatchedReferences.TryGetValue(sourceId, out Dictionary<string, LoadFailure> mismatchesForDocument))
         {
+            if (mismatchesForDocument.Count >= MaxMismatchedReferencesPerSource)
+                return;
+            
             // another mismatch referencing the same document
             if (mismatchesForDocument.TryGetValue(referencedDocument.Id, out LoadFailure loadFailure))
                 loadFailure.MismatchedCollections.Add(referencedCollectionName);

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -187,7 +187,7 @@ namespace Raven.Server.NotificationCenter
         
         private AlertRaised GetMismatchedReferencesAlert()
         {
-            return AlertRaised.Create(_database, "Loading documents with mismatched collection name",
+            return AlertRaised.Create(_database, $"Loading documents with mismatched collection name in '{_mismatchedReferencesLoadWarning.IndexName}' index",
                 "We have detected usage of LoadDocument(doc, collectionName) where loaded document collection is different than given parameter.",
                 AlertType.MismatchedReferenceLoad, NotificationSeverity.Warning, Source, _mismatchedReferencesLoadWarning);
         }

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -133,19 +133,17 @@ namespace Raven.Server.NotificationCenter
                     ((IndexingReferenceLoadWarning)referenceLoadsHint.Details).Update(tuple.indexName, tuple.warningDetails);
                 }
 
-                AlertRaised mismatchedReferencesAlert = null;
-                
-                if (_mismatchedReferencesLoadWarning != null) 
-                    mismatchedReferencesAlert = GetMismatchedReferencesAlert();
-                
                 if (indexOutputPerDocumentHint != null)
                     _notificationCenter.Add(indexOutputPerDocumentHint);
 
                 if (referenceLoadsHint != null)
                     _notificationCenter.Add(referenceLoadsHint);
                 
-                if (mismatchedReferencesAlert != null)
+                if (_mismatchedReferencesLoadWarning != null)
+                {
+                    AlertRaised mismatchedReferencesAlert = GetMismatchedReferencesAlert();
                     _notificationCenter.Add(mismatchedReferencesAlert);
+                }
             }
             catch (Exception e)
             {
@@ -191,7 +189,7 @@ namespace Raven.Server.NotificationCenter
         {
             return AlertRaised.Create(_database, "Loading documents with mismatched collection name",
                 "We have detected usage of LoadDocument(doc, collectionName) where loaded document collection is different than given parameter.",
-                AlertType.Etl_Warning, NotificationSeverity.Warning, Source, _mismatchedReferencesLoadWarning);
+                AlertType.MismatchedReferenceLoad, NotificationSeverity.Warning, Source, _mismatchedReferencesLoadWarning);
         }
 
         public void Dispose()

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -189,8 +189,8 @@ namespace Raven.Server.NotificationCenter
         
         private AlertRaised GetMismatchedReferencesAlert()
         {
-            return AlertRaised.Create(_database, "bla bla",
-                "bla bla",
+            return AlertRaised.Create(_database, "Loading documents with mismatched collection name",
+                "We have detected usage of LoadDocument(doc, collectionName) where loaded document collection is different than given parameter.",
                 AlertType.Etl_Warning, NotificationSeverity.Warning, Source, _mismatchedReferencesLoadWarning);
         }
 

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -135,7 +135,7 @@ namespace Raven.Server.NotificationCenter
 
                 AlertRaised mismatchedReferencesAlert = null;
                 
-                if(_mismatchedReferencesLoadWarning != null) 
+                if (_mismatchedReferencesLoadWarning != null) 
                     mismatchedReferencesAlert = GetMismatchedReferencesAlert();
                 
                 if (indexOutputPerDocumentHint != null)
@@ -144,7 +144,7 @@ namespace Raven.Server.NotificationCenter
                 if (referenceLoadsHint != null)
                     _notificationCenter.Add(referenceLoadsHint);
                 
-                if(mismatchedReferencesAlert != null)
+                if (mismatchedReferencesAlert != null)
                     _notificationCenter.Add(mismatchedReferencesAlert);
             }
             catch (Exception e)

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -78,6 +78,8 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         UnrecoverableClusterError,
         
-        MicrosoftLogsConfigurationLoadError
+        MicrosoftLogsConfigurationLoadError,
+        
+        MismatchedReferenceLoad
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
@@ -15,7 +15,7 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
         //deserialization
     }
     
-    public MismatchedReferencesLoadWarning(string indexName, Dictionary<string, Dictionary<string, CurrentIndexingScope.LoadFailure>> mismatchedReferences)
+    public MismatchedReferencesLoadWarning(string indexName, Dictionary<string, Dictionary<string, MismatchedReferencesHandler.LoadFailure>> mismatchedReferences)
     {
         IndexName = indexName;
         
@@ -77,7 +77,7 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
             //deserialization
         }
         
-        public WarningDetails(CurrentIndexingScope.LoadFailure loadFailure)
+        public WarningDetails(MismatchedReferencesHandler.LoadFailure loadFailure)
         {
             SourceId = loadFailure.SourceId;
             ReferenceId = loadFailure.ReferenceId;

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
@@ -12,10 +12,10 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
 
     public MismatchedReferencesLoadWarning()
     {
-        //deserialization
+        // deserialization
     }
     
-    public MismatchedReferencesLoadWarning(string indexName, Dictionary<string, Dictionary<string, MismatchedReferencesHandler.LoadFailure>> mismatchedReferences)
+    public MismatchedReferencesLoadWarning(string indexName, Dictionary<string, Dictionary<string, MismatchedReferencesWarningHandler.LoadFailure>> mismatchedReferences)
     {
         IndexName = indexName;
         
@@ -74,10 +74,10 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
 
         public WarningDetails()
         {
-            //deserialization
+            // deserialization
         }
         
-        public WarningDetails(MismatchedReferencesHandler.LoadFailure loadFailure)
+        public WarningDetails(MismatchedReferencesWarningHandler.LoadFailure loadFailure)
         {
             SourceId = loadFailure.SourceId;
             ReferenceId = loadFailure.ReferenceId;

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
@@ -50,6 +50,7 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
                 {
                     [nameof(WarningDetails.ReferenceId)] = details.ReferenceId,
                     [nameof(WarningDetails.SourceId)] = details.SourceId,
+                    [nameof(WarningDetails.ActualCollection)] = details.ActualCollection,
                     [nameof(WarningDetails.MismatchedCollections)] = details.MismatchedCollections
                 });
             }
@@ -68,6 +69,7 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
     {
         public string SourceId { get; set; }
         public string ReferenceId { get; set; }
+        public string ActualCollection { get; set; }
         public HashSet<string> MismatchedCollections { get; set; }
 
         public WarningDetails()
@@ -80,6 +82,7 @@ public class MismatchedReferencesLoadWarning : INotificationDetails
             SourceId = loadFailure.SourceId;
             ReferenceId = loadFailure.ReferenceId;
             MismatchedCollections = loadFailure.MismatchedCollections;
+            ActualCollection = loadFailure.ActualCollection;
         }
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/MismatchedReferencesLoadWarning.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using Raven.Server.Documents.Indexes.Static;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details;
+
+public class MismatchedReferencesLoadWarning : INotificationDetails
+{
+    public Dictionary<string, List<WarningDetails>> Warnings { get; set; }
+    
+    public string IndexName { get; set; }
+
+    public MismatchedReferencesLoadWarning()
+    {
+        //deserialization
+    }
+    
+    public MismatchedReferencesLoadWarning(string indexName, Dictionary<string, Dictionary<string, CurrentIndexingScope.LoadFailure>> mismatchedReferences)
+    {
+        IndexName = indexName;
+        
+        Warnings = new Dictionary<string, List<WarningDetails>>();
+
+        foreach (var warningsForDocument in mismatchedReferences)
+        {
+            List<WarningDetails> warningsForDocumentList = new();
+            
+            foreach (var warning in warningsForDocument.Value)
+            {
+                warningsForDocumentList.Add(new WarningDetails(warning.Value));
+            }
+            
+            Warnings.Add(warningsForDocument.Key, warningsForDocumentList);
+        }
+    }
+    
+    public DynamicJsonValue ToJson()
+    {
+        var djv = new DynamicJsonValue(GetType());
+
+        var listOfWarnings = new DynamicJsonValue();
+
+        foreach (var warning in Warnings)
+        {
+            var warningsForDocument = new DynamicJsonArray();
+            
+            foreach (var details in warning.Value)
+            {
+                warningsForDocument.Add( new DynamicJsonValue
+                {
+                    [nameof(WarningDetails.ReferenceId)] = details.ReferenceId,
+                    [nameof(WarningDetails.SourceId)] = details.SourceId,
+                    [nameof(WarningDetails.MismatchedCollections)] = details.MismatchedCollections
+                });
+            }
+            
+            listOfWarnings[warning.Key] = warningsForDocument;
+        }
+
+        djv[nameof(Warnings)] = listOfWarnings;
+
+        djv[nameof(IndexName)] = IndexName;
+
+        return djv;
+    }
+    
+    public class WarningDetails
+    {
+        public string SourceId { get; set; }
+        public string ReferenceId { get; set; }
+        public HashSet<string> MismatchedCollections { get; set; }
+
+        public WarningDetails()
+        {
+            //deserialization
+        }
+        
+        public WarningDetails(CurrentIndexingScope.LoadFailure loadFailure)
+        {
+            SourceId = loadFailure.SourceId;
+            ReferenceId = loadFailure.ReferenceId;
+            MismatchedCollections = loadFailure.MismatchedCollections;
+        }
+    }
+}

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -54,6 +54,8 @@ import dumpRawIndexDataDetails = require("viewmodels/common/notificationCenter/d
 
 import studioSettings = require("common/settings/studioSettings");
 import optimizeIndexDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/optimizeIndexDetails");
+import mismatchedReferenceLoadDetails
+    from "viewmodels/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails";
 
 interface detailsProvider {
     supportsDetailsFor(notification: abstractNotification): boolean;
@@ -172,6 +174,7 @@ class notificationCenter {
             // alerts:
             newVersionAvailableDetails,
             etlTransformOrLoadErrorDetails,
+            mismatchedReferenceLoadDetails,
 
             genericAlertDetails  // leave it as last item on this list - this is fallback handler for all alert types
         );

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails.ts
@@ -1,0 +1,91 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import alert = require("common/notifications/models/alert");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import abstractAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/abstractAlertDetails");
+import MismatchedReferencesLoadWarning = Raven.Server.NotificationCenter.Notifications.Details.MismatchedReferencesLoadWarning;
+import genUtils from "common/generalUtils";
+
+interface WarningItem {
+    actualCollection: string;
+    mismatchedCollections: string[];
+    referenceId: string;
+    sourceId: string;
+}
+
+class mismatchedReferenceLoadDetails extends abstractAlertDetails {
+    
+    view = require("views/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails.html");
+
+    tableItems: WarningItem[] = [];
+    private gridController = ko.observable<virtualGridController<WarningItem>>();
+    private columnPreview = new columnPreviewPlugin<WarningItem>();
+
+    constructor(alert: alert, notificationCenter: notificationCenter) {
+        super(alert, notificationCenter);
+
+        const warning = this.alert.details() as MismatchedReferencesLoadWarning;
+        
+        Object.values(warning.Warnings).forEach(perSourceList => {
+            this.tableItems.push(...perSourceList.map(x => ({
+                actualCollection: x.ActualCollection,
+                mismatchedCollections: x.MismatchedCollections,
+                referenceId: x.ReferenceId,
+                sourceId: x.SourceId
+            })))
+        });
+    }
+    
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(() => this.fetcher(), () => {
+            const sourceIdColumn = new textColumn<WarningItem>(grid, x => x.sourceId, "Source ID", "25%", {
+                sortable: x => x.sourceId
+            });
+            const referenceId = new textColumn<WarningItem>(grid, x => x.referenceId, "Reference ID", "25%", {
+                sortable: x => x.referenceId
+            });
+            const actualCollectionColumn = new textColumn<WarningItem>(grid, x => x.actualCollection, "Actual Collection", "25%", {
+                sortable: x => x.actualCollection
+            });
+            const mismatchedCollectionColumn = new textColumn<WarningItem>(grid, x => x.mismatchedCollections.join(", "), "Mismatched collections", "25%");
+
+            return [sourceIdColumn, referenceId, actualCollectionColumn, mismatchedCollectionColumn];
+        });
+        
+        this.columnPreview.install(".mismatchedReferenceLoadDetails", ".js-mismatched-reference-load-tooltip",
+            (details: WarningItem,
+             column: textColumn<WarningItem>,
+             e: JQueryEventObject, onValue: (context: any, valueToCopy?: string) => void) => {
+                const value = column.getCellValue(details);
+                if (value) {
+                    onValue(genUtils.escapeHtml(value), value);
+                }
+            });
+    }
+    
+    private fetcher(): JQueryPromise<pagedResult<WarningItem>> {
+        return $.Deferred<pagedResult<WarningItem>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+    
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof alert) && notification.alertType() === "MismatchedReferenceLoad";
+    }
+
+    static showDetailsFor(alert: alert, center: notificationCenter) {
+        return app.showBootstrapDialog(new mismatchedReferenceLoadDetails(alert, center));
+    }
+}
+
+export = mismatchedReferenceLoadDetails;

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails.html
@@ -1,0 +1,23 @@
+<div class="modal-dialog modal-lg mismatchedReferenceLoadDetails" id="js-mismatched-reference-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: alert">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: alert.message"></h3>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-mismatched-reference-load-tooltip" style="opacity: 0">
+</div>

--- a/test/SlowTests/Issues/RavenDB-17068.cs
+++ b/test/SlowTests/Issues/RavenDB-17068.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17068: RavenTestBase
+{
+    public RavenDB_17068(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [InlineData(@"from index 'DummyIndex' as o")]
+    public async Task Temp(string q)
+    {
+        using var store = GetDocumentStore();
+        var db = await GetDatabase(store.Database);
+        
+        var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
+        using (db.NotificationCenter.TrackActions(notificationsQueue, null))
+        using (var session = store.OpenSession())
+        {
+            var c1 = new Cat() { Name = "Bingus" };
+            var c2 = new Cat() { Name = "Kitty" };
+            var c3 = new Cat() { Name = "Jinx" };
+            var c4 = new Cat() { Name = "Cat" };
+
+            session.Store(c1);
+            session.Store(c2);
+            session.Store(c3);
+            session.Store(c4);
+            
+            var d1 = new Dog() { Name = "Doggo" };
+            
+            session.Store(d1);
+
+            var o1 = new Order() { AnimalId = c1.Id, AnimalId2 = c2.Id, AnimalId3 = c3.Id, AnimalId4 = c4.Id, Price = 21 };
+            var o2 = new Order() { AnimalId = c2.Id, Price = 37 };
+            var o3 = new Order() { AnimalId = c3.Id, Price = 11 };
+            var o4 = new Order() { AnimalId = c4.Id, Price = 22 };
+            
+            session.Store(o1);
+            session.Store(o2);
+            session.Store(o3);
+            session.Store(o4);
+            
+            session.SaveChanges();
+
+            var index = new DummyIndex();
+            
+            await index.ExecuteAsync(store);
+            Indexes.WaitForIndexing(store);
+            Tuple<bool, DynamicJsonValue> alertRaised;
+
+            do
+            {
+                alertRaised = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                
+            } while (alertRaised.Item2["Type"].ToString() != NotificationType.AlertRaised.ToString());
+            
+            var details = alertRaised.Item2[nameof(AlertRaised.Details)] as DynamicJsonValue;
+            
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                var json = ctx.ReadObject(details, "foo");
+
+                var detailsObject = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<MismatchedReferencesLoadWarning>(json, "Warnings");
+            }
+        }
+    }
+    
+    private class DummyIndex : AbstractIndexCreationTask<Order>
+    {
+        public DummyIndex()
+        {
+            Map = orders => from o in orders
+                let a = LoadDocument<Animal>(o.AnimalId, "Cats") ?? LoadDocument<Animal>(o.AnimalId, "Dogs")
+                let nothing = LoadDocument<object>(o.AnimalId, "NotAnAnimal") ?? LoadDocument<object>(o.AnimalId, "zzz")
+                let nothing2 = LoadDocument<object>(o.AnimalId2, "NotAnAnimal2")
+                let nothing3 = LoadDocument<object>(o.AnimalId3, "NotAnAnimal3")
+                let nothing4 = LoadDocument<object>(o.AnimalId4, "NotAnAnimal4")
+                select new { Content = a.Name };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class Order
+    {
+        public string Id { get; set; }
+        public string AnimalId { get; set; }
+        
+        public string AnimalId2 { get; set; }
+        
+        public string AnimalId3 { get; set; }
+        
+        public string AnimalId4 { get; set; }
+        public int Price { get; set; }
+    }
+    
+    private class Animal
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Cat
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Dog
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17068.cs
+++ b/test/SlowTests/Issues/RavenDB-17068.cs
@@ -78,6 +78,7 @@ public class RavenDB_17068: RavenTestBase
                 Assert.Equal(1, warnings.Count);
                 Assert.Equal("animals/1-A", warnings.First().ReferenceId);
                 Assert.Equal("orders/2-A", warnings.First().SourceId);
+                Assert.Equal("Animals", warnings.First().ActualCollection);
                 Assert.Equal(2, warnings.First().MismatchedCollections.Count);
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17068.cs
+++ b/test/SlowTests/Issues/RavenDB-17068.cs
@@ -65,7 +65,7 @@ public class RavenDB_17068: RavenTestBase
             } while (alertRaised.Item2["Type"].ToString() != NotificationType.AlertRaised.ToString());
             
             var details = alertRaised.Item2[nameof(AlertRaised.Details)] as DynamicJsonValue;
-            
+
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
             {
                 var json = ctx.ReadObject(details, "foo");

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -239,6 +239,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(PagingPerformanceDetails));
             scripter.AddType(typeof(HugeDocumentsDetails));
             scripter.AddType(typeof(HugeDocumentInfo));
+            scripter.AddType(typeof(MismatchedReferencesLoadWarning));
             scripter.AddType(typeof(RequestLatencyDetail));
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));
             scripter.AddType(typeof(IndexingReferenceLoadWarning));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17068/Raise-a-notification-in-studio-when-there-is-a-LoadDocument-with-missmatch-collection-in-index

### Additional description

We want to raise notification in studio when user loads a document from different collection than given as a parameter

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
