### PR TITLE
RavenDB-20057 Renaming convention UseCompression to UseHttpDecompression since it was only about accepting compressed HTTP responses. Introducing new convention UseHttpCompression which is respected by BlittableJsonContent so we won't send compressed requests if it's disabled. Default values are `true`.

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -110,7 +110,7 @@ namespace Raven.Client.Documents.Commands.Batches
                         }
                         writer.WriteEndObject();
                     }
-                })
+                }, _conventions)
             };
 
             if (_attachmentStreams != null && _attachmentStreams.Count > 0)

--- a/src/Raven.Client/Documents/Commands/CreateSubscriptionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/CreateSubscriptionCommand.cs
@@ -12,11 +12,13 @@ namespace Raven.Client.Documents.Commands
 {
     public class CreateSubscriptionCommand : RavenCommand<CreateSubscriptionResult>, IRaftCommand
     {
+        private readonly DocumentConventions _conventions;
         private readonly SubscriptionCreationOptions _options;
         private readonly string _id;
 
         public CreateSubscriptionCommand(DocumentConventions conventions, SubscriptionCreationOptions options, string id = null)
         {
+            _conventions = conventions;
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _id = id;
         }
@@ -30,7 +32,7 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Put,
-                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false))
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false), _conventions)
             };
             return request;
         }

--- a/src/Raven.Client/Documents/Commands/ExplainQueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/ExplainQueryCommand.cs
@@ -56,7 +56,7 @@ namespace Raven.Client.Documents.Commands
 
                             writer.WriteIndexQuery(_conventions, ctx, _indexQuery);
                         }
-                    }
+                    }, _conventions
                 )
             };
 

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -114,7 +114,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
 
                         writer.WriteEndObject();
                     }
-                })
+                }, _requestExecutor.Conventions)
             };
 
             return request;

--- a/src/Raven.Client/Documents/Commands/PutDocumentCommand.cs
+++ b/src/Raven.Client/Documents/Commands/PutDocumentCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
@@ -10,12 +11,14 @@ namespace Raven.Client.Documents.Commands
 {
     public class PutDocumentCommand : RavenCommand<PutResult>
     {
+        private readonly DocumentConventions _conventions;
         private readonly string _id;
         private readonly string _changeVector;
         private readonly BlittableJsonReaderObject _document;
 
-        public PutDocumentCommand(string id, string changeVector, BlittableJsonReaderObject document)
+        public PutDocumentCommand(DocumentConventions conventions, string id, string changeVector, BlittableJsonReaderObject document)
         {
+            _conventions = conventions;
             _id = id ?? throw new ArgumentNullException(nameof(id));
             _changeVector = changeVector;
             _document = document ?? throw new ArgumentNullException(nameof(document));
@@ -28,7 +31,7 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Put,
-                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _document).ConfigureAwait(false))
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _document).ConfigureAwait(false), _conventions)
             };
             AddChangeVectorIfNotNull(_changeVector, request);
             return request;

--- a/src/Raven.Client/Documents/Commands/QueryCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryCommand.cs
@@ -120,7 +120,7 @@ namespace Raven.Client.Documents.Commands
                     {
                         writer.WriteIndexQuery(_conventions, ctx, _indexQuery);
                     }
-                }
+                }, _session.DocumentStore.Conventions
             );
         }
 

--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -34,7 +34,7 @@ namespace Raven.Client.Documents.Commands
                     {
                         writer.WriteIndexQuery(_conventions, ctx, _indexQuery);
                     }
-                })
+                }, _conventions)
             };
 
             url = $"{node.Url}/databases/{node.Database}/streams/queries";

--- a/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Http;
@@ -11,10 +12,12 @@ namespace Raven.Client.Documents.Commands
 {
     internal class UpdateSubscriptionCommand : RavenCommand<UpdateSubscriptionResult>, IRaftCommand
     {
+        private readonly DocumentConventions _conventions;
         private readonly SubscriptionUpdateOptions _options;
 
-        public UpdateSubscriptionCommand(SubscriptionUpdateOptions options)
+        public UpdateSubscriptionCommand(DocumentConventions conventions, SubscriptionUpdateOptions options)
         {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _options = options;
         }
 
@@ -25,7 +28,7 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false))
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false), _conventions)
             };
             return request;
         }

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -327,7 +327,8 @@ namespace Raven.Client.Documents.Conventions
         private ReadBalanceBehavior _readBalanceBehavior;
         private bool _preserveDocumentPropertiesNotFoundOnModel;
         private Size _maxHttpCacheSize;
-        private bool? _useCompression;
+        private bool? _useHttpDecompression;
+        private bool? _useHttpCompression;
         private Func<MemberInfo, string> _propertyNameConverter;
         private Func<Type, bool> _typeIsKnownServerSide = _ => false;
         private Func<MemberInfo, bool> _shouldApplyPropertyNameConverter;
@@ -568,18 +569,31 @@ namespace Raven.Client.Documents.Conventions
             }
         }
 
-        internal bool HasExplicitlySetCompressionUsage => _useCompression.HasValue;
-
         /// <summary>
-        /// Should accept gzip/deflate headers be added to all requests?
+        /// Use gzip compression when sending content of HTTP request
         /// </summary>
-        public bool UseCompression
+        public bool UseHttpCompression
         {
-            get => _useCompression ?? true;
+            get => _useHttpCompression ?? true;
             set
             {
                 AssertNotFrozen();
-                _useCompression = value;
+                _useHttpCompression = value;
+            }
+        }
+
+        internal bool HasExplicitlySetDecompressionUsage => _useHttpDecompression.HasValue;
+
+        /// <summary>
+        /// Can accept compressed HTTP response content and will use gzip/deflate decompression methods
+        /// </summary>
+        public bool UseHttpDecompression
+        {
+            get => _useHttpDecompression ?? true;
+            set
+            {
+                AssertNotFrozen();
+                _useHttpDecompression = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Operations/Analyzers/PutAnalyzersOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Analyzers/PutAnalyzersOperation.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.Documents.Operations.Analyzers
 
         private class PutAnalyzersCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject[] _analyzersToAdd;
 
             public PutAnalyzersCommand(DocumentConventions conventions, JsonOperationContext context, AnalyzerDefinition[] analyzersToAdd)
@@ -38,6 +39,7 @@ namespace Raven.Client.Documents.Operations.Analyzers
                     throw new ArgumentNullException(nameof(analyzersToAdd));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _analyzersToAdd = new BlittableJsonReaderObject[analyzersToAdd.Length];
 
@@ -65,7 +67,7 @@ namespace Raven.Client.Documents.Operations.Analyzers
                             writer.WriteArray("Analyzers", _analyzersToAdd);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -30,18 +30,19 @@ namespace Raven.Client.Documents.Operations.Attachments
 
         public RavenCommand<AttachmentResult> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new GetAttachmentCommand(context, _documentId, _name, _type, _changeVector);
+            return new GetAttachmentCommand(conventions, context, _documentId, _name, _type, _changeVector);
         }
 
         internal class GetAttachmentCommand : RavenCommand<AttachmentResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly JsonOperationContext _context;
             private readonly string _documentId;
             private readonly string _name;
             private readonly AttachmentType _type;
             private readonly string _changeVector;
 
-            public GetAttachmentCommand(JsonOperationContext context, string documentId, string name, AttachmentType type, string changeVector)
+            public GetAttachmentCommand(DocumentConventions conventions, JsonOperationContext context, string documentId, string name, AttachmentType type, string changeVector)
             {
                 if (string.IsNullOrWhiteSpace(documentId))
                     throw new ArgumentNullException(nameof(documentId));
@@ -51,6 +52,7 @@ namespace Raven.Client.Documents.Operations.Attachments
                 if (type != AttachmentType.Document && changeVector == null)
                     throw new ArgumentNullException(nameof(changeVector), $"Change Vector cannot be null for attachment type {type}");
 
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _context = context;
                 _documentId = documentId;
                 _name = name;
@@ -87,7 +89,7 @@ namespace Raven.Client.Documents.Operations.Attachments
 
                             writer.WriteEndObject();
                         }
-                    });
+                    }, _conventions);
                 }
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
@@ -30,18 +30,20 @@ namespace Raven.Client.Documents.Operations.Attachments
 
         public RavenCommand<IEnumerator<AttachmentEnumeratorResult>> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new GetAttachmentsCommand(context, _attachments, _type);
+            return new GetAttachmentsCommand(conventions, context, _attachments, _type);
         }
 
         internal class GetAttachmentsCommand : RavenCommand<IEnumerator<AttachmentEnumeratorResult>>
         {
+            private readonly DocumentConventions _conventions;
             private readonly JsonOperationContext _context;
             private readonly AttachmentType _type;
             internal IEnumerable<AttachmentRequest> Attachments { get; }
             internal List<AttachmentDetails> AttachmentsMetadata { get; } = new List<AttachmentDetails>();
 
-            public GetAttachmentsCommand(JsonOperationContext context, IEnumerable<AttachmentRequest> attachments, AttachmentType type)
+            public GetAttachmentsCommand(DocumentConventions conventions, JsonOperationContext context, IEnumerable<AttachmentRequest> attachments, AttachmentType type)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _context = context;
                 _type = type;
                 Attachments = attachments;
@@ -87,7 +89,7 @@ namespace Raven.Client.Documents.Operations.Attachments
 
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
@@ -22,17 +22,19 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public RavenCommand<OperationIdResult<StartBackupOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new BackupCommand(_backupConfiguration, null);
+            return new BackupCommand(conventions, _backupConfiguration, null);
         }
 
         internal class BackupCommand : RavenCommand<OperationIdResult<StartBackupOperationResult>>
         {
             public override bool IsReadRequest => false;
+            private readonly DocumentConventions _conventions;
             private readonly BackupConfiguration _backupConfiguration;
             private readonly long? _operationId;
 
-            public BackupCommand(BackupConfiguration backupConfiguration, long? operationId = null)
+            public BackupCommand(DocumentConventions conventions, BackupConfiguration backupConfiguration, long? operationId = null)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _backupConfiguration = backupConfiguration;
                 _operationId = operationId;
             }
@@ -51,7 +53,7 @@ namespace Raven.Client.Documents.Operations.Backups
                     {
                         var config = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_backupConfiguration, ctx);
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public RavenCommand<UpdatePeriodicBackupOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdatePeriodicBackupCommand(_configuration);
+            return new UpdatePeriodicBackupCommand(conventions, _configuration);
         }
 
         private class UpdatePeriodicBackupCommand : RavenCommand<UpdatePeriodicBackupOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly PeriodicBackupConfiguration _configuration;
 
-            public UpdatePeriodicBackupCommand(PeriodicBackupConfiguration configuration)
+            public UpdatePeriodicBackupCommand(DocumentConventions conventions, PeriodicBackupConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.Backups
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.cs
@@ -73,7 +73,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethods.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, blittable).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, blittable).ConfigureAwait(false), _conventions)
                 };
                 return request;
             }

--- a/src/Raven.Client/Documents/Operations/Configuration/PutClientConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Configuration/PutClientConfigurationOperation.cs
@@ -24,6 +24,7 @@ namespace Raven.Client.Documents.Operations.Configuration
 
         private class PutClientConfigurationCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _configuration;
 
             public PutClientConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, ClientConfiguration configuration)
@@ -34,6 +35,7 @@ namespace Raven.Client.Documents.Operations.Configuration
                     throw new ArgumentNullException(nameof(configuration));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
             }
@@ -45,7 +47,7 @@ namespace Raven.Client.Documents.Operations.Configuration
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
 
         public RavenCommand<PutConnectionStringResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new PutConnectionStringCommand(_connectionString);
+            return new PutConnectionStringCommand(conventions, _connectionString);
         }
 
         private class PutConnectionStringCommand : RavenCommand<PutConnectionStringResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly T _connectionString;
 
-            public PutConnectionStringCommand(T connectionString)
+            public PutConnectionStringCommand(DocumentConventions conventions, T connectionString)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_connectionString, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_connectionString, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
@@ -19,15 +19,17 @@ namespace Raven.Client.Documents.Operations.Counters
 
         public RavenCommand<CountersDetail> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new CounterBatchCommand(_counterBatch);
+            return new CounterBatchCommand(conventions, _counterBatch);
         }
 
         internal class CounterBatchCommand : RavenCommand<CountersDetail>
         {
+            private readonly DocumentConventions _conventions;
             private readonly CounterBatch _counterBatch;
 
-            public CounterBatchCommand(CounterBatch counterBatch)
+            public CounterBatchCommand(DocumentConventions conventions, CounterBatch counterBatch)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _counterBatch = counterBatch ?? throw new ArgumentNullException(nameof(counterBatch));
             }
 
@@ -39,7 +41,7 @@ namespace Raven.Client.Documents.Operations.Counters
                 {
                     Method = HttpMethod.Post,
 
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_counterBatch, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_counterBatch, ctx)).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
@@ -39,17 +39,19 @@ namespace Raven.Client.Documents.Operations.Counters
 
         public RavenCommand<CountersDetail> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new GetCounterValuesCommand(_docId, _counters, _returnFullResults);
+            return new GetCounterValuesCommand(conventions, _docId, _counters, _returnFullResults);
         }
 
         internal class GetCounterValuesCommand : RavenCommand<CountersDetail>
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _docId;
             private readonly string[] _counters;
             private readonly bool _returnFullResults;
 
-            public GetCounterValuesCommand(string docId, string[] counters, bool returnFullResults)
+            public GetCounterValuesCommand(DocumentConventions conventions, string docId, string[] counters, bool returnFullResults)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _docId = docId ?? throw new ArgumentNullException(nameof(docId));
                 _counters = counters;
                 _returnFullResults = returnFullResults;
@@ -140,7 +142,7 @@ namespace Raven.Client.Documents.Operations.Counters
                         ReplyWithAllNodesValues = _returnFullResults
                     };
 
-                    request.Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(batch, ctx)).ConfigureAwait(false));
+                    request.Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(batch, ctx)).ConfigureAwait(false), _conventions);
                 }
             }
 

--- a/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DeleteByQueryOperation.cs
@@ -130,7 +130,7 @@ namespace Raven.Client.Documents.Operations
                         {
                             writer.WriteIndexQuery(_conventions, ctx, _queryToDelete);
                         }
-                    })
+                    }, _conventions)
                 };
 
                 url = path.ToString();

--- a/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
@@ -21,15 +21,17 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public RavenCommand<AddEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new AddEtlCommand(_configuration);
+            return new AddEtlCommand(conventions, _configuration);
         }
 
         private class AddEtlCommand : RavenCommand<AddEtlOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly EtlConfiguration<T> _configuration;
 
-            public AddEtlCommand(EtlConfiguration<T> configuration)
+            public AddEtlCommand(DocumentConventions conventions, EtlConfiguration<T> configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -42,7 +44,7 @@ namespace Raven.Client.Documents.Operations.ETL
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
@@ -23,16 +23,18 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdateEtlCommand(_taskId, _configuration);
+            return new UpdateEtlCommand(conventions, _taskId, _configuration);
         }
 
         private class UpdateEtlCommand : RavenCommand<UpdateEtlOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly long _taskId;
             private readonly EtlConfiguration<T> _configuration;
 
