### PR TITLE
RDBCL-2590 - Backups stopped working for one of the DBs due to replic…

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1285,7 +1285,7 @@ namespace Raven.Server.Documents.Replication
                                     // the other side will receive negative ack and will retry sending again.
                                     try
                                     {
-                                        AssertAttachmentsFromReplication(context, doc.Id, document);
+                                        AssertAttachmentsFromReplication(context, doc);
                                     }
                                     catch (MissingAttachmentException)
                                     {
@@ -1557,9 +1557,9 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            public void AssertAttachmentsFromReplication(DocumentsOperationContext context, string id, BlittableJsonReaderObject document)
+            public void AssertAttachmentsFromReplication(DocumentsOperationContext context, DocumentReplicationItem doc)
             {
-                foreach (var attachment in AttachmentsStorage.GetAttachmentsFromDocumentMetadata(document))
+                foreach (var attachment in AttachmentsStorage.GetAttachmentsFromDocumentMetadata(doc.Data))
                 {
                     if (attachment.TryGet(nameof(AttachmentName.Hash), out LazyStringValue hash) == false)
                         continue;
@@ -1577,7 +1577,8 @@ namespace Raven.Server.Documents.Replication
 
                         attachment.TryGet(nameof(AttachmentName.Name), out LazyStringValue attachmentName);
 
-                        var msg = $"Document '{id}' has attachment " +
+                        var type = doc.Flags.Contain(DocumentFlags.Revision) ? "Revision" : "Document";
+                        var msg = $"{type} '{doc.Id}' has attachment " +
                                   $"named: '{attachmentName?.ToString() ?? "unknown"}', hash: '{hash?.ToString() ?? "unknown"}' " +
                                   $"listed as one of its attachments but it doesn't exist in the attachment storage";
 

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1577,8 +1577,8 @@ namespace Raven.Server.Documents.Replication
 
                         attachment.TryGet(nameof(AttachmentName.Name), out LazyStringValue attachmentName);
 
-                        var type = doc.Flags.Contain(DocumentFlags.Revision) ? "Revision" : "Document";
-                        var msg = $"{type} '{doc.Id}' has attachment " +
+                        var type = doc.Flags.Contain(DocumentFlags.Revision) ? $"Revision '{doc.Id}' with change vector '{doc.ChangeVector}'" : $"Document '{doc.Id}'";
+                        var msg = $"{type} has attachment " +
                                   $"named: '{attachmentName?.ToString() ?? "unknown"}', hash: '{hash?.ToString() ?? "unknown"}' " +
                                   $"listed as one of its attachments but it doesn't exist in the attachment storage";
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1209,7 +1209,7 @@ namespace Raven.Server.Documents.Replication
             _missingAttachmentsAlert = AlertRaised.Create(
                 _database.Name,
                 "Replication delay due to a missing attachments loop",
-                msg + $"{Environment.NewLine}Please try to delete the missing attachment from '{_database.Name}' on Node {_database.ServerStore.NodeTag} (see additional information regarding the document and attachment below)",
+                msg + $"{Environment.NewLine}Please try to delete the missing attachment from '{_database.Name}' on node {_database.ServerStore.NodeTag} (see additional information regarding the document and attachment below)",
                 AlertType.Replication,
                 NotificationSeverity.Error,
                 details: new ExceptionDetails { Exception = exceptionDetails});

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1209,7 +1209,7 @@ namespace Raven.Server.Documents.Replication
             _missingAttachmentsAlert = AlertRaised.Create(
                 _database.Name,
                 "Replication delay due to a missing attachments loop",
-                msg + $"{Environment.NewLine}Please try to delete the missing attachment from '{_database.Name}' (see additional information regarding the document and attachment below)",
+                msg + $"{Environment.NewLine}Please try to delete the missing attachment from '{_database.Name}' on Node {_database.ServerStore.NodeTag} (see additional information regarding the document and attachment below)",
                 AlertType.Replication,
                 NotificationSeverity.Error,
                 details: new ExceptionDetails { Exception = exceptionDetails});


### PR DESCRIPTION
…ation issue

### Issue link

https://issues.hibernatingrhinos.com/issue/RDBCL-2590/Backups-stopped-working-for-one-of-the-DBs-due-to-replication-issue

### Additional description

Add more information to alert.


### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
