### PR TITLE
RavenDB-19337 Upgrade to Jint 3.0.0-beta-2047

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -228,7 +228,8 @@ function map(name, lambda) {
                     .AddObjectConverter(new JintEnumConverter())
                     .AddObjectConverter(new JintDateTimeConverter())
                     .AddObjectConverter(new JintTimeSpanConverter())
-                    .LocalTimeZone(TimeZoneInfo.Utc);
+                    .LocalTimeZone(TimeZoneInfo.Utc)
+                    .StringCompilationAllowed = false;
             });
 
             using (_engine.DisableMaxStatements())

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -273,7 +273,8 @@ namespace Raven.Server.Documents.Patch
                         .AddObjectConverter(new JintEnumConverter())
                         .AddObjectConverter(new JintDateTimeConverter())
                         .AddObjectConverter(new JintTimeSpanConverter())
-                        .LocalTimeZone(TimeZoneInfo.Utc);
+                        .LocalTimeZone(TimeZoneInfo.Utc)
+                        .StringCompilationAllowed = false;
                 });
 
                 JavaScriptUtils = new JavaScriptUtils(_runner, ScriptEngine);

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -165,7 +165,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Jint" Version="3.0.0-beta-2046" />
+    <PackageReference Include="Jint" Version="3.0.0-beta-2047" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="4.3.1" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.3.0" />
     <PackageReference Include="Lextm.SharpSnmpLib.Engine" Version="11.3.102" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19337

### Additional description

* https://github.com/sebastienros/jint/releases/tag/v3.0.0-beta-2047
* also disables dynamic code evaluation via eval and function constructor that is a new option in Jint

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Current CI tests should cover

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
