### PR TITLE
RavenDB-19205 AutoIndex will use ticks for `DateOnly` and `TimeOnly`.

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTraverserHelper.cs
+++ b/src/Raven.Server/Json/BlittableJsonTraverserHelper.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Json
             if (blittableJsonTraverser.TryRead(document, path, out value, out StringSegment leftPath) &&
                 leftPath.Length == 0)
             {
-                value = TypeConverter.ConvertForIndexing(value);
+                value = TypeConverter.ConvertForIndexing(value, leftPath);
                 return true;
             }
 
@@ -60,7 +60,7 @@ namespace Raven.Server.Json
 
         public static bool TryReadComputedProperties(BlittableJsonTraverser blittableJsonTraverser, StringSegment leftPath, ref object value)
         {
-            value = TypeConverter.ConvertForIndexing(value);
+            value = TypeConverter.ConvertForIndexing(value, leftPath);
 
             if (leftPath == "Length" || leftPath == "length" ||
                 leftPath == "Count" || leftPath == "count")
@@ -125,7 +125,7 @@ namespace Raven.Server.Json
                     {
                         obj.GetPropertyByIndex(i, ref property);
                         var val = isKey ? property.Name : property.Value;
-                        values[index++] = TypeConverter.ConvertForIndexing(val);
+                        values[index++] = TypeConverter.ConvertForIndexing(val, default);
                     }
 
                     value = values;
@@ -135,7 +135,7 @@ namespace Raven.Server.Json
                     return true;
             }
 
-            if (value is DateTime || value is DateTimeOffset || value is TimeSpan)
+            if (value is DateTime || value is DateTimeOffset || value is TimeSpan || value is TimeOnly || value is DateOnly)
             {
                 int indexOfPropertySeparator;
                 do

--- a/test/SlowTests/Issues/RavenDB-19205.cs
+++ b/test/SlowTests/Issues/RavenDB-19205.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19205 : RavenTestBase
+{
+    public RavenDB_19205(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task UnableToFilterOnNullableDateOnlyProperty(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Employee {Id = "employees/1", DateTimeDateOfBirth = new DateTime(2000, 1, 1), DateOnlyDateOfBirth = new DateOnly(2000, 1, 1)});
+            await session.SaveChangesAsync();
+        }
+
+        // Querying the DateTime property works fine.
+        using (var session = store.OpenAsyncSession())
+        {
+            var employees = await session
+                .Query<Employee>()
+                .Customize(i => i.WaitForNonStaleResults())
+                .Where(e => e.DateTimeDateOfBirth != null && e.DateTimeDateOfBirth.Value.Year == 2000)
+                .ToListAsync();
+
+            Assert.Equal(1, employees.Count);
+        }
+
+
+        // Querying the DateOnly property returns no results.
+        using (var session = store.OpenAsyncSession())
+        {
+            var employees = await session
+                .Query<Employee>()
+                .Customize(i => i.WaitForNonStaleResults())
+                .Where(e => e.DateOnlyDateOfBirth != null && e.DateOnlyDateOfBirth.Value.Year == 2000)
+                .ToListAsync();
+            Assert.Equal(1, employees.Count);
+        }
+    }
+
+
+    private class Employee
+    {
+        public string Id { get; init; }
+        public DateTime? DateTimeDateOfBirth { get; init; }
+        public DateOnly? DateOnlyDateOfBirth { get; init; }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanProduceTicksFromTimeOnlyDateOnlyViaAutoIndex(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var initialDate = new DateTime(2023, 3, 6, 12, 5, 0);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new ItemWithoutNullValues("Data1", DateOnly.FromDateTime(initialDate), TimeOnly.FromDateTime(initialDate)));
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            // ReSharper disable once ReplaceWithSingleCallToCount
+            var result = session
+                .Query<ItemWithoutNullValues>()
+                .Customize(i => i.WaitForNonStaleResults())
+                .Where(item => item.DateOnly != null 
+                               && item.DateOnly.Value.Year == 2023 
+                               && item.TimeOnly != null
+                               && item.TimeOnly.Value.Minute == 5)
+                .Count();
+
+            WaitForUserToContinueTheTest(store);
+            Assert.Equal(1L, result);
+        }
+    }
+
+    private record ItemWithoutNullValues(string Name, DateOnly? DateOnly, TimeOnly? TimeOnly);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19205 

### Additional description

This PR includes:
-  AutoIndex will use ticks for `DateOnly` and `TimeOnly`.
   - in order to distinguish members of TimeOnly and TimeSpan (TimeOnly can be parsed as TimeSpan) we've to check what property from the object user wants. 

### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
