### PR TITLE
RavenDB-19064 Removing TODO from ShardedAggregatedAnonymousObjects

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/Sharding/ShardedAggregatedAnonymousObjects.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/Sharding/ShardedAggregatedAnonymousObjects.cs
@@ -3,7 +3,6 @@ using Raven.Client;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Static.Sharding;
 
@@ -13,8 +12,6 @@ public class ShardedAggregatedAnonymousObjects : AggregatedAnonymousObjects
 
     public ShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor, JsonOperationContext indexContext) : base(results, propertyAccessor, indexContext)
     {
-        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Grisha, DevelopmentHelper.Severity.Normal, "RavenDB-19064 handle metadata merge, score, distance");
-
         ModifyOutputToStore = djv =>
         {
             djv[Constants.Documents.Metadata.Key] = DummyDynamicJsonValue;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19064/Sharding-Indexes-Map-Reduce-metadata-merge-score-distance

### Additional description

Apparently there isn't anything to do there or we have dedicated issues for that