### PR TITLE
RavenDB-19454 Add what host / port we try to bind to when we fail to …

### DIFF
--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -259,10 +259,22 @@ namespace Raven.Server
                             }
                             else if (e is SocketException && PlatformDetails.RunningOnPosix)
                             {
+                                string urls;
+                                try
+                                {
+                                    var web = server.Configuration.Core?.ServerUrls ?? Array.Empty<string>();
+                                    var tcp = server.Configuration.Core.TcpServerUrls ?? Array.Empty<string>();
+                                    urls = string.Join(", ", web.Concat(tcp));
+                                }
+                                catch (Exception eUrl)
+                                {
+                                    urls = "Unable to figure our which URL is used because: " + eUrl; // should never happen
+                                }
                                 message =
                                     $"{Environment.NewLine}In Linux low-level port (below 1024) will need a special permission, " +
                                     $"if this is your case please run{Environment.NewLine}" +
-                                    $"sudo setcap CAP_NET_BIND_SERVICE=+eip {Path.Combine(AppContext.BaseDirectory, "Raven.Server")}";
+                                    $"sudo setcap CAP_NET_BIND_SERVICE=+eip {Path.Combine(AppContext.BaseDirectory, "Raven.Server")}{Environment.NewLine}" + 
+                                    $"Urls: [{urls}]";
                             }
                             else if (e.InnerException is LicenseExpiredException)
                             {


### PR DESCRIPTION
…listen to the network

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19454 

### Type of change

- Better error message

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

