### PR TITLE
RavenDB-19524 - 'TombstonesBucketAndEtag' storage index maps revision-tombstones to the wrong bucket

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -23,6 +23,16 @@ namespace Raven.Server.Documents
             }
         }
 
+        public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
+        {
+            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, CounterTombstonesSchema.DynamicKeyIndexes[CounterTombstonesBucketAndEtagSlice], bucket, etag))
+            {
+                yield return TableValueToCounterTombstoneDetail(context, ref result.Result.Reader);
+            }
+        }
+
         [StorageIndexEntryKeyGenerator]
         internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForCounters(Transaction tx, ref TableValueReader tvr, out Slice slice)
         {

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -7,6 +7,7 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.Schemas.Counters;
+using static Raven.Server.Documents.Schemas.CounterTombstones;
 
 namespace Raven.Server.Documents
 {
@@ -26,6 +27,12 @@ namespace Raven.Server.Documents
         internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForCounters(Transaction tx, ref TableValueReader tvr, out Slice slice)
         {
             return ShardedDocumentsStorage.ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)CountersTable.CounterKey, (int)CountersTable.Etag, ref tvr, out slice);
+        }
+
+        [StorageIndexEntryKeyGenerator]
+        internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForCounterTombstones(Transaction tx, ref TableValueReader tvr, out Slice slice)
+        {
+            return ShardedDocumentsStorage.ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)CounterTombstonesTable.CounterTombstoneKey, (int)CounterTombstonesTable.Etag, ref tvr, out slice);
         }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -42,14 +42,13 @@ namespace Raven.Server.Documents
             new List<ByteStringContext<ByteStringMemoryCache>.InternalScope>();
 
         internal readonly TableSchema CountersSchema;
+        internal readonly TableSchema CounterTombstonesSchema;
 
         private readonly DocumentDatabase _documentDatabase;
         private readonly DocumentsStorage _documentsStorage;
 
         private readonly ObjectPool<Dictionary<LazyStringValue, PutCountersData>> _dictionariesPool
             = new ObjectPool<Dictionary<LazyStringValue, PutCountersData>>(() => new Dictionary<LazyStringValue, PutCountersData>(LazyStringValueComparer.Instance));
-
-        private static readonly TableSchema CounterTombstonesSchema = Schemas.CounterTombstones.Current;
 
         [StructLayout(LayoutKind.Explicit)]
         internal struct CounterValues