-            public UpdateEtlCommand(long taskId, EtlConfiguration<T> configuration)
+            public UpdateEtlCommand(DocumentConventions conventions, long taskId, EtlConfiguration<T> configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _taskId = taskId;
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
@@ -46,7 +48,7 @@ namespace Raven.Client.Documents.Operations.ETL
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         public RavenCommand<ConfigureExpirationOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigureExpirationCommand(_configuration);
+            return new ConfigureExpirationCommand(conventions, _configuration);
         }
 
         private class ConfigureExpirationCommand : RavenCommand<ConfigureExpirationOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly ExpirationConfiguration _configuration;
 
-            public ConfigureExpirationCommand(ExpirationConfiguration configuration)
+            public ConfigureExpirationCommand(DocumentConventions conventions, ExpirationConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.Expiration
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
@@ -24,6 +24,7 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         private class IndexHasChangedCommand : RavenCommand<bool>
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _definition;
 
             public IndexHasChangedCommand(DocumentConventions conventions, JsonOperationContext context, IndexDefinition definition)
@@ -36,6 +37,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                     throw new ArgumentNullException(nameof(definition.Name));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
                 _definition = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(definition, context);
             }
 
@@ -48,7 +50,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _definition).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _definition).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
@@ -29,6 +29,7 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         private class PutIndexesCommand : RavenCommand<PutIndexResult[]>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject[] _indexToAdd;
             private bool _allJavaScriptIndexes;
 
@@ -40,6 +41,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                     throw new ArgumentNullException(nameof(indexesToAdd));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _indexToAdd = new BlittableJsonReaderObject[indexesToAdd.Length];
                 _allJavaScriptIndexes = true;
@@ -70,7 +72,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                             writer.WriteArray("Indexes", _indexToAdd);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Indexes/SetIndexesLockOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/SetIndexesLockOperation.cs
@@ -52,19 +52,21 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new SetIndexLockCommand(context, _parameters);
+            return new SetIndexLockCommand(conventions, context, _parameters);
         }
 
         internal class SetIndexLockCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _parameters;
 
-            public SetIndexLockCommand(JsonOperationContext context, Parameters parameters)
+            public SetIndexLockCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters)
             {
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
 
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -76,7 +78,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/Indexes/SetIndexesPriorityOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/SetIndexesPriorityOperation.cs
@@ -43,6 +43,7 @@ namespace Raven.Client.Documents.Operations.Indexes
 
         private class SetIndexPriorityCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _parameters;
 
             public SetIndexPriorityCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters)
@@ -53,6 +54,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
+                _conventions = conventions;
 
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -64,7 +66,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/Integrations/PostgreSQL/ConfigurePostgreSqlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Integrations/PostgreSQL/ConfigurePostgreSqlOperation.cs
@@ -21,15 +21,17 @@ namespace Raven.Client.Documents.Operations.Integrations.PostgreSQL
 
         public RavenCommand<ConfigurePostgreSqlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigurePostgreSqlCommand(_configuration);
+            return new ConfigurePostgreSqlCommand(conventions, _configuration);
         }
 
         private class ConfigurePostgreSqlCommand : RavenCommand<ConfigurePostgreSqlOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly PostgreSqlConfiguration _configuration;
 
-            public ConfigurePostgreSqlCommand(PostgreSqlConfiguration configuration)
+            public ConfigurePostgreSqlCommand(DocumentConventions conventions, PostgreSqlConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -42,7 +44,7 @@ namespace Raven.Client.Documents.Operations.Integrations.PostgreSQL
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/JsonPatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/JsonPatchOperation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Raven.Client.Documents.Conventions;
@@ -23,17 +24,19 @@ namespace Raven.Client.Documents.Operations
 
         public RavenCommand<JsonPatchResult> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new JsonPatchCommand(Id, JsonPatchDocument);
+            return new JsonPatchCommand(conventions, Id, JsonPatchDocument);
         }
 
         internal class JsonPatchCommand : RavenCommand<JsonPatchResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _id;
             private readonly JsonPatchDocument _jsonPatchDocument;
             public override bool IsReadRequest => false;
 
-            public JsonPatchCommand(string id, JsonPatchDocument jsonPatchDocument)
+            public JsonPatchCommand(DocumentConventions conventions, string id, JsonPatchDocument jsonPatchDocument)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _id = id;
                 _jsonPatchDocument = jsonPatchDocument;
             }
@@ -58,7 +61,7 @@ namespace Raven.Client.Documents.Operations
                                     Operations = _jsonPatchDocument.Operations
                                 }, ctx, serializer));
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
@@ -94,7 +94,7 @@ namespace Raven.Client.Documents.Operations
 
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 url = path.ToString();

--- a/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.Documents.Operations.Refresh
 
         public RavenCommand<ConfigureRefreshOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigureRefreshCommand(_configuration);
+            return new ConfigureRefreshCommand(conventions, _configuration);
         }
 
         private class ConfigureRefreshCommand : RavenCommand<ConfigureRefreshOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly RefreshConfiguration _configuration;
 
-            public ConfigureRefreshCommand(RefreshConfiguration configuration)
+            public ConfigureRefreshCommand(DocumentConventions conventions, RefreshConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.Refresh
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
@@ -35,15 +35,17 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand<ModifyOngoingTaskResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new UpdatePullReplicationDefinitionCommand(_pullReplicationDefinition);
+            return new UpdatePullReplicationDefinitionCommand(conventions, _pullReplicationDefinition);
         }
 
         private class UpdatePullReplicationDefinitionCommand : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly PullReplicationDefinition _pullReplicationDefinition;
 
-            public UpdatePullReplicationDefinitionCommand(PullReplicationDefinition pullReplicationDefinition)
+            public UpdatePullReplicationDefinitionCommand(DocumentConventions conventions, PullReplicationDefinition pullReplicationDefinition)
             {
+                _conventions = conventions;
                 _pullReplicationDefinition = pullReplicationDefinition;
             }
 
@@ -54,7 +56,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, ctx.ReadObject(_pullReplicationDefinition.ToJson(), "update-pull-replication-definition")).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, ctx.ReadObject(_pullReplicationDefinition.ToJson(), "update-pull-replication-definition")).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
@@ -26,18 +26,20 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new RegisterReplicationHubAccessCommand(_hubName, _access);
+            return new RegisterReplicationHubAccessCommand(conventions, _hubName, _access);
         }
 
         private class RegisterReplicationHubAccessCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _hubName;
             private readonly ReplicationHubAccess _access;
 
-            public RegisterReplicationHubAccessCommand(string hubName, ReplicationHubAccess access)
+            public RegisterReplicationHubAccessCommand(DocumentConventions conventions, string hubName, ReplicationHubAccess access)
             {
                 if (string.IsNullOrWhiteSpace(hubName))
                     throw new ArgumentException("Value cannot be null or whitespace.", nameof(hubName));
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _hubName = hubName;
                 _access = access ?? throw new ArgumentNullException(nameof(access));
                 ResponseType = RavenCommandResponseType.Raw;
@@ -52,7 +54,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await blittable.WriteJsonToAsync(stream).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await blittable.WriteJsonToAsync(stream).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
@@ -22,15 +22,17 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand<ModifyOngoingTaskResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdateExternalReplication(_newWatcher);
+            return new UpdateExternalReplication(conventions, _newWatcher);
         }
 
         private class UpdateExternalReplication : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly ExternalReplication _newWatcher;
 
-            public UpdateExternalReplication(ExternalReplication newWatcher)
+            public UpdateExternalReplication(DocumentConventions conventions, ExternalReplication newWatcher)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _newWatcher = newWatcher ?? throw new ArgumentNullException(nameof(newWatcher));
             }
 
@@ -49,7 +51,7 @@ namespace Raven.Client.Documents.Operations.Replication
                         };
 
                         await ctx.WriteAsync(stream, ctx.ReadObject(json, "update-replication")).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -36,15 +36,17 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand<ModifyOngoingTaskResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdatePullEdgeReplication(_pullReplication);
+            return new UpdatePullEdgeReplication(conventions, _pullReplication);
         }
 
         private class UpdatePullEdgeReplication : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly PullReplicationAsSink _pullReplication;
 
-            public UpdatePullEdgeReplication(PullReplicationAsSink pullReplication)
+            public UpdatePullEdgeReplication(DocumentConventions conventions, PullReplicationAsSink pullReplication)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _pullReplication = pullReplication ?? throw new ArgumentNullException(nameof(pullReplication));
             }
 
@@ -63,7 +65,7 @@ namespace Raven.Client.Documents.Operations.Replication
                         };
 
                         await ctx.WriteAsync(stream, ctx.ReadObject(json, "update-pull-replication")).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.Documents.Operations.Revisions
 
         public RavenCommand<ConfigureRevisionsOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigureRevisionsCommand(_configuration);
+            return new ConfigureRevisionsCommand(conventions, _configuration);
         }
 
         private class ConfigureRevisionsCommand : RavenCommand<ConfigureRevisionsOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly RevisionsConfiguration _configuration;
 
-            public ConfigureRevisionsCommand(RevisionsConfiguration configuration)
+            public ConfigureRevisionsCommand(DocumentConventions conventions, RevisionsConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.Revisions
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/Sorters/PutSortersOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Sorters/PutSortersOperation.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.Documents.Operations.Sorters
 
         private class PutSortersCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject[] _sortersToAdd;
 
             public PutSortersCommand(DocumentConventions conventions, JsonOperationContext context, SorterDefinition[] sortersToAdd)
@@ -38,6 +39,7 @@ namespace Raven.Client.Documents.Operations.Sorters
                     throw new ArgumentNullException(nameof(sortersToAdd));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _sortersToAdd = new BlittableJsonReaderObject[sortersToAdd.Length];
 
@@ -65,7 +67,7 @@ namespace Raven.Client.Documents.Operations.Sorters
                             writer.WriteArray("Sorters", _sortersToAdd);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
@@ -19,15 +20,17 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 
         public RavenCommand<ConfigureTimeSeriesOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigureTimeSeriesCommand(_configuration);
+            return new ConfigureTimeSeriesCommand(conventions, _configuration);
         }
 
         private class ConfigureTimeSeriesCommand : RavenCommand<ConfigureTimeSeriesOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly TimeSeriesConfiguration _configuration;
 
-            public ConfigureTimeSeriesCommand(TimeSeriesConfiguration configuration)
+            public ConfigureTimeSeriesCommand(DocumentConventions conventions, TimeSeriesConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration;
             }
 
@@ -44,7 +47,7 @@ namespace Raven.Client.Documents.Operations.TimeSeries
                     {
                         var config = ctx.ReadObject(_configuration.ToJson(), "convert time-series configuration");
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
@@ -22,16 +22,18 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 
         public RavenCommand<ConfigureTimeSeriesOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ConfigureTimeSeriesPolicyCommand(_collection, _config);
+            return new ConfigureTimeSeriesPolicyCommand(conventions, _collection, _config);
         }
 
         private class ConfigureTimeSeriesPolicyCommand : RavenCommand<ConfigureTimeSeriesOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly TimeSeriesPolicy _configuration;
             private readonly string _collection;
 
-            public ConfigureTimeSeriesPolicyCommand(string collection, TimeSeriesPolicy configuration)
+            public ConfigureTimeSeriesPolicyCommand(DocumentConventions conventions, string collection, TimeSeriesPolicy configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
                 _collection = collection ?? throw new ArgumentNullException(nameof(collection));
             }
@@ -49,7 +51,7 @@ namespace Raven.Client.Documents.Operations.TimeSeries
                     {
                         var config = ctx.ReadObject(_configuration.ToJson(), "convert time-series policy");
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesValueNamesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesValueNamesOperation.cs
@@ -22,15 +22,17 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 
         public RavenCommand<ConfigureTimeSeriesOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ConfigureTimeSeriesValueNamesCommand(_parameters);
+            return new ConfigureTimeSeriesValueNamesCommand(conventions, _parameters);
         }
 
         private class ConfigureTimeSeriesValueNamesCommand : RavenCommand<ConfigureTimeSeriesOperationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly Parameters _parameters;
 
-            public ConfigureTimeSeriesValueNamesCommand(Parameters parameters)
+            public ConfigureTimeSeriesValueNamesCommand(DocumentConventions conventions, Parameters parameters)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _parameters = parameters;
             }
 
@@ -46,7 +48,7 @@ namespace Raven.Client.Documents.Operations.TimeSeries
                     {
                         var config = ctx.ReadObject(_parameters.ToJson(), "convert time-series configuration");
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesRangesCommand.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesRangesCommand.cs
@@ -12,13 +12,15 @@ namespace Raven.Client.Documents.Operations.TimeSeries;
 
 internal class GetMultipleTimeSeriesRangesCommand : RavenCommand<GetMultipleTimeSeriesRangesCommand.Response>
 {
+    private readonly DocumentConventions _conventions;
     private readonly int _start;
     private readonly int _pageSize;
     private readonly bool _returnFullResults;
     private readonly RequestBody _ranges;
 
-    public GetMultipleTimeSeriesRangesCommand(Dictionary<string, List<TimeSeriesRange>> ranges, int start = 0, int pageSize = int.MaxValue, bool returnFullResults = false)
+    public GetMultipleTimeSeriesRangesCommand(DocumentConventions conventions, Dictionary<string, List<TimeSeriesRange>> ranges, int start = 0, int pageSize = int.MaxValue, bool returnFullResults = false)
     {
+        _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
         _start = start;
         _pageSize = pageSize;
         _returnFullResults = returnFullResults;
@@ -59,7 +61,7 @@ internal class GetMultipleTimeSeriesRangesCommand : RavenCommand<GetMultipleTime
         return new HttpRequestMessage
         {
             Method = HttpMethod.Post,
-            Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_ranges, ctx)).ConfigureAwait(false))
+            Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_ranges, ctx)).ConfigureAwait(false), _conventions)
         };
     }
 

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesBatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesBatchOperation.cs
@@ -20,16 +20,18 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 
         public RavenCommand GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new TimeSeriesBatchCommand(_documentId, _operation);
+            return new TimeSeriesBatchCommand(conventions, _documentId, _operation);
         }
 
         internal class TimeSeriesBatchCommand : RavenCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _documentId;
             private readonly TimeSeriesOperation _operation;
 
-            public TimeSeriesBatchCommand(string documentId, TimeSeriesOperation operation)
+            public TimeSeriesBatchCommand(DocumentConventions conventions, string documentId, TimeSeriesOperation operation)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _documentId = documentId;
                 _operation = operation;
             }
@@ -46,7 +48,7 @@ namespace Raven.Client.Documents.Operations.TimeSeries
                     {
                         var op = ctx.ReadObject(_operation.ToJson(), "convert-time-series-operation");
                         await ctx.WriteAsync(stream, op).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
             }
 

--- a/src/Raven.Client/Documents/Operations/TransactionsRecording/StartTransactionsRecordingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TransactionsRecording/StartTransactionsRecordingOperation.cs
@@ -17,16 +17,18 @@ namespace Raven.Client.Documents.Operations.TransactionsRecording
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new StartTransactionsRecordingCommand(_filePath);
+            return new StartTransactionsRecordingCommand(conventions, _filePath);
         }
 
         private class StartTransactionsRecordingCommand : RavenCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _filePath;
 
