### PR TITLE
RavenDB-19541 Allow to Select() after ProjectInto()

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2752,6 +2752,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             var memberExpression = ((MemberExpression)body);
 
             var selectPath = GetSelectPath(memberExpression);
+            FieldsToFetch.Clear(); // this overwrite any previous projection
             AddToFieldsToFetch(selectPath, selectPath);
 
             if (_insideSelect == 1)

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2570,6 +2570,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
         private void SelectCall(Expression body, LambdaExpression lambdaExpression)
         {
+            FieldsToFetch?.Clear();
+
             if (body is MethodCallExpression call)
             {
                 if (LinqPathProvider.IsTimeSeriesCall(call))
@@ -2603,13 +2605,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 throw new NotSupportedException($"Using constructor with parameters in projection is not supported. {memberInitExpression}");
             
             _newExpressionType = memberInitExpression.NewExpression.Type;
+            FieldsToFetch?.Clear();
 
             if (_declareBuilder != null)
             {
                 AddReturnStatementToOutputFunction(memberInitExpression);
                 return;
             }
-
+            
             if (FromAlias != null)
             {
                 //lambda 2 js
@@ -2664,7 +2667,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     AddFromAlias(lambdaExpression?.Parameters[0].Name);
                 }
 
-                FieldsToFetch.Clear();
+                FieldsToFetch?.Clear();
                 _jsSelectBody = TranslateSelectBodyToJs(memberInitExpression);
 
                 break;
@@ -2681,6 +2684,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
 
             _newExpressionType = newExpression.Type;
+            FieldsToFetch?.Clear();
 
             if (_declareBuilder != null)
             {
@@ -2741,7 +2745,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     AddFromAlias(lambdaExpression?.Parameters[0].Name);
                 }
 
-                FieldsToFetch.Clear();
+                FieldsToFetch?.Clear();
                 _jsSelectBody = TranslateSelectBodyToJs(newExpression);
                 break;
             }
@@ -2752,10 +2756,10 @@ The recommended method is to use full text search (mark the field as Analyzed an
             var memberExpression = ((MemberExpression)body);
 
             var selectPath = GetSelectPath(memberExpression);
-            FieldsToFetch.Clear(); // this overwrite any previous projection
+            FieldsToFetch?.Clear(); // this overwrite any previous projection
             AddToFieldsToFetch(selectPath, selectPath);
 
-            if (_insideSelect == 1)
+            if (_insideSelect == 1 && FieldsToFetch != null)
             {
                 foreach (var fieldToFetch in FieldsToFetch)
                 {

--- a/test/SlowTests/Issues/GH-15634.cs
+++ b/test/SlowTests/Issues/GH-15634.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Server.Documents.Indexes.Static.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class GH_15634 : RavenTestBase
+{
+    public GH_15634(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    
+    [Fact]
+    public async Task CanProjectFromProjectInto()
+    {
+        using var store = GetDocumentStore();
+        store.ExecuteIndex(new EntityBaseIndex());
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Asset { Id = "Asset/d07bba18-685f-4eb8-b974-ed2ab5aa1ff5", Tags = new() { "tag1", "tag2" } });
+            await session.StoreAsync(new Asset { Id = "Asset/bca893c9-c8c6-4913-b373-df2547aa128a", Tags = new() { "tag2" } });
+            await session.StoreAsync(new Asset { Id = "Asset/d322936f-66e0-463f-8cda-cf5031b97d8d", Tags = new() { "tag1" } });
+            await session.StoreAsync(new Asset { Id = "Asset/d2646c1f-edee-44fc-b173-093589493726", Tags = new() { "tag1", "tag2" } });
+            await session.SaveChangesAsync();
+        }
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var assignableTypeNames = new[] { "Asset" };
+            var tags = new[] { "tag1", "tag2" };
+
+            // this query works using RavenDb.Client <=5.4.2
+            // from version 5.4.3, it fails with a JsonSerializationException
+            var ravenQueryable = session.Query<EntityBaseResult>("EntityBaseIndex")
+                .ProjectInto<EntityBaseResult>()
+                .Where(d => d.ModelType.In(assignableTypeNames))
+                .Where(a => a.Tags.ContainsAll(tags))
+                .Select(a => a.Tags_Count );
+            var results = await ravenQueryable.ToListAsync();
+            Assert.NotEmpty(results);
+            Assert.Equal(2, results[0]);
+        }
+    }
+    class EntityBaseIndex : AbstractIndexCreationTask<Asset>
+    {
+        public EntityBaseIndex()
+        {
+            Map = assets => from asset in assets
+                select new EntityBaseResult
+                {
+                    DatabaseId = asset.Id,
+                    ModelType = asset.ModelType,
+                    Tags = asset.Tags,
+                    Tags_Count = asset.Tags.Count,
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    class Asset
+    {
+        public string Id { get; set; } = "";
+        public HashSet<string> Tags { get; set; } = new();
+        public string ModelType => GetType().Name;
+    }
+
+    class EntityBaseResult
+    {
+        public string DatabaseId { get; set; } = "";
+        public string ModelType { get; set; } = "";
+        public IEnumerable<string> Tags { get; set; } = default!;
+        public int Tags_Count { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19541.cs
+++ b/test/SlowTests/Issues/RavenDB-19541.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+using Raven.Server.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19541 : RavenTestBase
+{
+    public RavenDB_19541(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanProjectOnlyOneFieldAfterProjectInto() // Hits: ExpressionType.MemberAccess
+    {
+        using var store = GetDocumentStoreWithDocuments();
+        using var session = OpenSessionAndGetProjectIntoQuery(store, out var projectIntoQuery);
+
+        var selectSingle = projectIntoQuery.Select(i => i.FirstName);
+
+        Assert.Equal("from index 'CapsLockIndex' where FirstName = $p0 select FirstName", selectSingle.ToString());
+        Assert.Equal("MACIEJ", selectSingle.Single());
+    }
+
+    [Fact]
+    public void CanProjectIntoAnonymousAfterProjectInfo() // Hits:  ExpressionType.New
+    {
+        using var store = GetDocumentStoreWithDocuments();
+        using var session = OpenSessionAndGetProjectIntoQuery(store, out var projectIntoQuery);
+        var selectAnonymous = projectIntoQuery.Select(i => new {i.FirstName, i.FavoriteFood});
+        Assert.Equal("from index 'CapsLockIndex' where FirstName = $p0 select FirstName, FavoriteFood", selectAnonymous.ToString());
+        Assert.Equal("MACIEJ", selectAnonymous.Single().FirstName);
+        Assert.Equal("Zylc", selectAnonymous.Single().FavoriteFood);
+    }
+
+    private class MemberInitProjection
+    {
+        public string FirstName { get; set; }
+
+        public string FavoriteFood { get; set; }
+    }
+
+    [Fact]
+    public void CanProjectIntoKnownMemberAfterProjectInfo() // Hits:  ExpressionType.MemberInit
+    {
+        using var store = GetDocumentStoreWithDocuments();
+        using var session = OpenSessionAndGetProjectIntoQuery(store, out var projectIntoQuery);
+        var selectAnonymous = projectIntoQuery.Select(i => new MemberInitProjection() {FirstName = i.FirstName, FavoriteFood = i.FavoriteFood});
+
+        Assert.Equal("from index 'CapsLockIndex' where FirstName = $p0 select FirstName, FavoriteFood", selectAnonymous.ToString());
+        Assert.Equal("MACIEJ", selectAnonymous.Single().FirstName);
+        Assert.Equal("Zylc", selectAnonymous.Single().FavoriteFood);
+    }
+
+    [Fact]
+    public void CanProjectIntoCallAfterProjectInfo() // Hits:  ExpressionType.Call
+    {
+        using var store = GetDocumentStoreWithDocuments();
+        using var session = OpenSessionAndGetProjectIntoQuery(store, out var projectIntoQuery);
+        var selectAnonymous = projectIntoQuery.Select(into => into.Props["nested"]);
+
+        Assert.Equal("from index 'CapsLockIndex' where FirstName = $p0 select Props_nested", selectAnonymous.ToString());
+        Assert.Equal(1, selectAnonymous.Single());
+    }
+
+    private IDocumentSession OpenSessionAndGetProjectIntoQuery(IDocumentStore store, out IRavenQueryable<ProjectionInto> projectIntoQuery)
+    {
+        var session = store.OpenSession();
+        projectIntoQuery = Queryable.Where(session.Query<FullData, CapsLockIndex>(), i => i.FirstName == "maciej").ProjectInto<ProjectionInto>();
+        Assert.Equal("from index 'CapsLockIndex' where FirstName = $p0 select FirstName, LastNameName, Age, FavoriteFood, Props", projectIntoQuery.ToString());
+        return session;
+    }
+
+    private IDocumentStore GetDocumentStoreWithDocuments()
+    {
+        Assert.True(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion < 60_000); //This tests will be removed (or changed to Assert on exceptions). This is the guardian to check them during merge.  
+
+        var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new FullData("Maciej", "John", 123, "Zylc", "Torun", "Szeroka", new Dictionary<string, int> {{"nested", 1}}));
+            session.Store(new FullData("John", "Book", 99, "Burger", "New York", "French street", default));
+            session.SaveChanges();
+        }
+
+        new CapsLockIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+        return store;
+    }
+
+    private class CapsLockIndex : AbstractIndexCreationTask<FullData>
+    {
+        public CapsLockIndex()
+        {
+            Map = data => from i in data
+                let x = i.Props == null ? -1 : i.Props["nested"]
+                select new
+                {
+                    FirstName = i.FirstName.ToUpper(CultureInfo.InvariantCulture),
+                    Age = i.Age % 97,
+                    City = i.City.ToLowerInvariant(),
+                    Props_nested = x
+                };
+
+            Store(i => i.FirstName, FieldStorage.Yes);
+            Store(i => i.Age, FieldStorage.Yes);
+            Store(i => i.City, FieldStorage.Yes);
+            Store("Props_nested", FieldStorage.Yes);
+        }
+    }
+
+    private class FullData
+    {
+        public FullData()
+        {
+        }
+        
+        public FullData(string firstName, string lastName, int age, string favoriteFood, string city, string street, Dictionary<string, int> props)
+        {
+            FirstName = firstName;
+            LastName = lastName;
+            Age = age;
+            FavoriteFood = favoriteFood;
+            City = city;
+            Street = street;
+            Props = props;
+        }
+        
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public int Age { get; set; }
+        public string FavoriteFood { get; set; }
+        public string City { get; set; }
+        public string Street { get; set; }
+        public Dictionary<string, int> Props { get; set; }
+    }
+
+    private class ProjectionInto
+    {
+        public string FirstName { get; set; }
+        public string LastNameName { get; set; }
+        public int Age { get; set; }
+        public string FavoriteFood { get; set; }
+
+        public Dictionary<string, int> Props { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19541 
https://issues.hibernatingrhinos.com/issue/RavenDB-19831


### Additional description

In https://github.com/ravendb/ravendb/pull/14794, we fixed a bug related to .As<T>. Since .As<T> is a client-side query type casting operation, it should not have an impact on the generated RQL. However, it did have an impact because it called `For<TS>`, which deleted the previous FieldsToFetch (all select functions go through it). Since this fix is a breaking change, we restored the previous behavior.

This behavior is only valid up to version 5.X. Starting from version 6.0, we turned off the possibility to do chained projections because it is confusing and problematic to determine what the user really wants to get from the server. [RavenDB-19440](https://issues.hibernatingrhinos.com/issue/RavenDB-19440/Duplicated-id-in-RQL-when-using-ProjectInto
)

### Type of change

- Regression bug fix


### How risky is the change?

- Moderate 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- Tested on 5.3.101 to check if it restores previous behavior.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
