### PR TITLE
RavenDB-20017 added the ability to alter database record before it is being created

### DIFF
--- a/src/Raven.TestDriver/RavenTestDriver.cs
+++ b/src/Raven.TestDriver/RavenTestDriver.cs
@@ -77,7 +77,11 @@ namespace Raven.TestDriver
             var name = database + "_" + Interlocked.Increment(ref _index);
             var documentStore = TestServerStore.Value;
 
-            var createDatabaseOperation = new CreateDatabaseOperation(new DatabaseRecord(name));
+            var databaseRecord = new DatabaseRecord(name);
+
+            PreConfigureDatabase(databaseRecord);
+
+            var createDatabaseOperation = new CreateDatabaseOperation(databaseRecord);
             documentStore.Maintenance.Server.Send(createDatabaseOperation);
 
             var store = new DocumentStore
@@ -101,7 +105,7 @@ namespace Raven.TestDriver
 
                 try
                 {
-                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(store.Database, hardDelete: true));
+                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(databaseRecord.DatabaseName, hardDelete: true));
                 }
                 catch (DatabaseDoesNotExistException)
                 {
@@ -124,6 +128,10 @@ namespace Raven.TestDriver
         }
 
         protected virtual void PreInitialize(IDocumentStore documentStore)
+        {
+        }
+
+        protected virtual void PreConfigureDatabase(DatabaseRecord databaseRecord)
         {
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20017

### Additional description

This way we will allow user to create e.g. sharded database

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
