### PR TITLE
RavenDB-19729 Changing `int` to `long` in `IndexStorage` for fields that are already saved as longs.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexStats.cs
@@ -50,17 +50,17 @@ namespace Raven.Client.Documents.Indexes
         /// <summary>
         /// Indicates how many times database tried to index documents (reduce) using this index.
         /// </summary>
-        public int? ReduceAttempts { get; set; }
+        public long? ReduceAttempts { get; set; }
 
         /// <summary>
         /// Indicates how many reducing attempts succeeded.
         /// </summary>
-        public int? ReduceSuccesses { get; set; }
+        public long? ReduceSuccesses { get; set; }
 
         /// <summary>
         /// Indicates how many reducing attempts failed.
         /// </summary>
-        public int? ReduceErrors { get; set; }
+        public long? ReduceErrors { get; set; }
         
         /// <summary>
         /// The reduce output collection.

--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceOperation.cs
@@ -12,7 +12,7 @@ namespace Raven.Client.Documents.Indexes
         public IndexingPerformanceOperation(TimeSpan duration)
         {
             DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
-            Operations = new IndexingPerformanceOperation[0];
+            Operations = Array.Empty<IndexingPerformanceOperation>();
         }
 
         public string Name { get; set; }

--- a/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingPerformanceStats.cs
@@ -36,13 +36,13 @@ namespace Raven.Client.Documents.Indexes
             DurationInMs = Math.Round(duration.TotalMilliseconds, 2);
         }
 
-        public int InputCount { get; set; }
+        public long InputCount { get; set; }
 
-        public int FailedCount { get; set; }
+        public long FailedCount { get; set; }
 
-        public int OutputCount { get; set; }
+        public long OutputCount { get; set; }
 
-        public int SuccessCount { get; set; }
+        public long SuccessCount { get; set; }
 
         public DateTime Started { get; set; }
 

--- a/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
+++ b/src/Raven.Client/Documents/Indexes/ReduceRunDetails.cs
@@ -8,11 +8,11 @@
 
         public long CurrentlyAllocated { get; set; }
 
-        public int ReduceAttempts { get; set; }
+        public long ReduceAttempts { get; set; }
 
-        public int ReduceSuccesses { get; set; }
+        public long ReduceSuccesses { get; set; }
 
-        public int ReduceErrors { get; set; }
+        public long ReduceErrors { get; set; }
 
         public TreesReduceDetails TreesReduceDetails { get; set; }
     }

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -356,22 +356,22 @@ namespace Raven.Server.Documents.Indexes
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
-            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
+            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
 
-            int? reduceAttempts = null, reduceErrors = null;
+            long? reduceAttempts = null, reduceErrors = null;
 
             if (_index.Type.IsMapReduce())
             {
-                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
+                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
             }
 
-            int mapReferenceAttempts = 0, mapReferenceErrors = 0;
+            long mapReferenceAttempts = 0, mapReferenceErrors = 0;
             if (_index.GetReferencedCollections()?.Count > 0)
             {
-                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
+                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
             }
 
             return IndexFailureInformation.CheckIndexInvalid(mapAttempts, mapErrors,
@@ -433,9 +433,9 @@ namespace Raven.Server.Documents.Indexes
 
                 if (_index.Type.IsMapReduce())
                 {
-                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
+                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
                 }
 
                 if (_index.GetReferencedCollections()?.Count > 0)

--- a/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingRunStats.cs
@@ -10,19 +10,19 @@ namespace Raven.Server.Documents.Indexes
 {
     public class IndexingRunStats
     {
-        public int MapAttempts;
-        public int MapReferenceAttempts;
-        public int MapSuccesses;
-        public int MapReferenceSuccesses;
-        public int TombstoneDeleteSuccesses;
-        public int MapErrors;
-        public int MapReferenceErrors;
+        public long MapAttempts;
+        public long MapReferenceAttempts;
+        public long MapSuccesses;
+        public long MapReferenceSuccesses;
+        public long TombstoneDeleteSuccesses;
+        public long MapErrors;
+        public long MapReferenceErrors;
 
-        public int ReduceAttempts;
-        public int ReduceSuccesses;
-        public int ReduceErrors;
+        public long ReduceAttempts;
+        public long ReduceSuccesses;
+        public long ReduceErrors;
 
-        public int IndexingOutputs;
+        public long IndexingOutputs;
         
         public Size AllocatedManagedBytes;
         

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -109,21 +109,21 @@ namespace Raven.Server.Documents.Indexes
             return new IndexingStatsScope(stats, start);
         }
 
-        public int MapAttempts => _stats.MapAttempts;
+        public long MapAttempts => _stats.MapAttempts;
 
-        public int MapReferenceAttempts => _stats.MapReferenceAttempts;
+        public long MapReferenceAttempts => _stats.MapReferenceAttempts;
 
-        public int MapErrors => _stats.MapErrors;
+        public long MapErrors => _stats.MapErrors;
 
-        public int ReduceAttempts => _stats.ReduceAttempts;
+        public long ReduceAttempts => _stats.ReduceAttempts;
 
-        public int ReduceErrors => _stats.ReduceErrors;
+        public long ReduceErrors => _stats.ReduceErrors;
 
         public int ErrorsCount => _stats.Errors?.Count ?? 0;
 
         public int NumberOfKeptReduceErrors => _stats.NumberOfKeptReduceErrors;
 
-        public int TombstoneDeleteSuccesses => _stats.TombstoneDeleteSuccesses;
+        public long TombstoneDeleteSuccesses => _stats.TombstoneDeleteSuccesses;
 
         public void SetAllocatedManagedBytes(long sizeInBytes)
         {

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
@@ -587,7 +587,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 for (var i = 0; i < numberOfBatches; i++)
                 {
                     index.DoIndexingWork(stats, CancellationToken.None);
-                    Assert.Equal((i + 1) * mapBatchSize, stats.MapAttempts);
+                    Assert.Equal((i + 1L) * mapBatchSize, stats.MapAttempts);
                 }
 
                 index.DoIndexingWork(stats, CancellationToken.None);
@@ -621,7 +621,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                 for (var i = 0; i < numberOfBatches; i++)
                 {
                     index.DoIndexingWork(stats, CancellationToken.None);
-                    Assert.Equal((i + 1) * mapBatchSize, stats.MapReferenceAttempts);
+                    Assert.Equal((i + 1L) * mapBatchSize, stats.MapReferenceAttempts);
                 }
 
                 index.DoIndexingWork(stats, CancellationToken.None);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19729 

### Additional description


### Type of change


- Optimization

### How risky is the change?

- Moderate 


### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
