### PR TITLE
RavenDB-19965 Handle retry of BatchPatch, server generated id & attachments

### DIFF
--- a/src/Raven.Client/Documents/Operations/Attachments/LimitedStream.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/LimitedStream.cs
@@ -117,7 +117,6 @@ namespace Raven.Client.Documents.Operations.Attachments
                     if (read == 0)
                         break;
 
-                    _read += read;
                     OverallRead += read;
                 }
 
@@ -145,7 +144,6 @@ namespace Raven.Client.Documents.Operations.Attachments
                     if (read == 0)
                         break;
 
-                    _read += read;
                     OverallRead += read;
                 }
 

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        protected virtual void ValidateId(Slice lowerId)
+        public virtual void ValidateId(Slice lowerId)
         {
 
         }

--- a/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
@@ -21,7 +21,7 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Handlers.Batches;
 
-public abstract class AbstractBatchCommandsReader<TBatchCommand, TOperationContext>
+public abstract class AbstractBatchCommandsReader<TBatchCommand, TOperationContext> : IDisposable
     where TBatchCommand : IBatchCommand
     where TOperationContext : JsonOperationContext
 {
@@ -242,5 +242,9 @@ public abstract class AbstractBatchCommandsReader<TBatchCommand, TOperationConte
     {
         throw new InvalidOperationException($"You cannot use change vector ({commandData.ChangeVector}) " +
                                             $"when using identity in the document ID ({commandData.Id}).");
+    }
+
+    public virtual void Dispose()
+    {
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -30,8 +30,7 @@ namespace Raven.Server.Documents.Handlers.Batches
     {
         internal static BatchRequestParser Instance = new BatchRequestParser();
 
-        // TODO sharding: CommandData seems to grew beyond the good practice of struct
-        public struct CommandData : IBatchCommandData
+        public class CommandData : IBatchCommandData
         {
             public CommandType Type { get; set; }
             public string Id { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -41,8 +41,7 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
         var indexBatchOptions = GetIndexBatchOptions();
         var replicationBatchOptions = GetReplicationBatchOptions();
 
-        var commandsReader = GetCommandsReader();
-
+        using (var commandsReader = GetCommandsReader())
         using (ContextPool.AllocateOperationContext(out TOperationContext context))
         {
             var contentType = HttpContext.Request.ContentType;

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -13,6 +13,7 @@ using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Voron;
 
 namespace Raven.Server.Documents.Patch
 {
@@ -64,6 +65,11 @@ namespace Raven.Server.Documents.Patch
             run.DebugMode = _debugMode;
             if (runIfMissing != null)
                 runIfMissing.DebugMode = _debugMode;
+
+            using (DocumentIdWorker.GetLower(context.Allocator, id, out Slice lowerId))
+            {
+                _database.DocumentsStorage.DocumentPut.ValidateId(lowerId);
+            }
 
             var originalDocument = GetCurrentDocument(context, id);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/BatchPatchSingleShardedCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/BatchPatchSingleShardedCommand.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Batches;
+
+public class BatchPatchSingleShardedCommand : SingleShardedCommand
+{
+    public List<(string Id, string ChangeVector)> List;
+
+    public BufferedCommand BufferedCommand;
+
+    public override IEnumerable<BatchPatchSingleShardedCommand> Retry(ShardedDatabaseContext databaseContext, TransactionOperationContext context)
+    {
+        var idsByShard = new Dictionary<int, List<(string Id, string ChangeVector)>>();
+        foreach (var item in List)
+        {
+            var result = databaseContext.GetShardNumberAndBucketFor(context, item.Id);
+            if (idsByShard.TryGetValue(result.ShardNumber, out var list) == false)
+                idsByShard[result.ShardNumber] = list = new List<(string Id, string ChangeVector)>();
+
+            list.Add(item);
+        }
+
+        foreach (var kvp in idsByShard)
+        {
+            var list = kvp.Value;
+            yield return new BatchPatchSingleShardedCommand
+            {
+                ShardNumber = kvp.Key,
+                BufferedCommand = BufferedCommand,
+                List = list,
+                CommandStream = BufferedCommand.ModifyBatchPatchStream(list),
+                PositionInResponse = PositionInResponse
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/SingleShardedCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/SingleShardedCommand.cs
@@ -1,9 +1,13 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Batches;
 
 public class SingleShardedCommand
 {
+    public string Id;
+
     public int ShardNumber;
 
     public Stream AttachmentStream;
@@ -11,4 +15,10 @@ public class SingleShardedCommand
     public Stream CommandStream;
 
     public int PositionInResponse;
+
+    public virtual IEnumerable<SingleShardedCommand> Retry(ShardedDatabaseContext databaseContext, TransactionOperationContext context)
+    {
+        ShardNumber = databaseContext.RecalculateShardNumberFor(context, Id);
+        yield return this;
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Testing.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Testing.cs
@@ -1,0 +1,27 @@
+﻿namespace Raven.Server.Documents.Sharding
+{
+    public partial class ShardedDatabaseContext
+    {
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff(this);
+        }
+
+        internal class TestingStuff
+        {
+            private readonly ShardedDatabaseContext _databaseContext;
+
+            public TestingStuff(ShardedDatabaseContext databaseContext)
+            {
+                _databaseContext = databaseContext;
+            }
+
+            internal int ModifyShardNumber(int shardNumber) => ++shardNumber % _databaseContext.ShardCount;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -128,6 +128,8 @@ namespace Raven.Server.Documents.Sharding
 
         public int GetShardNumberFor(TransactionOperationContext context, string id) => ShardHelper.GetShardNumberFor(_record.Sharding, context, id);
 
+        public int RecalculateShardNumberFor(TransactionOperationContext context, string id) => ShardHelper.GetShardNumberFor(_record.Sharding, context, id, IdentityPartsSeparator);
+
         public int GetShardNumberFor(ByteStringContext allocator, string id) => ShardHelper.GetShardNumberFor(_record.Sharding, allocator, id);
 
         public int GetShardNumberFor(ByteStringContext allocator, LazyStringValue id) => ShardHelper.GetShardNumberFor(_record.Sharding, allocator, id);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
@@ -15,7 +15,7 @@ public class ShardedDocumentPutAction : DocumentPutAction
     }
 
     // TODO need to make sure we check that for counters/TS/etc...
-    protected override void ValidateId(Slice lowerId)
+    public override void ValidateId(Slice lowerId)
     {
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "Handle write documents to the wrong shard");
         var config = _documentDatabase.ShardingConfiguration;

--- a/src/Raven.Server/Documents/StreamsTempFile.cs
+++ b/src/Raven.Server/Documents/StreamsTempFile.cs
@@ -191,30 +191,40 @@ namespace Raven.Server.Documents
             public LimitedStream CreateReaderStream()
             {
                 var streamDispose = CreateReaderStream(out var stream);
-                var disposableAction = new DisposableAction(() =>
-                {
-                    using (streamDispose)
-                    {
-                        
-                    }
-                });
-                stream._disposable = disposableAction;
+                stream._disposable = new LimitedStreamDisposable(streamDispose);
                 return stream;
             }
 
             public LimitedStream CreateDisposableReaderStream(IDisposable onDisposable)
             {
                 var streamDispose = CreateReaderStream(out var stream);
-                var disposableAction = new DisposableAction(() =>
+                stream._disposable = new LimitedStreamDisposable(streamDispose, onDisposable);
+                return stream;
+            }
+            
+            private readonly struct LimitedStreamDisposable : IDisposable
+            {
+                private readonly IDisposable _streamDispose;
+                private readonly IDisposable _parentDisposable;
+
+                public LimitedStreamDisposable(IDisposable streamDispose)
                 {
-                    using (onDisposable)
-                    using (streamDispose)
+                    _streamDispose = streamDispose;
+                }
+
+                public LimitedStreamDisposable(IDisposable streamDispose, IDisposable parentDisposable) : this(streamDispose)
+                {
+                    _parentDisposable = parentDisposable;
+                }
+
+                public void Dispose()
+                {
+                    using (_parentDisposable)
+                    using (_streamDispose)
                     {
                         
                     }
-                });
-                stream._disposable = disposableAction;
-                return stream;
+                }
             }
         }
 

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -46,19 +46,22 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, List<Stream> items)
+        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<Stream> items)
         {
             writer.WritePropertyName(name);
 
             writer.WriteStartArray();
-            for (int i = 0; i < items.Count; i++)
+            var first = true;
+            foreach (var item in items)
             {
-                if (i > 0)
+                if (first == false)
                     writer.WriteComma();
+                first = false;
 
-                items[i].Position = 0;
-                await writer.WriteStreamAsync(items[i]).ConfigureAwait(false);
+                item.Position = 0;
+                await writer.WriteStreamAsync(item).ConfigureAwait(false);
             }
+
             writer.WriteEndArray();
         }
 

--- a/test/FastTests/Utils/LimitedStreamTests.cs
+++ b/test/FastTests/Utils/LimitedStreamTests.cs
@@ -60,5 +60,28 @@ namespace FastTests.Utils
                 position += prev - pos;
             }
         }
+
+        
+        [Theory]
+        [InlineDataWithRandomSeed]
+        public void Should_properly_seek(int seed)
+        {
+            var r = new Random(seed);
+
+            var bytes = new byte[r.Next(128, 1024 * 1024)];
+            r.NextBytes(bytes);
+
+            var ms = new MemoryStream(bytes);
+            var entireStream = new LimitedStream(ms, ms.Length, 0, 0);
+            Assert.Equal(bytes, entireStream.ReadData());
+
+            var p = r.Next(0, bytes.Length - 1);
+            entireStream.Seek(p, SeekOrigin.Begin);
+
+            var x = new Span<byte>(bytes, p, bytes.Length - p);
+            var y = new Span<byte>(entireStream.ReadData());
+
+            Assert.True(x.SequenceEqual(y));
+        }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -179,6 +179,14 @@ public partial class RavenTestBase
             }
         }
 
+        public ShardedDatabaseContext GetOrchestrator(string database)
+        {
+            if (_parent.Server.ServerStore.DatabasesLandlord.ShardedDatabasesCache.TryGetValue(database, out var task) == false)
+                throw new InvalidOperationException($"The orchestrator for '{database}' wasn't found on this node");
+
+            return task.Result;
+        }
+
         public async Task WaitForOrchestratorsToUpdate(string database, long index)
         {
             var servers = _parent.GetServers();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19965

### Additional description

If we need to retry due to `ShardMismatchException`, special treatment is needed for 
1. `BatchPatch`, the ids can be mapped to different shards, so was needed to redistribute them if required.
2. Server generated ids such as `users/` had to be generated once on the orchestrator.
3. Attachments had to use a single `StreamsTempFile` and not one per attachment.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
