### PR TITLE
RavenDB-19974: Fixed improperly sizing the buffer. 

### DIFF
--- a/src/Corax/Queries/MultiTermBoostingMatch.cs
+++ b/src/Corax/Queries/MultiTermBoostingMatch.cs
@@ -167,9 +167,8 @@ namespace Corax.Queries
             var bufferHandler = _context.Allocate(2 * size * sizeof(long), out var buffer);
 
             // Ensure we copy the content and then switch the buffers. 
-
             new Span<long>(_documentBuffer, _bufferIdx).CopyTo(new Span<long>(buffer.Ptr, size));
-            new Span<long>(_countBuffer, _bufferIdx).CopyTo(new Span<long>(buffer.Ptr + currentLength, size));
+            new Span<long>(_countBuffer, _bufferIdx).CopyTo(new Span<long>(buffer.Ptr + size, size));
             _bufferHandler.Dispose();
 
             _bufferSize = size;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19974

### Additional description
MultiTermMatch was splitting incorrectly the growth buffer causing overflows under certain conditions. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
