### PR TITLE
RavenDB-19241 - fixing PR comments

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Background/ShardedPeriodicDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedPeriodicDocumentsMigrator.cs
@@ -23,10 +23,10 @@ namespace Raven.Server.Documents.Sharding.Background
             if (_database.ServerStore.Sharding.HasActiveMigrations(_database.ShardedDatabaseName))
                 return;
 
-            await ExecuteMoveDocuments();
+            await ExecuteMoveDocumentsAsync();
         }
 
-        internal async Task ExecuteMoveDocuments()
+        internal async ValueTask ExecuteMoveDocumentsAsync()
         {
             try
             {
@@ -67,12 +67,7 @@ namespace Raven.Server.Documents.Sharding.Background
                 }
 
                 if (found)
-                    await MoveDocumentsToShard(bucket, moveToShard);
-            }
-            catch (OperationCanceledException)
-            {
-                // this will stop processing
-                throw;
+                    await MoveDocumentsToShardAsync(bucket, moveToShard);
             }
             catch (Exception e)
             {
@@ -83,7 +78,7 @@ namespace Raven.Server.Documents.Sharding.Background
             }
         }
 
-        private async Task MoveDocumentsToShard(int bucket, int moveToShard)
+        private async ValueTask MoveDocumentsToShardAsync(int bucket, int moveToShard)
         {
             var cmd = new StartBucketMigrationCommand(bucket, _database.ShardNumber, moveToShard, _database.ShardedDatabaseName,
                 $"{Guid.NewGuid()}/{bucket}");

--- a/test/SlowTests/Sharding/BucketMigration/PeriodicDocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/PeriodicDocumentsMigrationTests.cs
@@ -47,7 +47,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -122,7 +122,7 @@ namespace SlowTests.Sharding.BucketMigration
                 session.SaveChanges();
             }
 
-            await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+            await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             Assert.True(WaitForValue(() =>
             {
@@ -178,7 +178,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -220,7 +220,7 @@ namespace SlowTests.Sharding.BucketMigration
                 session.SaveChanges();
             }
 
-            await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+            await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             var id = await store.Subscriptions.CreateAsync<User>();
             var users = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -287,7 +287,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -338,7 +338,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -389,7 +389,7 @@ namespace SlowTests.Sharding.BucketMigration
                 await SetupReplicationAsync(dest, source);
                 await EnsureReplicatingAsync(dest, source);
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -461,7 +461,7 @@ namespace SlowTests.Sharding.BucketMigration
                 b1.Mend();
                 b2.Mend();
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocuments();
+                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19241/Sharding-Handle-writes-to-the-wrong-shard

### Additional description

https://github.com/ravendb/ravendb/pull/15848


### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
