### PR TITLE
RavenDB-19936 - Sharding - SetIndexStateCommand sends wrong database name

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -118,7 +118,7 @@ public abstract class AbstractExecutor : IDisposable
             if (result == null)
                 return default;
 
-            var blittable = result as BlittableJsonReaderObject; //TODO stav: dispose?
+            var blittable = result as BlittableJsonReaderObject;
             return (TCombinedResult)(object)blittable.Clone(operation.CreateOperationContext());
         }
 

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -1275,7 +1275,9 @@ namespace FastTests.Server.Documents.Indexing.Auto
 
         private async Task CleanupUnusedAutoIndexesOnNonSharded(ClusterObserver.DatabaseObservationState state)
         {
-            var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(new Dictionary<int, ClusterObserver.DatabaseObservationState> { {0, state} });
+            var mergedState = new ClusterObserver.MergedDatabaseObservationState(state.RawDatabase);
+            mergedState.AddState(state);
+            var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(mergedState);
             foreach (var (cmd, _) in indexCleanupCommands)
             {
                 await Server.ServerStore.Engine.PutAsync(cmd);

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -1011,7 +1011,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                         }
                     };
 
-                    await CleanupUnusedAutoIndexes(state);
+                    await CleanupUnusedAutoIndexesOnNonSharded(state);
                 }
 
                 WaitForIndexDeletion(database, index0.Name);
@@ -1079,7 +1079,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     };
 
                     // nothing should happen because difference between querying time between those two indexes is less than TimeToWaitBeforeMarkingAutoIndexAsIdle
-                    await CleanupUnusedAutoIndexes(state);
+                    await CleanupUnusedAutoIndexesOnNonSharded(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1141,7 +1141,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     };
 
                     // this will mark index2 as idle, because the difference between two indexes and index last querying time is more than TimeToWaitBeforeMarkingAutoIndexAsIdle
-                    await CleanupUnusedAutoIndexes(state);
+                    await CleanupUnusedAutoIndexesOnNonSharded(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
@@ -1203,7 +1203,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     };
 
                     // should not remove anything, age will be greater than 2x TimeToWaitBeforeMarkingAutoIndexAsIdle but less than TimeToWaitBeforeDeletingAutoIndexMarkedAsIdle
-                    await CleanupUnusedAutoIndexes(state);
+                    await CleanupUnusedAutoIndexesOnNonSharded(state);
                 }
 
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Idle);
@@ -1265,7 +1265,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                     };
 
                     // this will delete indexes
-                    await CleanupUnusedAutoIndexes(state);
+                    await CleanupUnusedAutoIndexesOnNonSharded(state);
                 }
 
                 WaitForIndexDeletion(database, index1.Name);
@@ -1273,9 +1273,9 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        private async Task CleanupUnusedAutoIndexes(ClusterObserver.DatabaseObservationState state)
+        private async Task CleanupUnusedAutoIndexesOnNonSharded(ClusterObserver.DatabaseObservationState state)
         {
-            var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(state);
+            var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(new Dictionary<int, ClusterObserver.DatabaseObservationState> { {0, state} });
             foreach (var (cmd, _) in indexCleanupCommands)
             {
                 await Server.ServerStore.Engine.PutAsync(cmd);

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -219,6 +219,22 @@ public partial class RavenTestBase
             }
         }
 
+        public async ValueTask<ShardedDocumentDatabase> GetShardDocumentDatabaseInstanceFor(string database, List<RavenServer> servers = null)
+        {
+            servers ??= _parent.GetServers();
+            foreach (var server in servers)
+            {
+                foreach (var task in server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(database))
+                {
+                    var databaseInstance = await task;
+                    Debug.Assert(databaseInstance != null, $"The requested database '{database}' is null, probably you try to loaded sharded database without the $");
+                    return databaseInstance;
+                }
+            }
+
+            return null;
+        }
+
         public bool AllShardHaveDocs(IDictionary<string, List<DocumentDatabase>> servers, long count = 1L)
         {
             foreach (var kvp in servers)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19936

### Additional description

`ClusterObserver` fires `SetIndexStateCommand` to mark auto index as idle after some time of unuse. In Sharding it used the shard database name for the command while needing the sharded name.

Changed the database name fed into the command to the sharded name. Also now calculating the time difference for idle check across the database states for all shards, instead of per each like before. This is to prevent an auto index going idle on one shard while staying active on others.. or being deleting only on one shard etc.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