-            public StartTransactionsRecordingCommand(string filePath)
+            public StartTransactionsRecordingCommand(DocumentConventions conventions, string filePath)
             {
                 EnsureIsNotNullOrEmpty(filePath, nameof(filePath));
+                _conventions = conventions;
                 _filePath = filePath;
             }
 
@@ -41,7 +43,7 @@ namespace Raven.Client.Documents.Operations.TransactionsRecording
                     {
                         var parametersJson = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(new Parameters { File = _filePath }, ctx);
                         await ctx.WriteAsync(stream, parametersJson).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
                 return request;
             }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -63,7 +63,7 @@ namespace Raven.Client.Documents.Session
                     throw new InvalidOperationException("Cannot refresh a transient instance");
                 IncrementRequestCount();
 
-                var command = new GetDocumentsCommand(new[] { documentInfo.Id }, includes: null, metadataOnly: false);
+                var command = new GetDocumentsCommand(Conventions, new[] { documentInfo.Id }, includes: null, metadataOnly: false);
                 await RequestExecutor.ExecuteAsync(command, Context, _sessionInfo, token).ConfigureAwait(false);
 
                 var commandResult = (BlittableJsonReaderObject)command.Result.Results[0];
@@ -79,7 +79,7 @@ namespace Raven.Client.Documents.Session
 
                 IncrementRequestCount();
 
-                var command = new GetDocumentsCommand(idsEntitiesPairs.Keys.ToArray(), includes: null, metadataOnly: false);
+                var command = new GetDocumentsCommand(Conventions, idsEntitiesPairs.Keys.ToArray(), includes: null, metadataOnly: false);
                 await RequestExecutor.ExecuteAsync(command, Context, sessionInfo: _sessionInfo, token).ConfigureAwait(false);
 
                 RefreshEntities(command, idsEntitiesPairs);

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -141,7 +141,7 @@ namespace Raven.Client.Documents.Session
                 ThrowCouldNotRefreshDocument("Cannot refresh a transient instance");
             IncrementRequestCount();
 
-            var command = new GetDocumentsCommand(new[] { documentInfo.Id }, includes: null, metadataOnly: false);
+            var command = new GetDocumentsCommand(Conventions, new[] { documentInfo.Id }, includes: null, metadataOnly: false);
             RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);
 
             var commandResult = (BlittableJsonReaderObject)command.Result.Results[0];
@@ -159,7 +159,7 @@ namespace Raven.Client.Documents.Session
 
             IncrementRequestCount();
 
-            var command = new GetDocumentsCommand(idsEntitiesPairs.Keys.ToArray(), includes: null, metadataOnly: false);
+            var command = new GetDocumentsCommand(Conventions, idsEntitiesPairs.Keys.ToArray(), includes: null, metadataOnly: false);
             RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);
 
             RefreshEntities(command, idsEntitiesPairs);

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -40,9 +40,9 @@ namespace Raven.Client.Documents.Session.Operations
                 Logger.Info($"Requesting the following ids '{string.Join(", ", _ids)}' from {_session.StoreIdentifier}");
 
             if (_includeAllCounters)
-                return new GetDocumentsCommand(_ids, _includes, includeAllCounters: true, timeSeriesIncludes: _timeSeriesToInclude, compareExchangeValueIncludes: _compareExchangeValuesToInclude, metadataOnly: false);
+                return new GetDocumentsCommand(_session.Conventions, _ids, _includes, includeAllCounters: true, timeSeriesIncludes: _timeSeriesToInclude, compareExchangeValueIncludes: _compareExchangeValuesToInclude, metadataOnly: false);
             
-            return new GetDocumentsCommand(_ids, _includes, _countersToInclude, _revisionsToIncludeByChangeVector, _revisionsToIncludeByDateTimeBefore, _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
+            return new GetDocumentsCommand(_session.Conventions, _ids, _includes, _countersToInclude, _revisionsToIncludeByChangeVector, _revisionsToIncludeByDateTimeBefore, _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
         }
 
         public LoadOperation ById(string id)

--- a/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
@@ -34,7 +34,7 @@ namespace Raven.Client.Documents.Session.Operations
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Requesting documents with ids starting with '{_startWith}' from {_session.StoreIdentifier}");
 
-            return new GetDocumentsCommand(_startWith, _startAfter, _matches, _exclude, _start, _pageSize, metadataOnly: false);
+            return new GetDocumentsCommand(_session.Conventions, _startWith, _startAfter, _matches, _exclude, _start, _pageSize, metadataOnly: false);
         }
 
         public void WithStartWith(string idPrefix, string matches = null, int start = 0, int pageSize = 25,

--- a/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
@@ -572,7 +572,7 @@ namespace Raven.Client.Documents.Subscriptions
             var requestExecutor = _store.GetRequestExecutor(database);
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                var command = new UpdateSubscriptionCommand(options);
+                var command = new UpdateSubscriptionCommand(requestExecutor.Conventions, options);
                 await requestExecutor.ExecuteAsync(command, context, sessionInfo: null, token: token).ConfigureAwait(false);
 
                 return command.Result.Name;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -265,7 +265,7 @@ namespace Raven.Client.Http
             TimeSpan? httpPooledConnectionIdleTimeout = null;
 #endif
 
-            return new HttpClientCacheKey(Certificate?.Thumbprint ?? string.Empty, Conventions.UseCompression, httpPooledConnectionLifetime, httpPooledConnectionIdleTimeout, GlobalHttpClientTimeout, Conventions.HttpClientType);
+            return new HttpClientCacheKey(Certificate?.Thumbprint ?? string.Empty, Conventions.UseHttpDecompression, httpPooledConnectionLifetime, httpPooledConnectionIdleTimeout, GlobalHttpClientTimeout, Conventions.HttpClientType);
         }
 
         internal static void ClearHttpClientsPool()
@@ -1867,7 +1867,7 @@ namespace Raven.Client.Http
             _disposeOnceRunner.Dispose();
         }
 
-        public static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
+        public static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useHttpDecompression, bool hasExplicitlySetDecompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
         {
             HttpClientHandler httpMessageHandler;
 
@@ -1888,11 +1888,11 @@ namespace Raven.Client.Http
             if (httpMessageHandler.SupportsAutomaticDecompression)
             {
                 httpMessageHandler.AutomaticDecompression =
-                    useCompression ?
+                    useHttpDecompression ?
                         DecompressionMethods.GZip | DecompressionMethods.Deflate
                         : DecompressionMethods.None;
             }
-            else if (useCompression && hasExplicitlySetCompressionUsage)
+            else if (useHttpDecompression && hasExplicitlySetDecompressionUsage)
             {
                 throw new NotSupportedException("HttpClient implementation for the current platform does not support request compression.");
             }
@@ -1932,8 +1932,8 @@ namespace Raven.Client.Http
 
             var httpMessageHandler = CreateHttpMessageHandler(Certificate,
                 setSslProtocols: true,
-                useCompression: Conventions.UseCompression,
-                hasExplicitlySetCompressionUsage: Conventions.HasExplicitlySetCompressionUsage,
+                useHttpDecompression: Conventions.UseHttpDecompression,
+                hasExplicitlySetDecompressionUsage: Conventions.HasExplicitlySetDecompressionUsage,
                 httpPooledConnectionLifetime,
                 httpPooledConnectionIdleTimeout
             );
@@ -2282,16 +2282,16 @@ namespace Raven.Client.Http
         private readonly struct HttpClientCacheKey
         {
             private readonly string _certificateThumbprint;
-            private readonly bool _useCompression;
+            private readonly bool _useHttpDecompression;
             private readonly TimeSpan? _pooledConnectionLifetime;
             private readonly TimeSpan? _pooledConnectionIdleTimeout;
             private readonly TimeSpan _globalHttpClientTimeout;
             private readonly Type _httpClientType;
 
-            public HttpClientCacheKey(string certificateThumbprint, bool useCompression, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout, TimeSpan globalHttpClientTimeout, Type httpClientType)
+            public HttpClientCacheKey(string certificateThumbprint, bool useHttpDecompression, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout, TimeSpan globalHttpClientTimeout, Type httpClientType)
             {
                 _certificateThumbprint = certificateThumbprint;
-                _useCompression = useCompression;
+                _useHttpDecompression = useHttpDecompression;
                 _pooledConnectionLifetime = pooledConnectionLifetime;
                 _pooledConnectionIdleTimeout = pooledConnectionIdleTimeout;
                 _globalHttpClientTimeout = globalHttpClientTimeout;
@@ -2302,7 +2302,7 @@ namespace Raven.Client.Http
             private bool Equals(HttpClientCacheKey other)
             {
                 return _certificateThumbprint == other._certificateThumbprint 
-                       && _useCompression == other._useCompression 
+                       && _useHttpDecompression == other._useHttpDecompression 
                        && Nullable.Equals(_pooledConnectionLifetime, other._pooledConnectionLifetime) 
                        && Nullable.Equals(_pooledConnectionIdleTimeout, other._pooledConnectionIdleTimeout)
                        && Nullable.Equals(_globalHttpClientTimeout, other._globalHttpClientTimeout)
@@ -2316,7 +2316,7 @@ namespace Raven.Client.Http
 
             public override int GetHashCode()
             {
-                return HashCode.Combine(_certificateThumbprint, _useCompression, _pooledConnectionLifetime, _pooledConnectionIdleTimeout, _pooledConnectionIdleTimeout, _httpClientType);
+                return HashCode.Combine(_certificateThumbprint, _useHttpDecompression, _pooledConnectionLifetime, _pooledConnectionIdleTimeout, _pooledConnectionIdleTimeout, _httpClientType);
             }
         }
     }

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -4,21 +4,31 @@ using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
 
 namespace Raven.Client.Json
 {
     internal class BlittableJsonContent : HttpContent
     {
         private readonly Func<Stream, Task> _asyncTaskWriter;
+        private readonly DocumentConventions _conventions;
 
-        public BlittableJsonContent(Func<Stream, Task> writer)
+        public BlittableJsonContent(Func<Stream, Task> writer, DocumentConventions conventions)
         {
             _asyncTaskWriter = writer ?? throw new ArgumentNullException(nameof(writer));
-            Headers.ContentEncoding.Add("gzip");
+            _conventions = conventions;
+
+            if (_conventions.UseHttpCompression)
+                Headers.ContentEncoding.Add("gzip");
         }
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
+            if (_conventions.UseHttpCompression == false)
+            {
+                await _asyncTaskWriter(stream).ConfigureAwait(false);
+                return;
+            }
 
 #if NETSTANDARD2_0 || NETCOREAPP2_1
             using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))

--- a/src/Raven.Client/ServerWide/Operations/Analyzers/PutServerWideAnalyzersOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Analyzers/PutServerWideAnalyzersOperation.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.ServerWide.Operations.Analyzers
 
         private class PutServerWideAnalyzersCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject[] _analyzersToAdd;
 
             public PutServerWideAnalyzersCommand(DocumentConventions conventions, JsonOperationContext context, AnalyzerDefinition[] analyzersToAdd)
@@ -38,6 +39,7 @@ namespace Raven.Client.ServerWide.Operations.Analyzers
                     throw new ArgumentNullException(nameof(analyzersToAdd));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _analyzersToAdd = new BlittableJsonReaderObject[analyzersToAdd.Length];
 
@@ -65,7 +67,7 @@ namespace Raven.Client.ServerWide.Operations.Analyzers
                             writer.WriteArray("Analyzers", _analyzersToAdd);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
@@ -26,18 +26,20 @@ namespace Raven.Client.ServerWide.Operations.Certificates
 
         public RavenCommand<CertificateRawData> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new CreateClientCertificateCommand(_name, _permissions, _clearance, _password);
+            return new CreateClientCertificateCommand(conventions, _name, _permissions, _clearance, _password);
         }
 
         private class CreateClientCertificateCommand : RavenCommand<CertificateRawData>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _name;
             private readonly Dictionary<string, DatabaseAccess> _permissions;
             private readonly SecurityClearance _clearance;
             private readonly string _password;
 
-            public CreateClientCertificateCommand(string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance, string password = null)
+            public CreateClientCertificateCommand(DocumentConventions conventions, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance, string password = null)
             {
+                _conventions = conventions;
                 _name = name ?? throw new ArgumentNullException(nameof(name));
                 _permissions = permissions ?? throw new ArgumentNullException(nameof(permissions));
                 _clearance = clearance;
@@ -93,7 +95,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
 
                         writer.WriteEndObject();
                     }
-                });
+                }, _conventions);
 
                 return request;
             }

--- a/src/Raven.Client/ServerWide/Operations/Certificates/EditClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/EditClientCertificateOperation.cs
@@ -36,18 +36,20 @@ namespace Raven.Client.ServerWide.Operations.Certificates
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new EditClientCertificateCommand(_thumbprint, _name, _permissions, _clearance);
+            return new EditClientCertificateCommand(conventions, _thumbprint, _name, _permissions, _clearance);
         }
 
         private class EditClientCertificateCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _thumbprint;
             private readonly Dictionary<string, DatabaseAccess> _permissions;
             private readonly string _name;
             private readonly SecurityClearance _clearance;
 
-            public EditClientCertificateCommand(string thumbprint, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance)
+            public EditClientCertificateCommand(DocumentConventions conventions, string thumbprint, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _thumbprint = thumbprint;
                 _name = name;
                 _permissions = permissions;
@@ -70,7 +72,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(definition, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(definition, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/Certificates/PutClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/PutClientCertificateOperation.cs
@@ -27,18 +27,20 @@ namespace Raven.Client.ServerWide.Operations.Certificates
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new PutClientCertificateCommand(_name, _certificate, _permissions, _clearance);
+            return new PutClientCertificateCommand(conventions, _name, _certificate, _permissions, _clearance);
         }
 
         private class PutClientCertificateCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly X509Certificate2 _certificate;
             private readonly Dictionary<string, DatabaseAccess> _permissions;
             private readonly string _name;
             private readonly SecurityClearance _clearance;
 
-            public PutClientCertificateCommand(string name, X509Certificate2 certificate, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance)
+            public PutClientCertificateCommand(DocumentConventions conventions, string name, X509Certificate2 certificate, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
                 _permissions = permissions ?? throw new ArgumentNullException(nameof(permissions));
                 _name = name;
@@ -84,7 +86,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                             writer.WriteEndObject();
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/Certificates/ReplaceClusterCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/ReplaceClusterCertificateOperation.cs
@@ -21,16 +21,18 @@ namespace Raven.Client.ServerWide.Operations.Certificates
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ReplaceClusterCertificateCommand(_certBytes, _replaceImmediately);
+            return new ReplaceClusterCertificateCommand(conventions, _certBytes, _replaceImmediately);
         }
 
         private class ReplaceClusterCertificateCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly byte[] _certBytes;
             private readonly bool _replaceImmediately;
 
-            public ReplaceClusterCertificateCommand(byte[] certBytes, bool replaceImmediately)
+            public ReplaceClusterCertificateCommand(DocumentConventions conventions, byte[] certBytes, bool replaceImmediately)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _certBytes = certBytes ?? throw new ArgumentNullException(nameof(certBytes));
                 _replaceImmediately = replaceImmediately;
             }
@@ -53,7 +55,7 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                             writer.WriteString(Convert.ToBase64String(_certBytes)); // keep the private key -> this is a server cert
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/CompactDatabaseOperation.cs
@@ -31,6 +31,7 @@ namespace Raven.Client.ServerWide.Operations
 
         private class CompactDatabaseCommand : RavenCommand<OperationIdResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _compactSettings;
 
             public CompactDatabaseCommand(DocumentConventions conventions, JsonOperationContext context, CompactSettings compactSettings, string selectedNode)
@@ -41,6 +42,7 @@ namespace Raven.Client.ServerWide.Operations
                     throw new ArgumentNullException(nameof(compactSettings));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _compactSettings = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(compactSettings, context);
 
@@ -54,7 +56,7 @@ namespace Raven.Client.ServerWide.Operations
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _compactSettings).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _compactSettings).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideBackupConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideBackupConfigurationOperation.cs
@@ -21,19 +21,21 @@ namespace Raven.Client.ServerWide.Operations.Configuration
 
         public RavenCommand<PutServerWideBackupConfigurationResponse> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new PutServerWideBackupConfigurationCommand(context, _configuration);
