### PR TITLE
RavenDB-20059: `Failed to parse` on registering the behaviour function in a script engine when script contains `GlobalObject`

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -46,7 +46,7 @@ namespace Raven.Server.Documents.ETL
         {
             if (_behaviorFunctions != null)
             {
-                _behaviorFunctionsRun = Database.Scripts.GetScriptRunner(_behaviorFunctions, true, out BehaviorsScript);
+                _behaviorFunctionsRun = Database.Scripts.GetScriptRunner(_behaviorFunctions, true, out BehaviorsScript, ignoreValidationErrors: true);
 
                 if (debugMode)
                     BehaviorsScript.DebugMode = true;

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Jint;
 using Jint.Native;
 using Jint.Runtime.Interop;
@@ -46,7 +47,7 @@ namespace Raven.Server.Documents.ETL
         {
             if (_behaviorFunctions != null)
             {
-                _behaviorFunctionsRun = Database.Scripts.GetScriptRunner(_behaviorFunctions, true, out BehaviorsScript, ignoreValidationErrors: true);
+                _behaviorFunctionsRun = Database.Scripts.GetScriptRunner(_behaviorFunctions, readOnly: true, ignoreValidationErrors: true, out BehaviorsScript);
 
                 if (debugMode)
                     BehaviorsScript.DebugMode = true;

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Jint;
 using Jint.Native;
 using Jint.Native.Array;
-using Jint.Native.Global;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Lucene.Net.Store;
@@ -38,7 +36,6 @@ namespace Raven.Server.Documents.Patch
         private readonly ScriptRunner _runner;
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
         private readonly Engine _scriptEngine;
-        private static readonly Dictionary<object,object> EmptyMetadataDummy = new Dictionary<object, object>();
 
         public bool ReadOnly;
 
@@ -52,11 +49,7 @@ namespace Raven.Server.Documents.Patch
         {
             if (args.Length != 1 && args.Length != 2 || //length == 2 takes into account Query Arguments that can be added to args
                 !(args[0].AsObject() is BlittableObjectInstance boi))
-            {
-                if (args[0].AsObject() is GlobalObject) // Supposed to happen during the initialize of the script runner  - RavenDB-19466
-                    return JsValue.FromObject(_scriptEngine, EmptyMetadataDummy);
                 throw new InvalidOperationException("metadataFor(doc) must be called with a single entity argument");
-            }
 
             if (!(boi.Blittable[Constants.Documents.Metadata.Key] is BlittableJsonReaderObject metadata))
                 return JsValue.Null;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Documents.Patch
             TimeSeriesDeclaration.Add(func.Name, func);
         }
 
-        public ReturnRun GetRunner(out SingleRun run, ScriptRunnerCache.Key key)
+        public ReturnRun GetRunner(out SingleRun run, bool ignoreValidationErrors)
         {
             _lastRun = DateTime.UtcNow;
             Interlocked.Increment(ref Runs);
@@ -125,7 +125,7 @@ namespace Raven.Server.Documents.Patch
                 }
                 else
                 {
-                    holder.Value = new SingleRun(_db, _configuration, this, ScriptsSource, key);
+                    holder.Value = new SingleRun(_db, _configuration, this, ScriptsSource, ignoreValidationErrors);
                 }
             }
 
@@ -223,7 +223,7 @@ namespace Raven.Server.Documents.Patch
             private const string _timeSeriesSignature = "timeseries(doc, name)";
             public const string GetMetadataMethod = "getMetadata";
 
-            public SingleRun(DocumentDatabase database, RavenConfiguration configuration, ScriptRunner runner, List<string> scriptsSource, ScriptRunnerCache.Key key)
+            public SingleRun(DocumentDatabase database, RavenConfiguration configuration, ScriptRunner runner, List<string> scriptsSource, bool ignoreValidationErrors)
             {
                 _database = database;
                 _configuration = configuration;
@@ -316,7 +316,7 @@ namespace Raven.Server.Documents.Patch
                     }
                     catch (Exception e)
                     {
-                        if (key is not PatchRequest { Type: PatchRequestType.EtlBehaviorFunctions })
+                        if (ignoreValidationErrors == false)
                             throw new JavaScriptParseException("Failed to parse: " + Environment.NewLine + script, e);
                     }
                 }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Documents.Patch
             TimeSeriesDeclaration.Add(func.Name, func);
         }
 
-        public ReturnRun GetRunner(out SingleRun run)
+        public ReturnRun GetRunner(out SingleRun run, ScriptRunnerCache.Key key)
         {
             _lastRun = DateTime.UtcNow;
             Interlocked.Increment(ref Runs);
@@ -125,7 +125,7 @@ namespace Raven.Server.Documents.Patch
                 }
                 else
                 {
-                    holder.Value = new SingleRun(_db, _configuration, this, ScriptsSource);
+                    holder.Value = new SingleRun(_db, _configuration, this, ScriptsSource, key);
                 }
             }
 
@@ -223,7 +223,7 @@ namespace Raven.Server.Documents.Patch
             private const string _timeSeriesSignature = "timeseries(doc, name)";
             public const string GetMetadataMethod = "getMetadata";
 
-            public SingleRun(DocumentDatabase database, RavenConfiguration configuration, ScriptRunner runner, List<string> scriptsSource)
+            public SingleRun(DocumentDatabase database, RavenConfiguration configuration, ScriptRunner runner, List<string> scriptsSource, ScriptRunnerCache.Key key)
             {
                 _database = database;
                 _configuration = configuration;
@@ -316,7 +316,8 @@ namespace Raven.Server.Documents.Patch
                     }
                     catch (Exception e)
                     {
-                        throw new JavaScriptParseException("Failed to parse: " + Environment.NewLine + script, e);
+                        if (key is not PatchRequest { Type: PatchRequestType.EtlBehaviorFunctions })
+                            throw new JavaScriptParseException("Failed to parse: " + Environment.NewLine + script, e);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Documents.Patch
             TimeSeriesDeclaration.Add(func.Name, func);
         }
 
