### PR TITLE
RavenDB-18766 Throwing exception on MoreLikeThis queries in a sharded db

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
@@ -142,6 +142,9 @@ internal class ShardedQueriesHandlerProcessorForGet : AbstractQueriesHandlerProc
     {
         if (indexQuery.Diagnostics != null)
             throw new NotSupportedInShardingException("Query diagnostics for a sharded database are currently not supported.");
+
+        if (indexQuery.Metadata.HasMoreLikeThis)
+            throw new NotSupportedInShardingException("MoreLikeThis queries are currently not supported in a sharded database ");
     }
 
     private static TimingsScope Timings(IndexQueryServerSide query) => new(query);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18766/Sharding-Queries-MoreLikeThis

### Additional description

For now we're just throwing `NotSupportedInShardingException` exception

### Type of change

- Feature blocking in sharding

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
