### PR TITLE
RavenDB-19945  Optimizing Changes API for use in aggressive caching

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -38,9 +38,9 @@ namespace Raven.Client.Documents.Changes
         }
     }
 
-    public class AggressiveCacheUpdate : DatabaseChange
+    internal class AggressiveCacheUpdate : DatabaseChange
     {
-        public static readonly AggressiveCacheUpdate Instance = new();
+        internal static readonly AggressiveCacheUpdate Instance = new();
     }
 
     public class DocumentChange : DatabaseChange

--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -38,9 +38,19 @@ namespace Raven.Client.Documents.Changes
         }
     }
 
-    internal class AggressiveCacheUpdate : DatabaseChange
+    internal class AggressiveCacheChange : DatabaseChange
     {
-        internal static readonly AggressiveCacheUpdate Instance = new();
+        internal static readonly AggressiveCacheChange Instance = new();
+
+        internal static bool ShouldUpdateAggressiveCache(DocumentChange change)
+        {
+            return change.Type is DocumentChangeTypes.Put or DocumentChangeTypes.Delete;
+        }
+
+        internal static bool ShouldUpdateAggressiveCache(IndexChange change)
+        {
+            return change.Type is IndexChangeTypes.BatchCompleted or IndexChangeTypes.IndexRemoved;
+        }
     }
 
     public class DocumentChange : DatabaseChange
@@ -308,7 +318,7 @@ namespace Raven.Client.Documents.Changes
                 DocumentId = documentId,
                 ChangeVector = changeVector,
                 Type = (TimeSeriesChangeTypes)Enum.Parse(typeof(TimeSeriesChangeTypes), type, ignoreCase: true),
-                CollectionName = collectionName 
+                CollectionName = collectionName
             };
         }
     }

--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -38,6 +38,11 @@ namespace Raven.Client.Documents.Changes
         }
     }
 
