### PR TITLE
RavenDB-19226: specified the source of Subscription at the log lines

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
         protected SubscriptionProcessor(ServerStore server, DocumentDatabase database, SubscriptionConnection connection) :
             base(server, database, connection)
         {
-            Logger = LoggingSource.Instance.GetLogger<SubscriptionProcessor<T>>(Database.Name);
+            Logger = LoggingSource.Instance.GetLogger(Database.Name, connection == null ? $"{nameof(TestDocumentsSubscriptionProcessor)}" : $"{nameof(SubscriptionProcessor)}<{connection.Options.SubscriptionName}>");
         }
 
         protected abstract SubscriptionFetcher<T> CreateFetcher();

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.TcpHandlers
         public readonly TcpConnectionOptions TcpConnection;
         public readonly string ClientUri;
         private readonly MemoryStream _buffer = new MemoryStream();
-        private readonly Logger _logger;
+        private  Logger _logger;
         public readonly SubscriptionConnectionStats Stats;
 
         private SubscriptionConnectionStatsScope _connectionScope;
@@ -155,7 +155,6 @@ namespace Raven.Server.Documents.TcpHandlers
             TcpConnection = connectionOptions;
             _subscriptionConnectionInProgress = subscriptionConnectionInProgress;
             ClientUri = connectionOptions.TcpClient.Client.RemoteEndPoint.ToString();
-            _logger = LoggingSource.Instance.GetLogger<SubscriptionConnection>(connectionOptions.DocumentDatabase.Name);
             CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TcpConnection.DocumentDatabase.DatabaseShutdown);
             _supportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Subscription, connectionOptions.ProtocolVersion);
             Stats = new SubscriptionConnectionStats();
@@ -181,7 +180,8 @@ namespace Raven.Server.Documents.TcpHandlers
 
                 if (string.IsNullOrEmpty(_options.SubscriptionName))
                     return;
-
+                
+                _logger = LoggingSource.Instance.GetLogger(TcpConnection.DocumentDatabase.Name, $"{nameof(SubscriptionConnection)}<{_options.SubscriptionName}>");
                 context.OpenReadTransaction();
 
                 var subscriptionItemKey = SubscriptionState.GenerateSubscriptionItemKeyName(TcpConnection.DocumentDatabase.Name, _options.SubscriptionName);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19226/Pass-the-logger-from-SubscriptionConnection-to-SubscriptionProcessor

### Additional description

specified the source of Subscription at the log lines (SubscriptionProcessor/SubscriptionConnection). 
examples:
`2023-02-26T11:19:47.5240911Z, 23, Information, test, SubscriptionProcessor<testTask>, orders/1-A filtered out by criteria`
`2023-02-26T11:19:47.4158739Z, 23, Information, test, SubscriptionConnection<testTask>, Starting processing documents for subscription 65 received from 127.0.0.1:61040
`
### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