+            return new PutServerWideBackupConfigurationCommand(conventions, context, _configuration);
         }
 
         private class PutServerWideBackupConfigurationCommand : RavenCommand<PutServerWideBackupConfigurationResponse>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _configuration;
 
-            public PutServerWideBackupConfigurationCommand(JsonOperationContext context, ServerWideBackupConfiguration configuration)
+            public PutServerWideBackupConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, ServerWideBackupConfiguration configuration)
             {
                 if (configuration == null)
                     throw new ArgumentNullException(nameof(configuration));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
 
                 _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
             }
@@ -49,7 +51,7 @@ namespace Raven.Client.ServerWide.Operations.Configuration
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideClientConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Configuration/PutServerWideClientConfigurationOperation.cs
@@ -25,6 +25,7 @@ namespace Raven.Client.ServerWide.Operations.Configuration
 
         private class PutServerWideClientConfigurationCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _configuration;
 
             public PutServerWideClientConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, ClientConfiguration configuration)
@@ -35,6 +36,7 @@ namespace Raven.Client.ServerWide.Operations.Configuration
                     throw new ArgumentNullException(nameof(configuration));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
             }
@@ -46,7 +48,7 @@ namespace Raven.Client.ServerWide.Operations.Configuration
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/ConfigureRevisionsForConflictsOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ConfigureRevisionsForConflictsOperation.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.ServerWide.Operations
                     {
                         var config = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx);
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
@@ -81,6 +81,7 @@ namespace Raven.Client.ServerWide.Operations
 
         private class DeleteDatabaseCommand : RavenCommand<DeleteDatabaseResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _parameters;
 
             public DeleteDatabaseCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters)
@@ -91,6 +92,7 @@ namespace Raven.Client.ServerWide.Operations
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
+                _conventions = conventions;
 
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -102,7 +104,7 @@ namespace Raven.Client.ServerWide.Operations
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Delete,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/DocumentsCompression/UpdateDocumentsCompressionConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DocumentsCompression/UpdateDocumentsCompressionConfigurationOperation.cs
@@ -20,15 +20,17 @@ namespace Raven.Client.ServerWide.Operations.DocumentsCompression
         }
         public RavenCommand<DocumentCompressionConfigurationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new UpdateDocumentCompressionConfigurationCommand(_documentsCompressionConfiguration);
+            return new UpdateDocumentCompressionConfigurationCommand(conventions, _documentsCompressionConfiguration);
         }
 
         private class UpdateDocumentCompressionConfigurationCommand : RavenCommand<DocumentCompressionConfigurationResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly DocumentsCompressionConfiguration _documentsCompressionConfiguration;
 
-            public UpdateDocumentCompressionConfigurationCommand(DocumentsCompressionConfiguration configuration)
+            public UpdateDocumentCompressionConfigurationCommand(DocumentConventions conventions, DocumentsCompressionConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _documentsCompressionConfiguration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
             public override bool IsReadRequest => false;
@@ -40,7 +42,7 @@ namespace Raven.Client.ServerWide.Operations.DocumentsCompression
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_documentsCompressionConfiguration, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_documentsCompressionConfiguration, ctx)).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/Logs/SetLogsConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Logs/SetLogsConfigurationOperation.cs
@@ -40,15 +40,17 @@ namespace Raven.Client.ServerWide.Operations.Logs
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new SetLogsConfigurationCommand(_parameters);
+            return new SetLogsConfigurationCommand(conventions, _parameters);
         }
 
         private class SetLogsConfigurationCommand : RavenCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly Parameters _parameters;
 
-            public SetLogsConfigurationCommand(Parameters parameters)
+            public SetLogsConfigurationCommand(DocumentConventions conventions, Parameters parameters)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             }
 
@@ -58,7 +60,7 @@ namespace Raven.Client.ServerWide.Operations.Logs
 
                 return new HttpRequestMessage(HttpMethod.Post, url)
                 {
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false), _conventions)
                 };
             }
         }

--- a/src/Raven.Client/ServerWide/Operations/Migration/OfflineMigrationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Migration/OfflineMigrationOperation.cs
@@ -21,15 +21,17 @@ namespace Raven.Client.ServerWide.Operations.Migration
 
         public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new OfflineMigrationCommand(_configuration);
+            return new OfflineMigrationCommand(conventions, _configuration);
         }
 
         private class OfflineMigrationCommand : RavenCommand<OperationIdResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly OfflineMigrationConfiguration _configuration;
 
-            public OfflineMigrationCommand(OfflineMigrationConfiguration configuration)
+            public OfflineMigrationCommand(DocumentConventions conventions, OfflineMigrationConfiguration configuration)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             }
 
@@ -46,7 +48,7 @@ namespace Raven.Client.ServerWide.Operations.Migration
                     {
                         var config = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx);
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/ModifyConflictSolverOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ModifyConflictSolverOperation.cs
@@ -60,7 +60,7 @@ namespace Raven.Client.ServerWide.Operations
                             ResolveToLatest = _solver.ResolveToLatest,
                         }, ctx);
                         await ctx.WriteAsync(stream, solver).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/ModifyDatabaseTopologyOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ModifyDatabaseTopologyOperation.cs
@@ -28,16 +28,18 @@ namespace Raven.Client.ServerWide.Operations
 
         public RavenCommand<ModifyDatabaseTopologyResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new ModifyDatabaseTopologyCommand(_databaseName, _databaseTopology);
+            return new ModifyDatabaseTopologyCommand(conventions, _databaseName, _databaseTopology);
         }
 
         internal class ModifyDatabaseTopologyCommand : RavenCommand<ModifyDatabaseTopologyResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly DatabaseTopology _databaseTopology;
             private readonly string _databaseName;
 
-            public ModifyDatabaseTopologyCommand(string databaseName, DatabaseTopology databaseTopology)
+            public ModifyDatabaseTopologyCommand(DocumentConventions conventions, string databaseName, DatabaseTopology databaseTopology)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _databaseTopology = databaseTopology;
                 _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseTopology));
             }
@@ -51,7 +53,7 @@ namespace Raven.Client.ServerWide.Operations
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, topologyDocument).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, topologyDocument).ConfigureAwait(false), _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/OngoingTasks/PutServerWideExternalReplicationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/OngoingTasks/PutServerWideExternalReplicationOperation.cs
@@ -20,19 +20,21 @@ namespace Raven.Client.ServerWide.Operations.OngoingTasks
 
         public RavenCommand<ServerWideExternalReplicationResponse> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new PutServerWideExternalReplicationCommand(context, _configuration);
+            return new PutServerWideExternalReplicationCommand(conventions, context, _configuration);
         }
 
         private class PutServerWideExternalReplicationCommand : RavenCommand<ServerWideExternalReplicationResponse>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _configuration;
 
-            public PutServerWideExternalReplicationCommand(JsonOperationContext context, ServerWideExternalReplication configuration)
+            public PutServerWideExternalReplicationCommand(DocumentConventions conventions, JsonOperationContext context, ServerWideExternalReplication configuration)
             {
                 if (configuration == null)
                     throw new ArgumentNullException(nameof(configuration));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
 
                 _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
             }
@@ -48,7 +50,7 @@ namespace Raven.Client.ServerWide.Operations.OngoingTasks
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Put,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/RestoreBackupOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/RestoreBackupOperation.cs
@@ -28,16 +28,18 @@ namespace Raven.Client.ServerWide.Operations
 
         public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new RestoreBackupCommand(_restoreConfiguration, NodeTag);
+            return new RestoreBackupCommand(conventions, _restoreConfiguration, NodeTag);
         }
 
         internal class RestoreBackupCommand : RavenCommand<OperationIdResult>
         {
             public override bool IsReadRequest => false;
+            private readonly DocumentConventions _conventions;
             private readonly RestoreBackupConfigurationBase _restoreConfiguration;
 
-            public RestoreBackupCommand(RestoreBackupConfigurationBase restoreConfiguration, string nodeTag = null)
+            public RestoreBackupCommand(DocumentConventions conventions, RestoreBackupConfigurationBase restoreConfiguration, string nodeTag = null)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _restoreConfiguration = restoreConfiguration ?? throw new ArgumentNullException(nameof(restoreConfiguration));
                 SelectedNodeTag = nodeTag;
             }
@@ -53,7 +55,7 @@ namespace Raven.Client.ServerWide.Operations
                     {
                         var config = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_restoreConfiguration, ctx);
                         await ctx.WriteAsync(stream, config).ConfigureAwait(false);
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/SetDatabasesLockOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/SetDatabasesLockOperation.cs
@@ -42,6 +42,7 @@ namespace Raven.Client.ServerWide.Operations
 
         private class SetDatabasesLockCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _parameters;
 
             public SetDatabasesLockCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters)
@@ -52,6 +53,7 @@ namespace Raven.Client.ServerWide.Operations
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
+                _conventions = conventions;
 
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -63,7 +65,7 @@ namespace Raven.Client.ServerWide.Operations
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/Sorters/PutServerWideSortersOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Sorters/PutServerWideSortersOperation.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.ServerWide.Operations.Sorters
 
         private class PutServerWideSortersCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject[] _sortersToAdd;
 
             public PutServerWideSortersCommand(DocumentConventions conventions, JsonOperationContext context, SorterDefinition[] sortersToAdd)
@@ -38,6 +39,7 @@ namespace Raven.Client.ServerWide.Operations.Sorters
                     throw new ArgumentNullException(nameof(sortersToAdd));
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
+                _conventions = conventions;
 
                 _sortersToAdd = new BlittableJsonReaderObject[sortersToAdd.Length];
 
@@ -65,7 +67,7 @@ namespace Raven.Client.ServerWide.Operations.Sorters
                             writer.WriteArray("Sorters", _sortersToAdd);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Client/ServerWide/Operations/ToggleDatabasesStateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ToggleDatabasesStateOperation.cs
@@ -45,21 +45,23 @@ namespace Raven.Client.ServerWide.Operations
 
         public RavenCommand<DisableDatabaseToggleResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ToggleDatabaseStateCommand(context, _parameters, _disable);
+            return new ToggleDatabaseStateCommand(conventions, context, _parameters, _disable);
         }
 
         private class ToggleDatabaseStateCommand : RavenCommand<DisableDatabaseToggleResult>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly bool _disable;
             private readonly BlittableJsonReaderObject _parameters;
 
-            public ToggleDatabaseStateCommand(JsonOperationContext context, Parameters parameters, bool disable)
+            public ToggleDatabaseStateCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters, bool disable)
             {
                 if (context == null)
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
 
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _disable = disable;
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -72,7 +74,7 @@ namespace Raven.Client.ServerWide.Operations
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Client/ServerWide/Operations/TrafficWatch/PutTrafficWatchConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/TrafficWatch/PutTrafficWatchConfigurationOperation.cs
@@ -21,15 +21,17 @@ namespace Raven.Client.ServerWide.Operations.TrafficWatch
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new SetTrafficWatchConfigurationCommand(_parameters);
+            return new SetTrafficWatchConfigurationCommand(conventions, _parameters);
         }
 
         private class SetTrafficWatchConfigurationCommand : RavenCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly Parameters _parameters;
 
-            public SetTrafficWatchConfigurationCommand(Parameters parameters)
+            public SetTrafficWatchConfigurationCommand(DocumentConventions conventions, Parameters parameters)
             {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             }
 
@@ -39,7 +41,7 @@ namespace Raven.Client.ServerWide.Operations.TrafficWatch
 
                 return new HttpRequestMessage(HttpMethod.Post, url)
                 {
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false), _conventions)
                 };
             }
         }

--- a/src/Raven.Client/ServerWide/Operations/UpdateDatabaseOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/UpdateDatabaseOperation.cs
@@ -39,7 +39,7 @@ namespace Raven.Client.ServerWide.Operations
 
         public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new CreateDatabaseOperation.CreateDatabaseCommand(_databaseRecord, _replicationFactor, _etag);
+            return new CreateDatabaseOperation.CreateDatabaseCommand(conventions, _databaseRecord, _replicationFactor, _etag);
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
@@ -28,16 +28,18 @@ namespace Raven.Client.ServerWide.Operations
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new UpdateUnusedDatabasesCommand(_database, _parameters);
+            return new UpdateUnusedDatabasesCommand(conventions, _database, _parameters);
         }
 
         private class UpdateUnusedDatabasesCommand : RavenCommand, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly string _database;
             private readonly Parameters _parameters;
 
-            public UpdateUnusedDatabasesCommand(string database, Parameters parameters)
+            public UpdateUnusedDatabasesCommand(DocumentConventions conventions, string database, Parameters parameters)
             {
+                _conventions = conventions;
                 _database = database;
                 _parameters = parameters;
             }
@@ -49,7 +51,7 @@ namespace Raven.Client.ServerWide.Operations
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
@@ -19,10 +19,15 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Sharding.Import.CompressionLevel", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public CompressionLevel CompressionLevel { get; set; }
 
-        [Description("The compression to use when distributing requests from the orchestrator to the shards")]
+        [Description("Accept compressed HTTP responses from shards")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Sharding.ShardExecutorUseCompression", ConfigurationEntryScope.ServerWideOnly)]
-        public bool ShardExecutorUseCompression { get; set; }
+        [ConfigurationEntry("Sharding.ShardExecutor.UseHttpDecompression", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ShardExecutorUseHttpDecompression { get; set; }
+
+        [Description("Use compression when sending HTTP requests to shards")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Sharding.ShardExecutor.UseHttpCompression", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ShardExecutorUseHttpCompression { get; set; }
 
         [Description("Enable the timeout of the orchestrator's requests to the shards")]
         [DefaultValue(DefaultValueSetInConstructor)]

--- a/src/Raven.Server/Documents/Commands/ETL/ElasticSearchEtlTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/ElasticSearchEtlTestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -7,11 +8,13 @@ namespace Raven.Server.Documents.Commands.ETL;
 
 internal class ElasticSearchEtlTestCommand : RavenCommand
 {
+    private readonly DocumentConventions _conventions;
     private readonly BlittableJsonReaderObject _testScript;
     public override bool IsReadRequest => true;
 
-    public ElasticSearchEtlTestCommand(BlittableJsonReaderObject testScript)
+    public ElasticSearchEtlTestCommand(DocumentConventions conventions, BlittableJsonReaderObject testScript)
     {
+        _conventions = conventions;
         _testScript = testScript;
     }
 
@@ -28,7 +31,7 @@ internal class ElasticSearchEtlTestCommand : RavenCommand
                 {
                     writer.WriteObject(_testScript);
                 }
-            })
+            }, _conventions)
         };
 
         return request;

