### PR TITLE
RavenDB-19056 / RavenDB-18766  / RavenDB-13927Added tests which verify that given querying / indexing features aren't supported in sharding

### DIFF
--- a/test/SlowTests/Sharding/Issues/RavenDB_13927.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_13927.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_13927 : RavenTestBase
+{
+    public RavenDB_13927(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Querying)]
+    public void ShouldThrowOnAttemptToCreateIndexWithOutputReduce()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var e = Assert.Throws<NotSupportedInShardingException>(() =>
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User() { Name = "Foo"});
+                    session.Store(new User() { Name = "Bar"});
+
+                    session.SaveChanges();
+
+                    var list = session.Query<User>().Where(x => x.Name == "foo").OrderByScore()
+                        .ToList();
+                }
+            });
+            Assert.Contains("Ordering by score is not supported in sharding", e.Message);
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_18663.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18663.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_18663 : RavenTestBase
+{
+    public RavenDB_18663(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Querying)]
+    public void ShouldThrowOnAttemptToCreateIndexWithOutputReduce()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var e = Assert.Throws<NotSupportedInShardingException>(() =>
+            {
+                var operation = store.Operations.Send(new PatchByQueryOperation("from Companies update { this.Name = this.Name + '_Patched'; } limit 3"));
+
+            });
+            Assert.Contains("Query with limit is not supported in patch / delete by query operation", e.Message);
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_18766.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18766.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FastTests;
+using Nest;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.MoreLikeThis;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_18766 : RavenTestBase
+{
+    public RavenDB_18766(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Querying)]
+    public void ShouldThrowOnAttemptToCreateIndexWithOutputReduce()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var e = Assert.Throws<NotSupportedInShardingException>(() =>
+            {
+                using (var session = store.OpenSession())
+                {
+                    var list = session.Query<Data, DataIndex>()
+                        .MoreLikeThis(f => f.UsingDocument(x => x.Id == "data/1").WithOptions(new MoreLikeThisOptions
+                        {
+                            Fields = new[] { "Body" }
+                        }))
+                        .ToList();
+                }
+            });
+            Assert.Contains("MoreLikeThis queries are currently not supported in a sharded database ", e.Message);
+        }
+    }
+
+    private class Data
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+        public string WhitespaceAnalyzerField { get; set; }
+        public string PersonId { get; set; }
+    }
+
+    private class DataIndex : AbstractIndexCreationTask<Data>
+    {
+        public DataIndex()
+        {
+            Map = docs => from doc in docs
+                select new { doc.Body, doc.WhitespaceAnalyzerField };
+
+            Analyzers = new Dictionary<Expression<Func<Data, object>>, string>
+            {
+                {
+                    x => x.Body,
+                    typeof (StandardAnalyzer).FullName
+                },
+            };
+
+            TermVectors = new Dictionary<Expression<Func<Data, object>>, FieldTermVector>
+            {
+                {
+                    x => x.Body, FieldTermVector.Yes
+                },
+                {
+                    x => x.WhitespaceAnalyzerField, FieldTermVector.Yes
+                }
+            };
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_19056.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19056.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Sharding;
+using SlowTests.Server.Documents.Indexing.MapReduce;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_19056 : RavenTestBase
+{
+    public RavenDB_19056(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Querying)]
+    public void ShouldThrowOnAttemptToCreateIndexWithOutputReduce()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var e = Assert.Throws<NotSupportedInShardingException>(() => new DailyInvoicesIndex().Execute(store));
+            Assert.Contains("Index with output reduce to collection is not supported in sharding.", e.Message);
+        }
+    }
+
+    private class DailyInvoicesIndex : AbstractIndexCreationTask<OutputReduceToCollectionTests.Invoice, OutputReduceToCollectionTests.DailyInvoice>
+    {
+        public DailyInvoicesIndex()
+        {
+            Map = invoices =>
+                from invoice in invoices
+                select new OutputReduceToCollectionTests.DailyInvoice
+                {
+                    Date = invoice.IssuedAt.Date,
+                    Amount = invoice.Amount
+                };
+
+            Reduce = results =>
+                from r in results
+                group r by r.Date
+                into g
+                select new OutputReduceToCollectionTests.DailyInvoice
+                {
+                    Date = g.Key,
+                    Amount = g.Sum(x => x.Amount)
+                };
+
+            OutputReduceToCollection = "DailyInvoices";
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

Just for reference - please **do not** mark issues as fixed

https://issues.hibernatingrhinos.com/issue/RavenDB-13927/Sharding-ordering-by-score
https://issues.hibernatingrhinos.com/issue/RavenDB-18766/Sharding-Queries-MoreLikeThis
https://issues.hibernatingrhinos.com/issue/RavenDB-19056/Sharding-Indexes-OutputReduceToCollection
https://issues.hibernatingrhinos.com/issue/RavenDB-18663/Sharding-Patch-by-Query-Support-for-queries-with-limit-keyword


### Additional description

Tests which ensure that we throw appropriate exceptions

### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
