### PR TITLE
RavenDB-15601 Additional option to collect debug-info

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -194,7 +194,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                             if (debugInfoType.HasFlag(DebugInfoPackageContent.Databases))
                             {
-                                await WriteForAllLocalDatabases(archive, context, localEndpointClient, databases, token: token.Token);
+                                await WriteForAllLocalDatabases(archive, context, localEndpointClient, databases, token.Token);
                             }
 
                             if (debugInfoType.HasFlag(DebugInfoPackageContent.LogFile))
@@ -263,7 +263,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 url += $"&type={type}";
 
             if (databases.Count > 0)
-                url += $"&database={WebUtility.UrlEncode(string.Join("&database=", databases))}";
+                url += $"&database={Uri.EscapeDataString(string.Join("&database=", databases))}";
 
             var rawStreamCommand = new GetRawStreamResultCommand(url);
             var requestExecutionTask = requestExecutor.ExecuteAsync(rawStreamCommand, context);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15601/Additional-option-to-collect-debug-info

### Additional description

in the UI we need to add the option to choose if you want to get the server wide, log file, and all the databases or a subset of the databases

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing

### UI work

- It requires further work in the Studio