--- a/src/Raven.Server/Documents/Commands/ETL/OlapEtlTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/OlapEtlTestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -7,11 +8,13 @@ namespace Raven.Server.Documents.Commands.ETL;
 
 internal class OlapEtlTestCommand : RavenCommand
 {
+    private readonly DocumentConventions _conventions;
     private readonly BlittableJsonReaderObject _testScript;
     public override bool IsReadRequest => true;
 
-    public OlapEtlTestCommand(BlittableJsonReaderObject testScript)
+    public OlapEtlTestCommand(DocumentConventions conventions, BlittableJsonReaderObject testScript)
     {
+        _conventions = conventions;
         _testScript = testScript;
     }
 
@@ -28,7 +31,7 @@ internal class OlapEtlTestCommand : RavenCommand
                 {
                     writer.WriteObject(_testScript);
                 }
-            })
+            }, _conventions)
         };
 
         return request;

--- a/src/Raven.Server/Documents/Commands/ETL/QueueEtlTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/QueueEtlTestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -7,11 +8,13 @@ namespace Raven.Server.Documents.Commands.ETL
 {
     public class QueueEtlTestCommand : RavenCommand
     {
+        private readonly DocumentConventions _conventions;
         private readonly BlittableJsonReaderObject _testScript;
         public override bool IsReadRequest => true;
 
-        public QueueEtlTestCommand(BlittableJsonReaderObject testScript)
+        public QueueEtlTestCommand(DocumentConventions conventions, BlittableJsonReaderObject testScript)
         {
+            _conventions = conventions;
             _testScript = testScript;
         }
 
@@ -28,7 +31,7 @@ namespace Raven.Server.Documents.Commands.ETL
                     {
                         writer.WriteObject(_testScript);
                     }
-                })
+                }, _conventions)
             };
 
             return request;

--- a/src/Raven.Server/Documents/Commands/ETL/RavenEtlTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/RavenEtlTestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -7,11 +8,13 @@ namespace Raven.Server.Documents.Commands.ETL;
 
 internal class RavenEtlTestCommand : RavenCommand
 {
+    private readonly DocumentConventions _conventions;
     private readonly BlittableJsonReaderObject _testConfig;
     public override bool IsReadRequest => true;
 
-    public RavenEtlTestCommand(BlittableJsonReaderObject testConfig)
+    public RavenEtlTestCommand(DocumentConventions conventions, BlittableJsonReaderObject testConfig)
     {
+        _conventions = conventions;
         _testConfig = testConfig;
     }
 
@@ -28,7 +31,7 @@ internal class RavenEtlTestCommand : RavenCommand
                 {
                     writer.WriteObject(_testConfig);
                 }
-            })
+            }, _conventions)
         };
 
         return request;

--- a/src/Raven.Server/Documents/Commands/ETL/SqlEtlTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/SqlEtlTestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -7,11 +8,13 @@ namespace Raven.Server.Documents.Commands.ETL;
 
 internal class SqlEtlTestCommand : RavenCommand
 {
+    private readonly DocumentConventions _conventions;
     private readonly BlittableJsonReaderObject _testScript;
     public override bool IsReadRequest => true;
 
-    public SqlEtlTestCommand(BlittableJsonReaderObject testScript)
+    public SqlEtlTestCommand(DocumentConventions conventions, BlittableJsonReaderObject testScript)
     {
+        _conventions = conventions;
         _testScript = testScript;
     }
 
@@ -28,7 +31,7 @@ internal class SqlEtlTestCommand : RavenCommand
                 {
                     writer.WriteObject(_testScript);
                 }
-            })
+            }, _conventions)
         };
 
         return request;

--- a/src/Raven.Server/Documents/Commands/Queries/PatchByQueryTestCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Queries/PatchByQueryTestCommand.cs
@@ -15,6 +15,7 @@ namespace Raven.Server.Documents.Commands.Queries;
 
 public class PatchByQueryTestCommand : RavenCommand<PatchByQueryTestCommand.Response>
 {
+    private readonly DocumentConventions _conventions;
     private readonly string _id;
     private readonly IndexQueryServerSide _query;
 
@@ -25,8 +26,9 @@ public class PatchByQueryTestCommand : RavenCommand<PatchByQueryTestCommand.Resp
         public BlittableJsonReaderObject DebugActions { get; set; }
     }
 
-    public PatchByQueryTestCommand(string id, IndexQueryServerSide query)
+    public PatchByQueryTestCommand(DocumentConventions conventions, string id, IndexQueryServerSide query)
     {
+        _conventions = conventions ?? throw new ArgumentNullException(nameof(id));
         _id = id ?? throw new ArgumentNullException(nameof(id));
         _query = query ?? throw new ArgumentNullException(nameof(query));
     }
@@ -51,7 +53,7 @@ public class PatchByQueryTestCommand : RavenCommand<PatchByQueryTestCommand.Resp
 
                     writer.WriteEndObject();
                 }
-            })
+            }, _conventions)
         };
     }
 

--- a/src/Raven.Server/Documents/Commands/Studio/DeleteStudioCollectionOperation.cs
+++ b/src/Raven.Server/Documents/Commands/Studio/DeleteStudioCollectionOperation.cs
@@ -27,17 +27,19 @@ namespace Raven.Server.Documents.Commands.Studio
 
         public RavenCommand<OperationIdResult> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new DeleteStudioCollectionCommand(_operationId, _collectionName, _excludeIds);
+            return new DeleteStudioCollectionCommand(conventions, _operationId, _collectionName, _excludeIds);
         }
 
         internal class DeleteStudioCollectionCommand : RavenCommand<OperationIdResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly long? _operationId;
             private readonly string _collectionName;
             private readonly List<string> _excludeIds;
 
-            public DeleteStudioCollectionCommand(long? operationId, string collectionName, List<string> excludeIds)
+            public DeleteStudioCollectionCommand(DocumentConventions conventions, long? operationId, string collectionName, List<string> excludeIds)
             {
+                _conventions = conventions;
                 _operationId = operationId;
                 _collectionName = collectionName;
                 _excludeIds = excludeIds;
@@ -70,7 +72,7 @@ namespace Raven.Server.Documents.Commands.Studio
                             writer.WriteArray("ExcludeIds", _excludeIds);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, _conventions)
                 };
 
                 return request;

--- a/src/Raven.Server/Documents/Commands/WaitForIndexNotificationCommand.cs
+++ b/src/Raven.Server/Documents/Commands/WaitForIndexNotificationCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -32,7 +33,7 @@ internal class WaitForIndexNotificationCommand : RavenCommand
                     writer.WriteArray(nameof(WaitForIndexNotificationRequest.RaftCommandIndexes), _indexes);
                     writer.WriteEndObject();
                 }
-            })
+            }, DocumentConventions.DefaultForServer)
         };
 
         return request;

--- a/src/Raven.Server/Documents/Operations/RevertRevisionsOperation.cs
+++ b/src/Raven.Server/Documents/Operations/RevertRevisionsOperation.cs
@@ -25,16 +25,18 @@ namespace Raven.Server.Documents.Operations
 
         public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new RevertRevisionsCommand(_request);
+            return new RevertRevisionsCommand(conventions, _request);
         }
 
         public class RevertRevisionsCommand : RavenCommand<OperationIdResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly RevertRevisionsRequest _request;
             private readonly long? _operationId;
 
-            public RevertRevisionsCommand(RevertRevisionsRequest request, long? operationId = null)
+            public RevertRevisionsCommand(DocumentConventions conventions, RevertRevisionsRequest request, long? operationId = null)
             {
+                _conventions = conventions;
                 _request = request;
                 _operationId = operationId;
             }
@@ -52,7 +54,7 @@ namespace Raven.Server.Documents.Operations
                 {
                     Method = HttpMethod.Post,
                     Content = new BlittableJsonContent(async stream =>
-                        await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
+                        await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/src/Raven.Server/Documents/Revisions/DeleteRevisionsOperation.cs
+++ b/src/Raven.Server/Documents/Revisions/DeleteRevisionsOperation.cs
@@ -24,6 +24,7 @@ namespace Raven.Server.Documents.Revisions
 
         internal class DeleteRevisionsCommand : RavenCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _parameters;
 
             public DeleteRevisionsCommand(DocumentConventions conventions, JsonOperationContext context, Parameters parameters)
@@ -34,6 +35,7 @@ namespace Raven.Server.Documents.Revisions
                     throw new ArgumentNullException(nameof(context));
                 if (parameters == null)
                     throw new ArgumentNullException(nameof(parameters));
+                _conventions = conventions;
 
                 _parameters = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(parameters, context);
             }
@@ -45,7 +47,7 @@ namespace Raven.Server.Documents.Revisions
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Delete,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _parameters).ConfigureAwait(false), _conventions)
                 };
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedImportCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedImportCommand.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents.Sharding.Commands
                     Content = new MultipartFormDataContent
                     {
                         {
-                            new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx))),
+                            new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)), DocumentConventions.DefaultForServer),
                             Constants.Smuggler.ImportOptions
                         },
                         {

--- a/src/Raven.Server/Documents/Sharding/Commands/ShardedSingleNodeBatchCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Commands/ShardedSingleNodeBatchCommand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Server.Documents.Sharding.Handlers.Batches;
@@ -13,6 +14,7 @@ namespace Raven.Server.Documents.Sharding.Commands;
 
 public class ShardedSingleNodeBatchCommand : RavenCommand<BlittableJsonReaderObject>
 {
+    private readonly DocumentConventions _conventions;
     public readonly int ShardNumber;
     private readonly IndexBatchOptions _indexBatchOptions;
     private readonly ReplicationBatchOptions _replicationBatchOptions;
@@ -23,8 +25,9 @@ public class ShardedSingleNodeBatchCommand : RavenCommand<BlittableJsonReaderObj
     private List<Stream> _attachmentStreams;
     private HashSet<Stream> _uniqueAttachmentStreams;
 
-    public ShardedSingleNodeBatchCommand(int shardNumber, IndexBatchOptions indexBatchOptions, ReplicationBatchOptions replicationBatchOptions)
+    public ShardedSingleNodeBatchCommand(DocumentConventions conventions, int shardNumber, IndexBatchOptions indexBatchOptions, ReplicationBatchOptions replicationBatchOptions)
     {
+        _conventions = conventions;
         ShardNumber = shardNumber;
         _indexBatchOptions = indexBatchOptions;
         _replicationBatchOptions = replicationBatchOptions;
@@ -92,7 +95,7 @@ public class ShardedSingleNodeBatchCommand : RavenCommand<BlittableJsonReaderObj
 
                     writer.WriteEndObject();
                 }
-            })
+            }, _conventions)
         };
 
         if (_attachmentStreams is { Count: > 0 })

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
@@ -53,7 +53,7 @@ public class ShardedBatchCommand : IBatchCommand
             var shardNumber = c.ShardNumber;
             if (_batchPerShard.TryGetValue(shardNumber, out var shardedBatchCommand) == false)
             {
-                shardedBatchCommand = new ShardedSingleNodeBatchCommand(shardNumber, indexBatchOptions, replicationBatchOptions);
+                shardedBatchCommand = new ShardedSingleNodeBatchCommand(_databaseContext.ShardExecutor.Conventions, shardNumber, indexBatchOptions, replicationBatchOptions);
                 _batchPerShard.Add(shardNumber, shardedBatchCommand);
             }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetAttachment.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetAttachment.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Attachments
         protected override async ValueTask GetAttachmentAsync(TransactionOperationContext context, string documentId, string name, AttachmentType type, string changeVector, CancellationToken token)
         {
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, documentId);
-            var cmd = new GetAttachmentOperation.GetAttachmentCommand(context, documentId, name, type, changeVector);
+            var cmd = new GetAttachmentOperation.GetAttachmentCommand(RequestHandler.ShardExecutor.Conventions, context, documentId, name, type, changeVector);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new ProxyCommand<AttachmentResult>(cmd, RequestHandler.HttpContext.Response), shardNumber, token);
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForGetCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForGetCounters.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
 
         protected override async ValueTask<CountersDetail> GetCountersAsync(TransactionOperationContext context, string docId, StringValues counters, bool full)
         {
-            var op = new GetCountersOperation.GetCounterValuesCommand(docId, counters, full);
+            var op = new GetCountersOperation.GetCounterValuesCommand(RequestHandler.ShardExecutor.Conventions, docId, counters, full);
 
             var shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
                     countersBatchForShard.Documents.Add(counterBatch.Documents[pos]);
                 }
                 
-                commandsPerShard[shardNumber] = new CounterBatchOperation.CounterBatchCommand(countersBatchForShard);
+                commandsPerShard[shardNumber] = new CounterBatchOperation.CounterBatchCommand(RequestHandler.ShardExecutor.Conventions, countersBatchForShard);
                 
             }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPatch.cs
@@ -16,7 +16,7 @@ internal class ShardedDocumentHandlerProcessorForPatch : AbstractDocumentHandler
 
     protected override async ValueTask HandleDocumentPatchAsync(string id, string changeVector, BlittableJsonReaderObject patchRequest, bool skipPatchIfChangeVectorMismatch, bool returnDebugInformation, bool test, TransactionOperationContext context)
     {
-        var command = new PatchOperation.PatchCommand(id, changeVector, patchRequest, skipPatchIfChangeVectorMismatch, returnDebugInformation, test);
+        var command = new PatchOperation.PatchCommand(RequestHandler.ShardExecutor.Conventions, id, changeVector, patchRequest, skipPatchIfChangeVectorMismatch, returnDebugInformation, test);
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, id);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPut.cs
@@ -17,7 +17,7 @@ internal class ShardedDocumentHandlerProcessorForPut : AbstractDocumentHandlerPr
 
     protected override async ValueTask HandleDocumentPutAsync(string id, string changeVector, BlittableJsonReaderObject doc, TransactionOperationContext context)
     {
-        var command = new PutDocumentCommand(id, changeVector, doc);
+        var command = new PutDocumentCommand(RequestHandler.ShardExecutor.Conventions, id, changeVector, doc);
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, id);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedElasticSearchEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedElasticSearchEtlHandlerProcessorForTest.cs
@@ -16,5 +16,5 @@ internal class ShardedElasticSearchEtlHandlerProcessorForTest : AbstractShardedE
 
     protected override TestElasticSearchEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestElasticSearchEtlScript(json);
 