+    public class AggressiveCacheUpdate : DatabaseChange
+    {
+        public static readonly AggressiveCacheUpdate Instance = new();
+    }
+
     public class DocumentChange : DatabaseChange
     {
         /// <summary>

--- a/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
+++ b/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
@@ -3,5 +3,5 @@ namespace Raven.Client.Documents.Changes;
 public class ChangesSupportedFeatures
 {
     public bool TopologyChange;
-    public bool AggressiveCaching;
+    public bool AggressiveCachingChange;
 }

--- a/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
+++ b/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
@@ -1,0 +1,7 @@
+namespace Raven.Client.Documents.Changes;
+
+public class ChangesSupportedFeatures
+{
+    public bool TopologyChange;
+    public bool AggressiveCaching;
+}

--- a/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
+++ b/src/Raven.Client/Documents/Changes/ChangesSupportedFeatures.cs
@@ -1,6 +1,6 @@
 namespace Raven.Client.Documents.Changes;
 
-public class ChangesSupportedFeatures
+internal class ChangesSupportedFeatures
 {
     public bool TopologyChange;
     public bool AggressiveCachingChange;

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Changes
         private int _immediateConnection;
         
         private readonly TaskCompletionSource<ChangesSupportedFeatures> _supportedFeaturesTcs = new();
-        internal Task<ChangesSupportedFeatures> GetSupportedFeatures() => _supportedFeaturesTcs.Task;
+        internal Task<ChangesSupportedFeatures> GetSupportedFeaturesAsync() => _supportedFeaturesTcs.Task;
 
         private ServerNode _serverNode;
         private int _nodeIndex;
@@ -60,7 +60,7 @@ namespace Raven.Client.Documents.Changes
             _cts = new CancellationTokenSource();
             _client = CreateClientWebSocket(_requestExecutor);
 
-            GetSupportedFeatures().ContinueWith(async t =>
+            GetSupportedFeaturesAsync().ContinueWith(async t =>
             {
                 if (t.Result.TopologyChange == false)
                     return;
@@ -182,11 +182,11 @@ namespace Raven.Client.Documents.Changes
             return taskedObservable;
         }
 
-        internal IChangesObservable<AggressiveCacheUpdate> ForAggressiveCaching()
+        internal IChangesObservable<AggressiveCacheChange> ForAggressiveCaching()
         {
             var counter = GetOrAddConnectionState("aggressive-caching", "watch-aggressive-caching", "unwatch-aggressive-caching", null);
 
-            var taskedObservable = new ChangesObservable<AggressiveCacheUpdate, DatabaseConnectionState>(
+            var taskedObservable = new ChangesObservable<AggressiveCacheChange, DatabaseConnectionState>(
                 counter,
                 notification => true);
 
@@ -726,10 +726,10 @@ namespace Raven.Client.Documents.Changes
         {
             switch (type)
             {
-                case nameof(AggressiveCacheUpdate):
+                case nameof(AggressiveCacheChange):
                     foreach (var state in _counters)
                     {
-                        state.Value.Send(AggressiveCacheUpdate.Instance);
+                        state.Value.Send(AggressiveCacheChange.Instance);
                     }
                     break;
                 case nameof(DocumentChange):

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Changes
         private int _immediateConnection;
         
         private readonly TaskCompletionSource<ChangesSupportedFeatures> _supportedFeaturesTcs = new();
-        public Task<ChangesSupportedFeatures> SupportedFeatures => _supportedFeaturesTcs.Task;
+        internal Task<ChangesSupportedFeatures> GetSupportedFeatures() => _supportedFeaturesTcs.Task;
 
         private ServerNode _serverNode;
         private int _nodeIndex;
@@ -60,7 +60,7 @@ namespace Raven.Client.Documents.Changes
             _cts = new CancellationTokenSource();
             _client = CreateClientWebSocket(_requestExecutor);
 
-            SupportedFeatures.ContinueWith(async t =>
+            GetSupportedFeatures().ContinueWith(async t =>
             {
                 if (t.Result.TopologyChange == false)
                     return;
@@ -182,8 +182,7 @@ namespace Raven.Client.Documents.Changes
             return taskedObservable;
         }
 
-        
-        public IChangesObservable<AggressiveCacheUpdate> ForAggressiveCaching()
+        internal IChangesObservable<AggressiveCacheUpdate> ForAggressiveCaching()
         {
             var counter = GetOrAddConnectionState("aggressive-caching", "watch-aggressive-caching", "unwatch-aggressive-caching", null);
 
@@ -193,6 +192,7 @@ namespace Raven.Client.Documents.Changes
 
             return taskedObservable;
         }
+        
         public IChangesObservable<OperationStatusChange> ForOperationId(long operationId)
         {
             var counter = GetOrAddConnectionState("operations/" + operationId, "watch-operation", "unwatch-operation", operationId.ToString());

--- a/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
@@ -6,7 +6,7 @@ using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Changes
 {
-    internal class DatabaseConnectionState : IChangesConnectionState<DocumentChange>, IChangesConnectionState<IndexChange>, IChangesConnectionState<OperationStatusChange>, IChangesConnectionState<CounterChange>, IChangesConnectionState<TimeSeriesChange>
+    internal class DatabaseConnectionState : IChangesConnectionState<DocumentChange>, IChangesConnectionState<IndexChange>, IChangesConnectionState<OperationStatusChange>, IChangesConnectionState<CounterChange>, IChangesConnectionState<TimeSeriesChange>, IChangesConnectionState<AggressiveCacheUpdate>
     {
         public event Action<Exception> OnError;
 
@@ -91,6 +91,12 @@ namespace Raven.Client.Documents.Changes
             add => OnDocumentChangeNotification += value;
             remove => OnDocumentChangeNotification -= value;
         }
+        
+        event Action<AggressiveCacheUpdate> IChangesConnectionState<AggressiveCacheUpdate>.OnChangeNotification
+        {
+            add => OnAggressiveCacheUpdateNotification += value;
+            remove => OnAggressiveCacheUpdateNotification -= value;
+        }
 
         public void Dispose()
         {
@@ -99,6 +105,7 @@ namespace Raven.Client.Documents.Changes
             OnCounterChangeNotification = null;
             OnTimeSeriesChangeNotification = null;
             OnIndexChangeNotification = null;
+            OnAggressiveCacheUpdateNotification = null;
             OnOperationStatusChangeNotification = null;
             OnError = null;
         }
@@ -117,6 +124,7 @@ namespace Raven.Client.Documents.Changes
         private event Action<IndexChange> OnIndexChangeNotification;
 
         private event Action<OperationStatusChange> OnOperationStatusChangeNotification;
+        private event Action<AggressiveCacheUpdate> OnAggressiveCacheUpdateNotification;
 
         private event Action<TimeSeriesChange> OnTimeSeriesChangeNotification;
 
@@ -143,6 +151,11 @@ namespace Raven.Client.Documents.Changes
         public void Send(OperationStatusChange operationStatusChange)
         {
             OnOperationStatusChangeNotification?.Invoke(operationStatusChange);
+        }
+        
+        public void Send(AggressiveCacheUpdate aggressiveCacheUpdate)
+        {
+            OnAggressiveCacheUpdateNotification?.Invoke(aggressiveCacheUpdate);
         }
     }
 }

--- a/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
@@ -6,7 +6,7 @@ using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Changes
 {
-    internal class DatabaseConnectionState : IChangesConnectionState<DocumentChange>, IChangesConnectionState<IndexChange>, IChangesConnectionState<OperationStatusChange>, IChangesConnectionState<CounterChange>, IChangesConnectionState<TimeSeriesChange>, IChangesConnectionState<AggressiveCacheUpdate>
+    internal class DatabaseConnectionState : IChangesConnectionState<DocumentChange>, IChangesConnectionState<IndexChange>, IChangesConnectionState<OperationStatusChange>, IChangesConnectionState<CounterChange>, IChangesConnectionState<TimeSeriesChange>, IChangesConnectionState<AggressiveCacheChange>
     {
         public event Action<Exception> OnError;
 
@@ -92,7 +92,7 @@ namespace Raven.Client.Documents.Changes
             remove => OnDocumentChangeNotification -= value;
         }
         
-        event Action<AggressiveCacheUpdate> IChangesConnectionState<AggressiveCacheUpdate>.OnChangeNotification
+        event Action<AggressiveCacheChange> IChangesConnectionState<AggressiveCacheChange>.OnChangeNotification
         {
             add => OnAggressiveCacheUpdateNotification += value;
             remove => OnAggressiveCacheUpdateNotification -= value;
@@ -124,7 +124,7 @@ namespace Raven.Client.Documents.Changes
         private event Action<IndexChange> OnIndexChangeNotification;
 
         private event Action<OperationStatusChange> OnOperationStatusChangeNotification;
-        private event Action<AggressiveCacheUpdate> OnAggressiveCacheUpdateNotification;
+        private event Action<AggressiveCacheChange> OnAggressiveCacheUpdateNotification;
 
         private event Action<TimeSeriesChange> OnTimeSeriesChangeNotification;
 
@@ -153,9 +153,9 @@ namespace Raven.Client.Documents.Changes
             OnOperationStatusChangeNotification?.Invoke(operationStatusChange);
         }
         
-        public void Send(AggressiveCacheUpdate aggressiveCacheUpdate)
+        public void Send(AggressiveCacheChange aggressiveCacheChange)
         {
-            OnAggressiveCacheUpdateNotification?.Invoke(aggressiveCacheUpdate);
+            OnAggressiveCacheUpdateNotification?.Invoke(aggressiveCacheChange);
         }
     }
 }

--- a/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
+++ b/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
@@ -26,15 +26,15 @@ namespace Raven.Client.Documents.Changes
         {
             _databaseName = databaseName;
             _requestExecutor = store.GetRequestExecutor(databaseName);
-            _changes = new DatabaseChanges(_requestExecutor, databaseName, null, null);
+            _changes = new DatabaseChanges(_requestExecutor, databaseName, onDispose: null,nodeTag: null);
             _taskConnected = EnsureConnectedInternalAsync();
         }
 
         private async Task EnsureConnectedInternalAsync()
         {
             await _changes.EnsureConnectedNow().ConfigureAwait(false);
-            var changesSupportedFeatures = await _changes.SupportedFeatures.ConfigureAwait(false);
-            if (changesSupportedFeatures.AggressiveCaching)
+            var changesSupportedFeatures = await _changes.GetSupportedFeatures().ConfigureAwait(false);
+            if (changesSupportedFeatures.AggressiveCachingChange)
             {
                 var forAggressiveCachingChanges = _changes.ForAggressiveCaching();
                 _aggressiveCachingSubscription = forAggressiveCachingChanges.Subscribe(this);

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Identity;
@@ -62,6 +63,8 @@ namespace Raven.Client.Json.Serialization
         public static readonly Func<BlittableJsonReaderObject, AttachmentName> AttachmentName = GenerateJsonDeserializationRoutine<AttachmentName>();
 
         public static readonly Func<BlittableJsonReaderObject, QueryResult> QueryResult = GenerateJsonDeserializationRoutine<QueryResult>();
+        
+        public static readonly Func<BlittableJsonReaderObject, ChangesSupportedFeatures> ChangesSupportedFeatures = GenerateJsonDeserializationRoutine<ChangesSupportedFeatures>();
 
         public static readonly Func<BlittableJsonReaderObject, MoreLikeThisQueryResult> MoreLikeThisQueryResult = GenerateJsonDeserializationRoutine<MoreLikeThisQueryResult>();
 

--- a/src/Raven.Server/Documents/ChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/ChangesClientConnection.cs
@@ -353,6 +353,7 @@ namespace Raven.Server.Documents
 
             if (_aggressiveChanges)
             {
+                Debug.Assert(_watchAllDocuments == 0 && (_matchingDocuments == null || _matchingDocuments.Count == 0));
                 PulseAggressiveCaching();
                 return;
             }
@@ -393,6 +394,7 @@ namespace Raven.Server.Documents
         {
             if (_aggressiveChanges)
             {
+                Debug.Assert(_watchAllIndexes == 0 && (_matchingIndexes == null || _matchingIndexes.Count == 0));
                 PulseAggressiveCaching();
                 return;
             }
@@ -755,7 +757,7 @@ namespace Raven.Server.Documents
                 ValueToSend = new DynamicJsonValue
                 {
                     [nameof(ChangesSupportedFeatures.TopologyChange)] = true,
-                    [nameof(ChangesSupportedFeatures.AggressiveCaching)] = true,
+                    [nameof(ChangesSupportedFeatures.AggressiveCachingChange)] = true,
                 },
                 AllowSkip = false
             });

--- a/src/Raven.Server/Documents/ChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/ChangesClientConnection.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents
         private readonly DocumentDatabase _documentDatabase;
         private readonly AsyncQueue<ChangeValue> _sendQueue = new AsyncQueue<ChangeValue>();
         private readonly MultipleUseFlag _lowMemoryFlag = new();
-        
+
         public CancellationTokenSource CancellationToken { get; }
 
         private readonly CancellationToken _disposeToken;
@@ -354,10 +354,12 @@ namespace Raven.Server.Documents
             if (_aggressiveChanges)
             {
                 Debug.Assert(_watchAllDocuments == 0 && (_matchingDocuments == null || _matchingDocuments.Count == 0));
-                PulseAggressiveCaching();
+
+                if (AggressiveCacheChange.ShouldUpdateAggressiveCache(change))
+                    PulseAggressiveCaching();
                 return;
             }
-            
+
             if (_watchAllDocuments > 0)
             {
                 Send(change);
@@ -395,7 +397,9 @@ namespace Raven.Server.Documents
             if (_aggressiveChanges)
             {
                 Debug.Assert(_watchAllIndexes == 0 && (_matchingIndexes == null || _matchingIndexes.Count == 0));
-                PulseAggressiveCaching();
+
+                if (AggressiveCacheChange.ShouldUpdateAggressiveCache(change))
+                    PulseAggressiveCaching();
                 return;
             }
 
@@ -416,7 +420,7 @@ namespace Raven.Server.Documents
             AllowSkip = true,
             ValueToSend = new DynamicJsonValue
             {
-                ["Type"] = nameof(AggressiveCacheUpdate),
+                ["Type"] = nameof(AggressiveCacheChange),
             }
         };
 

--- a/src/Sparrow.Server/Collections/AsyncQueue.cs
+++ b/src/Sparrow.Server/Collections/AsyncQueue.cs
@@ -10,7 +10,15 @@ namespace Sparrow.Server.Collections
         private readonly ConcurrentQueue<T> _inner = new ConcurrentQueue<T>();
         private readonly AsyncManualResetEvent _event = new AsyncManualResetEvent();
         public int Count => _inner.Count;
+        public bool IsEmpty => _inner.IsEmpty;
 
+        public void AddIfEmpty(T item)
+        {
+            if (_event.IsSet)
+                return;
+            Enqueue(item);
+        }
+        
         public void Enqueue(T item)
         {
             _inner.Enqueue(item);

--- a/test/SlowTests/Issues/RavenDB-19945.cs
+++ b/test/SlowTests/Issues/RavenDB-19945.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Nito.AsyncEx;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Http;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues ;
+
+public class RavenDB_19945 : RavenTestBase
+{
+    public RavenDB_19945(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task WillNotSendEvenForEachChangeForAggressiveCaching()
+    {
+        using var store = GetDocumentStore();
+
+        const int count = 100;
+        var cde = new CountdownEvent(count);
+        var requestExecutor = store.GetRequestExecutor();
+        int cacheGeneration = requestExecutor.Cache.Generation;
+        using(await store.AggressivelyCacheAsync())
+        {
+            IDatabaseChanges databaseChanges = store.Changes();
+            await databaseChanges.EnsureConnectedNow().ConfigureAwait(false);
+            IChangesObservable<DocumentChange> forAllDocuments = databaseChanges.ForAllDocuments();
+            await forAllDocuments.EnsureSubscribedNow().ConfigureAwait(false);
+            forAllDocuments.Subscribe(_ => cde.Signal());
+
+            for (int i = 0; i < count / 10; i++)
+            {
+                using var s = store.OpenAsyncSession();
+                for (int j = 0; j < count/10; j++)
+                {
+                    await s.StoreAsync(new { });
+                }
+                await s.SaveChangesAsync();
+            }
+        }
+
+        Assert.True(cde.Wait(TimeSpan.FromSeconds(30)));
+        
+        Assert.NotEqual(cacheGeneration, requestExecutor.Cache.Generation); // has updates
+        Assert.True(cacheGeneration + count > requestExecutor.Cache.Generation); // not for every single one
+    }
+}


### PR DESCRIPTION
- Optimizing Changes API for use in aggressive caching under high load-
- Added a dedicated option to handle aggressive changes that will let the client know when changes happen.
- Separated aggressive caching & changes channels
- Will only notify the client *once* per set of events, to avoid overwhelming it (or creating big set of messages on the server)
- Handle older servers as well properly using older mechanism

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19945  

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

