### PR TITLE
RavenDB-20022 Add the /setup/alive to the ping endpoint

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     context.Write(writer, task.Result.ToJson());
 
                     if (setStatusCodeOnError && task.Result.HasErrors)
-                        HttpContext.Response.StatusCode = (int)HttpStatusCode.ExpectationFailed;
+                        HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
                     if (tasks.Count > 0)
                         writer.WriteComma();

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        internal class SetupAliveInfo : IDynamicJsonValueConvertible
+        internal class SetupAliveInfo : IDynamicJson
         {
             public long Time;
             public string Error;
@@ -186,7 +186,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        internal class TcpInfo : IDynamicJsonValueConvertible
+        internal class TcpInfo : IDynamicJson
         {
             public long TcpInfoTime;
             public long SendTime;

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     context.Write(writer, task.Result.ToJson());
 
                     if (setStatusCodeOnError && task.Result.HasErrors)
-                        HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                        HttpContext.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
 
                     if (tasks.Count > 0)
                         writer.WriteComma();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20022/Add-the-setup-alive-to-the-ping-endpoint

### Additional description

Added the SetupAlive time and fixed a bug in the JSON formatting when there is an error in PingOnce

### Type of change

- Bug fix
- New feature

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing
