### PR TITLE
RavenDB-19641 - EnforceConfiguration should not delete 'conflicted' and 'resolved' revisions

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -54,7 +54,8 @@ namespace Raven.Server.Documents
         ResolveTimeSeriesConflict = 0x2000,
         ByTimeSeriesUpdate = 0x4000,
         LegacyDeleteMarker = 0x8000,
-        ForceRevisionCreation = 0x10000
+        ForceRevisionCreation = 0x10000,
+        FromDeleteDocument = 0x20000
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -29,8 +29,9 @@ namespace Raven.Server.Documents
         FromClusterTransaction = 0x1000,
         Reverted = 0x2000,
 
-        HasTimeSeries = 0x4000
+        HasTimeSeries = 0x4000,
 
+        ForceCreated = 0x8000
     }
 
     [Flags]

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -244,7 +244,6 @@ namespace Raven.Server.Documents
 
                     if (shouldVersion)
                     {
-
                         if (newDoc == false && _documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, oldDoc, oldChangeVector, collectionName))
                         {
 
@@ -257,15 +256,29 @@ namespace Raven.Server.Documents
                         flags |= DocumentFlags.HasRevisions;
                         _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks,
                             configuration, collectionName);
+
+                        var prevRevisionsCount = _documentDatabase.DocumentsStorage.RevisionsStorage.GetRevisionsCount(context, id);
+                        if (prevRevisionsCount == 0)
+                        {
+                            flags = flags.Strip(DocumentFlags.HasRevisions);
+                        }
                     }
-                    else if (newDoc==false &&
-                             nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration) == false &&
-                             oldFlags.Contain(DocumentFlags.HasRevisions) &&
-                             configuration.Disabled)
+                    // else if (newDoc==false &&
+                    //          nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration) == false &&
+                    //          oldFlags.Contain(DocumentFlags.HasRevisions) &&
+                    //          (configuration.Disabled ||  (configuration.MinimumRevisionsToKeep.HasValue && configuration.MinimumRevisionsToKeep==0) ))
+                    else if(newDoc == false &&
+                            nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration) == false &&
+                            oldFlags.Contain(DocumentFlags.HasRevisions))
                     {
-                        bool moreWork = false;
-                        _documentDatabase.DocumentsStorage.RevisionsStorage.EnforceConfigurationFor(context, id, ref moreWork, stripHasRevisions: false);
-                        if (moreWork==false)
+                        // bool moreWork = false;
+                        // _documentDatabase.DocumentsStorage.RevisionsStorage.EnforceConfigurationFor(context, id, ref moreWork, stripHasRevisions: false);
+                        // if (moreWork == false)
+                        // {
+                        //     flags = flags.Strip(DocumentFlags.HasRevisions);
+                        // }
+                        var finished = _documentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id);
+                        if (finished)
                         {
                             flags = flags.Strip(DocumentFlags.HasRevisions);
                         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1776,6 +1776,11 @@ namespace Raven.Server.Documents
                         flags |= DocumentFlags.HasRevisions;
                         revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
                             modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
+                        var prevRevisionsCount = revisionsStorage.GetRevisionsCount(context, id);
+                        if (prevRevisionsCount == 0)
+                        {
+                            flags = flags.Strip(DocumentFlags.HasRevisions);
+                        }
                     }
                     // else
                     // {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1781,15 +1781,16 @@ namespace Raven.Server.Documents
 
                 if (flags.Contain(DocumentFlags.HasRevisions))
                 {
-                    revisionsStorage.DeleteRevisionsFor(context, id, purgeOnDelete: true);
+                    revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone?.ChangeVector,
+                        modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
                 }
 
                 if (flags.Contain(DocumentFlags.HasRevisions) 
                     && revisionsStorage.Configuration == null &&
                     flags.Contain(DocumentFlags.Resolved) == false &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
-                    revisionsStorage.DeleteRevisionsFor(context, id);
-
+                revisionsStorage.DeleteRevisionsFor(context, id);
+                
                 if (flags.Contain(DocumentFlags.HasRevisions) &&
                     revisionsStorage.Configuration != null &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1779,8 +1779,13 @@ namespace Raven.Server.Documents
                     }
                 }
 
