### PR TITLE
RavenDB-18888 Provide possibility to define UID:GID of user created during .deb package post-inst

### DIFF
--- a/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postinst
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postinst
@@ -4,8 +4,20 @@ set -e
 
 case "$1" in
     configure)
-        
-        adduser --disabled-login --disabled-password --system --home /var/empty --no-create-home --quiet --group ravendb
+        if [[ -n "$RAVEN_GROUP_ID" ]]; then
+            RAVEN_GID="$RAVEN_GROUP_ID"
+            groupadd --gid "$RAVEN_GID" ravendb
+        else
+            groupadd ravendb
+            RAVEN_GID=$(getent group ravendb | cut -d ':' -f 3)
+        fi
+
+        UID_ARG=""
+        if [[ -n "$RAVEN_USER_ID" ]]; then
+            UID_ARG="--uid $RAVEN_USER_ID"
+        fi
+
+        adduser --disabled-login --disabled-password --system --home /var/lib/ravendb --no-create-home --quiet $UID_ARG --gid "$RAVEN_GID" ravendb
 
         ldconfig
     ;;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18888/Running-as-a-non-root-user-in-Linux-containers

### Additional description

A minor part of [this PR](https://github.com/ravendb/ravendb/pull/15857) that is needed to be merged also on the v5.2.

### Type of change

- Bug fix
- New feature

### How risky is the change?
- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Linux/.deb package


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