-    protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new ElasticSearchEtlTestCommand(json);
+    protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new ElasticSearchEtlTestCommand(RequestHandler.ShardExecutor.Conventions, json);
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedOlapEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedOlapEtlHandlerProcessorForTest.cs
@@ -16,5 +16,5 @@ internal class ShardedOlapEtlHandlerProcessorForTest : AbstractShardedEtlHandler
 
     protected override TestOlapEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestOlapEtlScript(json);
 
-    protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new OlapEtlTestCommand(json);
+    protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new OlapEtlTestCommand(RequestHandler.ShardExecutor.Conventions, json);
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedQueueEtlHandlerProcessorForPostScriptTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedQueueEtlHandlerProcessorForPostScriptTest.cs
@@ -16,6 +16,6 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.ETL
 
         protected override TestQueueEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestQueueEtlScript(json);
 
-        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new QueueEtlTestCommand(json);
+        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new QueueEtlTestCommand(RequestHandler.ShardExecutor.Conventions, json);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedRavenEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedRavenEtlHandlerProcessorForTest.cs
@@ -16,6 +16,6 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.ETL
 
         protected override TestRavenEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestRavenEtlScript(json);
 
-        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new RavenEtlTestCommand(json);
+        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new RavenEtlTestCommand(RequestHandler.ShardExecutor.Conventions, json);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedSqlEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedSqlEtlHandlerProcessorForTest.cs
@@ -16,6 +16,6 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.ETL
 
         protected override TestSqlEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestSqlEtlScript(json);
 
-        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new SqlEtlTestCommand(json);
+        protected override RavenCommand CreateCommand(BlittableJsonReaderObject json) => new SqlEtlTestCommand(RequestHandler.ShardExecutor.Conventions, json);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
                 OperationType.DatabaseBackup,
                 $"Manual backup for database: {RequestHandler.DatabaseName}",
                 detailedDescription: null,
-                commandFactory: (context, shardNumber) => new BackupOperation.BackupCommand(backupConfiguration, operationId),
+                commandFactory: (context, shardNumber) => new BackupOperation.BackupCommand(RequestHandler.ShardExecutor.Conventions, backupConfiguration, operationId),
                 token);
 
             var _ = t.ContinueWith(_ =>

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
@@ -22,7 +22,7 @@ internal class ShardedQueriesHandlerProcessorForPatchTest : AbstractQueriesHandl
 
     protected override async ValueTask HandleDocumentPatchTestAsync(IndexQueryServerSide query, string docId, TransactionOperationContext context)
     {
-        var command = new PatchByQueryTestCommand(docId, query);
+        var command = new PatchByQueryTestCommand(RequestHandler.ShardExecutor.Conventions, docId, query);
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForRevertRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForRevertRevisions.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
                     OperationType.DatabaseRevert,
                     $"Revert database '{RequestHandler.DatabaseName}' to {configuration.Time} UTC.",
                     detailedDescription: null,
-                    (c, shardNumber) => new RevertRevisionsOperation.RevertRevisionsCommand(configuration, operationId),
+                    (c, shardNumber) => new RevertRevisionsOperation.RevertRevisionsCommand(RequestHandler.ShardExecutor.Conventions, configuration, operationId),
                     token);
 
             _ = task.ContinueWith(_ =>

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             var shard = RequestHandler.DatabaseContext.GetShardNumberFor(context, fromDocument);
 
             var docs = await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(context,
-                new GetDocumentsCommand(new[] { fromDocument }, includes: null, metadataOnly: false), shard);
+                new GetDocumentsCommand(RequestHandler.ShardExecutor.Conventions, new[] { fromDocument }, includes: null, metadataOnly: false), shard);
             return (BlittableJsonReaderObject)docs.Results[0];
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -32,8 +32,8 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
                     (_, shardNumber) =>
                     {
                         if (shardToIds.ContainsKey(shardNumber) == false)
-                            return new DeleteStudioCollectionOperation.DeleteStudioCollectionCommand(operationId, collectionName, null);
-                        return new DeleteStudioCollectionOperation.DeleteStudioCollectionCommand(operationId, collectionName, shardToIds[shardNumber].Ids);
+                            return new DeleteStudioCollectionOperation.DeleteStudioCollectionCommand(RequestHandler.ShardExecutor.Conventions, operationId, collectionName, null);
+                        return new DeleteStudioCollectionOperation.DeleteStudioCollectionCommand(RequestHandler.ShardExecutor.Conventions, operationId, collectionName, shardToIds[shardNumber].Ids);
                     },
                     token: token);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForPostTimeSeries.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForPostTimeSeries.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.TimeSeries
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
             using (var token = RequestHandler.CreateOperationToken())
             {
-                var cmd = new TimeSeriesBatchOperation.TimeSeriesBatchCommand(docId, operation);
+                var cmd = new TimeSeriesBatchOperation.TimeSeriesBatchCommand(RequestHandler.ShardExecutor.Conventions, docId, operation);
                 await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new ProxyCommand<object>(cmd, RequestHandler.HttpContext.Response), shardNumber, token.Token);
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Operations/FetchDocumentsFromShardsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/FetchDocumentsFromShardsOperation.cs
@@ -154,7 +154,7 @@ namespace Raven.Server.Documents.Sharding.Operations
             };
         }
 
-        public RavenCommand<GetDocumentsResult> CreateCommandForShard(int shardNumber) => new GetDocumentsCommand(_idsByShards[shardNumber].Ids.ToArray(), _includePaths,
+        public RavenCommand<GetDocumentsResult> CreateCommandForShard(int shardNumber) => new GetDocumentsCommand(_databaseContext.ShardExecutor.Conventions, _idsByShards[shardNumber].Ids.ToArray(), _includePaths,
             counterIncludes: _counterIncludes.Count > 0 ? _counterIncludes.ToArray() : null,
             revisionsIncludesByChangeVector: _includeRevisions?.RevisionsChangeVectorsPaths,
             revisionIncludeByDateTimeBefore: _includeRevisions?.RevisionsBeforeDateTime,

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedSubscriptionTryoutOperation.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
@@ -101,7 +102,7 @@ public readonly struct ShardedSubscriptionTryoutOperation : IShardedOperation<Ge
                         writer.WriteString(_tryout.Query);
                         writer.WriteEndObject();
                     }
-                })
+                }, DocumentConventions.DefaultForServer)
             };
 
             return request;

--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -87,7 +87,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(Context, facetField.FacetSetupDocumentId);
 
             var result = await RequestHandler.DatabaseContext.ShardExecutor.ExecuteSingleShardAsync(Context,
-                new GetDocumentsCommand(facetField.FacetSetupDocumentId, includes: null, metadataOnly: false), shardNumber, Token);
+                new GetDocumentsCommand(RequestHandler.ShardExecutor.Conventions, facetField.FacetSetupDocumentId, includes: null, metadataOnly: false), shardNumber, Token);
 
             return result;
         }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -162,7 +162,7 @@ public class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQueryResul
                 countersBatchForShard.Documents.Add(counterBatch.Documents[pos]);
             }
 
-            commandsPerShard[shardNumber] = new CounterBatchOperation.CounterBatchCommand(countersBatchForShard);
+            commandsPerShard[shardNumber] = new CounterBatchOperation.CounterBatchCommand(databaseContext.ShardExecutor.Conventions, countersBatchForShard);
         }
 
         var counterIncludes = await databaseContext.ShardExecutor.ExecuteParallelForShardsAsync(shardsToPositions.Keys.ToArray(),
@@ -192,7 +192,7 @@ public class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQueryResul
                 rangesForShard[id] = missingTimeSeriesIncludes[id];
             }
 
-            commandsPerShard[shardNumber] = new GetMultipleTimeSeriesRangesCommand(rangesForShard);
+            commandsPerShard[shardNumber] = new GetMultipleTimeSeriesRangesCommand(databaseContext.ShardExecutor.Conventions, rangesForShard);
         }
 
         var timeSeriesIncludes = await databaseContext.ShardExecutor.ExecuteParallelForShardsAsync(shardsToPositions.Keys.ToArray(),

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -316,7 +316,7 @@ namespace Raven.Server.ServerWide
 
         private static async Task<bool> AssertNoDocsStartingWith(string prefix, JsonOperationContext context, RequestExecutor requestExecutor)
         {
-            var command = new GetDocumentsCommand(startWith: prefix,
+            var command = new GetDocumentsCommand(requestExecutor.Conventions, startWith: prefix,
                 startAfter: null, matches: null, exclude: null, start: 0, pageSize: int.MaxValue, metadataOnly: false);
 
             await requestExecutor.ExecuteAsync(command, context, sessionInfo: null);

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Smuggler.Migration
             _skipServerCertificateValidation = configuration.SkipServerCertificateValidation;
 
             //because of backward compatibility useCompression == false here
-            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression: false, hasExplicitlySetCompressionUsage: false, DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime, DocumentConventions.DefaultForServer.HttpPooledConnectionIdleTimeout);
+            var httpClientHandler = RequestExecutor.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useHttpDecompression: false, hasExplicitlySetDecompressionUsage: false, DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime, DocumentConventions.DefaultForServer.HttpPooledConnectionIdleTimeout);
             httpClientHandler.UseDefaultCredentials = false;
 
             if (configuration.SkipServerCertificateValidation)

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -112,7 +112,7 @@ namespace FastTests.Client
 
                 store.GetRequestExecutor(store.Database).ContextPool.AllocateOperationContext(out JsonOperationContext context);
 
-                var getDocumentCommand = new GetDocumentsCommand(new[] { "FooBars/1-A", "FooBars/2-A", "FooBars/3-A", "FooBars/4-A" }, includes: null, metadataOnly: false);
+                var getDocumentCommand = new GetDocumentsCommand(store.Conventions, new[] { "FooBars/1-A", "FooBars/2-A", "FooBars/3-A", "FooBars/4-A" }, includes: null, metadataOnly: false);
 
                 store.GetRequestExecutor(store.Database).Execute(getDocumentCommand, context);
 

--- a/test/FastTests/Client/CRUD.cs
+++ b/test/FastTests/Client/CRUD.cs
@@ -7,6 +7,7 @@ using Raven.Client;
 using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,10 +19,17 @@ namespace FastTests.Client
         {
         }
 
-        [Fact]
-        public void CRUD_Operations()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CRUD_Operations(bool useCompression)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(new Options(){ ModifyDocumentStore = x =>
+                       {
+                           x.Conventions.UseHttpCompression = useCompression;
+                           x.Conventions.UseHttpDecompression = useCompression;
+                       }
+                   }))
             {
                 using (var newSession = store.OpenSession())
                 {

--- a/test/FastTests/Client/Documents/BasicDocuments.cs
+++ b/test/FastTests/Client/Documents/BasicDocuments.cs
@@ -78,7 +78,7 @@ namespace FastTests.Client.Documents
 
                 using (requestExecuter.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    var getDocumentCommand = new GetDocumentsCommand(new[] { "users/1", "users/2" }, includes: null, metadataOnly: false);
+                    var getDocumentCommand = new GetDocumentsCommand(store.Conventions, new[] { "users/1", "users/2" }, includes: null, metadataOnly: false);
 
                     requestExecuter
                         .Execute(getDocumentCommand, context);
@@ -110,7 +110,7 @@ namespace FastTests.Client.Documents
                         Assert.Equal("Arek", user2.Name);
                     }
 
-                    getDocumentCommand = new GetDocumentsCommand(new[] { "users/1", "users/2" }, includes: null,
+                    getDocumentCommand = new GetDocumentsCommand(store.Conventions, new[] { "users/1", "users/2" }, includes: null,
                         metadataOnly: true);
 
                     requestExecuter

--- a/test/FastTests/Client/Load.cs
+++ b/test/FastTests/Client/Load.cs
@@ -187,7 +187,7 @@ namespace FastTests.Client
                     session.SaveChanges();
                 }
                 var rq1 = store.GetRequestExecutor();
-                var cmd = new GetDocumentsCommand(ids.ToArray(), null, true);
+                var cmd = new GetDocumentsCommand(store.Conventions, ids.ToArray(), null, true);
                 using (var ctx = new JsonOperationContext(1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
                 {
                     rq1.Execute(cmd, ctx);

--- a/test/FastTests/Client/Queries/QueryTests.cs
+++ b/test/FastTests/Client/Queries/QueryTests.cs
@@ -44,9 +44,16 @@ namespace FastTests.Client.Queries
         }
         
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-        public  void Query_CreateClausesForQueryDynamicallyWithOnBeforeQueryEvent(Options options)
+        [RavenData(true, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(false, SearchEngineMode = RavenSearchEngineMode.All)]
+        public  void Query_CreateClausesForQueryDynamicallyWithOnBeforeQueryEvent(Options options, bool useCompression)
         {
+            options.ModifyDocumentStore = x =>
+            {
+                x.Conventions.UseHttpCompression = useCompression;
+                x.Conventions.UseHttpDecompression = useCompression;
+            };
+
             using (var store = GetDocumentStore(options))
             {
                 const string id1 = "users/1";

--- a/test/FastTests/Client/RequestExecutorTests.cs
+++ b/test/FastTests/Client/RequestExecutorTests.cs
@@ -85,7 +85,7 @@ namespace FastTests.Client
 
             using var dis = requestExecutor.ContextPool.AllocateOperationContext(out var context);
             var documentJson = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(new User(), context);
-            var command = new FirstFailCommand("User/1", null, documentJson, failCount);
+            var command = new FirstFailCommand(requestExecutor.Conventions, "User/1", null, documentJson, failCount);
             try
             {
                 await requestExecutor.ExecuteAsync(command, context);
@@ -105,8 +105,8 @@ namespace FastTests.Client
 
             public override bool IsReadRequest { get; }
 
-            public FirstFailCommand(string id, string changeVector, BlittableJsonReaderObject document, int timeToFail)
-                : base(id, changeVector, document)
+            public FirstFailCommand(DocumentConventions conventions, string id, string changeVector, BlittableJsonReaderObject document, int timeToFail)
+                : base(conventions, id, changeVector, document)
             {
                 _timeToFail = timeToFail;
             }

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1196,7 +1196,7 @@ namespace FastTests.Client.Subscriptions
 
             public RavenCommand<DatabasePutResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
             {
-                return new CreateDatabaseOperation.CreateDatabaseCommand(_databaseRecord, _replicationFactor);
+                return new CreateDatabaseOperation.CreateDatabaseCommand(conventions, _databaseRecord, _replicationFactor);
             }
         }
     }

--- a/test/FastTests/Issues/RavenDB-12568.cs
+++ b/test/FastTests/Issues/RavenDB-12568.cs
@@ -25,7 +25,7 @@ namespace FastTests.Issues
                 using (var stringStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)))
                 using (var blittableJson = context.Sync.ReadForDisk(stringStream, "Reading of foo/bar"))
                 {
-                    Assert.Throws<RavenException>(() => requestExecutor.Execute(new PutDocumentCommand("foo/bar", null, blittableJson), context));
+                    Assert.Throws<RavenException>(() => requestExecutor.Execute(new PutDocumentCommand(store.Conventions, "foo/bar", null, blittableJson), context));
                 }
             }
         }

--- a/test/FastTests/Issues/RavenDB_10734.cs
+++ b/test/FastTests/Issues/RavenDB_10734.cs
@@ -25,7 +25,7 @@ namespace FastTests.Issues
                 using (var stringStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(ComplexDocument)))
                 using (var blittableJson = await context.ReadForDiskAsync(stringStream, "Reading of foo/bar"))
                 {
-                    requestExecutor.Execute(new PutDocumentCommand("foo/bar", null, blittableJson), context);
+                    requestExecutor.Execute(new PutDocumentCommand(requestExecutor.Conventions, "foo/bar", null, blittableJson), context);
                 }
 
                 var url = $"{store.Urls[0]}/databases/{store.Database}/docs/class?id=foo/bar";

--- a/test/FastTests/Issues/RavenDB_12582.cs
+++ b/test/FastTests/Issues/RavenDB_12582.cs
@@ -25,7 +25,7 @@ namespace FastTests.Issues
                     }, "users/1");
                     session.SaveChanges();
 
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         session.Advanced.Context,
                         "users/1",
                         null,
