### PR TITLE
RavenDB-19633 Allow to enable and set Microsoft logs configuration (studio)

### DIFF
--- a/src/Raven.Studio/typescript/commands/maintenance/disableAdminLogsMicrosoftCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/disableAdminLogsMicrosoftCommand.ts
@@ -3,7 +3,7 @@ import endpoints = require("endpoints");
 
 class disableAdminLogsMicrosoftCommand extends commandBase {
     
-    execute(): JQueryPromise<string> {
+    execute(): JQueryPromise<void> {
         const url = endpoints.global.adminLogs.adminLogsMicrosoftDisable;
 
         return this.post<void>(url, null, null, { dataType: undefined })

--- a/src/Raven.Studio/typescript/commands/maintenance/disableAdminLogsMicrosoftCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/disableAdminLogsMicrosoftCommand.ts
@@ -1,0 +1,15 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class disableAdminLogsMicrosoftCommand extends commandBase {
+    
+    execute(): JQueryPromise<string> {
+        const url = endpoints.global.adminLogs.adminLogsMicrosoftDisable;
+
+        return this.post<void>(url, null, null, { dataType: undefined })
+            .done(() => this.reportSuccess("Microsoft logs was successfully disabled"))
+            .fail((response: JQueryXHR) => this.reportError("Failed to disable Microsoft logs", response.responseText, response.statusText));
+    }
+}
+
+export = disableAdminLogsMicrosoftCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/enableAdminLogsMicrosoftCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/enableAdminLogsMicrosoftCommand.ts
@@ -3,7 +3,7 @@ import endpoints = require("endpoints");
 
 class enableAdminLogsMicrosoftCommand extends commandBase {
     
-    execute(): JQueryPromise<string> {
+    execute(): JQueryPromise<void> {
         const url = endpoints.global.adminLogs.adminLogsMicrosoftEnable;
 
         return this.post<void>(url, null, null, { dataType: undefined })

--- a/src/Raven.Studio/typescript/commands/maintenance/enableAdminLogsMicrosoftCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/enableAdminLogsMicrosoftCommand.ts
@@ -1,0 +1,15 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class enableAdminLogsMicrosoftCommand extends commandBase {
+    
+    execute(): JQueryPromise<string> {
+        const url = endpoints.global.adminLogs.adminLogsMicrosoftEnable;
+
+        return this.post<void>(url, null, null, { dataType: undefined })
+            .done(() => this.reportSuccess("Microsoft logs was successfully enabled"))
+            .fail((response: JQueryXHR) => this.reportError("Failed to enable Microsoft logs", response.responseText, response.statusText));
+    }
+}
+
+export = enableAdminLogsMicrosoftCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftConfigurationCommand.ts
@@ -1,0 +1,14 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class getAdminLogsMicrosoftConfigurationCommand extends commandBase {
+    
+    execute(): JQueryPromise<object> {
+        const url = endpoints.global.adminLogs.adminLogsMicrosoftConfiguration;
+        
+        return this.query<object>(url, null)
+            .fail((response: JQueryXHR) => this.reportError("Failed to get Microsoft logs configuration", response.responseText, response.statusText)) 
+    }
+}
+
+export = getAdminLogsMicrosoftConfigurationCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftConfigurationCommand.ts
@@ -1,12 +1,13 @@
 import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
+import Dictionary = System.Collections.Generic.Dictionary;
 
 class getAdminLogsMicrosoftConfigurationCommand extends commandBase {
     
-    execute(): JQueryPromise<object> {
+    execute(): JQueryPromise<Dictionary<string, string>> {
         const url = endpoints.global.adminLogs.adminLogsMicrosoftConfiguration;
         
-        return this.query<object>(url, null)
+        return this.query<Dictionary<string, string>>(url, null)
             .fail((response: JQueryXHR) => this.reportError("Failed to get Microsoft logs configuration", response.responseText, response.statusText)) 
     }
 }

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftStateCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsMicrosoftStateCommand.ts
@@ -1,0 +1,20 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+import Dictionary = System.Collections.Generic.Dictionary;
+
+interface GetAdminLogsMicrosoftStateCommandResult {
+    IsActive: boolean;
+    Loggers: Dictionary<string, string>;
+}
+
+class getAdminLogsMicrosoftStateCommand extends commandBase {
+    
+    execute(): JQueryPromise<GetAdminLogsMicrosoftStateCommandResult> {
+        const url = endpoints.global.adminLogs.adminLogsMicrosoftState;
+        
+        return this.query<GetAdminLogsMicrosoftStateCommandResult>(url, null)
+            .fail((response: JQueryXHR) => this.reportError("Failed to get Microsoft logs state", response.responseText, response.statusText)) 
+    }
+}
+
+export = getAdminLogsMicrosoftStateCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand.ts
@@ -1,0 +1,22 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class saveAdminLogsMicrosoftConfigurationCommand extends commandBase {
+    
+    private readonly configuration: string;
+    
+    constructor(configuration: string) {
+        super();
+        this.configuration = configuration;
+    }
+    
+    execute(): JQueryPromise<void> {
+        const url = endpoints.global.adminLogs.adminLogsMicrosoftConfiguration;
+
+        return this.post<void>(url, this.configuration, null, { dataType: undefined })
+            .done(() => this.reportSuccess("Microsoft logs configuration was successfully set"))
+            .fail((response: JQueryXHR) => this.reportError("Failed to set Microsoft logs configuration", response.responseText, response.statusText));
+    }
+}
+
+export = saveAdminLogsMicrosoftConfigurationCommand;

--- a/src/Raven.Studio/typescript/common/bindingHelpers/aceEditorBindingHandler.ts
+++ b/src/Raven.Studio/typescript/common/bindingHelpers/aceEditorBindingHandler.ts
@@ -118,6 +118,7 @@ class aceEditorBindingHandler {
             bubbleEscKey: boolean;
             bubbleEnterKey: boolean;
             allowResize: boolean;
+            fullScreenNotAllowed: boolean;
         },
         allBindings: any,
         viewModel: any,
@@ -135,6 +136,7 @@ class aceEditorBindingHandler {
         const selectAll = bindingValues.selectAll || this.defaults.selectAll;
         const bubbleEscKey = bindingValues.bubbleEscKey || this.defaults.bubbleEscKey;
         const hasFocus = bindingValues.hasFocus;
+        const fullScreenNotAllowed = bindingValues.fullScreenNotAllowed || false;
 
         if (!ko.isObservable(code)) {
             throw new Error("code should be an observable");
@@ -183,7 +185,9 @@ class aceEditorBindingHandler {
             });
         }
         
-        aceEditorBindingHandler.initFullScreenModeCommands(aceEditor);
+        if (!fullScreenNotAllowed) {
+            aceEditorBindingHandler.initFullScreenModeCommands(aceEditor);
+        }
         
         if (completer) {
             aceEditorBindingHandler.completitionCache.set(aceEditor, completer);
@@ -223,7 +227,10 @@ class aceEditorBindingHandler {
         $(element).find('.ui-resizable-se').removeClass('ui-icon-gripsmall-diagonal-se');
         $(element).find('.ui-resizable-se').addClass('ui-icon-carat-1-s');
         $('.ui-resizable-se').css('cursor', 's-resize');
-        $(element).append('<span class="fullScreenModeLabel" style="font-size:90%; z-index: 1000; position: absolute; bottom: 22px; right: 22px; opacity: 0.4">Press Shift+F11 to enter full screen mode</span>');
+        
+        if (!fullScreenNotAllowed) {
+            $(element).append('<span class="fullScreenModeLabel" style="font-size:90%; z-index: 1000; position: absolute; bottom: 22px; right: 22px; opacity: 0.4">Press Shift+F11 to enter full screen mode</span>');
+        }
 
         // When the element is removed from the DOM, unhook our keyup and focus event handlers and remove the  resizable functionality completely. lest we leak memory.
         ko.utils.domNodeDisposal.addDisposeCallback(element, () => {

--- a/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
@@ -19,6 +19,12 @@ import app = require("durandal/app");
 import getTrafficWatchConfigurationCommand = require("commands/maintenance/getTrafficWatchConfigurationCommand");
 import trafficWatchConfiguration = require("models/resources/trafficWatchConfiguration");
 import saveTrafficWatchConfigurationCommand = require("commands/maintenance/saveTrafficWatchConfigurationCommand");
+import getAdminLogsMicrosoftStateCommand = require("../../commands/maintenance/getAdminLogsMicrosoftStateCommand");
+import getAdminLogsMicrosoftConfigurationCommand = require("../../commands/maintenance/getAdminLogsMicrosoftConfigurationCommand");
+import enableAdminLogsMicrosoftCommand = require("../../commands/maintenance/enableAdminLogsMicrosoftCommand");
+import disableAdminLogsMicrosoftCommand = require("../../commands/maintenance/disableAdminLogsMicrosoftCommand");
+import saveAdminLogsMicrosoftConfigurationCommand = require("../../commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand");
+import configureMicrosoftLogsDialog = require("./configureMicrosoftLogsDialog");
 
 class heightCalculator {
     
@@ -91,6 +97,9 @@ class adminLogs extends viewModelBase {
     private onDiskConfiguration = ko.observable<adminLogsOnDiskConfig>();
     private configuration = ko.observable<adminLogsConfig>(adminLogsConfig.empty());
     private trafficWatchConfiguration = ko.observable<trafficWatchConfiguration>();
+
+    isMicrosoftLogsEnabled = ko.observable<boolean>(false);
+    microsoftLogsConfiguration = ko.observable<string>("");
     
     editedConfiguration = ko.observable<adminLogsConfig>(adminLogsConfig.empty());
     editedHeaderName = ko.observable<adminLogsHeaderType>("Source");
@@ -137,7 +146,7 @@ class adminLogs extends viewModelBase {
         
         this.bindToCurrentInstance("toggleTail", "itemHeightProvider", "applyConfiguration", "loadLogsConfig",
             "includeFilter", "excludeFilter", "removeConfigurationEntry", "itemHtmlProvider", "setAdminLogMode", 
-            "configureTrafficWatch");
+            "configureTrafficWatch", "configureMicrosoftLogs");
         
         this.initObservables();
         this.initValidation();
@@ -282,8 +291,10 @@ class adminLogs extends viewModelBase {
     loadConfigs() {
         const logConfigsTask = this.loadLogsConfig();
         const trafficWatchConfigTask = this.loadTrafficWatchConfig();
+        const loadIsMicrosoftLogsEnabledTask = this.loadIsMicrosoftLogsEnabled();
+        const loadMicrosoftLogsConfigurationTask = this.loadMicrosoftLogsConfiguration();
         
-        return $.when<any>(logConfigsTask, trafficWatchConfigTask);
+        return $.when<any>(logConfigsTask, trafficWatchConfigTask, loadIsMicrosoftLogsEnabledTask, loadMicrosoftLogsConfigurationTask);
     }
     
     loadLogsConfig() {
@@ -294,6 +305,16 @@ class adminLogs extends viewModelBase {
     loadTrafficWatchConfig() {
         return new getTrafficWatchConfigurationCommand().execute()
             .done(result => this.trafficWatchConfiguration(new trafficWatchConfiguration(result)))
+    }
+    
+    loadIsMicrosoftLogsEnabled() {
+        return new getAdminLogsMicrosoftStateCommand().execute()
+            .done(result => this.isMicrosoftLogsEnabled(result.IsActive));
+    }
+
+    loadMicrosoftLogsConfiguration() {
+        return new getAdminLogsMicrosoftConfigurationCommand().execute()
+            .done(result => this.microsoftLogsConfiguration(JSON.stringify(result, null, 4)));
     }
 
     setAdminLogMode(newMode: Sparrow.Logging.LogMode) {
@@ -637,6 +658,34 @@ class adminLogs extends viewModelBase {
                     this.trafficWatchConfiguration(result);
                     new saveTrafficWatchConfigurationCommand(this.trafficWatchConfiguration().toDto())
                         .execute();
+                }
+            });
+    }
+
+    configureMicrosoftLogs() {
+        app.showBootstrapDialog(new configureMicrosoftLogsDialog(this.isMicrosoftLogsEnabled(), this.microsoftLogsConfiguration()))
+            .done((result) => {
+                if (!result) {
+                    return;
+                }
+                
+                if (this.isMicrosoftLogsEnabled() !== result.isEnabled) { 
+                    if (result.isEnabled) {
+                        new enableAdminLogsMicrosoftCommand()
+                            .execute()
+                            .done(() => this.loadIsMicrosoftLogsEnabled());
+                    } else {
+                        new disableAdminLogsMicrosoftCommand()
+                            .execute()
+                            .done(() => this.loadIsMicrosoftLogsEnabled());
+                    }
+                    
+                }
+                
+                if (result.configuration) {
+                    new saveAdminLogsMicrosoftConfigurationCommand(result.configuration)
+                        .execute()
+                        .done(() => this.loadMicrosoftLogsConfiguration());
                 }
             });
     }

--- a/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
@@ -19,11 +19,11 @@ import app = require("durandal/app");
 import getTrafficWatchConfigurationCommand = require("commands/maintenance/getTrafficWatchConfigurationCommand");
 import trafficWatchConfiguration = require("models/resources/trafficWatchConfiguration");
 import saveTrafficWatchConfigurationCommand = require("commands/maintenance/saveTrafficWatchConfigurationCommand");
-import getAdminLogsMicrosoftStateCommand = require("../../commands/maintenance/getAdminLogsMicrosoftStateCommand");
-import getAdminLogsMicrosoftConfigurationCommand = require("../../commands/maintenance/getAdminLogsMicrosoftConfigurationCommand");
-import enableAdminLogsMicrosoftCommand = require("../../commands/maintenance/enableAdminLogsMicrosoftCommand");
-import disableAdminLogsMicrosoftCommand = require("../../commands/maintenance/disableAdminLogsMicrosoftCommand");
-import saveAdminLogsMicrosoftConfigurationCommand = require("../../commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand");
+import getAdminLogsMicrosoftStateCommand = require("commands/maintenance/getAdminLogsMicrosoftStateCommand");
+import getAdminLogsMicrosoftConfigurationCommand = require("commands/maintenance/getAdminLogsMicrosoftConfigurationCommand");
+import enableAdminLogsMicrosoftCommand = require("commands/maintenance/enableAdminLogsMicrosoftCommand");
+import disableAdminLogsMicrosoftCommand = require("commands/maintenance/disableAdminLogsMicrosoftCommand");
+import saveAdminLogsMicrosoftConfigurationCommand = require("commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand");
 import configureMicrosoftLogsDialog = require("./configureMicrosoftLogsDialog");
 
 class heightCalculator {

--- a/src/Raven.Studio/typescript/viewmodels/manage/configureMicrosoftLogsDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/configureMicrosoftLogsDialog.ts
@@ -1,6 +1,6 @@
 import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
 import dialog = require("plugins/dialog");
-import aceEditorBindingHandler = require("../../common/bindingHelpers/aceEditorBindingHandler");
+import aceEditorBindingHandler = require("common/bindingHelpers/aceEditorBindingHandler");
 
 interface ConfigureMicrosoftLogsDialogResult {
     isEnabled: boolean;
@@ -22,15 +22,7 @@ class configureMicrosoftLogsDialog extends dialogViewModelBase {
     }
 
     attached() {
-        
-    }
-
-    deactivate() {
-        super.deactivate(null);
-    }
-
-    compositionComplete() {
-        super.compositionComplete();
+        // empty by design, so that pressing enter does not call save button click
     }
 
     close() {

--- a/src/Raven.Studio/typescript/viewmodels/manage/configureMicrosoftLogsDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/configureMicrosoftLogsDialog.ts
@@ -1,0 +1,50 @@
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import dialog = require("plugins/dialog");
+import aceEditorBindingHandler = require("../../common/bindingHelpers/aceEditorBindingHandler");
+
+interface ConfigureMicrosoftLogsDialogResult {
+    isEnabled: boolean;
+    configuration: string;
+}
+
+class configureMicrosoftLogsDialog extends dialogViewModelBase {
+    
+    code = ko.observable<string>("");
+    isEnabled = ko.observable<boolean>(false);
+    
+    constructor(isEnabled:boolean, configuration: string) {
+        super();
+
+        aceEditorBindingHandler.install();
+
+        this.code(configuration);
+        this.isEnabled(isEnabled);
+    }
+
+    attached() {
+        
+    }
+
+    deactivate() {
+        super.deactivate(null);
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+    }
+
+    close() {
+        dialog.close(this);
+    }
+    
+    save() {
+        const result: ConfigureMicrosoftLogsDialogResult = {
+            isEnabled: this.isEnabled(),
+            configuration: this.isEnabled() ? this.code() : null
+        };
+        
+        dialog.close(this, result);
+    }
+}
+
+export = configureMicrosoftLogsDialog;

--- a/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
@@ -135,6 +135,19 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="row">
+                                <label class="col-md-3 control-label">Microsoft logs:</label>
+                                <div class="col-md-9">
+                                    <div class="form-control-static">
+                                        <button type="button" class="btn btn-default btn-sm close-panel margin-right" data-bind="click: $root.configureMicrosoftLogs">
+                                            <i class="icon-settings"></i>
+                                            <span>Configure</span>
+                                        </button>
+                                        <span class="text-success" data-bind="visible: $root.isMicrosoftLogsEnabled()">Active</span>
+                                        <span class="text-default" data-bind="visible: !$root.isMicrosoftLogsEnabled()">Disabled</span>
+                                    </div>
+                                </div>
+                            </div>
                         </form>
                         <div class="flex-horizontal">
                             <div class="flex-separator"></div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/configureMicrosoftLogsDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/configureMicrosoftLogsDialog.html
@@ -1,0 +1,34 @@
+<div class="modal-dialog modal-lg prevent-close" role="document">
+    <div class="modal-content" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <h4 class="modal-title">Configure Microsoft Logs</h4>
+        </div>
+        <div class="modal-body">
+            
+            <div class="margin-left">
+                <div class="toggle">
+                    <input id="enableAdminLogsMicrosoft" type="checkbox" data-bind="checked: isEnabled">
+                    <label for="enableAdminLogsMicrosoft">Enable Microsoft logs</label>
+                </div>
+            </div>
+
+            <div data-bind="collapse: isEnabled">
+                <pre class="form-control margin-top" data-bind="aceEditor: { code: code, fullScreenNotAllowed: true }" style="height: 250px;">
+                </pre>
+            </div>
+            
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-bind="click: close">
+                Cancel
+            </button>
+            <button type="button" class="btn btn-primary" data-bind="click: save">
+                <i class="icon-save"></i>
+                <span>Save</span>
+            </button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19633/Wire-up-to-Microsoft.Extensions.Logging-to-enable-Kestrel-logs

### Additional description

Added the ability to configure and toggle admin Microsoft logs.

### Type of change

- New feature

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/224015507-4b4949d5-b972-41e8-9792-3672d1b022eb.png)
