### PR TITLE
RavenDB-19843 Set default value of order by ticks when field contains dates to false

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -458,8 +458,8 @@ namespace Raven.Server.Config.Categories
             ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex { get; set; }
         
-        [Description("Sort by ticks when field contains dates.")]
-        [DefaultValue(true)]
+        [Description("Sort by ticks when field contains dates. Null dates are returned at the end with this option enabled.")]
+        [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool OrderByTicksAutomaticallyWhenDatesAreInvolved { get; set; }

--- a/test/SlowTests/Issues/RavenDB-19843.cs
+++ b/test/SlowTests/Issues/RavenDB-19843.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19843 : RavenTestBase
+{
+    public RavenDB_19843(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CheckIfNullDatesAreReturnedLastWithConfigOptionEnabled(bool configEnabled)
+    {
+        //guardian to set different config for 6_0
+        Assert.True(Raven.Server.Documents.Indexes.IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion < 60_000);
+
+        using (var store = GetDocumentStore(new Options
+               {
+                   ModifyDatabaseRecord = r =>
+                   {
+                       r.Settings[RavenConfiguration.GetKey(x => x.Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved)] = configEnabled.ToString();
+                   }
+               }))
+        {
+            using (var session = store.OpenSession())
+            {
+                var now = DateTime.UtcNow;
+
+                var dto1 = new DtoWithDate() { CreationTime = now };
+                var dto2 = new DtoWithDate() { CreationTime = now.AddHours(2) };
+                var dto3 = new DtoWithDate() { };
+
+                session.Store(dto1);
+                session.Store(dto2);
+                session.Store(dto3);
+
+                session.SaveChanges();
+
+                var results = session.Query<DtoWithDate>()
+                    .OrderByDescending(x => x.CreationTime).ToList();
+                
+                if(configEnabled)
+                    Assert.Equal(null, results[2].CreationTime);
+                else
+                    Assert.Equal(null, results[0].CreationTime);
+            }
+        }
+    }
+}
+
+public class DtoWithDate
+{
+    public string Id { get; set; }
+    public DateTime? CreationTime { get; set; }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19843/Lucene-order-by-ticks-when-field-contains-dates.

### Additional description

Changed indexing configuration option "OrderByTicksAutomaticallyWhenDatesAreInvolved" default value to false. 
Updated description to inform that null dates are returned at the end with this option enabled, and added test to assert it.

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Revert breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
