### PR TITLE
RavenDB-19357: Backup status out of sync for some databases

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupHelper.cs
@@ -61,7 +61,10 @@ namespace Raven.Server.Documents.PeriodicBackup
                 catch (TimeoutException)
                 {
                     if (++retries < maxRetries)
+                    {
+                        await Task.Delay(1_000);
                         continue;
+                    }
 
                     smugglerResult?.AddError(errorMessage);
                     onProgress?.Invoke(smugglerResult?.Progress);

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupHelper.cs
@@ -50,7 +50,8 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 try
                 {
-                    operationCancelToken?.Token.ThrowIfCancellationRequested();
+                    if (retries > 0)
+                        operationCancelToken?.Token.ThrowIfCancellationRequested();
 
                     smugglerResult?.AddInfo(infoMessage);
                     onProgress?.Invoke(smugglerResult?.Progress);

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -516,8 +516,12 @@ namespace Raven.Server.Documents.PeriodicBackup
                         periodicBackup.BackupStatus.LastFullBackupInternal = startTimeInUtc;
                     else
                         periodicBackup.BackupStatus.LastIncrementalBackupInternal = startTimeInUtc;
-
-                    BackupTask.SaveBackupStatus(periodicBackup.BackupStatus, _database, _logger);
+                    
+                    AsyncHelpers.RunSync(() => BackupTask.SaveBackupStatusAsync(
+                        periodicBackup.BackupStatus, 
+                        _database, 
+                        _logger, 
+                        operationCancelToken: periodicBackup.CancelToken));
 
                     var message = $"Failed to start the backup task: '{periodicBackup.Configuration.Name}'";
                     if (_logger.IsOperationsEnabled)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -517,11 +517,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     else
                         periodicBackup.BackupStatus.LastIncrementalBackupInternal = startTimeInUtc;
                     
-                    AsyncHelpers.RunSync(() => BackupTask.SaveBackupStatusAsync(
-                        periodicBackup.BackupStatus, 
-                        _database, 
-                        _logger, 
-                        operationCancelToken: periodicBackup.CancelToken));
+                    BackupTask.SaveBackupStatus(periodicBackup.BackupStatus, _database, _logger, operationCancelToken: periodicBackup.CancelToken);
 
                     var message = $"Failed to start the backup task: '{periodicBackup.Configuration.Name}'";
                     if (_logger.IsOperationsEnabled)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -517,7 +517,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     else
                         periodicBackup.BackupStatus.LastIncrementalBackupInternal = startTimeInUtc;
 
-                    BackupTask.SaveBackupStatus(periodicBackup.BackupStatus, _database, _logger, backupResult: null);
+                    BackupTask.SaveBackupStatus(periodicBackup.BackupStatus, _database, _logger);
 
                     var message = $"Failed to start the backup task: '{periodicBackup.Configuration.Name}'";
                     if (_logger.IsOperationsEnabled)

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -487,7 +487,8 @@ namespace Raven.Server.Web.System
                                     {
                                         var runningBackupStatus = new PeriodicBackupStatus { TaskId = 0, BackupType = backupConfiguration.BackupType };
                                         var backupResult = backupTask.RunPeriodicBackup(onProgress, ref runningBackupStatus);
-                                        BackupTask.SaveBackupStatus(runningBackupStatus, Database, Logger, backupResult);
+                                        AsyncHelpers.RunSync(() => 
+                                            BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken));
                                         tcs.SetResult(backupResult);
                                     }
                                 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -476,7 +476,7 @@ namespace Raven.Server.Web.System
                         onProgress =>
                         {
                             var tcs = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-                            PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
+                            PoolOfThreads.GlobalRavenThreadPool.LongRunning(async _ =>
                             {
                                 try
                                 {
@@ -487,8 +487,7 @@ namespace Raven.Server.Web.System
                                     {
                                         var runningBackupStatus = new PeriodicBackupStatus { TaskId = 0, BackupType = backupConfiguration.BackupType };
                                         var backupResult = backupTask.RunPeriodicBackup(onProgress, ref runningBackupStatus);
-                                        AsyncHelpers.RunSync(() => 
-                                            BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken));
+                                        await BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken);
                                         tcs.SetResult(backupResult);
                                     }
                                 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -476,7 +476,7 @@ namespace Raven.Server.Web.System
                         onProgress =>
                         {
                             var tcs = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-                            PoolOfThreads.GlobalRavenThreadPool.LongRunning(async _ =>
+                            PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
                             {
                                 try
                                 {
@@ -487,7 +487,8 @@ namespace Raven.Server.Web.System
                                     {
                                         var runningBackupStatus = new PeriodicBackupStatus { TaskId = 0, BackupType = backupConfiguration.BackupType };
                                         var backupResult = backupTask.RunPeriodicBackup(onProgress, ref runningBackupStatus);
-                                        await BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken);
+                                        AsyncHelpers.RunSync(() => 
+                                            BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken));
                                         tcs.SetResult(backupResult);
                                     }
                                 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -487,8 +487,7 @@ namespace Raven.Server.Web.System
                                     {
                                         var runningBackupStatus = new PeriodicBackupStatus { TaskId = 0, BackupType = backupConfiguration.BackupType };
                                         var backupResult = backupTask.RunPeriodicBackup(onProgress, ref runningBackupStatus);
-                                        AsyncHelpers.RunSync(() => 
-                                            BackupTask.SaveBackupStatusAsync(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken));
+                                        BackupTask.SaveBackupStatus(runningBackupStatus, Database, Logger, backupResult, operationCancelToken: cancelToken);
                                         tcs.SetResult(backupResult);
                                     }
                                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19357/Backup-status-out-of-sync-for-some-dbs

### Additional description

In conditions of cluster instability, the last backup status on different nodes is likely to be out of sync.
To improve failover resilience, we will now make 10 attempts to update the backup status in the cluster instead of just one.
To implement this functionality, we utilized a method from another class. In accordance with the DRY principle, this method has been moved to the appropriate class.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed