### PR TITLE
RavenDB-19988 do not allow to execute WaitForUserToContinueTheTest on CI

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -509,6 +509,8 @@ namespace FastTests
             if (debug && Debugger.IsAttached == false)
                 return;
 
+            RavenTestHelper.AssertNotRunningOnCi();
+
             if (clientCert != null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 using (var userPersonalStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -544,6 +546,11 @@ namespace FastTests
 
         public static void WaitForUserToContinueTheTest(IDocumentStore documentStore, bool debug = true, string database = null, X509Certificate2 clientCert = null)
         {
+            if (debug && Debugger.IsAttached == false)
+                return;
+
+            RavenTestHelper.AssertNotRunningOnCi();
+
             if (clientCert != null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 using (var userPersonalStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -555,9 +562,6 @@ namespace FastTests
 
             try
             {
-                if (debug && Debugger.IsAttached == false)
-                    return;
-
                 var urls = documentStore.Urls;
                 if (clientCert != null)
                     Console.WriteLine($"Using certificate with serial: {clientCert.SerialNumber}");

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -18,6 +18,7 @@ using Xunit;
 using System.Text;
 using Xunit.Sdk;
 using ExceptionAggregator = Raven.Server.Utils.ExceptionAggregator;
+using System.Runtime.CompilerServices;
 
 namespace FastTests
 {
@@ -243,6 +244,12 @@ namespace FastTests
             {
                 return obj.GetHashCode();
             }
+        }
+
+        public static void AssertNotRunningOnCi([CallerMemberName] string caller = null)
+        {
+            if (IsRunningOnCI)
+                throw new InvalidOperationException($"Operation '{caller}' is forbidden, because tests are running on CI.");
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19988

### Type of change

- Bug fix
- 
### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
