### PR TITLE
RavenDB-19614 : Sharding - Keep track of merged change vector during insertion to the bucket

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -42,6 +42,11 @@ namespace Raven.Server.Documents
                 (int)AttachmentsTable.Etag, ref tvr, out slice);
         }
 
+        internal static void UpdateBucketStatsForAttachments(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)AttachmentsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
+
         private void UpdateBucketStatsOnPutOrDeleteStream(DocumentsOperationContext context, Slice attachmentKey, long sizeChange)
         {
             if (_documentDatabase is not ShardedDocumentDatabase)
@@ -49,7 +54,7 @@ namespace Raven.Server.Documents
 
             using (GetBucketFromAttachmentKey(context, attachmentKey, out var bucketSlice))
             {
-                ShardedDocumentsStorage.UpdateBucketStats(context.Transaction.InnerTransaction, bucketSlice, oldSize: 0, newSize: sizeChange);
+                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, value: default, changeVectorIndex: -1, sizeChange: sizeChange);
             }
         }
 

--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Raven.Server.Documents.Replication.ReplicationItems;
+﻿using Raven.Server.Documents.Replication.ReplicationItems;
 using System.Collections.Generic;
-using System.Text;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -10,7 +10,6 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.Schemas.Attachments;
-using Voron.Util;
 
 namespace Raven.Server.Documents
 {
@@ -53,7 +52,7 @@ namespace Raven.Server.Documents
 
             using (GetBucketFromAttachmentKey(context, attachmentKey, out var bucketSlice))
             {
-                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, value: ref TableValueReaderUtils.EmptyReader, changeVectorIndex: -1, sizeChange: sizeChange);
+                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, sizeChange: sizeChange);
             }
         }
 
@@ -66,8 +65,7 @@ namespace Raven.Server.Documents
                     break;
             }
 
-
-            var database = context.Transaction.InnerTransaction.Owner as ShardedDocumentDatabase;
+            var database = context.DocumentDatabase as ShardedDocumentDatabase;
             
             var bucket = ShardHelper.GetBucketFor(database.ShardingConfiguration, attachmentKey.AsReadOnlySpan()[..sizeOfDocId]);
 

--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -12,6 +12,7 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.Schemas.Attachments;
+using Voron.Util;
 
 namespace Raven.Server.Documents
 {
@@ -42,9 +43,9 @@ namespace Raven.Server.Documents
                 (int)AttachmentsTable.Etag, ref tvr, out slice);
         }
 
-        internal static void UpdateBucketStatsForAttachments(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateBucketStatsForAttachments(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)AttachmentsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)AttachmentsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
 
         private void UpdateBucketStatsOnPutOrDeleteStream(DocumentsOperationContext context, Slice attachmentKey, long sizeChange)
@@ -54,7 +55,7 @@ namespace Raven.Server.Documents
 
             using (GetBucketFromAttachmentKey(context, attachmentKey, out var bucketSlice))
             {
-                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, value: default, changeVectorIndex: -1, sizeChange: sizeChange);
+                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, value: ref TableValueReaderUtils.EmptyReader, changeVectorIndex: -1, sizeChange: sizeChange);
             }
         }
 

--- a/src/Raven.Server/Documents/BucketStats.cs
+++ b/src/Raven.Server/Documents/BucketStats.cs
@@ -1,4 +1,6 @@
 using System.Runtime.InteropServices;
+using Sparrow.Server;
+using Voron;
 
 namespace Raven.Server.Documents
 {
@@ -13,5 +15,19 @@ namespace Raven.Server.Documents
 
         [FieldOffset(16)]
         public long LastModifiedTicks;
+
+        public unsafe ByteStringContext.InternalScope GetMergedChangeVector(ByteStringContext context, ValueReader reader, out Slice changeVector)
+        {
+            if (reader.Length <= sizeof(BucketStats))
+            {
+                changeVector = default;
+                return default;
+            }
+
+            return Slice.From(context,
+                reader.Base + sizeof(BucketStats),
+                reader.Length - sizeof(BucketStats),
+                out changeVector);
+        }
     }
 }

--- a/src/Raven.Server/Documents/BucketStats.cs
+++ b/src/Raven.Server/Documents/BucketStats.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents
         [FieldOffset(16)]
         public long LastModifiedTicks;
 
