### PR TITLE
RavenDB-19127 Added cloning document Id and LowerId in QueryResultRetrieverBase CreateNewDocument()

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -359,11 +359,6 @@ namespace Raven.Server.Documents.Queries.Results
                     return r;
                 foreach (Document item in r.List)
                 {
-                    // https://issues.hibernatingrhinos.com/issue/RavenDB-19350
-                    // We need to have a different instance of the strings, otherwise, they
-                    // will be disposed (but then try to be used).
-                    item.Id = doc.Id.CloneOnSameContext();
-                    item.LowerId = doc.LowerId.CloneOnSameContext();
                     FinishDocumentSetup(item, scoreDoc);
                 }
                 return r;
@@ -401,13 +396,17 @@ namespace Raven.Server.Documents.Queries.Results
                 case BlittableJsonReaderObject nested:
                     return (new Document
                     {
-                        Id = doc.Id,
+                        // https://issues.hibernatingrhinos.com/issue/RavenDB-19350
+                        // https://issues.hibernatingrhinos.com/issue/RavenDB-19127
+                        // We need to have a different instance of Id / LowerId, otherwise 
+                        // they will be disposed (but then try to be used)
+                        Id = doc.IgnoreDispose ? doc.Id.CloneOnSameContext() : doc.Id,
                         ChangeVector = doc.ChangeVector,
                         Data = nested,
                         Etag = doc.Etag,
                         Flags = doc.Flags,
                         LastModified = doc.LastModified,
-                        LowerId = doc.LowerId,
+                        LowerId = doc.IgnoreDispose ? doc.LowerId.CloneOnSameContext() : doc.LowerId,
                         NonPersistentFlags = doc.NonPersistentFlags,
                         StorageId = doc.StorageId,
                         TransactionMarker = doc.TransactionMarker
@@ -419,13 +418,13 @@ namespace Raven.Server.Documents.Queries.Results
                 case TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult ts:
                     return (new Document
                     {
-                        Id = doc.Id,
+                        Id = doc.IgnoreDispose ? doc.Id.CloneOnSameContext() : doc.Id,
                         ChangeVector = doc.ChangeVector,
                         Data = _context.ReadObject(ts.Metadata, "time-series-metadata"),
                         Etag = doc.Etag,
                         Flags = doc.Flags,
                         LastModified = doc.LastModified,
-                        LowerId = doc.LowerId,
+                        LowerId = doc.IgnoreDispose ? doc.LowerId.CloneOnSameContext() : doc.LowerId,
                         NonPersistentFlags = doc.NonPersistentFlags,
                         StorageId = doc.StorageId,
                         TransactionMarker = doc.TransactionMarker,

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -400,13 +400,13 @@ namespace Raven.Server.Documents.Queries.Results
                         // https://issues.hibernatingrhinos.com/issue/RavenDB-19127
                         // We need to have a different instance of Id / LowerId, otherwise 
                         // they will be disposed (but then try to be used)
-                        Id = doc.IgnoreDispose ? doc.Id.CloneOnSameContext() : doc.Id,
+                        Id = doc.IgnoreDispose ? doc.Id?.CloneOnSameContext() : doc.Id,
                         ChangeVector = doc.ChangeVector,
                         Data = nested,
                         Etag = doc.Etag,
                         Flags = doc.Flags,
                         LastModified = doc.LastModified,
-                        LowerId = doc.IgnoreDispose ? doc.LowerId.CloneOnSameContext() : doc.LowerId,
+                        LowerId = doc.IgnoreDispose ? doc.LowerId?.CloneOnSameContext() : doc.LowerId,
                         NonPersistentFlags = doc.NonPersistentFlags,
                         StorageId = doc.StorageId,
                         TransactionMarker = doc.TransactionMarker
@@ -418,13 +418,13 @@ namespace Raven.Server.Documents.Queries.Results
                 case TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult ts:
                     return (new Document
                     {
-                        Id = doc.IgnoreDispose ? doc.Id.CloneOnSameContext() : doc.Id,
+                        Id = doc.IgnoreDispose ? doc.Id?.CloneOnSameContext() : doc.Id,
                         ChangeVector = doc.ChangeVector,
                         Data = _context.ReadObject(ts.Metadata, "time-series-metadata"),
                         Etag = doc.Etag,
                         Flags = doc.Flags,
                         LastModified = doc.LastModified,
-                        LowerId = doc.IgnoreDispose ? doc.LowerId.CloneOnSameContext() : doc.LowerId,
+                        LowerId = doc.IgnoreDispose ? doc.LowerId?.CloneOnSameContext() : doc.LowerId,
                         NonPersistentFlags = doc.NonPersistentFlags,
                         StorageId = doc.StorageId,
                         TransactionMarker = doc.TransactionMarker,

--- a/test/SlowTests/Issues/RavenDB-19127.cs
+++ b/test/SlowTests/Issues/RavenDB-19127.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using SlowTests.Client.Lazy.Async;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19127: RavenTestBase
+{
+    public RavenDB_19127(ITestOutputHelper output) : base(output)
+    {
+
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void Streaming_Query_On_Index_With_Load()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var definition = new IndexDefinitionBuilder<User>("UsersByNameAndFriendId")
+            {
+                Map = docs => from doc in docs
+                    select new { doc.Name, doc.FriendId }
+            }.ToIndexDefinition(store.Conventions);
+            store.Maintenance.Send(new PutIndexesOperation(definition));
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Jerry", LastName = "Garcia", FriendId = "users/2" }, "users/1");
+                session.Store(new User { Name = "Bob", LastName = "Weir", FriendId = "users/1" }, "users/2");
+                session.Store(new User { Name = "Pigpen", FriendId = "users/1" }, "users/3");
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var query = from u in session.Query<User>("UsersByNameAndFriendId")
+                    where u.Name != "Pigpen"
+                    let friend = RavenQuery.Load<User>(u.FriendId)
+                    select new { Name = u.Name, Friend = friend.Name };
+
+                Assert.Equal("from index \'UsersByNameAndFriendId\' as u where u.Name != $p0 " +
+                             "load u.FriendId as friend select { Name : u.Name, Friend : friend.Name }"
+                    , query.ToString());
+
+                var queryResult = session.Advanced.Stream(query);
+
+                List<dynamic> resList = new();
+                while (queryResult.MoveNext())
+                {
+                    var cur = queryResult.Current.Document;
+                    resList.Add(cur);
+                }
+
+                Assert.Equal(2, resList.Count);
+
+                Assert.Equal("Jerry", resList[0].Name);
+                Assert.Equal("Bob", resList[0].Friend);
+
+                Assert.Equal("Bob", resList[1].Name);
+                Assert.Equal("Jerry", resList[1].Friend);
+            }
+        }
+    }
+    
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string LastName { get; set; }
+        public DateTime Birthday { get; set; }
+        public int IdNumber { get; set; }
+        public bool IsActive { get; set; }
+        public string[] Roles { get; set; }
+        public string DetailId { get; set; }
+        public string FriendId { get; set; }
+        public IEnumerable<string> DetailIds { get; set; }
+        public List<LazyAsync.Detail> Details { get; set; }
+        public string DetailShortId { get; set; }
+        public List<string> Groups { get; set; }
+    }
+    
+    [Fact]
+    public void CanLoadDocumentThatWasAlreadyHandledByStreamingQuery()
+    {
+        using var store = GetDocumentStore();
+
+        using(var session = store.OpenSession())
+        {
+            session.Store(new Employee("Jane", null), "emps/jane");
+            session.Store(new Employee("Sandra", "emps/jane"));
+            session.SaveChanges();
+        }
+        
+        using (var session = store.OpenSession())
+        {
+            var query = from e in session.Query<Employee>()
+                let r = RavenQuery.Load<Employee>(e.Manager)
+                select new { e = e.FirstName, r = r.FirstName };    
+            
+            
+            var queryResult = session.Advanced.Stream(query);
+                
+            List<dynamic> resList = new();
+            while (queryResult.MoveNext())
+            {
+                var cur = queryResult.Current.Document;
+                resList.Add(cur);
+            }
+        }
+    }
+    
+    private class Employee
+    {
+        public Employee(string FirstName, string Manager)
+        {
+            this.FirstName = FirstName;
+            this.Manager = Manager;
+        }
+
+        public string FirstName { get; }
+        public string Manager { get; }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19127/Streaming-query-with-load-throws-Invalid-Json

### Additional description

When creating new document object (projection result), we were passing to it Id and LowerId from original document. The cloned document was later disposed, including our original Id and LowerId that we later tried to use.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