@@ -93,7 +92,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public CountersStorage([NotNull] DocumentDatabase documentDatabase, [NotNull] Transaction tx, [NotNull] TableSchema schema)
+        public CountersStorage([NotNull] DocumentDatabase documentDatabase, [NotNull] Transaction tx, [NotNull] TableSchema schema, [NotNull] TableSchema tombstoneSchema)
         {
             if (tx == null)
                 throw new ArgumentNullException(nameof(tx));
@@ -102,6 +101,7 @@ namespace Raven.Server.Documents
             _documentsStorage = documentDatabase.DocumentsStorage;
 
             CountersSchema = schema ?? throw new ArgumentNullException(nameof(schema));
+            CounterTombstonesSchema = tombstoneSchema ?? throw new ArgumentNullException(nameof(tombstoneSchema));
 
             tx.CreateTree(CounterKeysSlice);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1716,7 +1716,7 @@ namespace Raven.Server.Documents
                     revisionsStorage.Configuration == null &&
                     flags.Contain(DocumentFlags.Resolved) == false &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
-                    revisionsStorage.DeleteRevisionsFor(context, id);
+                    revisionsStorage.DeleteRevisionsFor(context, id, flags: documentFlags);
 
                 if (flags.Contain(DocumentFlags.HasRevisions) &&
                     revisionsStorage.Configuration != null &&

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -51,6 +51,7 @@ namespace Raven.Server.Documents
         protected TableSchema AttachmentsSchema;
         protected TableSchema ConflictsSchema;
         public TableSchema CountersSchema;
+        public TableSchema CounterTombstonesSchema;
         protected TableSchema TimeSeriesSchema;
         protected TableSchema TimeSeriesDeleteRangesSchema;
         public TableSchema RevisionsSchema;
@@ -122,6 +123,7 @@ namespace Raven.Server.Documents
             AttachmentsSchema = Schemas.Attachments.AttachmentsSchemaBase;
             ConflictsSchema = Schemas.Conflicts.ConflictsSchemaBase;
             CountersSchema = Schemas.Counters.CountersSchemaBase;
+            CounterTombstonesSchema = Schemas.CounterTombstones.CounterTombstonesSchemaBase;
 
             TimeSeriesSchema = Schemas.TimeSeries.TimeSeriesSchemaBase;
             TimeSeriesDeleteRangesSchema = Schemas.DeletedRanges.DeleteRangesSchemaBase;
@@ -257,7 +259,7 @@ namespace Raven.Server.Documents
                     ExpirationStorage = new ExpirationStorage(DocumentDatabase, tx);
                     ConflictsStorage = new ConflictsStorage(DocumentDatabase, tx, ConflictsSchema);
                     AttachmentsStorage = new AttachmentsStorage(DocumentDatabase, tx, AttachmentsSchema);
-                    CountersStorage = new CountersStorage(DocumentDatabase, tx, CountersSchema);
+                    CountersStorage = new CountersStorage(DocumentDatabase, tx, CountersSchema, CounterTombstonesSchema);
                     TimeSeriesStorage = new TimeSeriesStorage(DocumentDatabase, tx, TimeSeriesSchema, TimeSeriesDeleteRangesSchema);
 
                     DocumentPut = CreateDocumentPutAction();

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -149,7 +149,11 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
     [StorageIndexEntryKeyGenerator]
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForTombstones(Transaction tx, ref TableValueReader tvr, out Slice slice)
     {
-        return GenerateBucketAndEtagIndexKey(tx, idIndex: (int)TombstoneTable.LowerId, etagIndex: (int)TombstoneTable.Etag, ref tvr, out slice);
+        var tombstoneType = *(Tombstone.TombstoneType*)tvr.Read((int)TombstoneTable.Type, out int _);
+        if (tombstoneType == Tombstone.TombstoneType.Revision)
+            return ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)TombstoneTable.LowerId, etagIndex: (int)TombstoneTable.Etag, ref tvr, out slice);
+
+        return GenerateBucketAndEtagIndexKey(tx, idIndex: (int)DocumentsTable.LowerId, etagIndex: (int)DocumentsTable.Etag, ref tvr, out slice);
     }
 
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKey(Transaction tx, int idIndex, int etagIndex, ref TableValueReader tvr, out Slice slice)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -311,11 +311,6 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
             var counterCv = TableValueToChangeVector(context, (int)CountersTable.ChangeVector, ref result.Result.Reader);
             merged = merged.MergeWith(counterCv, context);
         }
-        foreach (var result in GetItemsByBucket(context.Allocator, table, _documentDatabase.DocumentsStorage.CountersStorage.CounterTombstonesSchema.DynamicKeyIndexes[Schemas.CounterTombstones.CounterTombstonesBucketAndEtagSlice], bucket, 0))
-        {
-            var counterTombstoneCv = TableValueToChangeVector(context, (int)CounterTombstones.CounterTombstonesTable.ChangeVector, ref result.Result.Reader);
-            merged = merged.MergeWith(counterTombstoneCv, context);
-        }
         foreach (var result in GetItemsByBucket(context.Allocator, table, _documentDatabase.DocumentsStorage.ConflictsStorage.ConflictsSchema.DynamicKeyIndexes[ConflictsBucketAndEtagSlice], bucket, 0))
         {
             var conflictCv = TableValueToChangeVector(context, (int)ConflictsTable.ChangeVector, ref result.Result.Reader);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -444,7 +444,7 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
                     continue;
 
                 var tombstoneChangeVector = context.GetChangeVector(tombstone.ChangeVector);
-                if (ChangeVectorUtils.GetConflictStatus(tombstoneChangeVector, upTo) != ConflictStatus.AlreadyMerged)
+                if (ChangeVectorUtils.GetConflictStatus(upTo, tombstoneChangeVector) != ConflictStatus.AlreadyMerged)
                     break;
 
                 var collection = tombstone.Collection;

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -149,11 +148,7 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
     [StorageIndexEntryKeyGenerator]
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKeyForTombstones(Transaction tx, ref TableValueReader tvr, out Slice slice)
     {
-        var tombstoneType = *(Tombstone.TombstoneType*)tvr.Read((int)TombstoneTable.Type, out int _);
-        if (tombstoneType == Tombstone.TombstoneType.Revision)
-            return ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)TombstoneTable.LowerId, etagIndex: (int)TombstoneTable.Etag, ref tvr, out slice);
-
-        return GenerateBucketAndEtagIndexKey(tx, idIndex: (int)DocumentsTable.LowerId, etagIndex: (int)DocumentsTable.Etag, ref tvr, out slice);
+        return ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)TombstoneTable.LowerId, etagIndex: (int)TombstoneTable.Etag, ref tvr, out slice);
     }
 
     internal static ByteStringContext.Scope GenerateBucketAndEtagIndexKey(Transaction tx, int idIndex, int etagIndex, ref TableValueReader tvr, out Slice slice)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -126,7 +126,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             // this schema update uses DocumentsStorage.GenerateNextEtag() so we need to read and set LastEtag in storage
             step.DocumentsStorage.InitializeLastEtag(step.ReadTx);
 