-        public unsafe string GetMergedChangeVector(ValueReader reader)
+        public static unsafe string GetMergedChangeVector(ValueReader reader)
         {
             if (reader.Length <= sizeof(BucketStats))
                 return default;

--- a/src/Raven.Server/Documents/BucketStats.cs
+++ b/src/Raven.Server/Documents/BucketStats.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using Sparrow.Server;
+using Sparrow;
 using Voron;
 
 namespace Raven.Server.Documents
@@ -16,18 +16,13 @@ namespace Raven.Server.Documents
         [FieldOffset(16)]
         public long LastModifiedTicks;
 
-        public unsafe ByteStringContext.InternalScope GetMergedChangeVector(ByteStringContext context, ValueReader reader, out Slice changeVector)
+        public unsafe string GetMergedChangeVector(ValueReader reader)
         {
             if (reader.Length <= sizeof(BucketStats))
-            {
-                changeVector = default;
                 return default;
-            }
-
-            return Slice.From(context,
-                reader.Base + sizeof(BucketStats),
-                reader.Length - sizeof(BucketStats),
-                out changeVector);
+            
+            return Encodings.Utf8.GetString(reader.Base + sizeof(BucketStats), reader.Length - sizeof(BucketStats));
         }
+
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -49,5 +49,10 @@ namespace Raven.Server.Documents
         {
             ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)CountersTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
+
+        internal static void UpdateBucketStatsForCounterTombstones(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)CounterTombstonesTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -52,7 +52,8 @@ namespace Raven.Server.Documents
 
         internal static void UpdateBucketStatsForCounterTombstones(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)CounterTombstonesTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            // counter tombstones are not replicated, no need to update the merged-cv of the bucket 
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, sizeChange: newValue.Size - oldValue.Size);
         }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -44,5 +44,10 @@ namespace Raven.Server.Documents
         {
             return ShardedDocumentsStorage.ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)CounterTombstonesTable.CounterTombstoneKey, (int)CounterTombstonesTable.Etag, ref tvr, out slice);
         }
+
+        internal static void UpdateBucketStatsForCounters(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)CountersTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -45,9 +45,9 @@ namespace Raven.Server.Documents
             return ShardedDocumentsStorage.ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, (int)CounterTombstonesTable.CounterTombstoneKey, (int)CounterTombstonesTable.Etag, ref tvr, out slice);
         }
 
-        internal static void UpdateBucketStatsForCounters(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateBucketStatsForCounters(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)CountersTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)CountersTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1409,7 +1409,7 @@ namespace Raven.Server.Documents
             {
                 Memory.Set(newVal.Ptr + existingCounter.Length, 0, empties * SizeOfCounterValues);
             }
-;
+
             var newEntry = (CounterValues*)newVal.Ptr + dbIdIndex;
             newEntry->Value = sourceValue;
             newEntry->Etag = sourceEtag;
@@ -1472,15 +1472,6 @@ namespace Raven.Server.Documents
             }
 
             return countersCount;
-        }
-
-
-        internal IEnumerable<string> GetCountersForDocument(DocumentsOperationContext context, Transaction transaction, string docId)
-        {
-            var table = new Table(CountersSchema, transaction);
-
-            foreach (string c in GetCountersForDocumentInternal(context, docId, table))
-                yield return c;
         }
 
         internal static IEnumerable<string> GetCountersForDocumentInternal(DocumentsOperationContext context, string docId, Table table)

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents
             _context = context;
             _changes = changes;
 
-            transaction.Owner = _context.DocumentDatabase;
+            transaction.Owner = _context;
             transaction.OnBeforeCommit += _context.DocumentDatabase.DocumentsStorage.OnBeforeCommit;
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
@@ -26,5 +26,10 @@ namespace Raven.Server.Documents.Revisions
         {
             return ShardedDocumentsStorage.GenerateBucketAndEtagIndexKey(tx, idIndex: (int)RevisionsTable.LowerId, etagIndex: (int)RevisionsTable.Etag, ref tvr, out slice);
         }
+
+        internal static void UpdateBucketStatsForRevisions(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)RevisionsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
@@ -27,9 +27,9 @@ namespace Raven.Server.Documents.Revisions
             return ShardedDocumentsStorage.GenerateBucketAndEtagIndexKey(tx, idIndex: (int)RevisionsTable.LowerId, etagIndex: (int)RevisionsTable.Etag, ref tvr, out slice);
         }
 
-        internal static void UpdateBucketStatsForRevisions(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateBucketStatsForRevisions(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)RevisionsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)RevisionsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
     }
 }

--- a/src/Raven.Server/Documents/Schemas/Attachments.cs
+++ b/src/Raven.Server/Documents/Schemas/Attachments.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingAttachmentsSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = AttachmentsStorage.GenerateBucketAndEtagIndexKeyForAttachments,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = AttachmentsStorage.UpdateBucketStatsForAttachments,
                     IsGlobal = true,
                     Name = AttachmentsBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Schemas/CounterTombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/CounterTombstones.cs
@@ -1,6 +1,4 @@
-﻿using Raven.Server.Documents.Sharding;
-using Raven.Server.Documents.TimeSeries;
-using Sparrow.Server;
+﻿using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
 
@@ -69,7 +67,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingCounterTombstonesSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = CountersStorage.GenerateBucketAndEtagIndexKeyForCounterTombstones,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = CountersStorage.UpdateBucketStatsForCounterTombstones,
                     IsGlobal = true,
                     Name = CounterTombstonesBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Schemas/Counters.cs
+++ b/src/Raven.Server/Documents/Schemas/Counters.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingCountersSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = CountersStorage.GenerateBucketAndEtagIndexKeyForCounters,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = CountersStorage.UpdateBucketStatsForCounters,
                     IsGlobal = true,
                     Name = CountersBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
+++ b/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingDeleteRangesSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = TimeSeriesStorage.GenerateBucketAndEtagIndexKeyForDeletedRanges,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = TimeSeriesStorage.UpdateBucketStatsForDeletedRanges,
                     IsGlobal = true,
                     Name = DeletedRangesBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
+++ b/src/Raven.Server/Documents/Schemas/DeletedRanges.cs
@@ -1,5 +1,4 @@
-﻿using Raven.Server.Documents.Sharding;
-using Raven.Server.Documents.TimeSeries;
+﻿using Raven.Server.Documents.TimeSeries;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;

--- a/src/Raven.Server/Documents/Schemas/Revisions.cs
+++ b/src/Raven.Server/Documents/Schemas/Revisions.cs
@@ -1,5 +1,4 @@
 ﻿using Raven.Server.Documents.Revisions;
-using Raven.Server.Documents.Sharding;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;

--- a/src/Raven.Server/Documents/Schemas/Revisions.cs
+++ b/src/Raven.Server/Documents/Schemas/Revisions.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.Schemas
             schema.DefineIndex(new TableSchema.DynamicKeyIndexDef
             {
                 GenerateKey = RevisionsStorage.GenerateBucketAndEtagIndexKeyForRevisions,
-                OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                OnEntryChanged = RevisionsStorage.UpdateBucketStatsForRevisions,
                 IsGlobal = true,
                 Name = RevisionsBucketAndEtagSlice
             });

--- a/src/Raven.Server/Documents/Schemas/TimeSeries.cs
+++ b/src/Raven.Server/Documents/Schemas/TimeSeries.cs
@@ -1,5 +1,4 @@
-﻿using Raven.Server.Documents.Sharding;
-using Raven.Server.Documents.TimeSeries;
+﻿using Raven.Server.Documents.TimeSeries;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
@@ -81,7 +80,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingTimeSeriesSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = TimeSeriesStorage.GenerateBucketAndEtagIndexKeyForTimeSeries,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = TimeSeriesStorage.UpdateBucketStatsForTimeSeries,
                     IsGlobal = true,
                     Name = TimeSeriesBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Schemas/Tombstones.cs
+++ b/src/Raven.Server/Documents/Schemas/Tombstones.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Schemas
                 ShardingTombstonesSchema.DefineIndex(new TableSchema.DynamicKeyIndexDef
                 {
                     GenerateKey = ShardedDocumentsStorage.GenerateBucketAndEtagIndexKeyForTombstones,
-                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStats,
+                    OnEntryChanged = ShardedDocumentsStorage.UpdateBucketStatsForTombstones,
                     IsGlobal = true,
                     Name = TombstonesBucketAndEtagSlice
                 });

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedPeriodicDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedPeriodicDocumentsMigrator.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Raven.Server.Background;
 using Raven.Server.ServerWide.Commands.Sharding;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Sharding.Background
 {

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -108,7 +108,7 @@ namespace Raven.Server.Documents.Sharding
             _mergedChangeVectors.Clear();
         }
 