-                if (flags.Contain(DocumentFlags.HasRevisions) &&
-                    revisionsStorage.Configuration == null &&
+                if (flags.Contain(DocumentFlags.HasRevisions))
+                {
+                    revisionsStorage.DeleteRevisionsFor(context, id, purgeOnDelete: true);
+                }
+
+                if (flags.Contain(DocumentFlags.HasRevisions) 
+                    && revisionsStorage.Configuration == null &&
                     flags.Contain(DocumentFlags.Resolved) == false &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
                     revisionsStorage.DeleteRevisionsFor(context, id);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1775,15 +1775,20 @@ namespace Raven.Server.Documents
 
                         flags |= DocumentFlags.HasRevisions;
                         revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
-                            modifiedTicks, nonPersistentFlags, documentFlags);
+                            modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
                     }
+                    // else
+                    // {
+                        // revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone?.ChangeVector,
+                        //     modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
+                    // }
                 }
 
-                if (flags.Contain(DocumentFlags.HasRevisions))
-                {
-                    revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone?.ChangeVector,
-                        modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
-                }
+                // if (flags.Contain(DocumentFlags.HasRevisions))
+                // {
+                //     revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone?.ChangeVector,
+                //         modifiedTicks, nonPersistentFlags | NonPersistentDocumentFlags.FromDeleteDocument, flags);
+                // }
 
                 if (flags.Contain(DocumentFlags.HasRevisions) 
                     && revisionsStorage.Configuration == null &&

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1789,7 +1789,7 @@ namespace Raven.Server.Documents
                     && revisionsStorage.Configuration == null &&
                     flags.Contain(DocumentFlags.Resolved) == false &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
-                revisionsStorage.DeleteRevisionsFor(context, id);
+                    revisionsStorage.DeleteRevisionsFor(context, id);
                 
                 if (flags.Contain(DocumentFlags.HasRevisions) &&
                     revisionsStorage.Configuration != null &&

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             {
                 foreach (var id in _ids)
                 {
-                    _database.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id);
+                    _database.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, deleteAllRevisionsByForce: true);
                 }
                 return 1;
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -690,7 +690,7 @@ namespace Raven.Server.Documents.Revisions
             return passed < revisionsCount;
         }
 
-        public bool DeleteRevisionsFor(DocumentsOperationContext context, string id, bool purgeOnDelete = false)
+        public bool DeleteRevisionsFor(DocumentsOperationContext context, string id, bool purgeOnDelete = false, bool deleteAllRevisionsByForce = false)
         {
             using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
@@ -714,6 +714,11 @@ namespace Raven.Server.Documents.Revisions
                 if (deletedDoc)
                 {
                     configuration = GetRevisionsConfiguration(collectionName.Name, local.Tombstone.Flags);
+                }
+                if (deleteAllRevisionsByForce)
+                {
+                    purgeOnDelete = true;
+                    configuration = new RevisionsCollectionConfiguration { PurgeOnDelete = true };
                 }
                 var deletedRevisionsCount = DeleteRevisions(context, table, prefixSlice, changeVector, lastModifiedTicks, out _, deletedDoc: purgeOnDelete, docConfiguration: configuration);
                 var left = IncrementCountOfRevisions(context, prefixSlice, -deletedRevisionsCount);
@@ -1523,10 +1528,10 @@ namespace Raven.Server.Documents.Revisions
                 {
                     configuration = GetRevisionsConfiguration(collectionName.Name, local.Tombstone.Flags);
                 }
-                else
-                {
-                    configuration = GetRevisionsConfiguration(collectionName.Name, local.Document?.Flags ?? DocumentFlags.None);
-                }
+                // else
+                // {
+                //     configuration = GetRevisionsConfiguration(collectionName.Name, local.Document?.Flags ?? DocumentFlags.None);
+                // }
 
                 var needToDeleteMore = DeleteOldRevisions(context, table, prefixSlice, 
                     NonPersistentDocumentFlags.None,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -922,7 +922,7 @@ namespace Raven.Server.Documents.Revisions
             long maxEtagDeleted = 0;
             var reachedMaxUponUpdate = false;
             var passedAllWithoutRemoving = false;
-            var tables = new Dictionary<RevisionsCollectionConfiguration, Table>();
+            var tables = new Dictionary<string, Table>();
 
             while (reachedMaxUponUpdate == false && passedAllWithoutRemoving == false)
             {
@@ -968,13 +968,13 @@ namespace Raven.Server.Documents.Revisions
                                 }
 
                                 Table writeTable = null;
-                                if (tables.ContainsKey(config) && tables[config]!=null)
+                                if (tables.ContainsKey(collection) && tables[collection] !=null)
                                 {
-                                    writeTable = tables[config];
+                                    writeTable = tables[collection];
                                 }
                                 else
                                 {
-                                    tables[config] = writeTable = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, new CollectionName(collection));
+                                    tables[collection] = writeTable = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, new CollectionName(collection));
                                 }
 
                                 writeTable.DeleteByKey(keySlice);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1529,7 +1529,7 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, ref bool moreWork, bool stripHasRevisions = true)
