### PR TITLE
RavenDB-19990 Allow to skip over int.Max docs in query (for Corax) but limit projection up to int.Max

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
 using Amazon.SQS.Model;
@@ -9,6 +8,7 @@ using Corax;
 using Corax.Mappings;
 using Corax.Queries;
 using Corax.Utils;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Explanation;
 using Raven.Client.Documents.Queries.MoreLikeThis;
@@ -283,8 +283,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private struct NoDistinct : IHasDistinct { }
 
         private struct HasDistinct : IHasDistinct { }
-
-
+        
         // Even if there are no distinct statements we have to be sure that we are not including
         // documents that we have already included during this request. 
         protected struct IdentityTracker<TDistinct> where TDistinct : struct, IHasDistinct
@@ -297,8 +296,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
             private bool _isMap;
 
-            private HashSet<UnmanagedSpan> _alreadySeenDocumentKeysInPreviousPage;
-            private HashSet<ulong> _alreadySeenProjections;
+            private GrowableHashSet<UnmanagedSpan> _alreadySeenDocumentKeysInPreviousPage;
+            private GrowableHashSet<ulong> _alreadySeenProjections;
 
             public void Initialize(Index index, IndexQueryServerSide query, IndexSearcher searcher, IndexFieldsMapping fieldsMapping, FieldsToFetch fieldsToFetch, IQueryResultRetriever retriever)
             {
@@ -309,7 +308,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 _retriever = retriever;
 
                 _alreadySeenDocumentKeysInPreviousPage = new(UnmanagedSpanComparer.Instance);
-
                 _isMap = index.Type.IsMap();
             }
 