-        public ChangeVector TableValueToChangeVector(int changeVectorIndex, ref TableValueReader value)
+        private ChangeVector TableValueToChangeVector(int changeVectorIndex, ref TableValueReader value)
         {
             if (_ctx == null)
                 _storage.ContextPool.AllocateOperationContext(out _ctx);

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents.Sharding
                 stats.NumberOfDocuments += inMemoryStats.NumberOfDocuments;
                 stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
 
-                mergedCv = stats.GetMergedChangeVector(readResult.Reader);
+                mergedCv = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);
             }
 
             if (_mergedChangeVectors.TryGetValue(bucket, out var changeVector))

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Voron;
+using Voron.Impl;
+
+namespace Raven.Server.Documents.Sharding
+{
+    internal unsafe class BucketStatsHolder
+    {
+        private readonly Dictionary<int, Documents.BucketStats> _values = new();
+        private readonly Dictionary<int, ChangeVector> _mergedChangeVectors = new();
+
+        public void UpdateBucket(IChangeVectorOperationContext ctx, int bucket, long nowTicks, long sizeChange, long numOfDocsChanged, ChangeVector changeVector)
+        {
+            UpdateBucket(bucket, nowTicks, sizeChange, numOfDocsChanged);
+
+            ChangeVector mergedCv;
+            if (_mergedChangeVectors.TryGetValue(bucket, out var currentMergedCv) == false)
+            {
+                mergedCv = changeVector;
+            }
+            else
+            {
+                var mergedCvStr = ChangeVectorUtils.MergeVectors(currentMergedCv, changeVector);
+                mergedCv = ctx.GetChangeVector(mergedCvStr);
+            }
+
+            _mergedChangeVectors[bucket] = mergedCv;
+        }
+
+        public void UpdateBucket(int bucket, long nowTicks, long sizeChange, long numOfDocsChanged)
+        {
+            _values.TryGetValue(bucket, out var bucketStats);
+
+            bucketStats.Size += sizeChange;
+            bucketStats.NumberOfDocuments += numOfDocsChanged;
+            bucketStats.LastModifiedTicks = nowTicks;
+
+            _values[bucket] = bucketStats;
+        }
+
+        public void UpdateBucketStatsTreeBeforeCommit(Transaction tx)
+        {
+            int bucketStatsSize = sizeof(Documents.BucketStats);
+            var tree = tx.ReadTree(ShardedDocumentsStorage.BucketStatsSlice);
+
+            foreach ((int bucket, Documents.BucketStats inMemoryStats) in _values)
+            {
+                using (tx.Allocator.Allocate(sizeof(int), out var keyBuffer))
+                {
+                    *(int*)keyBuffer.Ptr = bucket;
+                    var keySlice = new Slice(keyBuffer);
+                    var readResult = tree.Read(keySlice);
+
+                    Documents.BucketStats stats;
+                    IDisposable cvScope = null;
+                    Slice cvSlice = default;
+
+                    if (readResult == null)
+                    {
+                        stats = inMemoryStats;
+                    }
+                    else
+                    {
+                        stats = *(Documents.BucketStats*)readResult.Reader.Base;
+                        stats.Size += inMemoryStats.Size;
+                        stats.NumberOfDocuments += inMemoryStats.NumberOfDocuments;
+                        stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
+
+                        if (readResult.Reader.Length > bucketStatsSize)
+                        {
+                            cvScope = Slice.From(tx.Allocator, readResult.Reader.Base + bucketStatsSize, readResult.Reader.Length - bucketStatsSize, out cvSlice);
+                        }
+                    }
+
+                    if (stats.Size == 0 && stats.NumberOfDocuments == 0)
+                    {
+                        tree.Delete(keySlice);
+                        continue;
+                    }
+
+                    if (_mergedChangeVectors.TryGetValue(bucket, out var changeVector))
+                    {
+                        using (cvScope)
+                        {
+                            // update merged change vector
+                            var mergedCv = cvSlice.HasValue
+                                ? ChangeVectorUtils.MergeVectors(cvSlice.ToString(), changeVector)
+                                : changeVector;
+                            cvScope = Slice.From(tx.Allocator, mergedCv, out cvSlice);
+                        }
+                    }
+
+                    using (cvScope)
+                    using (tree.DirectAdd(keySlice, bucketStatsSize + cvSlice.Size, out var ptr))
+                    {
+                        *(Documents.BucketStats*)ptr = stats;
+                        if (cvSlice.HasValue)
+                            cvSlice.CopyTo(ptr + bucketStatsSize);
+                    }
+                }
+            }
+
+            _values.Clear();
+            _mergedChangeVectors.Clear();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -9,7 +9,6 @@ using Raven.Server.Documents.Indexes.Sharding;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Sharding.Background;
 using Raven.Server.Documents.Sharding.Smuggler;
-using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.Sharding;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -151,17 +150,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
             }
         }
     }
-
-    public ShardingConfiguration ReadShardingState()
-    {
-        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-        using (context.OpenReadTransaction())
-        using (var raw = ServerStore.Cluster.ReadRawDatabaseRecord(context, ShardedDatabaseName))
-        {
-            return raw.Sharding.MaterializedConfiguration;
-        }
-    }
-
+    
     protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);
@@ -256,6 +245,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
             _bucket = bucket;
             _uptoChangeVector = uptoChangeVector;
         }
+
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Critical, "We need to create here proper tombstones so backup can pick it up RavenDB-19197");

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.Schemas;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
@@ -237,15 +236,15 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
 
         var nowTicks = documentDatabase.Time.GetUtcNow().Ticks;
         var bucket = *(int*)key.Content.Ptr;
-
         var inMemoryBucketStats = documentDatabase.ShardedDocumentsStorage._bucketStats;
+
         if (value.Size == 0)
-    {
-            // item deletion or put/delete attachment stream
-            // in both cases there's no need to update the merged-cv
+        {
+            // item deletion or put/delete attachment stream or artificial-tombstone insertion
+            // in all cases there's no need to update the merged-cv
             inMemoryBucketStats.UpdateBucket(bucket, nowTicks, sizeChange, numOfDocsChanged);
             return;
-                }
+        }
 
         // item was inserted/updated 
         // need to update the merged-cv of the bucket
@@ -279,7 +278,6 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
                 return true;
             }
 
-            var number = _documentDatabase.ShardNumber;
             merged = GetMergedChangeVectorInBucket(context, bucket);
             return false;
         }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
@@ -46,5 +46,15 @@ namespace Raven.Server.Documents.TimeSeries
             return ShardedDocumentsStorage.ExtractIdFromKeyAndGenerateBucketAndEtagIndexKey(tx, keyIndex: (int)DeletedRangeTable.RangeKey,
                 etagIndex: (int)DeletedRangeTable.Etag, ref tvr, out slice);
         }
+
+        internal static void UpdateBucketStatsForDeletedRanges(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)DeletedRangeTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
+
+        internal static void UpdateBucketStatsForTimeSeries(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        {
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)TimeSeriesTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+        }
     }
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
@@ -47,14 +47,14 @@ namespace Raven.Server.Documents.TimeSeries
                 etagIndex: (int)DeletedRangeTable.Etag, ref tvr, out slice);
         }
 
-        internal static void UpdateBucketStatsForDeletedRanges(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateBucketStatsForDeletedRanges(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)DeletedRangeTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)DeletedRangeTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
 
-        internal static void UpdateBucketStatsForTimeSeries(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateBucketStatsForTimeSeries(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, newValue, changeVectorIndex: (int)TimeSeriesTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)TimeSeriesTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
         }
     }
 }

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -16,6 +16,7 @@ using Voron.Debugging;
 using Voron.Exceptions;
 using Voron.Impl;
 using Voron.Impl.Paging;
+using Voron.Util;
 using Constants = Voron.Global.Constants;
 
 namespace Voron.Data.Tables
@@ -618,7 +619,7 @@ namespace Voron.Data.Tables
                 var indexTree = GetTree(dynamicKeyIndexDef);
                 using (dynamicKeyIndexDef.GetValue(_tx, ref value, out Slice val))
                 {
-                    dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: value, newValue: default(TableValueReader));
+                    dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: ref value, newValue: ref TableValueReaderUtils.EmptyReader);
 
                     var fst = GetFixedSizeTree(indexTree, val.Clone(_tx.Allocator), 0, dynamicKeyIndexDef.IsGlobal);
                     if (fst.Delete(id).NumberOfEntriesDeleted == 0)
@@ -854,7 +855,7 @@ namespace Voron.Data.Tables
                     using (dynamicKeyIndexDef.GetValue(_tx, ref oldVer, out Slice oldVal))
                     using (dynamicKeyIndexDef.GetValue(_tx, newVer, out Slice newVal))
                     {
-                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, key: newVal, oldValue: oldVer, newValue: newVer);
+                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, key: newVal, oldValue: ref oldVer, newValue: newVer);
 
                         if (SliceComparer.AreEqual(oldVal, newVal) == false ||
                             forceUpdate)
@@ -987,7 +988,7 @@ namespace Voron.Data.Tables
                 {
                     using (dynamicKeyIndexDef.GetValue(_tx, ref value, out Slice val))
                     {
-                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: default, newValue: value);
+                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: ref TableValueReaderUtils.EmptyReader, newValue: ref value);
 
                         var indexTree = GetTree(dynamicKeyIndexDef);
                         var index = GetFixedSizeTree(indexTree, val, 0, dynamicKeyIndexDef.IsGlobal);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -618,7 +618,7 @@ namespace Voron.Data.Tables
                 var indexTree = GetTree(dynamicKeyIndexDef);
                 using (dynamicKeyIndexDef.GetValue(_tx, ref value, out Slice val))
                 {
-                    dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldSize: value.Size, newSize: 0);
+                    dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: value, newValue: default(TableValueReader));
 
                     var fst = GetFixedSizeTree(indexTree, val.Clone(_tx.Allocator), 0, dynamicKeyIndexDef.IsGlobal);
                     if (fst.Delete(id).NumberOfEntriesDeleted == 0)
@@ -854,7 +854,7 @@ namespace Voron.Data.Tables
                     using (dynamicKeyIndexDef.GetValue(_tx, ref oldVer, out Slice oldVal))
                     using (dynamicKeyIndexDef.GetValue(_tx, newVer, out Slice newVal))
                     {
-                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, key: newVal, oldSize: oldVer.Size, newSize: newVer.Size);
+                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, key: newVal, oldValue: oldVer, newValue: newVer);
 
                         if (SliceComparer.AreEqual(oldVal, newVal) == false ||
                             forceUpdate)
@@ -987,7 +987,7 @@ namespace Voron.Data.Tables
                 {
                     using (dynamicKeyIndexDef.GetValue(_tx, ref value, out Slice val))
                     {
-                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldSize: 0, newSize: value.Size);
+                        dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: default, newValue: value);
 
                         var indexTree = GetTree(dynamicKeyIndexDef);
                         var index = GetFixedSizeTree(indexTree, val, 0, dynamicKeyIndexDef.IsGlobal);

--- a/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
+++ b/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Server;
+using Sparrow.Utils;
 using Voron.Impl;
 
 namespace Voron.Data.Tables
@@ -241,7 +242,8 @@ namespace Voron.Data.Tables
 
                 using (tx.Allocator.Allocate(newValue.Size, out var buffer))
                 {
-                    // todo RavenDB-18105 : try to optimize this - avoid creating a copy of the value here
+                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
+                        "RavenDB-18105 : try to optimize this - avoid creating a copy of the value here");
 
                     newValue.CopyTo(buffer.Ptr);
                     var reader = newValue.CreateReader(buffer.Ptr);

--- a/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
+++ b/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
@@ -202,7 +202,7 @@ namespace Voron.Data.Tables
 
             public delegate ByteStringContext.Scope IndexEntryKeyGenerator(Transaction tx, ref TableValueReader value, out Slice slice);
 
-            public delegate void OnIndexEntryChangedDelegate(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue);
+            public delegate void OnIndexEntryChangedDelegate(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue);
 
             public OnIndexEntryChangedDelegate OnEntryChanged;
 
@@ -228,13 +228,13 @@ namespace Voron.Data.Tables
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void OnIndexEntryChanged(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+            public void OnIndexEntryChanged(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
             {
-                OnEntryChanged?.Invoke(tx, key, oldValue, newValue);
+                OnEntryChanged?.Invoke(tx, key, ref oldValue, ref newValue);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public void OnIndexEntryChanged(Transaction tx, Slice key, TableValueReader oldValue, TableValueBuilder newValue)
+            public void OnIndexEntryChanged(Transaction tx, Slice key, ref TableValueReader oldValue, TableValueBuilder newValue)
             {
                 if (OnEntryChanged == null)
                     return;
@@ -245,7 +245,7 @@ namespace Voron.Data.Tables
 
                     newValue.CopyTo(buffer.Ptr);
                     var reader = newValue.CreateReader(buffer.Ptr);
-                    OnIndexEntryChanged(tx, key, oldValue, reader);
+                    OnIndexEntryChanged(tx, key, ref oldValue, ref reader);
                 }
             }
 

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -252,13 +252,11 @@ namespace Voron
             return External(context, value.Ptr, size, ByteStringType.Mutable | ByteStringType.External, out slice);
         }
 
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.ExternalScope External(ByteStringContext context, ByteString value,out Slice slice)
         {
             return External(context, value.Ptr, value.Length, ByteStringType.Mutable | ByteStringType.External, out slice);
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.ExternalScope External(ByteStringContext context, byte* value, int size, out Slice slice)

--- a/src/Voron/Util/TableValuereaderUtils.cs
+++ b/src/Voron/Util/TableValuereaderUtils.cs
@@ -1,0 +1,9 @@
+﻿using Voron.Data.Tables;
+
+namespace Voron.Util
+{
+    public static class TableValueReaderUtils
+    {
+        public static TableValueReader EmptyReader = default;
+    }
+}

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -424,7 +424,7 @@ namespace FastTests.Voron.Tables
             return scope;
         }
 
-        internal static void UpdateStats(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
+        internal static void UpdateStats(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
             var tree = tx.ReadTree(StatsTree);
             var bucket = *(int*)key.Content.Ptr;

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -424,7 +424,7 @@ namespace FastTests.Voron.Tables
             return scope;
         }
 
-        internal static void UpdateStats(Transaction tx, Slice key, long oldSize, long newSize)
+        internal static void UpdateStats(Transaction tx, Slice key, TableValueReader oldValue, TableValueReader newValue)
         {
             var tree = tx.ReadTree(StatsTree);
             var bucket = *(int*)key.Content.Ptr;
@@ -441,7 +441,7 @@ namespace FastTests.Voron.Tables
                     size = *(long*)reader.Base;
                 }
 
-                size += newSize - oldSize;
+                size += newValue.Size - oldValue.Size;
 
                 using (tree.DirectAdd(keySlice, sizeof(long), out var ptr))
                 {

--- a/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
+++ b/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
@@ -27,9 +25,9 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Sharding.Cluster
 {
-    public class BucketStats : ClusterTestBase
+    public class BucketStatsTests : ClusterTestBase
     {
-        public BucketStats(ITestOutputHelper output) : base(output)
+        public BucketStatsTests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
+++ b/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
@@ -118,7 +118,6 @@ namespace SlowTests.Sharding.Cluster
         [RavenFact(RavenTestCategory.Sharding)]
         public async Task CanGetBucketStats2()
         {
-            
             using (var store = Sharding.GetDocumentStore())
             {
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));

--- a/test/SlowTests/Sharding/Cluster/RavenDB_19614.cs
+++ b/test/SlowTests/Sharding/Cluster/RavenDB_19614.cs
@@ -1,0 +1,407 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Schemas;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Cluster
+{
+    public class RavenDB_19614 : ClusterTestBase
+    {
+        public RavenDB_19614(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanGetMergedChangeVectorInBucketFromBucketStats_SingleBucket()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var id = "users/1/$abc";
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                var shardNumber = await Sharding.GetShardNumberFor(store, id);
+
+                // insert
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        await session.StoreAsync(new Raven.Tests.Core.Utils.Entities.User(), $"users/{i}/$abc");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var db = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shardNumber))
+                    as ShardedDocumentDatabase;
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // update
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i % 2 == 0)
+                            continue;
+                        var doc = await session.LoadAsync<Raven.Tests.Core.Utils.Entities.User>($"users/{i}/$abc");
+                        doc.Age = i * 8;
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // delete
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i % 2 != 0)
+                            continue;
+                        session.Delete($"users/{i}/$abc");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanGetMergedChangeVectorInBucketFromBucketStats_ManyBuckets()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < 10_000; i++)
+                    {
+                        await bulk.StoreAsync(new Raven.Tests.Core.Utils.Entities.User
+                        {
+                            Name = i.ToString()
+                        }, $"users/{i}");
+                    }
+                }
+
+                await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+                {
+                    using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var bucketsStats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
+                        Assert.NotEmpty(bucketsStats);
+
+                        foreach (var stats in bucketsStats)
+                        {
+                            AssertMergedChangeVectorInBucket(shard, stats.Bucket);
+                        }
+                    }
+                }
+
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanGetMergedChangeVectorInBucketFromBucketStats_WithDocumentExtensions()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var bucket = await Sharding.GetBucketAsync(store, "users/1/$abc");
+                var shardNumber = await Sharding.GetShardNumberFor(store, "users/1/$abc");
+                var shardName = ShardHelper.ToShardName(store.Database, shardNumber);
+                var baseline = DateTime.UtcNow;
+
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false
+                    }
+                }));
+
+                // insert data
+                for (int i = 0; i < 10; i++)
+                {
+                    var id = $"users/{i}/$abc";
+
+                    using var session = store.OpenAsyncSession();
+                    await session.StoreAsync(new User(), id);
+
+                    var cf = session.CountersFor(id);
+                    cf.Increment("likes", i);
+                    cf.Increment("dislikes", -i);
+
+                    var tsf1 = session.TimeSeriesFor(id, "heartrate");
+                    var tsf2 = session.TimeSeriesFor(id, "blood-pressure");
+                    for (int j = 0; j < 10; j++)
+                    {
+                        tsf1.Append(baseline.AddDays(j), j);
+                        tsf2.Append(baseline.AddDays(j), j);
+                    }
+
+                    using var ms1 = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, (byte)i });
+                    using var ms2 = new MemoryStream(new byte[] { 6, 7, 8, 9, 10, (byte)i });
+                    session.Advanced.Attachments.Store(id, $"image-{i}", ms1);
+                    session.Advanced.Attachments.Store(id, $"file-{i}", ms2);
+
+                    await session.SaveChangesAsync();
+                }
+
+                var db = await GetDocumentDatabaseInstanceFor(store, shardName) as ShardedDocumentDatabase;
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // update docs
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        var id = $"users/{i}/$abc";
+                        var doc = await session.LoadAsync<User>(id);
+                        doc.Name = $"Name-{i}";
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // update extensions
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        var id = $"users/{i}/$abc";
+
+                        session.CountersFor(id).Increment("likes", i);
+                        session.TimeSeriesFor(id, "heartrate").Append(baseline.AddMinutes(10), i);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // delete some extensions
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i % 2 == 0)
+                            continue;
+
+                        var id = $"users/{i}/$abc";
+
+                        session.CountersFor(id).Delete("dislikes");
+                        session.TimeSeriesFor(id, "heartrate").Delete(baseline.AddDays(4), baseline.AddDays(8));
+                        session.TimeSeriesFor(id, "blood-pressure").Delete();
+                        session.Advanced.Attachments.Delete(id, $"file-{i}");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+
+                // delete some docs
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i % 2 != 0)
+                            continue;
+
+                        session.Delete($"users/{i}/$abc");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                AssertMergedChangeVectorInBucket(db, bucket);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task CanGetMergedChangeVectorInBucketFromBucketStats_InCluster()
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 2, orchestratorReplicationFactor: 3);
+            
+            using (var store = Sharding.GetDocumentStore(options))
+            {
+                await using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        await bulk.StoreAsync(new User
+                        {
+                            Name = i.ToString()
+                        }, $"users/{i}");
+                    }
+                }
+
+                await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+                {
+                    using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var bucketsStats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
+                        Assert.NotEmpty(bucketsStats);
+
+                        foreach (var stats in bucketsStats)
+                        {
+                            AssertMergedChangeVectorInBucket(shard, stats.Bucket);
+                        }
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding, Skip = "RavenDB-19745 : Importing an attachment mess up the stream tag")]
+        public async Task CanGetMergedChangeVectorInBucketFromBucketStats_UsingSampleData()
+        {
+            var t = GetTempFileName();
+            using (var store2 = Sharding.GetDocumentStore())
+            using (var store3 = Sharding.GetDocumentStore())
+            {
+                using (var ms = new MemoryStream(new byte[]{1, 2, 3, 4}))
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        session.Store(new(), "users/1");
+                        session.Advanced.Attachments.Store("users/1", "a", ms);
+
+                        session.SaveChanges();
+                    }
+                }
+
+                var op = await store2.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), t);
+                await op.WaitForCompletionAsync();
+
+                op = await store3.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), t);
+                await op.WaitForCompletionAsync();
+            }
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents
+                                                                                | DatabaseItemType.Attachments 
+                                                                                | DatabaseItemType.CounterGroups 
+                                                                                | DatabaseItemType.RevisionDocuments 
+                                                                                | DatabaseItemType.TimeSeries 
+                                                                                | DatabaseItemType.Tombstones ));
+
+                await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+                {
+                    using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var bucketsStats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
+                        Assert.NotEmpty(bucketsStats);
+
+                        foreach (var stats in bucketsStats)
+                        {
+                            AssertMergedChangeVectorInBucket(shard, stats.Bucket);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static ChangeVector CalculateMergedChangeVectorInBucket(DocumentDatabase database, DocumentsOperationContext context, int bucket)
+        {
+            var storage = database.DocumentsStorage;
+            var merged = context.GetChangeVector(string.Empty);
+            var table = new Table(storage.DocsSchema, context.Transaction.InnerTransaction);
+
+            var index = storage.DocsSchema.DynamicKeyIndexes[Documents.AllDocsBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var documentCv = DocumentsStorage.TableValueToChangeVector(context, (int)Documents.DocumentsTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(documentCv, context);
+            }
+
+            index = storage.TombstonesSchema.DynamicKeyIndexes[Tombstones.TombstonesBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var tombstoneCv = DocumentsStorage.TableValueToChangeVector(context, (int)Tombstones.TombstoneTable.ChangeVector, ref result.Result.Reader);
+                var flags = DocumentsStorage.TableValueToFlags((int)Tombstones.TombstoneTable.Flags, ref result.Result.Reader);
+                if (flags.HasFlag(DocumentFlags.Artificial | DocumentFlags.FromResharding))
+                    continue;
+
+                merged = merged.MergeWith(tombstoneCv, context);
+            }
+
+            index = database.DocumentsStorage.CountersStorage.CountersSchema.DynamicKeyIndexes[Counters.CountersBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var counterCv = DocumentsStorage.TableValueToChangeVector(context, (int)Counters.CountersTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(counterCv, context);
+            }
+
+            index = database.DocumentsStorage.ConflictsStorage.ConflictsSchema.DynamicKeyIndexes[Conflicts.ConflictsBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var conflictCv = DocumentsStorage.TableValueToChangeVector(context, (int)Conflicts.ConflictsTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(conflictCv, context);
+            }
+
+            index = database.DocumentsStorage.RevisionsStorage.RevisionsSchema.DynamicKeyIndexes[Revisions.RevisionsBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var revisionCv = DocumentsStorage.TableValueToChangeVector(context, (int)Revisions.RevisionsTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(revisionCv, context);
+            }
+
+            index = database.DocumentsStorage.AttachmentsStorage.AttachmentsSchema.DynamicKeyIndexes[Attachments.AttachmentsBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var attachmentCv = DocumentsStorage.TableValueToChangeVector(context, (int)Attachments.AttachmentsTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(attachmentCv, context);
+            }
+
+            index = database.DocumentsStorage.TimeSeriesStorage.TimeSeriesSchema.DynamicKeyIndexes[
+                Raven.Server.Documents.Schemas.TimeSeries.TimeSeriesBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var tsCv = DocumentsStorage.TableValueToChangeVector(context, (int)Raven.Server.Documents.Schemas.TimeSeries.TimeSeriesTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(tsCv, context);
+            }
+
+            index = database.DocumentsStorage.TimeSeriesStorage.DeleteRangesSchema.DynamicKeyIndexes[DeletedRanges.DeletedRangesBucketAndEtagSlice];
+            foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, index, bucket, 0))
+            {
+                var deletedRangeCv = DocumentsStorage.TableValueToChangeVector(context, (int)DeletedRanges.DeletedRangeTable.ChangeVector, ref result.Result.Reader);
+                merged = merged.MergeWith(deletedRangeCv, context);
+            }
+
+            return merged;
+        }
+
+        private static void AssertMergedChangeVectorInBucket(ShardedDocumentDatabase db, int bucket)
+        {
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var expected = CalculateMergedChangeVectorInBucket(db, ctx, bucket);
+                var fromStats = db.ShardedDocumentsStorage.GetMergedChangeVectorInBucket(ctx, bucket);
+
+                Assert.Equal(expected.AsString(), fromStats.AsString());
+            }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Cluster/RavenDB_19614.cs
+++ b/test/SlowTests/Sharding/Cluster/RavenDB_19614.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Sharding.Cluster
                 {
                     for (int i = 0; i < 10; i++)
                     {
-                        await session.StoreAsync(new Raven.Tests.Core.Utils.Entities.User(), $"users/{i}/$abc");
+                        await session.StoreAsync(new User(), $"users/{i}/$abc");
                     }
 
                     await session.SaveChangesAsync();
@@ -239,7 +239,7 @@ namespace SlowTests.Sharding.Cluster
         public async Task CanGetMergedChangeVectorInBucketFromBucketStats_InCluster()
         {
             var cluster = await CreateRaftCluster(3, watcherCluster: true);
-            var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 2, orchestratorReplicationFactor: 3);
+            var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
             
             using (var store = Sharding.GetDocumentStore(options))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19614

### Additional description

- modify `DynamicKeyIndexDef.OnEntryChanged` to operate on old and new values (instead of just their sizes)
- modify `OnEntryChanged` of all storage `BucketAndEtag` indexes accordingly
- introduce `BucketStatsHolder` which will be in charge of keeping track of bucket stats and merged change-vectors during insertion/update/deletion, and updating the BucketStats tree before commit
- modify `GetMergedChangeVectorInBucket` to fetch the value from BucketStats tree instead of calculating it by iterating over all items in the bucket
- add tests

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