+        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, ref bool moreWork)
         {
             using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var prefixSlice))
@@ -1570,7 +1570,7 @@ namespace Raven.Server.Documents.Revisions
                 if (needToDeleteMore && currentRevisionsCount > 0)
                     moreWork = true;
 
-                if (stripHasRevisions==true && currentRevisionsCount == 0)
+                if (currentRevisionsCount == 0)
                 {
                     var res = _documentsStorage.GetDocumentOrTombstone(context, lowerId, throwOnConflict: false);
                     // need to strip the HasRevisions flag from the document/tombstone

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -919,11 +919,28 @@ namespace FastTests.Server.Documents.Revisions
         [Fact]
         public async Task CanExcludeEntitiesFromRevisions()
         {
+            var configuration = new RevisionsConfiguration
+            {
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        PurgeOnDelete = true,
+                        MinimumRevisionsToKeep = 123
+                    },
+                    ["Comments"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = true // => go to the default (which is null, that's why there is no revision for this collection).
+                    }
+                }
+            };
+
             var user = new User {Name = "User Name"};
             var comment = new Comment {Name = "foo"};
             using (var store = GetDocumentStore())
             {
-                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration);
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(user);
@@ -1046,7 +1063,17 @@ namespace FastTests.Server.Documents.Revisions
             var product = new Product {Description = "A fine document db", Quantity = 5};
             using (var store = GetDocumentStore())
             {
-                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+                var configuration = new RevisionsConfiguration
+                {
+                    Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                    {
+                        ["Products"] = new RevisionsCollectionConfiguration
+                        {
+                            Disabled = true // => go to the default (which is null, that's why there is no revision for this collection).
+                        }
+                    }
+                };
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration);
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(product);

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1237,6 +1237,8 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore2, "bar", x => x.Completed == true));
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
+            var forceCreatedConfiguration = hubDb.DocumentsStorage.RevisionsStorage._forceCreatedConfiguration;
+            forceCreatedConfiguration.Disabled = true;
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
                 await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
 

--- a/test/SlowTests/Issues/RavenDB-19641.cs
+++ b/test/SlowTests/Issues/RavenDB-19641.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task EEnforce_Conflicted_PurgeDelete_Configuration_Should_Delete_Conflicted_And_Resolved_Revisions()
+        public async Task Enforce_Conflicted_PurgeDelete_Configuration_Should_Delete_Conflicted_And_Resolved_Revisions()
         {
             using var source = GetDocumentStore();
             using var destination = GetDocumentStore();

--- a/test/SlowTests/Issues/RavenDB-19641.cs
+++ b/test/SlowTests/Issues/RavenDB-19641.cs
@@ -67,11 +67,10 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task EnforceConfiguration_Should_Not_Delete_Conflicted_And_Resolved_Revisions_With_Purge_Delete()
+        public async Task EEnforce_Conflicted_PurgeDelete_Configuration_Should_Delete_Conflicted_And_Resolved_Revisions()
         {
             using var source = GetDocumentStore();
             using var destination = GetDocumentStore();
-
 
             using (var session = source.OpenAsyncSession())
             {
@@ -100,31 +99,39 @@ namespace SlowTests.Issues
 
             await destination.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(destination.Database, new RevisionsCollectionConfiguration
             {
-                MinimumRevisionAgeToKeep = TimeSpan.MaxValue,
                 PurgeOnDelete = true
             }));
             var db = await Databases.GetDocumentDatabaseInstanceFor(destination);
-            Console.WriteLine("EnforceConfiguration");
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
 
             using (var session = destination.OpenAsyncSession())
             {
-                session.Delete("Docs/2");
+                session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc1RevCount);
+                Assert.Equal(3, doc2RevCount);
+            }
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                session.Delete("Docs/1");
                 await session.SaveChangesAsync();
             }
 
             using (var session = destination.OpenAsyncSession())
             {
+                session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
                 var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
-                Assert.Equal(3, doc1RevCount);
-                Assert.Equal(0, doc2RevCount);
+                Assert.Equal(0, doc1RevCount);
+                Assert.Equal(3, doc2RevCount);
             }
         }
 
         [Fact]
