### PR TITLE
RavenDB-7070 fixed issue with cloning of blittable in sharded changes API with multiple subscribers + fixed issue with not using appropriate topology when database is being removed

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
@@ -303,20 +303,17 @@ public class ShardedChangesClientConnection : AbstractChangesClientConnection<Tr
 
     public void OnNext(BlittableJsonReaderObject value)
     {
-        using (value)
+        BlittableJsonReaderObject copy;
+        lock (this)
         {
-            BlittableJsonReaderObject copy;
-            lock (this)
-            {
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Major, "avoid this lock here");
-                copy = value.Clone(_queueContext);
-            }
-
-            AddToQueue(new SendQueueItem
-            {
-                ValueToSend = copy
-            });
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Major, "avoid this lock here");
+            copy = value.Clone(_queueContext);
         }
+
+        AddToQueue(new SendQueueItem
+        {
+            ValueToSend = copy
+        });
     }
 
     public override void Dispose()

--- a/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteDatabaseCommand.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.ServerWide.Commands
                 record.DeletionInProgress = new Dictionary<string, DeletionInProgressStatus>();
             }
 
-            if (FromNodes != null && FromNodes.Length > 0) 
+            if (FromNodes != null && FromNodes.Length > 0)
             {
                 foreach (var node in FromNodes)
                 {
@@ -93,7 +93,7 @@ namespace Raven.Server.ServerWide.Commands
                 }
             }
         }
-        
+
         private DatabaseTopology RemoveDatabaseFromAllNodes(DatabaseRecord record, DatabaseTopology topology, int? shardNumber, DeletionInProgressStatus deletionInProgressStatus)
         {
             var allNodes = topology.AllNodes.Distinct();
@@ -104,7 +104,7 @@ namespace Raven.Server.ServerWide.Commands
                     record.DeletionInProgress[DatabaseRecord.GetKeyForDeletionInProgress(node, shardNumber)] = deletionInProgressStatus;
             }
 
-            return new DatabaseTopology {Stamp = record.Topology?.Stamp, ReplicationFactor = 0};
+            return new DatabaseTopology { Stamp = topology.Stamp, ReplicationFactor = 0 };
         }
 
         private void RemoveDatabaseFromSingleNode(DatabaseRecord record, DatabaseTopology topology, string node, int? shardNumber, DeletionInProgressStatus deletionInProgressStatus)
@@ -135,7 +135,7 @@ namespace Raven.Server.ServerWide.Commands
             json[nameof(ShardNumber)] = ShardNumber;
             if (FromNodes != null)
             {
-              json[nameof(FromNodes)] = new DynamicJsonArray(FromNodes);
+                json[nameof(FromNodes)] = new DynamicJsonArray(FromNodes);
             }
         }
     }


### PR DESCRIPTION
- do not dispose blittable in sharded changes - it is being disposed outside and with multiple subscribers we might end up with cloning a disposed blittable
- RemoveDatabaseFromAllNodes should use the topology from argument not from record, because this one is not valid for sharded databases