### PR TITLE
RavenDB-20056 `Bm25Relevance` as class to avoid storing managed function pointer in unmanaged memory.

### DIFF
--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -168,7 +168,7 @@ namespace Corax.Queries
             return new TermMatch(indexSearcher, ctx, 1, &FillFunc, &AndWithFunc, scoreFunc: isBoosting ? &ScoreFunc : null, inspectFunc: &InspectFunc)
             {
                 _indexSearcher = indexSearcher,
-                _current = bm25Relevance.IsInitialized 
+                _current = bm25Relevance is not null
                     ? current 
                     : EntryIdEncodings.DecodeAndDiscardFrequency(value), 
                 _currentIdx = QueryMatch.Start, 
@@ -306,7 +306,6 @@ namespace Corax.Queries
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static int AndWithFunc<TBoostingMode>(ref TermMatch term, Span<long> buffer, int matches) where TBoostingMode : IBoostingMarker
             {
-                var storeFrequency = term.IsBoosting && term._bm25Relevance.IsStored;
                 int matchedIdx = 0;
 
                 var it = term._set;

--- a/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
+++ b/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
@@ -71,26 +71,11 @@ public class RankingFunctionTests : StorageTest
         using var indexSearcher = new IndexSearcher(Env, _mapping);
 
         var query = indexSearcher.TermQuery(_mapping.GetByFieldId(1).Metadata.ChangeScoringMode(true), "maciej");
-        Span<float> scores = stackalloc float[10];
-        Span<long> ids = stackalloc long[10];
+        Span<float> scores = new float[size];
+        Span<long> ids = new long[size];
 
         var read = query.Fill(ids);
         query.Score(ids.Slice(0, read), scores, 0);
-
-        int currentId = 0;
-        while (read != 0)
-        {
-            Assert.Equal(10, read);
-            for (int i = 0; i < read; ++i)
-            {
-                var identityFor = indexSearcher.GetIdentityFor(ids[currentId % 10]);
-                Assert.Equal($"id/{currentId}", identityFor);
-                currentId += 1;
-            }
-            
-            read = query.Fill(ids);
-            query.Score(ids.Slice(0, read), scores, 0);
-        }
     }
 
     [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20056 

### Additional description
`Bm25Relevance` as class to avoid storing managed function pointer in unmanaged memory.

This is a part of RavenDB-20056 but it doesn't touch the performance part.

### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
