### PR TITLE
RavenDB-19712 Change analyzer for `Search` field in `FieldMetadata` when performing queries different than `search([...])`.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -824,7 +824,7 @@ internal static class CoraxQueryBuilder
         }
 
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, indexFieldsMapping, fieldsToFetch, builderParameters.HasDynamics,
-            builderParameters.DynamicFields);
+            builderParameters.DynamicFields, handleSearch: true);
 
         if (proximity.HasValue)
         {

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/Corax/MoreLikeThis.cs
@@ -71,7 +71,7 @@ internal class RavenMoreLikeThis : MoreLikeThisBase, IDisposable
 
             foreach (var fieldName in _fieldNames)
             {
-                var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(_builderParameters.Allocator, fieldName, _builderParameters.Index, _builderParameters.IndexFieldsMapping, _builderParameters.FieldsToFetch, _builderParameters.HasDynamics, _builderParameters.DynamicFields);
+                var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(_builderParameters.Allocator, fieldName, _builderParameters.Index, _builderParameters.IndexFieldsMapping, _builderParameters.FieldsToFetch, _builderParameters.HasDynamics, _builderParameters.DynamicFields, handleSearch: true);
                 var freq = indexSearcher.TermAmount(fieldMetadata, word);
                 topField = freq > docFreq ? fieldName : topField;
                 docFreq = freq > docFreq ? freq : docFreq;

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -522,14 +522,15 @@ public static class QueryBuilderHelper
     }
 
     internal static FieldMetadata GetFieldMetadata(ByteStringContext allocator, string fieldName, Index index, IndexFieldsMapping indexMapping, FieldsToFetch queryMapping, bool hasDynamics, Lazy<List<string>> dynamicFields, bool isForQuery = true,
-        bool exact = false, bool isSorting = false)
+        bool exact = false, bool isSorting = false, bool handleSearch = false)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
+        FieldMetadata metadata;
 
         if (fieldName.Equals(Constants.Documents.Indexing.Fields.DocumentIdMethodName, StringComparison.OrdinalIgnoreCase) 
             || fieldName is Constants.Documents.Indexing.Fields.DocumentIdFieldName)
         {
-            var metadata = indexMapping.GetByFieldId(0).Metadata;
+            metadata = indexMapping.GetByFieldId(0).Metadata;
             return exact 
                 ? FieldMetadata.Build(metadata.FieldName, 0, FieldIndexingMode.Exact, null) 
                 : metadata;
@@ -538,16 +539,20 @@ public static class QueryBuilderHelper
         if (isForQuery == false)
         {
             if (fieldName is "score" or "score()")
-                return FieldMetadata.Build(default, default, default, default);
+                return default;
         }
 
         var shouldTurnOffAnalyzersForTime = index.IndexFieldsPersistence.HasTimeValues(fieldName) && isSorting == false;
-
         if (indexMapping.TryGetByFieldName(allocator, fieldName, out var indexFinding))
         {
-            return exact || shouldTurnOffAnalyzersForTime
-                ? indexFinding.Metadata.ChangeAnalyzer(FieldIndexingMode.Exact) 
-                : indexFinding.Metadata;
+            if (exact || shouldTurnOffAnalyzersForTime) //When field has exact let's change the analyzer to do nothing
+                metadata = indexFinding.Metadata.ChangeAnalyzer(FieldIndexingMode.Exact);
+            else if (indexFinding.FieldIndexingMode is FieldIndexingMode.Search) // in case of search
+                metadata = handleSearch  
+                    ? indexFinding.Metadata //when we want mapping for search lets use 'search` analyzer 
+                    : indexFinding.Metadata.ChangeAnalyzer(FieldIndexingMode.Normal, indexMapping.DefaultAnalyzer); //but when we do a TermMatch we want to have just default analyzer, even on full-text search field
+            else
+                metadata = indexFinding.Metadata;
         }
         else
         {
@@ -557,9 +562,10 @@ public static class QueryBuilderHelper
             var mode = shouldTurnOffAnalyzersForTime || exact 
                 ? FieldIndexingMode.Exact 
                 : FieldIndexingMode.Normal;
-            return FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, indexMapping.DefaultAnalyzer);
+            metadata = FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, indexMapping.DefaultAnalyzer);
         }
 
+        return metadata;
         void ThrowNotFoundInIndex() => throw new InvalidQueryException($"Field {fieldName} not found in Index '{index.Name}'.");
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19712 
### Additional description

Search analyzer should be used only via `search([...]) method.

### Type of change

- Regression bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes: querying on `Search` field in Corax.

### UI work

- No UI work is needed