@@ -60,7 +60,7 @@ namespace FastTests.Issues
                     }, "users/1");
                     session.SaveChanges();
 
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         session.Advanced.Context,
                         "users/1",
                         null,

--- a/test/FastTests/Server/Basic/Crud.cs
+++ b/test/FastTests/Server/Basic/Crud.cs
@@ -65,7 +65,7 @@ namespace FastTests.Server.Basic
 
                     var json = context.ReadObject(djv, "users/1");
 
-                    var putCommand = new PutDocumentCommand("users/1", null, json);
+                    var putCommand = new PutDocumentCommand(requestExecuter.Conventions, "users/1", null, json);
 
                     requestExecuter.Execute(putCommand, context);
 
@@ -76,7 +76,7 @@ namespace FastTests.Server.Basic
 
                     json = context.ReadObject(djv, "users/1");
 
-                    putCommand = new PutDocumentCommand("users/1", null, json);
+                    putCommand = new PutDocumentCommand(requestExecuter.Conventions, "users/1", null, json);
 
                     requestExecuter.Execute(putCommand, context);
                 }

--- a/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
+++ b/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
@@ -88,7 +88,7 @@ namespace FastTests.Server.Basic
                     using (var requestExecutor = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, name, null, DocumentConventions.Default))
                     {
                         mre.WaitOne();
-                        requestExecutor.Execute(new GetDocumentsCommand("Raven/HiloPrefix", includes: null, metadataOnly: false), ctx);
+                        requestExecutor.Execute(new GetDocumentsCommand(requestExecutor.Conventions, "Raven/HiloPrefix", includes: null, metadataOnly: false), ctx);
                     }
                 });
                 await t;

--- a/test/FastTests/Server/ServerStore.cs
+++ b/test/FastTests/Server/ServerStore.cs
@@ -83,7 +83,7 @@ namespace FastTests.Server
                 };
 
                 message.Headers.Add("ETag", "0");
-                message.Content = new BlittableJsonContent(async stream => await databaseDocument.WriteJsonToAsync(stream));
+                message.Content = new BlittableJsonContent(async stream => await databaseDocument.WriteJsonToAsync(stream), DocumentConventions.Default);
 
                 return message;
             }

--- a/test/FastTests/Sharding/BasicSharding.cs
+++ b/test/FastTests/Sharding/BasicSharding.cs
@@ -191,7 +191,7 @@ namespace FastTests.Sharding
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 var blittableJsonReaderObject = context.ReadObject(user, id);
-                requestExecutor.Execute(new PutDocumentCommand(id, null, blittableJsonReaderObject), context);
+                requestExecutor.Execute(new PutDocumentCommand(requestExecutor.Conventions, id, null, blittableJsonReaderObject), context);
             }
         }
 
@@ -219,7 +219,7 @@ namespace FastTests.Sharding
                     ["Type"] = "Dog"
                 }, petId);
 
-                var command = new PatchOperation.PatchCommand(
+                var command = new PatchOperation.PatchCommand(store.Conventions,
                     context,
                     id,
                     null,

--- a/test/SlowTests/Authentication/SetupCommands.cs
+++ b/test/SlowTests/Authentication/SetupCommands.cs
@@ -23,10 +23,12 @@ namespace SlowTests.Authentication
     {
         private class ClaimDomainCommand : RavenCommand<ClaimDomainResult>
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _payload;
 
             public ClaimDomainCommand(DocumentConventions conventions, JsonOperationContext context, ClaimDomainInfo claimInfo)
             {
+                _conventions = conventions;
                 _payload = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(claimInfo, context);
             }
 
@@ -40,7 +42,7 @@ namespace SlowTests.Authentication
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _payload).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _payload).ConfigureAwait(false), _conventions)
                 };
             }
 
@@ -82,10 +84,12 @@ namespace SlowTests.Authentication
 
         private class SetupLetsEncryptCommand : RavenCommand<byte[]>, IRaftCommand
         {
+            private readonly DocumentConventions _conventions;
             private readonly BlittableJsonReaderObject _payload;
 
             public SetupLetsEncryptCommand(DocumentConventions conventions, JsonOperationContext context, SetupInfo setupInfo)
             {
+                _conventions = conventions;
                 _payload = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(setupInfo, context);
                 ResponseType = RavenCommandResponseType.Raw;
                 Timeout = TimeSpan.FromMinutes(30);
@@ -100,7 +104,7 @@ namespace SlowTests.Authentication
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _payload).ConfigureAwait(false))
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _payload).ConfigureAwait(false), _conventions)
                 };
             }
 

--- a/test/SlowTests/Client/OptimisticConcurrency.cs
+++ b/test/SlowTests/Client/OptimisticConcurrency.cs
@@ -233,7 +233,7 @@ namespace SlowTests.Client
                     }
                 };
                 var json = context.ReadObject(djv, id);
-                var putCommand = new PutDocumentCommand(id, "someConflictedChangeVector", json);
+                var putCommand = new PutDocumentCommand(store.Conventions, id, "someConflictedChangeVector", json);
                 await Assert.ThrowsAnyAsync<ConcurrencyException>(async () => await requestExecuter.ExecuteAsync(putCommand, context));
             }
 

--- a/test/SlowTests/Corax/RavenDB-18377.cs
+++ b/test/SlowTests/Corax/RavenDB-18377.cs
@@ -28,7 +28,7 @@ public class RavenDB_18377 : RavenTestBase
         var djv = new DynamicJsonValue {["Coll"] = new DynamicJsonValue {["$values"] = new DynamicJsonArray(new string[] {"a", "b", "c"})}};
         var requestExecutor = store.GetRequestExecutor();
         var json = context.ReadObject(djv, "tests/1");
-        requestExecutor.Execute(new PutDocumentCommand("tests/1-A", null, json), context);
+        requestExecutor.Execute(new PutDocumentCommand(store.Conventions, "tests/1-A", null, json), context);
         {
             using var session = store.OpenSession();
             var result = session.Advanced.RawQuery<object>("from \"@empty\" where Coll = 'a'").ToList();

--- a/test/SlowTests/Core/Commands/Patching.cs
+++ b/test/SlowTests/Core/Commands/Patching.cs
@@ -138,7 +138,7 @@ this.Comments = this.Comments.filter(function (c) {
                     result = commands.Get("posts/4"); ;
                     Assert.Equal("Post 5", result.Title.ToString());
 
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         "posts/4",
                         null,
@@ -191,7 +191,7 @@ this.Comments = this.Comments.filter(function (c) {
                         Comments = new Post[] { }
                     }, null);
 
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         "posts/1",
                         null,
@@ -221,7 +221,7 @@ this.Comments = this.Comments.filter(function (c) {
                         Assert.Equal(postId, post.Title);
                     }
 
-                    command = new PatchOperation.PatchCommand(
+                    command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         "posts/1",
                         null,
@@ -274,7 +274,7 @@ this.Comments = this.Comments.filter(function (c) {
 
                 using (var commands = store.Commands())
                 {
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         "posts/1-A",
                         null,
@@ -303,7 +303,7 @@ this.Comments = this.Comments.filter(function (c) {
 
                 using (var commands = store.Commands())
                 {
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         "posts/1-A",
                         null,

--- a/test/SlowTests/Issues/IAsyncDocumentSessionExtensionsTest.cs
+++ b/test/SlowTests/Issues/IAsyncDocumentSessionExtensionsTest.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Issues
 
                 using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var context))
                 {
-                    var cmd = new GetDocumentsCommand(startWith: "users/", startAfter: null, matches: null, exclude: null, start: 0, pageSize: int.MaxValue,
+                    var cmd = new GetDocumentsCommand(store.Conventions, startWith: "users/", startAfter: null, matches: null, exclude: null, start: 0, pageSize: int.MaxValue,
                         metadataOnly: false);
                     await store.GetRequestExecutor().ExecuteAsync(cmd, context);
 
@@ -158,7 +158,7 @@ namespace SlowTests.Issues
 
                 using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var context))
                 {
-                    var cmd = new GetDocumentsCommand(startWith: "users/", startAfter: null, matches: null, exclude: null, start: 6, pageSize: int.MaxValue,
+                    var cmd = new GetDocumentsCommand(store.Conventions, startWith: "users/", startAfter: null, matches: null, exclude: null, start: 6, pageSize: int.MaxValue,
                         metadataOnly: false);
                     await store.GetRequestExecutor().ExecuteAsync(cmd, context);
 
@@ -343,7 +343,7 @@ namespace SlowTests.Issues
 
                 using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var context))
                 {
-                    var cmd = new GetDocumentsCommand(startWith: "users/", start: 0, pageSize: int.MaxValue, startAfter: "users/95", matches: null, exclude: null, metadataOnly: false);
+                    var cmd = new GetDocumentsCommand(store.Conventions, startWith: "users/", start: 0, pageSize: int.MaxValue, startAfter: "users/95", matches: null, exclude: null, metadataOnly: false);
                     await store.GetRequestExecutor().ExecuteAsync(cmd, context);
 
                     var results = cmd.Result.Results;

--- a/test/SlowTests/Issues/RavenDB-10996.cs
+++ b/test/SlowTests/Issues/RavenDB-10996.cs
@@ -78,7 +78,7 @@ namespace SlowTests.Issues
                 {
                     var json = context.Sync.ReadForDisk(new MemoryStream(Encoding.UTF8.GetBytes(Doc)), "users/1");
 
-                    var putCommand = new PutDocumentCommand("users/1", null, json);
+                    var putCommand = new PutDocumentCommand(store.Conventions, "users/1", null, json);
 
                     requestExecuter.Execute(putCommand, context);
                 }

--- a/test/SlowTests/Issues/RavenDB-11001.cs
+++ b/test/SlowTests/Issues/RavenDB-11001.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Issues
                             [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
                         }
                     }, "newDoc");
-                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+                    store.Commands().Execute(new PutDocumentCommand(store.Conventions, "docs/1", null, docBlit));
 
                     using (var session = store.OpenSession())
                     {
@@ -79,7 +79,7 @@ namespace SlowTests.Issues
                             [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
                         }
                     }, "newDoc");
-                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+                    store.Commands().Execute(new PutDocumentCommand(store.Conventions, "docs/1", null, docBlit));
 
                     using (var session = store.OpenSession())
                     {
@@ -123,7 +123,7 @@ namespace SlowTests.Issues
                             [Raven.Client.Constants.Documents.Metadata.Collection] = "docs"
                         }
                     }, "newDoc");
-                    store.Commands().Execute(new PutDocumentCommand("docs/1", null, docBlit));
+                    store.Commands().Execute(new PutDocumentCommand(store.Conventions, "docs/1", null, docBlit));
 
                     using (var session = store.OpenSession())
                     {

--- a/test/SlowTests/Issues/RavenDB-11819.cs
+++ b/test/SlowTests/Issues/RavenDB-11819.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Issues
             {
                 var requestExecuter = store.GetRequestExecutor();
                 var blitUser = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(user, context);
-                requestExecuter.Execute(new PutDocumentCommand(id, null, blitUser), context);
+                requestExecuter.Execute(new PutDocumentCommand(store.Conventions, id, null, blitUser), context);
 
                 //Action
                 store.Operations.Send(new CounterBatchOperation(new CounterBatch

--- a/test/SlowTests/Issues/RavenDB-12051.cs
+++ b/test/SlowTests/Issues/RavenDB-12051.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Issues
                 using (var stringStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("{'Items': []}")))
                 using (var blittableJson = context.Sync.ReadForDisk(stringStream, "Reading of foo/bar"))
                 {
-                    store.GetRequestExecutor().Execute(new PutDocumentCommand("foo/bar", null, blittableJson), context);
+                    store.GetRequestExecutor().Execute(new PutDocumentCommand(store.Conventions, "foo/bar", null, blittableJson), context);
                 }
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-12775.cs
+++ b/test/SlowTests/Issues/RavenDB-12775.cs
@@ -71,7 +71,7 @@ namespace SlowTests.Issues
 
                 using (rq.ContextPool.AllocateOperationContext(out var ctx))
                 {
-                    var cmd = new PatchOperation.PatchCommand(ctx, "users/1", changeVector:null,
+                    var cmd = new PatchOperation.PatchCommand(store.Conventions, ctx, "users/1", changeVector:null,
                         new PatchRequest
                         {
                             Script = queryString

--- a/test/SlowTests/Issues/RavenDB-14650.cs
+++ b/test/SlowTests/Issues/RavenDB-14650.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                             ["$values"] = new DynamicJsonArray(list.Select(x => (object)x))
                         }
                     }, "users/1");
-                    requestExecuter.Execute(new PutDocumentCommand("users/1", null, reader), context);
+                    requestExecuter.Execute(new PutDocumentCommand(store.Conventions, "users/1", null, reader), context);
                 }
 
                 var javascriptProjection = @"from @all_docs as doc
@@ -81,7 +81,7 @@ select doc.Array";
                             ["$value"] = "AQIDBAU="
                         }
                     }, "users/1");
-                    requestExecuter.Execute(new PutDocumentCommand("users/1", null, reader), context);
+                    requestExecuter.Execute(new PutDocumentCommand(store.Conventions, "users/1", null, reader), context);
                 }
 
                 var javascriptProjection = @"from @all_docs as doc

--- a/test/SlowTests/Issues/RavenDB-15629.cs
+++ b/test/SlowTests/Issues/RavenDB-15629.cs
@@ -43,7 +43,7 @@ public class RavenDB_15629 : RavenTestBase
                 Content = new BlittableJsonContent(async stream =>
                 {
                     await ctx.WriteAsync(stream, payloadJson);
-                })
+                }, DocumentConventions.Default)
             };
         }
 

--- a/test/SlowTests/Issues/RavenDB-17128.cs
+++ b/test/SlowTests/Issues/RavenDB-17128.cs
@@ -170,7 +170,7 @@ namespace SlowTests.Issues
                     using (re.ContextPool.AllocateOperationContext(out var ctx))
                     using (var blittable = ctx.ReadObject(djv, "new/1"))
                     {
-                        var ex = Assert.Throws<ConcurrencyException>(() => re.Execute(new PutDocumentCommand("new/1", cv, blittable), ctx));
+                        var ex = Assert.Throws<ConcurrencyException>(() => re.Execute(new PutDocumentCommand(store.Conventions, "new/1", cv, blittable), ctx));
                         Assert.Equal(cv, ex.ExpectedChangeVector);
                     }
                 }