-            step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema);
+            step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema, step.DocumentsStorage.CounterTombstonesSchema);
 
             _dbId = ReadDbId(step);
 
@@ -233,7 +233,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                         step.Commit(context);
                         step.RenewTransactions();
 
-                        step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema);
+                        step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema, step.DocumentsStorage.CounterTombstonesSchema);
 
                         currentDocId = null;
                         continue;

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             if (countersTree == null)
                 return true;
 
-            step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema);
+            step.DocumentsStorage.CountersStorage = new CountersStorage(step.DocumentsStorage.DocumentDatabase, step.WriteTx, step.DocumentsStorage.CountersSchema, step.DocumentsStorage.CounterTombstonesSchema);
 
             // this schema update uses DocumentsStorage.GenerateNextEtag() so we need to read and set LastEtag in storage
             _dbId = From41016.ReadDbId(step);

--- a/test/SlowTests/Sharding/Cluster/BucketStats.cs
+++ b/test/SlowTests/Sharding/Cluster/BucketStats.cs
@@ -426,7 +426,7 @@ namespace SlowTests.Sharding.Cluster
                     session.Delete(id);
                     await session.SaveChangesAsync();
 
-                    expectedSize = 3502;
+                    expectedSize = 3635;
                 }
 
                 AssertStats(db, bucket, expectedSize, expectedDocs: 0);
@@ -436,7 +436,7 @@ namespace SlowTests.Sharding.Cluster
                     DocumentIds = new[] { id, id2, id3 }
                 }));
 
-                expectedSize = 540;
+                expectedSize = 1889;
                 AssertStats(db, bucket, expectedSize, expectedDocs: 0);
 
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
@@ -547,7 +547,7 @@ namespace SlowTests.Sharding.Cluster
                     Assert.Equal(2, count); // 2 revision attachments
 
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
-                    Assert.Equal(104859015, stats.Size);
+                    Assert.Equal(104859146, stats.Size);
                     Assert.Equal(0, stats.NumberOfDocuments);
                 }
 
@@ -564,7 +564,7 @@ namespace SlowTests.Sharding.Cluster
                     Assert.Equal(0, count);
 
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
-                    Assert.Equal(81, stats.Size);
+                    Assert.Equal(857, stats.Size);
                     Assert.Equal(0, stats.NumberOfDocuments);
                 }
 

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -1054,7 +1054,7 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
                     Assert.Equal(bucket, stats.Bucket);
-                    Assert.Equal(1594, stats.Size); // we still have 'artificial' tombstones on this shard
+                    Assert.Equal(2794, stats.Size); // we still have 'artificial' tombstones on this shard
                     Assert.Equal(0, stats.NumberOfDocuments);
                 }
 

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -1054,7 +1054,7 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
                     Assert.Equal(bucket, stats.Bucket);