-        public async Task EnforceConfiguration_Should_Not_Revisions()
+        public async Task EnforceConfiguration_Should_Not_Delete_Revisions()
         {
             using var source = GetDocumentStore();
         
@@ -166,11 +173,104 @@ namespace SlowTests.Issues
             }
         }
 
+        [Fact]
+        public async Task Enforce_PurgeDelete_Configuration_Should_Delete_Revisions()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                },
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        PurgeOnDelete = false,
+                        MinimumRevisionsToKeep = 123
+                    }
+                }
+            };
+
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "New" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(2, doc1RevCount);
+                Assert.Equal(2, doc2RevCount);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc1RevCount);
+                Assert.Equal(2, doc2RevCount);
+            }
+
+            var newConfiguartion = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                },
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        PurgeOnDelete = true,
+                        MinimumRevisionsToKeep = 123
+                    }
+                }
+            };
+
+            await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(newConfiguartion));
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(0, doc1RevCount);
+                Assert.Equal(2, doc2RevCount);
+            }
+        }
 
         private class User
         {
             public string Id { get; set; }
             public string Name { get; set; }
         }
+
     }
 }

--- a/test/SlowTests/Issues/RavenDB-19641.cs
+++ b/test/SlowTests/Issues/RavenDB-19641.cs
@@ -400,7 +400,7 @@ namespace SlowTests.Issues
             using (var session = store.OpenAsyncSession())
             {
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(1, doc1RevCount);
+                Assert.Equal(2, doc1RevCount);  // Old, New => New, New2
                 var d = await session.LoadAsync<User>("Docs/1");
                 var metadata = session.Advanced.GetMetadataFor(d);
                 Assert.Equal((DocumentFlags.HasRevisions).ToString(), metadata[Raven.Client.Constants.Documents.Metadata.Flags]);
@@ -416,10 +416,10 @@ namespace SlowTests.Issues
             using (var session = store.OpenAsyncSession())
             {
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(0, doc1RevCount);
+                Assert.Equal(2, doc1RevCount); // New, New2 => New2, New3
                 var d = await session.LoadAsync<User>("Docs/1");
                 var metadata = session.Advanced.GetMetadataFor(d);
-                Assert.False(metadata.ContainsKey(Raven.Client.Constants.Documents.Metadata.Flags));
+                Assert.Equal((DocumentFlags.HasRevisions).ToString(), metadata[Raven.Client.Constants.Documents.Metadata.Flags]);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-19641.cs
+++ b/test/SlowTests/Issues/RavenDB-19641.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.ServerWide;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19641 : ReplicationTestBase
+    {
+        public RavenDB_19641(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task EnforceConfiguration_Should_Not_Delete_Conflicted_And_Resolved_Revisions()
+        {
+            using var source = GetDocumentStore();
+            using var destination = GetDocumentStore();
+        
+        
+            using (var session = source.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "New" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+        
+            await SetupReplicationAsync(source, destination); // Conflicts resolved
+            await EnsureReplicatingAsync(source, destination);
+        
+            using (var session = destination.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount);
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc2RevCount);
+            }
+            
+            var db = await Databases.GetDocumentDatabaseInstanceFor(destination);
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                 await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc1RevCount);
+                Assert.Equal(3, doc2RevCount);
+            }
+        }
+
+        [Fact]
+        public async Task EnforceConfiguration_Should_Not_Delete_Conflicted_And_Resolved_Revisions_With_Purge_Delete()
+        {
+            using var source = GetDocumentStore();
+            using var destination = GetDocumentStore();
+
+
+            using (var session = source.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "New" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(source, destination); // Conflicts resolved
+            await EnsureReplicatingAsync(source, destination);
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount);
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc2RevCount);
+            }
+
+            await destination.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(destination.Database, new RevisionsCollectionConfiguration
+            {
+                MinimumRevisionAgeToKeep = TimeSpan.MaxValue,
+                PurgeOnDelete = true
+            }));
+            var db = await Databases.GetDocumentDatabaseInstanceFor(destination);
+            Console.WriteLine("EnforceConfiguration");
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                session.Delete("Docs/2");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(3, doc1RevCount);
+                Assert.Equal(0, doc2RevCount);
+            }
+        }
+
+        [Fact]
+        public async Task EnforceConfiguration_Should_Not_Revisions()
+        {
+            using var source = GetDocumentStore();
+        
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, source.Database);
+        
+            using (var session = source.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+        
+            using (var session = source.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.StoreAsync(new User { Name = "New" }, "Docs/2");
+                await session.SaveChangesAsync();
+            }
+        
+            using (var session = source.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(2, doc1RevCount);
+                Assert.Equal(2, doc2RevCount);
+            }
+        
+            var db = await Databases.GetDocumentDatabaseInstanceFor(source);
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+        
+        
+            using (var session = source.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                var doc2RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/2");
+                Assert.Equal(2, doc1RevCount);
+                Assert.Equal(2, doc2RevCount);
+            }
+        }
+
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RravenDB-16949.cs
+++ b/test/SlowTests/Issues/RravenDB-16949.cs
@@ -195,12 +195,11 @@ namespace SlowTests.Issues
                 }
                 using (var session = store.OpenAsyncSession())
                 {
-
-                    var revisionCount = session.Advanced.Revisions.GetForAsync<User>("users/1", 0, 1000).Result.Count;
+                    var revisionCount = await session.Advanced.Revisions.GetCountForAsync("users/1");
                     Assert.Equal(501, revisionCount);
-                    revisionCount = session.Advanced.Revisions.GetForAsync<User>("users/2", 0, 1000).Result.Count;
+                    revisionCount = await session.Advanced.Revisions.GetCountForAsync("users/2");
                     Assert.Equal(631, revisionCount);
-                    revisionCount = session.Advanced.Revisions.GetForAsync<User>("orders/1", 0, 1000).Result.Count;
+                    revisionCount = await session.Advanced.Revisions.GetCountForAsync("orders/1");
                     Assert.Equal(501, revisionCount);
                 }
 