--- a/test/SlowTests/Issues/RavenDB-6931.cs
+++ b/test/SlowTests/Issues/RavenDB-6931.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Issues
                     session.Store(new User { Name = "Bob" }, "users/1");
                     session.Advanced.Attachments.Store("users/1", "profile.png", profileStream, "image/png");
                     session.SaveChanges();
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         session.Advanced.Context,
                         "users/1",
                         null,

--- a/test/SlowTests/Issues/RavenDB-8450.cs
+++ b/test/SlowTests/Issues/RavenDB-8450.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Issues
                             writer.WriteString(_tryout.Query);
                             writer.WriteEndObject();
                         }
-                    })
+                    }, DocumentConventions.Default)
                 };
 
                 var sb = new StringBuilder($"{node.Url}/databases/{node.Database}/subscriptions/try?pageSize=10");

--- a/test/SlowTests/Issues/RavenDB_10546.cs
+++ b/test/SlowTests/Issues/RavenDB_10546.cs
@@ -105,6 +105,7 @@ namespace SlowTests.Issues
 
             private class PutStudioConfigurationCommand : RavenCommand, IRaftCommand
             {
+                private readonly DocumentConventions _conventions;
                 private readonly BlittableJsonReaderObject _configuration;
 
                 public PutStudioConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, StudioConfiguration configuration)
@@ -115,6 +116,7 @@ namespace SlowTests.Issues
                         throw new ArgumentNullException(nameof(configuration));
                     if (context == null)
                         throw new ArgumentNullException(nameof(context));
+                    _conventions = conventions;
 
                     _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
                 }
@@ -127,7 +129,7 @@ namespace SlowTests.Issues
                     return new HttpRequestMessage
                     {
                         Method = HttpMethod.Put,
-                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                     };
                 }
 
@@ -151,6 +153,7 @@ namespace SlowTests.Issues
 
             private class PutServerWideStudioConfigurationCommand : RavenCommand, IRaftCommand
             {
+                private readonly DocumentConventions _conventions;
                 private readonly BlittableJsonReaderObject _configuration;
 
                 public PutServerWideStudioConfigurationCommand(DocumentConventions conventions, JsonOperationContext context, ServerWideStudioConfiguration configuration)
@@ -161,6 +164,7 @@ namespace SlowTests.Issues
                         throw new ArgumentNullException(nameof(configuration));
                     if (context == null)
                         throw new ArgumentNullException(nameof(context));
+                    _conventions = conventions;
 
                     _configuration = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration, context);
                 }
@@ -173,7 +177,7 @@ namespace SlowTests.Issues
                     return new HttpRequestMessage
                     {
                         Method = HttpMethod.Put,
-                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false))
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _configuration).ConfigureAwait(false), _conventions)
                     };
                 }
 

--- a/test/SlowTests/Issues/RavenDB_10876.cs
+++ b/test/SlowTests/Issues/RavenDB_10876.cs
@@ -41,13 +41,13 @@ namespace SlowTests.Issues
                     {
                         ["BigNumber"] = new LazyNumberValue(context.GetLazyString(bigNumString))
                     }, "num");
-                    requestExecuter.Execute(new PutDocumentCommand("bignum/1", null, reader), context);
+                    requestExecuter.Execute(new PutDocumentCommand(store.Conventions, "bignum/1", null, reader), context);
                 }
 
                 using (requestExecuter.ContextPool.AllocateOperationContext(out var context))
                 {
 
-                    GetDocumentsCommand getDoc = new GetDocumentsCommand("bignum/1", null, false);
+                    GetDocumentsCommand getDoc = new GetDocumentsCommand(store.Conventions, "bignum/1", null, false);
                     requestExecuter.Execute(getDoc, context);
                     var doc = getDoc.Result.Results[0] as BlittableJsonReaderObject;
                     Assert.True(doc.TryGet<LazyNumberValue>("BigNumber", out var rawNum));
@@ -84,13 +84,13 @@ namespace SlowTests.Issues
                     {
                         ["BigNumber"] = new LazyNumberValue(context.GetLazyString(bigNumString))
                     }, "num");
-                    requestExecuter.Execute(new PutDocumentCommand("bignum/1", null, reader), context);
+                    requestExecuter.Execute(new PutDocumentCommand(store.Conventions, "bignum/1", null, reader), context);
                 }
 
                 using (requestExecuter.ContextPool.AllocateOperationContext(out var context))
                 {
 
-                    GetDocumentsCommand getDoc = new GetDocumentsCommand("bignum/1", null, false);
+                    GetDocumentsCommand getDoc = new GetDocumentsCommand(store.Conventions, "bignum/1", null, false);
                     requestExecuter.Execute(getDoc, context);
                     var doc = getDoc.Result.Results[0] as BlittableJsonReaderObject;
                     Assert.True(doc.TryGet<LazyNumberValue>("BigNumber", out var rawNum));
@@ -113,7 +113,7 @@ namespace SlowTests.Issues
                     {
                         ["BigNumber"] = new LazyNumberValue(context.GetLazyString(bigNumString))
                     }, "num");
-                    var thrownException =  Assert.Throws<RavenException>(() => requestExecuter.Execute(new PutDocumentCommand("bignum/1", null, reader), context));
+                    var thrownException =  Assert.Throws<RavenException>(() => requestExecuter.Execute(new PutDocumentCommand(store.Conventions, "bignum/1", null, reader), context));
 
                     Assert.StartsWith("System.IO.InvalidDataException: Could not parse double:", thrownException.Message);
                 }              

--- a/test/SlowTests/Issues/RavenDB_12383.cs
+++ b/test/SlowTests/Issues/RavenDB_12383.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
 
                 using (var commands = store.Commands())
                 {
-                    var getDocumentsCommand = new GetDocumentsCommand(
+                    var getDocumentsCommand = new GetDocumentsCommand(store.Conventions,
                         new[] { "employees/1", "employees/2" },
                         new[] { nameof(Employee.ReportsTo) },
                         metadataOnly: false);

--- a/test/SlowTests/Issues/RavenDB_14919.cs
+++ b/test/SlowTests/Issues/RavenDB_14919.cs
@@ -131,7 +131,7 @@ namespace SlowTests.Issues
                 var re = store.GetRequestExecutor();
                 using (re.ContextPool.AllocateOperationContext(out var context))
                 {
-                    var command = new GetDocumentsCommand(ids, includes: null, metadataOnly: false);
+                    var command = new GetDocumentsCommand(store.Conventions, ids, includes: null, metadataOnly: false);
                     re.Execute(command, context);
                     Assert.Equal(101, command.Result.Results.Length);
                     Assert.Null(command.Result.Results[^1]);
@@ -160,7 +160,7 @@ namespace SlowTests.Issues
                 var re = store.GetRequestExecutor();
                 using (re.ContextPool.AllocateOperationContext(out var context))
                 {
-                    var command = new GetDocumentsCommand(ids, includes: null, metadataOnly: false);
+                    var command = new GetDocumentsCommand(store.Conventions, ids, includes: null, metadataOnly: false);
                     re.Execute(command, context);
                     Assert.Equal(1001, command.Result.Results.Length);
                     Assert.Null(command.Result.Results[^1]);

--- a/test/SlowTests/Issues/RavenDB_5051.cs
+++ b/test/SlowTests/Issues/RavenDB_5051.cs
@@ -83,7 +83,7 @@ namespace SlowTests.Issues
 
                                 writer.WriteEndObject();
                             }
-                        })
+                        }, DocumentConventions.Default)
                     };
                 }
 

--- a/test/SlowTests/Issues/RavenDB_6292.cs
+++ b/test/SlowTests/Issues/RavenDB_6292.cs
@@ -123,7 +123,7 @@ namespace SlowTests.Issues
 
                     using (var commands = store2.Commands())
                     {
-                        var command = new GetDocumentsCommand("users/1", includes: new[] { "AddressId" }, metadataOnly: false);
+                        var command = new GetDocumentsCommand(commands.RequestExecutor.Conventions, "users/1", includes: new[] { "AddressId" }, metadataOnly: false);
 
                         commands.RequestExecutor.Execute(command, commands.Context);
 

--- a/test/SlowTests/Issues/RavenDB_8063.cs
+++ b/test/SlowTests/Issues/RavenDB_8063.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var command = new GetDocumentsCommand(new[] { orderId }, new[] { "Employee" }, false);
+                var command = new GetDocumentsCommand(store.Conventions, new[] { orderId }, new[] { "Employee" }, false);
                 using (var commands = store.Commands())
                 {
                     commands.RequestExecutor.Execute(command, commands.Context);

--- a/test/SlowTests/Issues/RavenDB_8267.cs
+++ b/test/SlowTests/Issues/RavenDB_8267.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                GetDocumentsCommand getDocsCommand = new GetDocumentsCommand("things/1", null, false);
+                GetDocumentsCommand getDocsCommand = new GetDocumentsCommand(store.Conventions, "things/1", null, false);
                 store.Commands().Execute(getDocsCommand);
                 var res = getDocsCommand.Result.Results[0] as BlittableJsonReaderObject;
                 

--- a/test/SlowTests/Issues/RavenDB_8651.cs
+++ b/test/SlowTests/Issues/RavenDB_8651.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
 
                     var json = ctx.ReadObject(djv, "users/1");
 
-                    var putCommand = new PutDocumentCommand("users/1", null, json);
+                    var putCommand = new PutDocumentCommand(store.Conventions, "users/1", null, json);
 
                     requestExecuter.Execute(putCommand, ctx);
                 }

--- a/test/SlowTests/Issues/RavenDB_9519.cs
+++ b/test/SlowTests/Issues/RavenDB_9519.cs
@@ -291,7 +291,7 @@ namespace SlowTests.Issues
                     var _csvConfigBlittable = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_csvConfig, ctx);
                     form = new MultipartFormDataContent
                     {
-                        {new BlittableJsonContent(async stream => { await ctx.WriteAsync(stream, _csvConfigBlittable); }), Constants.Smuggler.CsvImportOptions},
+                        {new BlittableJsonContent(async stream => { await ctx.WriteAsync(stream, _csvConfigBlittable); }, DocumentConventions.Default), Constants.Smuggler.CsvImportOptions},
                         {new StreamContent(_stream), "file", "name"}
                     };
                 }

--- a/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -348,7 +348,7 @@ namespace SlowTests.Server.Documents.Patching
                 {
                     await commands.PutAsync(_test.Id, null, _test, null);
 
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         commands.Context,
                         _test.Id,
                         null,
@@ -394,7 +394,7 @@ namespace SlowTests.Server.Documents.Patching
                 var requestExecutor = store.GetRequestExecutor();
                 using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
-                    var command = new PatchOperation.PatchCommand(
+                    var command = new PatchOperation.PatchCommand(store.Conventions,
                         context,
                         customType.Id,
                         null,

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2175,7 +2175,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var requestExecutor = store.GetRequestExecutor())
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
-                var command = new BackupOperation.BackupCommand(config);
+                var command = new BackupOperation.BackupCommand(store.Conventions, config);
                 var request = command.CreateRequest(context, new ServerNode { Url = store.Urls.First(), Database = store.Database }, out var url);
                 request.RequestUri = new Uri(url);
                 var client = store.GetRequestExecutor(store.Database).HttpClient;

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -810,7 +810,7 @@ namespace SlowTests.Server.Documents.Revisions
                     return new HttpRequestMessage
                     {
                         Method = HttpMethod.Post,
-                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false), DocumentConventions.Default)
                     };
                 }
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
@@ -33,11 +33,11 @@ namespace SlowTests.Sharding.Issues
                 using (var session = store.OpenSession())
                 using (var context = JsonOperationContext.ShortTermSingleUse())
                 {
-                    var command = new GetDocumentsCommand("users", null, null, null, 0, 100, false);
+                    var command = new GetDocumentsCommand(store.Conventions, "users", null, null, null, 0, 100, false);
 
                     session.Advanced.RequestExecutor.Execute(command, context);
 
-                    var command2 = new GetDocumentsCommand("users", null, null, null, 0, 100, false);
+                    var command2 = new GetDocumentsCommand(store.Conventions, "users", null, null, null, 0, 100, false);
 
                     session.Advanced.RequestExecutor.Execute(command2, context);
 
@@ -63,11 +63,11 @@ namespace SlowTests.Sharding.Issues
                 using (var session = store.OpenSession())
                 using (var context = JsonOperationContext.ShortTermSingleUse())
                 {
-                    var command = new GetDocumentsCommand(new[] { "users/1", "users/2" }, null, null, null, null, false);
+                    var command = new GetDocumentsCommand(store.Conventions, new[] { "users/1", "users/2" }, null, null, null, null, false);
 
                     session.Advanced.RequestExecutor.Execute(command, context);
 
-                    var command2 = new GetDocumentsCommand(new[] { "users/1", "users/2" }, null, null, null, null, false);
+                    var command2 = new GetDocumentsCommand(store.Conventions, new[] { "users/1", "users/2" }, null, null, null, null, false);
 
                     session.Advanced.RequestExecutor.Execute(command2, context);
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_19285.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19285.cs
@@ -112,7 +112,7 @@ public class RavenDB_19285: RavenTestBase
                         {
                             writer.WriteIndexQuery(DocumentConventions.Default, ctx, _indexQuery);
                         }
-                    }
+                    }, DocumentConventions.Default
                 )
             };
 

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -110,7 +110,7 @@ namespace FastTests
                         }
                     }
 
-                    var command = new PutDocumentCommand(id, changeVector, documentJson);
+                    var command = new PutDocumentCommand(RequestExecutor.Conventions, id, changeVector, documentJson);
 
                     await RequestExecutor.ExecuteAsync(command, Context, token: cancellationToken);
 
@@ -174,7 +174,7 @@ namespace FastTests
                 if (id == null)
                     throw new ArgumentNullException(nameof(id));
 
-                var command = new GetDocumentsCommand(id, includes: null, metadataOnly: metadataOnly);
+                var command = new GetDocumentsCommand(RequestExecutor.Conventions, id, includes: null, metadataOnly: metadataOnly);
 
                 await RequestExecutor.ExecuteAsync(command, Context);
 
@@ -231,7 +231,7 @@ namespace FastTests
                 if (ids == null)
                     throw new ArgumentNullException(nameof(ids));
 
-                var command = new GetDocumentsCommand(ids, includes: null, metadataOnly: false);
+                var command = new GetDocumentsCommand(RequestExecutor.Conventions, ids, includes: null, metadataOnly: false);
 
                 await RequestExecutor.ExecuteAsync(command, Context);
 
@@ -413,7 +413,7 @@ namespace FastTests
                         {
                             if (_payload != null)
                                 await ctx.WriteAsync(stream, _payload);
-                        })
+                        }, DocumentConventions.Default)
                     };
 
                     return request;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20057/DocumentConventions.UseCompression-isnt-respected-by-BlittableJsonContent

### Additional description

We'll be able to disable the compression of HTTP requests from now.

Turning off the gzip compression of requests when talking to other shards (as it was intended in https://github.com/ravendb/ravendb/pull/15851)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change - new conventions added, old one removed, many commands got a new ctor argument


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
