### PR TITLE
RavenDB-19726 Add endpoint to get MicrosoftLogs state

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -181,6 +181,28 @@ namespace Raven.Server.Documents.Handlers.Admin
                 writer.WriteObject(json);
             }
         }
+        
+        [RavenAction("/admin/logs/microsoft/state", "GET", AuthorizationStatus.Operator)]
+        public async Task GetMicrosoftLoggersState()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
+                var provider = Server.GetService<MicrosoftLoggingProvider>();
+                var minLogLevelPerLogger = new DynamicJsonValue();
+                var respondBody = new DynamicJsonValue
+                {
+                    ["IsActive"] = provider.IsActive,
+                    ["Loggers"] = minLogLevelPerLogger
+                };
+                foreach (var (category, logger) in provider.Loggers)
+                {
+                    minLogLevelPerLogger[category] = logger.MinLogLevel;
+                }
+                var json = context.ReadObject(respondBody, "logs/configuration");
+                writer.WriteObject(json);
+            }
+        }
 
         [RavenAction("/admin/logs/microsoft/configuration", "POST", AuthorizationStatus.Operator)]
         public async Task SetMicrosoftConfiguration()

--- a/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingProvider.cs
+++ b/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingProvider.cs
@@ -16,6 +16,10 @@ public class MicrosoftLoggingProvider : ILoggerProvider
     
     private readonly LoggingSource _loggingSource;
     private readonly MultipleUseFlag _enable = new MultipleUseFlag();
+
+    public bool IsActive => _enable.IsRaised();
+    public (string, SparrowLoggerWrapper)[] Loggers => _loggers.Select(x => (x.Key, x.Value)).ToArray(); 
+    
     public MicrosoftLoggingProvider(LoggingSource loggingSource, NotificationCenter.NotificationCenter notificationCenter)
     {
         _loggingSource = loggingSource;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19726

### Additional description
Add endpoint to get MicrosoftLogs state for UI 
```
{
	"IsActive": false,
	"Loggers": {
		"Microsoft.AspNetCore.Server.Kestrel.Http2": "None",
		"Microsoft.AspNetCore.Hosting.HostedServiceExecutor": "None",
		"Microsoft.AspNetCore.Server.Kestrel": "None",
		"Microsoft.AspNetCore.Hosting.ApplicationLifetime": "None",
		"Microsoft.AspNetCore.Hosting.Diagnostics": "None",
		"Microsoft.AspNetCore.Hosting.WebHost": "None",
		"Microsoft.AspNetCore.Server.Kestrel.Connections": "None",
		"Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "None",
		"Microsoft.AspNetCore.WebSockets.WebSocketMiddleware": "None",
		"Microsoft.AspNetCore.Server.Kestrel.BadRequests": "None",
		"Microsoft.AspNetCore.Server.Kestrel.Http3": "None",
		"Microsoft.AspNetCore.ResponseCompression.ResponseCompressionProvider": "None"
	}
}
```

### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.