### PR TITLE
HRINT-3161 windows docker container fix

### DIFF
--- a/docker/build-nanoserver.ps1
+++ b/docker/build-nanoserver.ps1
@@ -33,7 +33,8 @@ function BuildWindowsDockerImage ($version, $WinVer) {
     
     write-host "Tags: $tags"
 
-    docker build -t $fullNameTag -f "Dockerfile.$WinVer" "$DockerfileDir"
+    docker build -t $fullNameTag -f "$DockerfileDir/Dockerfile.$WinVer" "$DockerfileDir"
+    CheckLastExitCode
 
     foreach ($tag in $tags[1..$tags.Length]) {
         write-host "Tag $fullNameTag as $tag"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-3161

### Additional description

Wrong path  for dockerfile.

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
