### PR TITLE
RavenDB-19840 Handling of sorting suggestions by popularity when results are returned by Corax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/SuggestWord.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/SuggestWord.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using Raven.Server.Documents.Patch;
 
-namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Suggestions
+namespace Raven.Server.Documents.Indexes.Persistence
 {
     /// <summary>  SuggestWord Class, used in suggestSimilar method in SpellChecker class.
     /// 

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxSuggestionIndexReader.cs
@@ -1,0 +1,21 @@
+﻿using Corax.Mappings;
+using Raven.Client.Documents.Queries.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Raven.Server.Documents.Sharding.Queries;
+using Sparrow.Logging;
+using Voron.Impl;
+
+namespace Raven.Server.Documents.Indexes.Sharding.Persistence.Corax;
+
+public sealed class ShardedCoraxSuggestionIndexReader : CoraxSuggestionReader
+{
+    public ShardedCoraxSuggestionIndexReader(Index index, Logger logger, IndexFieldBinding binding, Transaction readTransaction, IndexFieldsMapping fieldsMapping) : base(index, logger, binding, readTransaction, fieldsMapping)
+    {
+    }
+
+    internal override void AddPopularity(SuggestWord suggestion, ref SuggestionResult result)
+    {
+        result = result.AddPopularity(suggestion);
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneSuggestionIndexReader.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using Raven.Client.Documents.Queries.Suggestions;
+﻿using Raven.Client.Documents.Queries.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
-using Raven.Server.Documents.Indexes.Persistence.Lucene.Suggestions;
-using Raven.Server.Documents.Sharding.Queries.Suggestions;
+using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.Indexing;
 using Voron.Impl;
 
@@ -16,24 +15,6 @@ public sealed class ShardedLuceneSuggestionIndexReader : LuceneSuggestionIndexRe
 
     internal override void AddPopularity(SuggestWord suggestion, ref SuggestionResult result)
     {
-        if (result is ShardedSuggestionResult resultWithPopularity)
-        {
-            resultWithPopularity.SuggestionsWithPopularity.Values.Add(suggestion);
-        }
-        else
-        {
-            result = new ShardedSuggestionResult
-            {
-                Name = result.Name,
-                Suggestions = result.Suggestions,
-                SuggestionsWithPopularity = new ShardedSuggestionResult.Popularity
-                {
-                    Values = new List<SuggestWord>
-                        {
-                            suggestion
-                        }
-                }
-            };
-        }
+        result = result.AddPopularity(suggestion);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedSuggestionQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedSuggestionQueryOperation.cs
@@ -6,7 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.Suggestions;
-using Raven.Server.Documents.Indexes.Persistence.Lucene.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Queries.Suggestions;
 using Raven.Server.Documents.Sharding.Commands.Querying;
 using Raven.Server.Documents.Sharding.Executors;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedSuggestionResultExtensions.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedSuggestionResultExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Documents.Queries.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Sharding.Queries.Suggestions;
+
+namespace Raven.Server.Documents.Sharding.Queries;
+
+public static class ShardedSuggestionResultExtensions
+{
+    internal static ShardedSuggestionResult AddPopularity(this SuggestionResult result, SuggestWord suggestion)
+    {
+        if (result is ShardedSuggestionResult resultWithPopularity)
+        {
+            resultWithPopularity.SuggestionsWithPopularity.Values.Add(suggestion);
+        }
+        else
+        {
+            resultWithPopularity = new ShardedSuggestionResult
+            {
+                Name = result.Name,
+                Suggestions = result.Suggestions,
+                SuggestionsWithPopularity = new ShardedSuggestionResult.Popularity
+                {
+                    Values = new List<SuggestWord>
+                    {
+                        suggestion
+                    }
+                }
+            };
+        }
+
+        return resultWithPopularity;
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionResult.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Suggestions/ShardedSuggestionResult.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Queries.Suggestions;
-using Raven.Server.Documents.Indexes.Persistence.Lucene.Suggestions;
+using Raven.Server.Documents.Indexes.Persistence;
 
 namespace Raven.Server.Documents.Sharding.Queries.Suggestions;
 

--- a/test/SlowTests/Corax/CoraxSlowQueryTests.cs
+++ b/test/SlowTests/Corax/CoraxSlowQueryTests.cs
@@ -496,7 +496,7 @@ public class CoraxSlowQueryTests : RavenTestBase
     private record SortingData(string data);
 
     [Theory]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void MaxSuggestionsShouldWork(Options options)
     {
         using (var store = GetDocumentStore(options))
@@ -514,6 +514,11 @@ public class CoraxSlowQueryTests : RavenTestBase
                     .Execute();
 
                 Assert.True(result["Name"].Suggestions.Count is > 0 and <= 5);
+
+                Assert.Equal("chai", result["Name"].Suggestions[0]);
+                Assert.Equal("chang", result["Name"].Suggestions[1]);
+                Assert.Equal("chocolade", result["Name"].Suggestions[2]);
+                Assert.Equal("tofu", result["Name"].Suggestions[3]);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_2670.cs
+++ b/test/SlowTests/Issues/RavenDB_2670.cs
@@ -59,8 +59,8 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void MaxSuggestionsShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_9584.cs
+++ b/test/SlowTests/Issues/RavenDB_9584.cs
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanChainSuggestions(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -108,7 +108,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseAliasInSuggestions(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -130,7 +130,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseSuggestionsWithAutoIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -152,7 +152,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanExtendAutoIndexWithSuggestions(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Suggestions/Suggestions.cs
+++ b/test/SlowTests/Tests/Suggestions/Suggestions.cs
@@ -116,7 +116,7 @@ namespace SlowTests.Tests.Suggestions
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void UsingLinq_with_typo_multiple_fields_in_reverse_order(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -135,7 +135,7 @@ namespace SlowTests.Tests.Suggestions
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void UsingLinq_WithOptions(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -157,7 +157,7 @@ namespace SlowTests.Tests.Suggestions
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void UsingLinq_Multiple_words(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19840/Sharding-Suggest-Handling-of-sorting-suggestions-by-popularity-in-Corax

### Additional description

Adding `@suggestions-popularity` to suggestion results when they come from Corax

### Type of change

- Sharding feature implementation

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests switched to Corax will verify the changes

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
