### PR TITLE
RavenDB-20058: HOPE encoder was not properly building optimized dictionaries.

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactTree.RandomBranchKeyScanner.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.RandomBranchKeyScanner.cs
@@ -108,7 +108,7 @@ unsafe partial class CompactTree
             Success:
             key = keySpan;
             _currentSample++;
-            return key.Length != 0;
+            return true;
 
             Failure:
             key = Span<byte>.Empty;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -1449,9 +1449,9 @@ namespace Voron.Data.CompactTrees
 
                 if (splitAnyways)
                 {
-                    DebugStuff.RenderAndShow(this);
+                    //DebugStuff.RenderAndShow(this);
                     SplitPage(key, value);
-                    DebugStuff.RenderAndShow(this);
+                    //DebugStuff.RenderAndShow(this);
                     return;
                 }
             }
@@ -1665,7 +1665,9 @@ namespace Voron.Data.CompactTrees
             DebugStuff.RenderAndShow(this);
         }
 
+#if !DEBUG
         [SkipLocalsInit]
+#endif
         private bool TryRecompressPage(in CursorState state)
         {
             var oldDictionary = GetEncodingDictionary(state.Header->DictionaryId);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20058

### Additional description
An error in the scanning for sample process would prevent the encoder to build better dictionaries and hamper the ability to adapt to keys structures.

### Type of change
Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change