-        public ReturnRun GetRunner(out SingleRun run, bool ignoreValidationErrors)
+        public ReturnRun GetRunner(bool ignoreValidationErrors, out SingleRun run)
         {
             _lastRun = DateTime.UtcNow;
             Interlocked.Increment(ref Runs);

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Patch
                 return new ScriptRunner.ReturnRun();
             }
             var scriptRunner = GetScriptRunner(key);
-            var returnRun = scriptRunner.GetRunner(out patchRun);
+            var returnRun = scriptRunner.GetRunner(out patchRun, key);
             patchRun.ReadOnly = readOnly;
             return returnRun;
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Patch
             public abstract override int GetHashCode();
         }
 
-        public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, out ScriptRunner.SingleRun patchRun)
+        public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, out ScriptRunner.SingleRun patchRun, bool ignoreValidationErrors = false)
         {
             if (key == null)
             {
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents.Patch
                 return new ScriptRunner.ReturnRun();
             }
             var scriptRunner = GetScriptRunner(key);
-            var returnRun = scriptRunner.GetRunner(out patchRun, key);
+            var returnRun = scriptRunner.GetRunner(out patchRun, ignoreValidationErrors);
             patchRun.ReadOnly = readOnly;
             return returnRun;
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunnerCache.cs
@@ -69,7 +69,12 @@ namespace Raven.Server.Documents.Patch
             public abstract override int GetHashCode();
         }
 
-        public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, out ScriptRunner.SingleRun patchRun, bool ignoreValidationErrors = false)
+        public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, out ScriptRunner.SingleRun patchRun)
+        {
+            return GetScriptRunner(key, readOnly, ignoreValidationErrors: false, out patchRun);
+        }
+
+        public ScriptRunner.ReturnRun GetScriptRunner(Key key, bool readOnly, bool ignoreValidationErrors, out ScriptRunner.SingleRun patchRun)
         {
             if (key == null)
             {
@@ -77,7 +82,7 @@ namespace Raven.Server.Documents.Patch
                 return new ScriptRunner.ReturnRun();
             }
             var scriptRunner = GetScriptRunner(key);
-            var returnRun = scriptRunner.GetRunner(out patchRun, ignoreValidationErrors);
+            var returnRun = scriptRunner.GetRunner(ignoreValidationErrors, out patchRun);
             patchRun.ReadOnly = readOnly;
             return returnRun;
         }

--- a/test/SlowTests/Issues/RavenDB_20059.cs
+++ b/test/SlowTests/Issues/RavenDB_20059.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading.Tasks;
+using SlowTests.Server.Documents.ETL;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20059 : EtlTestBase
+    {
+        public RavenDB_20059(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanModifyGlobalObjectUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction()
+        {
+            using (var srcStore = GetDocumentStore())
+            using (var destStore = GetDocumentStore())
+            {
+                AddEtl(srcStore, destStore, "Contracts", script:
+@"this.Contact.AdditionalInfo = 13;	
+loadToContractsTemp(this);
+function deleteDocumentsOfContractsBehavior(docId) {
+    return false;
+    }");
+
+                var etlDone = WaitForEtl(srcStore, (_, s) => s.LoadSuccesses > 0);
+
+                using (var session = srcStore.OpenSession())
+                {
+                    session.Store(new Contract { Contact = new Contact { AdditionalInfo = 10 } });
+
+                    session.SaveChanges();
+                }
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                WaitForUserToContinueTheTest(srcStore);
+
+                using (var session = destStore.OpenSession())
+                {
+                    var contract = session.Load<Contract>("contracts/1-A/ContractsTemp/0000000000000000001-A");
+                    Assert.NotNull(contract);
+                    Assert.Equal(13, contract.Contact.AdditionalInfo);
+                }
+
+                using (var session = srcStore.OpenSession())
+                {
+                    session.Delete("contracts/1-A");
+                    session.SaveChanges();
+                }
+
+                etlDone = WaitForEtl(srcStore, (_, s) => s.LoadSuccesses > 0);
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = destStore.OpenSession())
+                {
+                    var contract = session.Load<Contract>("contracts/1-A/ContractsTemp/0000000000000000001-A");
+
+                    Assert.NotNull(contract);
+                    Assert.Equal(13, contract.Contact.AdditionalInfo);
+                }
+            }
+        }
+
+        internal class Contract
+        {
+            public Contact Contact { get; init; }
+        }
+
+        internal class Contact
+        {
+            public int AdditionalInfo { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_20059.cs
+++ b/test/SlowTests/Issues/RavenDB_20059.cs
@@ -35,8 +35,6 @@ function deleteDocumentsOfContractsBehavior(docId) {
                 }
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                WaitForUserToContinueTheTest(srcStore);
-
                 using (var session = destStore.OpenSession())
                 {
                     var contract = session.Load<Contract>("contracts/1-A/ContractsTemp/0000000000000000001-A");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20059/Failed-to-parse-on-registering-the-behaviour-function-in-a-script-engine-when-script-contains-GlobalObject

### Additional description

When registering the behavior function in a script engine, we pass the entire script (not only the definitions of behavior functions).

This way, we don't have to deal with extracting behavior functions. The drawback is that the regular script is still executed during the registration, so we can detect parse errors

If the script contains `this.Contact.AdditionalInfo = 0` then `AdditionalInfo` is `GlobalObject` and we failed the check we have here.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed