### PR TITLE
RavenDB-20015 - NRE during replication from TestCloud to sharded database

### DIFF
--- a/test/SlowTests/Sharding/Issues/RavenDB_20015.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20015.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20015 : ReplicationTestBase
+    {
+        public RavenDB_20015(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Attachments | RavenTestCategory.Replication)]
+        public async Task ShouldNotThrowNREWhenSendingAttachmentWithoutStream()
+        {
+            using (var source = GetDocumentStore())
+            using (var destination = Sharding.GetDocumentStore())
+            {
+                await SetupReplicationAsync(source, destination);
+
+                int i = 0;
+                while (await Sharding.AllShardHaveDocsAsync(Server, destination.Database) == false)
+                {
+                    using (var session = source.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = "Foo" }, $"users/{i++}");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var docs = await Sharding.GetOneDocIdForEachShardAsync(Server, destination.Database);
+
+                var b = await BreakReplication(Server.ServerStore, source.Database);
+
+                using (var session = source.OpenAsyncSession())
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    for (i = 0; i < docs.Count - 1; i++)
+                    {
+                        var docId = docs[i];
+
+                        stream.Seek(0, SeekOrigin.Begin);
+                        session.Advanced.Attachments.Store(docId, "foo.png", stream, "image/png");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                b.Mend();
+
+                using (var session = source.OpenAsyncSession())
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var stream2 = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var docId = docs[0];
+                    var docId2 = docs[i];
+
+                    session.Advanced.Attachments.Store(docId, "foo2.png", stream2, "image/png");
+                    session.Advanced.Attachments.Store(docId2, "foo.png", stream, "image/png");
+                    await session.SaveChangesAsync();
+                }
+
+                foreach (var kvp in docs)
+                {
+                    var docId = kvp.Value;
+                    Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, docId, "foo.png", 30 * 1000));
+                }
+
+                for (i = 0; i < docs.Count; i++)
+                {
+                    var docId = docs[i];
+                    using (var session = destination.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<User>(docId);
+                        var attachments = session.Advanced.Attachments.GetNames(user);
+                        var expected = i == 0 ? 2 : 1;
+                        Assert.Equal(expected, attachments.Length);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20015/NRE-during-replication-from-TestCloud-to-sharded-database

### Additional info

_The general flow of sending attachments through replication for Sharded DB:_
In most cases, the source sends `AttachmentReplicationItem attachment` with `attachment.Stream = null` and the stream separately (in `AttachmentStreams`). `AttachmentStreams` are unique and can refer to multiple documents. 
For sharding, we needed to decide to which shard this attachment stream belongs; the idea here is to calculate the shard number for each `attachment` item and add a new entry for `shardBatch.AttachmentStreams` indicates that we should send the stream to this shard as well. Then, we iterate over the streams and add the values to `shardBatch.AttachmentStreams`.

_Bug explanation:_
We may get a batch with `AttachmentReplicationItem` but without the relevant stream (for example, if we sent it before, the assumption is the destination already has it); in that case, an entry of `shardBatch.AttachmentStreams` exist but the stream remains null - then, we got NRE.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