@@ -350,7 +348,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 if (typeof(TDistinct) == typeof(HasDistinct))
                 {
                     _alreadySeenProjections ??= new();
-
                     var retriever = _retriever;
                     foreach (var id in distinctIds)
                     {
@@ -1281,6 +1278,62 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 if (staticFields.Contains(field))
                     continue;
                 yield return field;
+            }
+        }
+        
+        internal class GrowableHashSet<TItem>
+        {
+            private List<HashSet<TItem>> _hashSetsBucket;
+            private HashSet<TItem> _newestHashSet;
+            private readonly int _maxSizePerCollection;
+            private readonly IEqualityComparer<TItem> _comparer;
+
+            public bool HasMultipleHashSets => _hashSetsBucket != null;
+
+            public GrowableHashSet(IEqualityComparer<TItem> comparer = null, int? maxSizePerCollection = null)
+            {
+                _comparer = comparer;
+                _hashSetsBucket = null;
+                _maxSizePerCollection = maxSizePerCollection ?? int.MaxValue;
+                CreateNewHashSet();
+            }
+
+            public bool Add(TItem item)
+            {
+                if (_newestHashSet!.Count >= _maxSizePerCollection)
+                    UnlikelyGrowBuffer();
+
+                if (_hashSetsBucket != null && Contains(item))
+                    return false;
+
+                return _newestHashSet.Add(item);
+            }
+
+            private void UnlikelyGrowBuffer()
+            {
+                _hashSetsBucket ??= new();
+                _hashSetsBucket.Add(_newestHashSet);
+                CreateNewHashSet();
+            }
+
+            public bool Contains(TItem item)
+            {
+                if (_hashSetsBucket != null)
+                {
+                    foreach (var hashSet in _hashSetsBucket)
+                        if (hashSet.Contains(item))
+                            return true;
+                }
+
+                return _newestHashSet!.Contains(item);
+            }
+
+            private void CreateNewHashSet()
+            {
+                if (_comparer == null)
+                    _newestHashSet = new();
+                else
+                    _newestHashSet = new(_comparer);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexOperationBase.cs
@@ -138,8 +138,7 @@ public abstract class IndexOperationBase : IDisposable
             : DefaultBufferSizeForCorax;
     }
     
-    protected QueryFilter GetQueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<long> skippedResults,
-        Reference<long> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
+    protected QueryFilter GetQueryFilter(Index index, IndexQueryServerSide query, DocumentsOperationContext documentsContext, Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever, QueryTimingsScope queryTimings)
     {
         if (query.Metadata.FilterScript is null)
             return null;

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -41,7 +41,6 @@ namespace Raven.Server.Documents.Queries
         [JsonDeserializationIgnore]
         public long? FilterLimit { get; set; }
 
-
         [JsonDeserializationIgnore]
         public QueryMetadata Metadata { get; private set; }
 
@@ -198,28 +197,28 @@ namespace Raven.Server.Documents.Queries
             {
                 if (result.Metadata.Query.Offset != null)
                 {
-                    var start = (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    var start = QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
                     result.Offset = start;
-                    result.Start = result.Start != 0 || json.TryGet(nameof(Start), out int _)
+                    result.Start = result.Start != 0 || json.TryGet(nameof(Start), out long _)
                         ? Math.Max(start, result.Start)
                         : start;
                 }
 
                 if (result.Metadata.Query.Limit != null)
                 {
-                    var limit = (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    var limit = Math.Min(int.MaxValue, QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue));
                     result.Limit = limit;
                     result.PageSize = Math.Min(limit, result.PageSize);
                 }
 
                 if (result.Metadata.Query.FilterLimit != null)
                 {
-                    result.FilterLimit = (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.FilterLimit, int.MaxValue);
+                    result.FilterLimit = Math.Min(int.MaxValue, QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.FilterLimit, int.MaxValue));
                 }
             }
         }
 
-        public static async Task<IndexQueryServerSide> CreateAsync(HttpContext httpContext, int start, int pageSize, JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties = false, string clientQueryId = null, string overrideQuery = null)
+        public static async Task<IndexQueryServerSide> CreateAsync(HttpContext httpContext, long start, long pageSize, JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties = false, string clientQueryId = null, string overrideQuery = null)
         {
             IndexQueryServerSide result = null;
             try
@@ -302,22 +301,21 @@ namespace Raven.Server.Documents.Queries
             {
                 if (result.Metadata.Query.Offset != null)
                 {
-                    var offset = (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
+                    var offset = QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Offset, 0);
                     result.Offset = offset;
                     result.Start = start + offset;
                 }
 
                 if (result.Metadata.Query.Limit != null)
                 {
-                    pageSize = (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue);
+                    pageSize = Math.Min(int.MaxValue, QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.Limit, int.MaxValue));
                     result.Limit = pageSize;
                     result.PageSize = Math.Min(result.PageSize, pageSize);
                 }
 
                 if (result.Metadata.Query.FilterLimit != null)
                 {
-                    result.FilterLimit =
-                        (int)QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.FilterLimit, int.MaxValue);
+                    result.FilterLimit = Math.Min(int.MaxValue, QueryBuilderHelper.GetLongValue(result.Metadata.Query, result.Metadata, result.QueryParameters, result.Metadata.Query.FilterLimit, int.MaxValue));
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-19932.cs
+++ b/test/SlowTests/Issues/RavenDB-19932.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19932 : RavenTestBase
+{
+    public RavenDB_19932(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void GrowableHashSetForProjectionInCoraxIndexReadOperation()
+    {
+        var growableHashSet = new CoraxIndexReadOperation.GrowableHashSet<ulong>(maxSizePerCollection: 100);
+        var random = new Random(64352);
+        var hashset = new HashSet<ulong>();
+
+        for (int i = 0; i < 10_000; ++i)
+        {
+            var rand = (ulong)random.NextInt64(0, long.MaxValue);
+            Assert.Equal(hashset.Add(rand), growableHashSet.Add(rand));
+        }
+
+        Assert.True(growableHashSet.HasMultipleHashSets);
+        var shuffledList = hashset.ToList();
+        shuffledList.Shuffle();
+
+        for (int i = 0; i < shuffledList.Count; ++i)
+        {
+            Assert.True(growableHashSet.Contains(shuffledList[i])); //exists
+            Assert.False(growableHashSet.Add(shuffledList[i])); //cannot add again
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19990
https://issues.hibernatingrhinos.com/issue/RavenDB-19932
### Additional description

When we've to register more than int32 results in hashsets let's change it single HashSet into the bucket of HashSets.
After a [discussion](https://github.com/ravendb/ravendb/pull/15850) we decided to:
- for Corax: you can skip over `int32.Max`
- for Lucene: since the max number of entries is `int32.Max` effectively we will do nothing since it skips whole collection.
-  the number of results from the single request is `int32.Max`. In case when a user sends `pageSize`  bigger than `int32.Max` we will trim it into `int32.Max` silently.
### Type of change


- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

It's hard to test it with DB so I provide a test for data structure.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
