### PR TITLE
RavenDB-19285 Sharding - Querying - Time-Series plotting not drawing a graph in the studio

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/Querying/ShardedQueryCommand.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
+using System.Net.Http;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Timings;
@@ -10,6 +12,8 @@ namespace Raven.Server.Documents.Sharding.Commands.Querying;
 
 public class ShardedQueryCommand : AbstractShardedQueryCommand<QueryResult, BlittableJsonReaderObject>
 {
+    private readonly IndexQueryServerSide _indexQuery;
+
     public ShardedQueryCommand(
         string query,
         IndexQueryServerSide indexQuery,
@@ -23,6 +27,19 @@ public class ShardedQueryCommand : AbstractShardedQueryCommand<QueryResult, Blit
         TimeSpan globalHttpClientTimeout)
         : base(query, indexQuery, scope, metadataOnly, indexEntriesOnly, ignoreLimit, indexName, canReadFromCache, raftUniqueRequestId, globalHttpClientTimeout)
     {
+        _indexQuery = indexQuery;
+    }
+
+    internal BlittableJsonReaderObject RawResult { get; set; }
+
+    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+    {
+        var request = base.CreateRequest(ctx, node, out url);
+
+        if (_indexQuery.AddTimeSeriesNames)
+            url += "&addTimeSeriesNames=true";
+
+        return request;
     }
 
     public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
@@ -37,6 +54,8 @@ public class ShardedQueryCommand : AbstractShardedQueryCommand<QueryResult, Blit
 
             if (fromCache)
                 response = HandleCachedResponse(context, response);
+
+            RawResult = response;
 
             Result = JsonDeserializationClient.QueryResult(response);
 

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Http;
+using System.Linq;
 using Raven.Client;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries;
@@ -25,6 +25,7 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
     private readonly bool _isDistinctQuery;
     private readonly IComparer<BlittableJsonReaderObject> _sortingComparer;
     private readonly HashSet<int> _alreadySeenProjections;
+    private HashSet<string> _timeSeriesFieldNames;
 
     public ShardedQueryOperation(IndexQueryServerSide query,
         bool isProjectionFromMapReduceIndex,
@@ -112,6 +113,20 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
 
                 compareExchangeValueIncludes.AddResults(queryResult.CompareExchangeValueIncludes, Context);
             }
+
+            if (_query.Metadata.HasTimeSeriesSelect)
+            {
+                if (QueryCommands[cmdResult.ShardNumber].RawResult != null && QueryCommands[cmdResult.ShardNumber].RawResult
+                        .TryGet<BlittableJsonReaderArray>(nameof(ShardedQueryResult.TimeSeriesFields), out var timeSeriesFieldNames) && timeSeriesFieldNames.Length > 0)
+                {
+                    _timeSeriesFieldNames ??= new HashSet<string>(StringComparer.Ordinal);
+
+                    foreach (object name in timeSeriesFieldNames)
+                    {
+                        _timeSeriesFieldNames.Add(name.ToString());
+                    }
+                }
+            }
         }
 
         if (revisionIncludes != null)
@@ -131,6 +146,9 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
 
         if (compareExchangeValueIncludes != null)
             result.AddCompareExchangeValueIncludes(compareExchangeValueIncludes);
+
+        if (_timeSeriesFieldNames != null)
+            result.TimeSeriesFields = _timeSeriesFieldNames.ToList();
 
         // all the results from each command are already ordered
         using (var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_sortingComparer))

--- a/test/SlowTests/Sharding/Issues/RavenDB_19285.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19285.cs
@@ -1,0 +1,128 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Documents.Queries;
+using SlowTests.Client.TimeSeries.Query;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_19285: RavenTestBase
+{
+    public RavenDB_19285(ITestOutputHelper output) : base(output)
+    {
+    }
+
+
+    [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task TimeSeriesQueryResultShouldAddTimeSeriesFields(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var baseline = RavenTestHelper.UtcToday;
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TimeSeriesLinqQuery.Person
+                {
+                    Name = "ayende"
+                }, "people/1");
+
+                var tsf = session.TimeSeriesFor("people/1", "Heartrate");
+                tsf.Append(baseline.AddMinutes(61), new[] { 59d }, "watches/fitbit");
+                tsf.Append(baseline.AddMinutes(62), new[] { 79d }, "watches/apple");
+                tsf.Append(baseline.AddMinutes(63), new[] { 69d }, "watches/fitbit");
+
+                tsf.Append(baseline.AddMonths(1).AddMinutes(61), new[] { 159d }, "watches/apple");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(62), new[] { 179d }, "watches/fitbit");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(63), new[] { 169d }, "watches/fitbit");
+
+                tsf = session.TimeSeriesFor("people/1", "BloodPressure");
+                tsf.Append(baseline.AddMinutes(61), new[] { 59d }, "watches/fitbit");
+                tsf.Append(baseline.AddMinutes(62), new[] { 79d }, "watches/apple");
+                tsf.Append(baseline.AddMinutes(63), new[] { 69d }, "watches/fitbit");
+
+                tsf.Append(baseline.AddMonths(1).AddMinutes(61), new[] { 159d }, "watches/apple");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(62), new[] { 179d }, "watches/fitbit");
+                tsf.Append(baseline.AddMonths(1).AddMinutes(63), new[] { 169d }, "watches/fitbit");
+
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var cmd = new RawTimeSeriesQueryCommandWithTimeSeriesFields(new IndexQuery()
+                {
+                    Query =
+                        "from 'People' as p select id() as Id, Name, timeseries(from p.Heartrate where (Tag == 'watches/fitbit')) as HeartRate, timeseries(from p.BloodPressure where (Tag == 'watches/apple')) as BloodPressure limit 0, 1"
+                });
+
+                await commands.ExecuteAsync(cmd);
+
+                var result = cmd.Result;
+
+                Assert.True(result.TryGet<BlittableJsonReaderArray>(nameof(DocumentQueryResult.TimeSeriesFields), out var tsFieldNames));
+
+                var names = tsFieldNames.Select(x => x.ToString()).ToList();
+
+                Assert.Contains("HeartRate", names);
+                Assert.Contains("BloodPressure", names);
+            }
+        }
+    }
+
+    private class RawTimeSeriesQueryCommandWithTimeSeriesFields : RavenCommand<BlittableJsonReaderObject>
+    {
+        private readonly IndexQuery _indexQuery;
+        public override bool IsReadRequest => true;
+
+        public override RavenCommandResponseType ResponseType { get; protected internal set; } = RavenCommandResponseType.Raw;
+
+        public RawTimeSeriesQueryCommandWithTimeSeriesFields(IndexQuery indexQuery)
+        {
+            _indexQuery = indexQuery;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var path = new StringBuilder(node.Url)
+                .Append("/databases/")
+                .Append(node.Database)
+                .Append("/queries?queryHash=1234");
+
+            path.Append("&addTimeSeriesNames=true");
+            
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                    {
+                        await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                        {
+                            writer.WriteIndexQuery(DocumentConventions.Default, ctx, _indexQuery);
+                        }
+                    }
+                )
+            };
+
+            url = path.ToString();
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result = response;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19285/Sharding-Studio-Time-Series-plotting-not-drawing-a-graph

### Additional description

Sending additional fields from shards so the studio can display a graph

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
