### PR TITLE
RavenDB-19995: Getting OperationCanceled during cluster debug package creation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/databases/*/debug/info-package", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetInfoPackage()
         {
-            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H:mm:ss} - Database [{Database.Name}].zip";
+            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H-mm-ss} - Database [{Database.Name}].zip";
             HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -97,7 +97,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/admin/debug/cluster-info-package", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task GetClusterWideInfoPackage()
         {
-            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H:mm:ss} Cluster Wide.zip";
+            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H-mm-ss} Cluster Wide.zip";
             HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
             HttpContext.Response.Headers["Content-Type"] = "application/zip";
 
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/admin/debug/info-package", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task GetInfoPackage()
         {
-            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H:mm:ss} - Node [{ServerStore.NodeTag}].zip";
+            var contentDisposition = $"attachment; filename={DateTime.UtcNow:yyyy-MM-dd H-mm-ss} - Node [{ServerStore.NodeTag}].zip";
             HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
             HttpContext.Response.Headers["Content-Type"] = "application/zip";
 
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                             var localEndpointClient = new LocalEndpointClient(Server);
 
                             await WriteServerInfo(archive, context, localEndpointClient, token.Token);
-                            await WriteForAllLocalDatabases(archive, context, localEndpointClient, token: token.Token);
+                            await WriteForAllLocalDatabases(archive, context, localEndpointClient, token.Token);
                             await WriteLogFile(archive, token.Token);
                         }
                         catch (Exception e)
@@ -201,7 +201,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
         private static async Task WriteLogFile(ZipArchive archive, CancellationToken token)
         {
-            var prefix = $"{_serverWidePrefix}/{DateTime.UtcNow:yyyy-MM-dd H:mm:ss}.log";
+            var prefix = $"{_serverWidePrefix}/{DateTime.UtcNow:yyyy-MM-dd H-mm-ss}.log";
             var entry = archive.CreateEntry(prefix, CompressionLevel.Optimal);
             entry.ExternalAttributes = (int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR) << 16;
             await using (var entryStream = entry.Open())
@@ -269,7 +269,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        private async Task WriteForAllLocalDatabases(ZipArchive archive, JsonOperationContext jsonOperationContext, LocalEndpointClient localEndpointClient,  CancellationToken token)
+        private async Task WriteForAllLocalDatabases(ZipArchive archive, JsonOperationContext jsonOperationContext, LocalEndpointClient localEndpointClient, CancellationToken token)
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -361,21 +361,24 @@ namespace Raven.Server.Documents.Handlers.Debugging
             await DebugInfoPackageUtils.WriteDebugInfoTimesAsZipEntryAsync(debugInfoDict, archive, databaseName);
         }
 
-        internal static async Task InvokeAndWriteToArchive(ZipArchive archive, JsonOperationContext jsonOperationContext, LocalEndpointClient localEndpointClient, RouteInformation route, string path, Dictionary<string, Microsoft.Extensions.Primitives.StringValues> endpointParameters = null, CancellationToken token = default)
+        internal static async Task InvokeAndWriteToArchive(ZipArchive archive, JsonOperationContext jsonOperationContext, 
+            LocalEndpointClient localEndpointClient, RouteInformation route, string path, Dictionary<string, 
+                Microsoft.Extensions.Primitives.StringValues> endpointParameters = null, CancellationToken token = default)
         {
             try
             {
-                var response = await localEndpointClient.InvokeAsync(route, endpointParameters);
+                var response = await localEndpointClient.InvokeAsync(route, endpointParameters, token);
 
                 var entryName = DebugInfoPackageUtils.GetOutputPathFromRouteInformation(route, path, response.ContentType == "text/plain" ? "txt" : "json");
                 var entry = archive.CreateEntry(entryName);
-                entry.ExternalAttributes = ((int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR)) << 16;
+                entry.ExternalAttributes = (int)(FilePermissions.S_IRUSR | FilePermissions.S_IWUSR) << 16;
 
+                // we have the response at this point, not using the cancel token here on purpose
                 await using (var entryStream = entry.Open())
                 {
                     if (response.ContentType == "text/plain")
                     {
-                        await response.Body.CopyToAsync(entryStream, token);
+                        await response.Body.CopyToAsync(entryStream);
                     }
                     else
                     {
@@ -383,11 +386,11 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         {
                             var endpointOutput = await jsonOperationContext.ReadForMemoryAsync(response.Body, $"read/local endpoint/{route.Path}");
                             jsonOperationContext.Write(writer, endpointOutput);
-                            await writer.FlushAsync(token);
+                            await writer.FlushAsync();
                         }
                     }
 
-                    await entryStream.FlushAsync(token);
+                    await entryStream.FlushAsync();
                 }
             }
             catch (Exception e)

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -214,7 +214,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        [RavenAction("/databases/*/debug/storage/all-environments/report", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
+        [RavenAction("/databases/*/debug/storage/all-environments/report", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = false)]
         public async Task AllEnvironmentsReport()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -59,7 +59,7 @@ namespace SlowTests.Authentication
                 "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
-                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", "storage.all-environments.report.json",
+                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
                 "admin.tombstones.state.json", "indexes.performance.json"
             };
@@ -77,7 +77,7 @@ namespace SlowTests.Authentication
                 "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
-                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", "storage.all-environments.report.json",
+                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
                 "admin.tombstones.state.json", "indexes.performance.json"
             };
@@ -95,7 +95,7 @@ namespace SlowTests.Authentication
                 "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
-                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", "storage.all-environments.report.json",
+                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
                 "admin.tombstones.state.json", "indexes.performance.json"
             };
@@ -114,7 +114,7 @@ namespace SlowTests.Authentication
                 "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
-                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", "storage.all-environments.report.json",
+                "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 
                 "etl.stats.json", "etl.progress.json", "indexes.performance.json"
             };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19995/Getting-OperationCanceled-during-cluster-debug-package-creation

### Additional description

1. Added cancellationToken for request execution on `LocalEndpointClient`, and as a result, we will no longer wait too long for executed endpoint requests.
2. Fixed file names for correct opening in Windows zip archiver.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed