### PR TITLE
RavenDB-19943 - SlowTests.Issues.RavenDB_19545.RemovingTimeSeriesEntr…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_19545.cs
+++ b/test/SlowTests/Issues/RavenDB_19545.cs
@@ -97,7 +97,7 @@ public class RavenDB_19545 : RavenTestBase
                     session.SaveChanges();
                 }
 
-                var entries = session.TimeSeriesFor(docId, timeSeriesName).Get(baseline.AddDays(9), baseline.AddDays(11));
+                var entries = session.TimeSeriesFor(docId, timeSeriesName).Get(baseline.AddDays(9).AddSeconds(1), baseline.AddDays(11));
                 Assert.Equal(1, entries.Length);
 
                 entries = session.TimeSeriesFor(docId, timeSeriesName).Get(null, baseline.AddDays(8));


### PR DESCRIPTION
…yShouldAffectCache3

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19943/SlowTests.Issues.RavenDB19545.RemovingTimeSeriesEntryShouldAffectCache3

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