-                    Assert.Equal(344, stats.Size); // we still have 'artificial' tombstones on this shard
+                    Assert.Equal(1594, stats.Size); // we still have 'artificial' tombstones on this shard
                     Assert.Equal(0, stats.NumberOfDocuments);
                 }
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_19524 : RavenTestBase
+    {
+        public RavenDB_19524(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ShouldMapRevisionTombstonesToTheRightShard()
+        {
+            const string id = "users/1";
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false
+                    }
+                }));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                for (int i = 0; i < 5; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<User>(id);
+                        user.Name = i.ToString();
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                await store.Maintenance.SendAsync(new DeleteRevisionsOperation(new DeleteRevisionsOperation.Parameters
+                {
+                    DocumentIds = new[] { id }
+                }));
+
+            
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var shard = await Sharding.GetShardNumberFor(store, id);
+                var bucket = Sharding.GetBucket(record.Sharding, id);
+              
+                var db = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shard)) as ShardedDocumentDatabase;
+                Assert.NotNull(db);
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var tombstones = db.DocumentsStorage.GetTombstonesFrom(ctx, 0).ToList();
+                    Assert.Equal(6, tombstones.Count);
+                    foreach (var tombstone in tombstones)
+                    {
+                        Assert.IsType<RevisionTombstoneReplicationItem>(tombstone);
+                    }
+
+                    var tombstonesByBucket = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(ctx, bucket, etag: 0).ToList();
+                    Assert.Equal(6, tombstonesByBucket.Count);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.Replication.ReplicationItems;
@@ -77,6 +79,121 @@ namespace SlowTests.Sharding.Issues
 
                     var tombstonesByBucket = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(ctx, bucket, etag: 0).ToList();
                     Assert.Equal(6, tombstonesByBucket.Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ShouldMapAttachmentTombstonesToTheRightShard()
+        {
+            const string id = "users/1";
+            const string attName = "foo";
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    store.Operations.Send(new PutAttachmentOperation("users/1", attName, profileStream, "image/png"));
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.NotNull(user);
+                    var att = await session.Advanced.Attachments.GetAsync(user, attName);
+                    Assert.NotNull(att);
+                }
+
+                store.Operations.Send(new DeleteAttachmentOperation("users/1", attName));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.NotNull(user);
+                    var att = await session.Advanced.Attachments.GetAsync(user, attName);
+                    Assert.Null(att);
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var shard = await Sharding.GetShardNumberFor(store, id);
+                var bucket = Sharding.GetBucket(record.Sharding, id);
+
+                var db = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shard)) as ShardedDocumentDatabase;
+                Assert.NotNull(db);
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var tombstones = db.DocumentsStorage.GetTombstonesFrom(ctx, 0).ToList();
+                    Assert.Equal(1, tombstones.Count);
+                    Assert.IsType<AttachmentTombstoneReplicationItem>(tombstones[0]);
+                    
+                    var tombstonesByBucket = db.ShardedDocumentsStorage.GetTombstonesByBucketFrom(ctx, bucket, etag: 0).ToList();
+                    Assert.Equal(1, tombstonesByBucket.Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ShouldMapCounterTombstonesToTheRightShard()
+        {
+            const string id = "users/1";
+            const string counterName = "likes";
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.CountersFor(id).Increment(counterName);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.NotNull(user);
+                    var counter = await session.CountersFor(id).GetAsync(counterName);
+                    Assert.NotNull(counter);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.CountersFor(id).Delete(counterName);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.NotNull(user);
+                    var counter = await session.CountersFor(id).GetAsync(counterName);
+                    Assert.Null(counter);
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var shard = await Sharding.GetShardNumberFor(store, id);
+                var bucket = Sharding.GetBucket(record.Sharding, id);
+
+                var db = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shard)) as ShardedDocumentDatabase;
+                Assert.NotNull(db);
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var tombstones = db.DocumentsStorage.CountersStorage.GetCounterTombstonesFrom(ctx, 0).ToList();
+                    Assert.Equal(1, tombstones.Count);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19524/TombstonesBucketAndEtag-storage-index-maps-revision-tombstones-to-the-wrong-bucket

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