@@ -228,15 +227,16 @@ namespace SlowTests.Issues
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                     await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {
-                    var revisionCount = session.Advanced.Revisions.GetForAsync<User>("users/1", 0, 100).Result.Count;
-                    Assert.Equal(10, revisionCount);
-                    revisionCount = session.Advanced.Revisions.GetForAsync<User>("users/2", 0, 100).Result.Count;
-                    Assert.Equal(10, revisionCount);
-                    revisionCount = session.Advanced.Revisions.GetForAsync<Order>("orders/1", 0, 100).Result.Count;
-                    Assert.Equal(33, revisionCount);
+                    var revisionCount = await session.Advanced.Revisions.GetCountForAsync("users/1");
+                    Assert.Equal(501 - 100, revisionCount);
+                    revisionCount = await session.Advanced.Revisions.GetCountForAsync("users/2");
+                    Assert.Equal(631 - 100, revisionCount);
+                    revisionCount = await session.Advanced.Revisions.GetCountForAsync("orders/1");
+                    Assert.Equal(501 - 35, revisionCount);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -279,7 +279,8 @@ namespace SlowTests.Server.Documents.Revisions
                 WaitForMarker(store2, store1);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1);
-
+                var conflictedConfig = db.DocumentsStorage.RevisionsStorage.ConflictConfiguration;
+                conflictedConfig.Default.Disabled = true;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                     await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19641

### Additional description

EnforceConfiguration should not delete 'conflicted' and 'resolved' revisions

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
