### PR TITLE
RavenDB-19032 Try to read `SearchEngineType` from corrupted index.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -28,23 +28,24 @@ namespace Raven.Server.Documents.Indexes.Errors
 
         private readonly DateTime _createdAt;
 
-        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, AutoIndexDefinitionBaseServerSide definition)
-            : this(e, configuration, new FaultyAutoIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition))
+        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, AutoIndexDefinitionBaseServerSide definition, SearchEngineType searchEngineType)
+            : this(e, configuration, new FaultyAutoIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition), searchEngineType)
         {
         }
 
-        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, IndexDefinition definition)
-            : this(e, configuration, new FaultyIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition))
+        public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, IndexDefinition definition, SearchEngineType searchEngineType)
+            : this(e, configuration, new FaultyIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition), searchEngineType)
         {
         }
 
-        private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBaseServerSide definition)
+        private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBaseServerSide definition, SearchEngineType searchEngineType)
             : base(IndexType.Faulty, IndexSourceType.None, definition)
         {
             _e = e;
             _createdAt = DateTime.UtcNow;
             State = IndexState.Error;
             Configuration = configuration;
+            SearchEngineType = searchEngineType;
         }
 
         protected override IIndexingWork[] CreateIndexWorkExecutors()
@@ -114,7 +115,8 @@ namespace Raven.Server.Documents.Indexes.Errors
             return new IndexStats
             {
                 Name = Name,
-                Type = Type
+                Type = Type,
+                SearchEngineType = SearchEngineType
             };
         }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Auto;
@@ -36,6 +37,11 @@ namespace Raven.Server.Documents.Indexes.Errors
         public FaultyInMemoryIndex(Exception e, string name, IndexingConfiguration configuration, IndexDefinition definition, SearchEngineType searchEngineType)
             : this(e, configuration, new FaultyIndexDefinition(name, new HashSet<string> { "@FaultyIndexes" }, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, new IndexField[0], definition), searchEngineType)
         {
+            if (searchEngineType is SearchEngineType.None && definition.Configuration.TryGetValue(RavenConfiguration.GetKey(i => i.Indexing.StaticIndexingEngineType), out var configKey))
+            {
+                if (Enum.TryParse(configKey, out Client.Documents.Indexes.SearchEngineType searchEngineKey))
+                    SearchEngineType = searchEngineKey;
+            }
         }
 
         private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBaseServerSide definition, SearchEngineType searchEngineType)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -394,7 +394,15 @@ namespace Raven.Server.Documents.Indexes
                 {
                     type = IndexStorage.ReadIndexType(name, environment);
                     sourceType = IndexStorage.ReadIndexSourceType(name, environment);
-                    searchEngineType = IndexStorage.ReadSearchEngineType(name, environment);
+                    try
+                    {
+                        searchEngineType = IndexStorage.ReadSearchEngineType(name, environment);
+                    }
+                    catch
+                    {
+                        // Since we only want to present the index search engine to the user when it's possible, we can simply ignore it when it's not possible
+                        // (for instance, if the index dates back to the pre-Corax era).
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -366,11 +366,11 @@ namespace Raven.Server.Documents.Indexes
             exceptionAggregator.ThrowIfNeeded();
         }
 
-        public static Index Open(string path, DocumentDatabase documentDatabase, bool generateNewDatabaseId)
+        public static Index Open(string path, DocumentDatabase documentDatabase, bool generateNewDatabaseId, out SearchEngineType searchEngineType)
         {
             var logger = LoggingSource.Instance.GetLogger<Index>(documentDatabase.Name);
-
             StorageEnvironment environment = null;
+            searchEngineType = SearchEngineType.None;
 
             var name = new DirectoryInfo(path).Name;
             var indexPath = path;
@@ -394,6 +394,7 @@ namespace Raven.Server.Documents.Indexes
                 {
                     type = IndexStorage.ReadIndexType(name, environment);
                     sourceType = IndexStorage.ReadIndexSourceType(name, environment);
+                    searchEngineType = IndexStorage.ReadSearchEngineType(name, environment);
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -460,7 +460,7 @@ namespace Raven.Server.Documents.Indexes
                     }
 
                     var configuration = new FaultyInMemoryIndexConfiguration(_documentDatabase.Configuration.Indexing.StoragePath, _documentDatabase.Configuration);
-                    var fakeIndex = new FaultyInMemoryIndex(exception, indexName, configuration, definition);
+                    var fakeIndex = new FaultyInMemoryIndex(exception, indexName, configuration, definition, SearchEngineType.None);
                     _indexes.Add(fakeIndex);
                 }
             }
@@ -1844,10 +1844,10 @@ namespace Raven.Server.Documents.Indexes
         private void OpenIndex(PathSetting path, string indexPath, List<Exception> exceptions, string name, bool startIndex, IndexDefinitionBase indexDefinition)
         {
             Index index = null;
-
+            SearchEngineType searchEngineType = SearchEngineType.None;
             try
             {
-                index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false);
+                index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false, out searchEngineType);
 
                 var differences = IndexDefinitionCompareDifferences.None;
 
@@ -1907,8 +1907,8 @@ namespace Raven.Server.Documents.Indexes
                 var configuration = new FaultyInMemoryIndexConfiguration(path, _documentDatabase.Configuration);
 
                 var faultyIndex = (indexDefinition is AutoIndexDefinition)
-                    ? new FaultyInMemoryIndex(e, name, configuration, CreateAutoDefinition((AutoIndexDefinition)indexDefinition, IndexDeploymentMode.Parallel))
-                    : new FaultyInMemoryIndex(e, name, configuration, (IndexDefinition)indexDefinition);
+                    ? new FaultyInMemoryIndex(e, name, configuration, CreateAutoDefinition((AutoIndexDefinition)indexDefinition, IndexDeploymentMode.Parallel), searchEngineType)
+                    : new FaultyInMemoryIndex(e, name, configuration, (IndexDefinition)indexDefinition, searchEngineType);
 
                 var message = $"Could not open index at '{indexPath}'. Created in-memory, fake instance: {faultyIndex.Name}";
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -435,7 +435,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     Index index = null;
                     try
                     {
-                        index = Index.Open(indexPath, database, generateNewDatabaseId: true);
+                        index = Index.Open(indexPath, database, generateNewDatabaseId: true, out _);
                     }
                     catch (Exception e)
                     {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -315,7 +315,7 @@ namespace Raven.Server.Web.System
                         if (documentDatabase.DatabaseShutdown.IsCancellationRequested)
                             return;
 
-                        index = Index.Open(indexPath, documentDatabase, generateNewDatabaseId: false);
+                        index = Index.Open(indexPath, documentDatabase, generateNewDatabaseId: false, out var _);
                         if (index == null)
                             continue;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19032

### Additional description

E.g. when the index schema changes we can show a user the search engine type of index (when possible).

![image](https://user-images.githubusercontent.com/86351904/223082488-8c9bd47e-020d-4e08-86d9-e0278e90bffd.png)


### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
