### PR TITLE
RavenDB-19964 Fixed dynamic returns marking

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -155,8 +155,6 @@ namespace Raven.Server.Documents.Indexes.Static
 
                         if (IsBoostExpression(ce))
                             HasBoostedFields = true;
-                        else if (IsCreateDynamicExpression(ce))
-                            HasDynamicReturns = true;
                         else if (IsArrowFunctionExpressionWithObjectExpressionBody(ce, out var oea))
                         {
                             foreach (var prop in oea.Properties)
@@ -170,7 +168,8 @@ namespace Raven.Server.Documents.Indexes.Static
                                 }
                             }
                         }
-
+                        else
+                            HasDynamicReturns = true;
                         break;
 
                     default:
@@ -184,11 +183,6 @@ namespace Raven.Server.Documents.Indexes.Static
                 return expression is CallExpression ce && ce.Callee is Identifier identifier && identifier.Name == "boost";
             }
             
-            static bool IsCreateDynamicExpression(Expression expression)
-            {
-                return expression is CallExpression ce && ce.Callee is Identifier identifier && identifier.Name == "createField";
-            }
-
             static bool IsArrowFunctionExpressionWithObjectExpressionBody(CallExpression callExpression, out ObjectExpression oea)
             {
                 oea = null;

--- a/test/SlowTests/Issues/RavenDB-19964.cs
+++ b/test/SlowTests/Issues/RavenDB-19964.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19964 : RavenTestBase
+{
+    public RavenDB_19964(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void CheckIfDynamicReturnsAreMarkedForQuery()
+    {
+        using var store = GetDocumentStore();
+        
+        using var file1 = new MemoryStream();
+        using var file2 = new MemoryStream();
+
+        file1.Write(Encodings.Utf8.GetBytes(new string('a', 5)).AsSpan());
+        file2.Write(Encodings.Utf8.GetBytes(new string('b', 4)).AsSpan());
+
+        file1.Position = 0;
+        file2.Position = 0;
+
+        using (var session = store.OpenSession())
+        {
+            User u1 = new(){Name = "abc"};
+
+            session.Store(u1);
+            
+            session.Advanced.Attachments.Store(u1.Id, "f1.txt", file1);
+            session.Advanced.Attachments.Store(u1.Id, "f2.txt", file2);
+            
+            session.SaveChanges();
+            
+            store.ExecuteIndex(new UsersByAttachments());
+            
+            Indexes.WaitForIndexing(store);
+            
+            WaitForUserToContinueTheTest(store);
+
+            string query = @"from index 'UsersByAttachments' where name = ""abc""";
+
+            var res = session.Advanced
+                .RawQuery<object>(query)
+                .WaitForNonStaleResults().ToList();
+            
+            Assert.Equal(1, res.Count);
+        }
+    }
+    
+    private class User
+    {
+        public string Id { get; set; }
+        
+        public string Name { get; set; }
+    }
+    
+    private class UsersByAttachments : AbstractJavaScriptIndexCreationTask
+    {
+        public UsersByAttachments()
+        {
+            Maps = new HashSet<string> { 
+                @"map('Users', user => {
+                      const attachments = attachmentsFor(user);
+                      return attachments.map(a => {
+                          return {
+                              name: user.Name,
+                              attachmentName: a.Name
+                          };
+                      });
+                })" 
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19964/RavenException-System.ArgumentException-The-field-name-is-not-indexed-for-index-Users-Attachments-cannot-query-sort-on-fields

### Additional description

Now we set HasDynamicReturns as true when CallExpression isn't BoostExpression and we can't extract field names easily from JS index. It's a regression bug introduced in https://github.com/ravendb/ravendb/pull/15692

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
