### PR TITLE
RavenDB-20025 ShardExecutor must use internal IPs

### DIFF
--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -9,6 +9,7 @@ namespace Raven.Client.ServerWide.Commands
     public class GetDatabaseTopologyCommand : RavenCommand<Topology>
     {
         private readonly Guid? _applicationIdentifier;
+        private readonly bool _usePrivateUrls;
         private readonly string _debugTag;
 
         public GetDatabaseTopologyCommand()
@@ -17,10 +18,11 @@ namespace Raven.Client.ServerWide.Commands
             Timeout = TimeSpan.FromSeconds(15);
         }
 
-        public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier)
+        public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier, bool usePrivateUrls = false)
             : this(debugTag)
         {
             _applicationIdentifier = applicationIdentifier;
+            _usePrivateUrls = usePrivateUrls;
         }
 
         public GetDatabaseTopologyCommand(string debugTag) : this()
@@ -36,6 +38,8 @@ namespace Raven.Client.ServerWide.Commands
                 url += "&" + _debugTag;
             if (_applicationIdentifier != null)
                 url += "&applicationIdentifier=" + _applicationIdentifier;
+            if (_usePrivateUrls)
+                url += "&private=true";
 
             if (node.Url.IndexOf(".fiddler", StringComparison.OrdinalIgnoreCase) != -1)
             {

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -18,11 +18,16 @@ namespace Raven.Client.ServerWide.Commands
             Timeout = TimeSpan.FromSeconds(15);
         }
 
-        public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier, bool usePrivateUrls = false)
+        internal GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier, bool usePrivateUrls)
+            : this(debugTag, applicationIdentifier)
+        {
+            _usePrivateUrls = usePrivateUrls;
+        }
+
+        public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier)
             : this(debugTag)
         {
             _applicationIdentifier = applicationIdentifier;
-            _usePrivateUrls = usePrivateUrls;
         }
 
         public GetDatabaseTopologyCommand(string debugTag) : this()

--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -25,6 +25,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("ServerUrl.Tcp", ConfigurationEntryScope.ServerWideOnly)]
         public string[] TcpServerUrls { get; set; }
 
+        [Description("When provided those URLs are used for Server->Server communications to this node. This is meant to allow inter-cluster communication via private IPs, while external clients will use external IPs.  The provided URL can be raw IPs or utilize hostnames.")]
+        [DefaultValue(null)]
+        [ConfigurationEntry("ServerUrl.Cluster", ConfigurationEntryScope.ServerWideOnly)]
+        public UriSetting? ClusterServerUrl { get; set; }
+
         [Description("When provided those URLs are used for Server->Server TCP communications to this node. The list is used in the order provided, and the first URL that can be successfully connected to will be used. This is meant to allow inter-cluster communication via private IPs, while external clients will use external IPs.  The provided URLs can be raw IPs or utilize hostnames.")]
         [DefaultValue(null)]
         [ConfigurationEntry("PublicServerUrl.Tcp.Cluster", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -216,7 +216,9 @@ public abstract class AbstractExecutor : IDisposable
         {
             Dispose();
         }
+#pragma warning disable CS0168
         catch (Exception e)
+#pragma warning restore CS0168
         {
 #if DEBUG
             Console.WriteLine($"Finalizer of {GetType()} got an exception:{Environment.NewLine}" + e);

--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -190,6 +190,21 @@ public abstract class AbstractExecutor : IDisposable
         }
     }
 
+    protected static void SafelyDisposeExecutors(IEnumerable<RequestExecutor> executors)
+    {
+        foreach (var disposable in executors)
+        {
+            try
+            {
+                disposable.Dispose();
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+
     public abstract void Dispose();
 }
 

--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -205,7 +205,25 @@ public abstract class AbstractExecutor : IDisposable
         }
     }
 
-    public abstract void Dispose();
+    public virtual void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    ~AbstractExecutor()
+    {
+        try
+        {
+            Dispose();
+        }
+        catch (Exception e)
+        {
+#if DEBUG
+            Console.WriteLine($"Finalizer of {GetType()} got an exception:{Environment.NewLine}" + e);
+#endif
+            // nothing we can do here
+        }
+    }
 }
 
 public interface IExecutionMode

--- a/src/Raven.Server/Documents/Sharding/Executors/AllOrchestratorNodesExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AllOrchestratorNodesExecutor.cs
@@ -91,6 +91,7 @@ public class AllOrchestratorNodesExecutor : AbstractExecutor
 
     public override void Dispose()
     {
+        base.Dispose();
         SafelyDisposeExecutors(_current.Values);
         _current.Clear();
     }

--- a/src/Raven.Server/Documents/Sharding/Executors/AllOrchestratorNodesExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AllOrchestratorNodesExecutor.cs
@@ -55,13 +55,6 @@ public class AllOrchestratorNodesExecutor : AbstractExecutor
         var oldCurrent = _current;
         var newCurrent = new Dictionary<string, RequestExecutor>(StringComparer.OrdinalIgnoreCase);
 
-        PublishedUrls published;
-        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-        using (context.OpenReadTransaction())
-        {
-            published = PublishedUrls.Read(context);
-        }
-
         foreach (var node in clusterTopology.AllNodes)
         {
             var tag = node.Key;
@@ -69,7 +62,7 @@ public class AllOrchestratorNodesExecutor : AbstractExecutor
             if (orchestrator.AllNodes.Contains(tag, StringComparer.OrdinalIgnoreCase) == false)
                 continue;
 
-            var url = published.SelectUrl(tag, clusterTopology);
+            var url = _store.PublishedServerUrls.SelectUrl(tag, clusterTopology);
 
             newCurrent[tag] = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, _record.DatabaseName, _store.Server.Certificate.Certificate,
                 ServerStore.Sharding.DocumentConventionsForOrchestrator);

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Sharding.Executors
         private Dictionary<int, RequestExecutor> _requestExecutors;
         private readonly int[] _fullRange;
 
-        private readonly DocumentConventions _conventions;
+        public readonly DocumentConventions Conventions;
 
         public ShardExecutor(ServerStore store, [NotNull] DatabaseRecord databaseRecord, [NotNull] string databaseName) : base(store)
         {
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Sharding.Executors
 
             _fullRange = databaseRecord.Sharding.Shards.Keys.ToArray();
 
-            _conventions = store.Sharding.DocumentConventionsForShard;
+            Conventions = store.Sharding.DocumentConventionsForShard;
 
             _requestExecutors = CreateExecutors();
         }
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents.Sharding.Executors
                     urls,
                     ShardHelper.ToShardName(_databaseName, shardNumber),
                     ServerStore.Server.Certificate.Certificate,
-                    _conventions);
+                    Conventions);
             }
 
             return requestExecutors;

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -116,6 +116,10 @@ namespace Raven.Server.Documents.Sharding.Executors
             return requestExecutors;
         }
 
-        public override void Dispose() => SafelyDisposeExecutors(_requestExecutors.Values);
+        public override void Dispose()
+        {
+            base.Dispose();
+            SafelyDisposeExecutors(_requestExecutors.Values);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -92,19 +92,17 @@ namespace Raven.Server.Documents.Sharding.Executors
         {
             var requestExecutors = new Dictionary<int, RequestExecutor>(_databaseRecord.Sharding.Shards.Count);
             
-            PublishedUrls published;
             ClusterTopology clusterTopology;
             
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 clusterTopology = ServerStore.GetClusterTopology(context);
-                published = PublishedUrls.Read(context);
             }
 
             foreach ((int shardNumber, var topology) in _databaseRecord.Sharding.Shards)
             {
-                var urls = topology.AllNodes.Select(tag => published.SelectUrl(tag, clusterTopology)).ToArray();
+                var urls = topology.AllNodes.Select(tag => ServerStore.PublishedUrls.SelectUrl(tag, clusterTopology)).ToArray();
 
                 requestExecutors[shardNumber] = RequestExecutor.CreateForShard(
                     urls,

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -102,7 +102,7 @@ namespace Raven.Server.Documents.Sharding.Executors
 
             foreach ((int shardNumber, var topology) in _databaseRecord.Sharding.Shards)
             {
-                var urls = topology.AllNodes.Select(tag => ServerStore.PublishedUrls.SelectUrl(tag, clusterTopology)).ToArray();
+                var urls = topology.AllNodes.Select(tag => ServerStore.PublishedServerUrls.SelectUrl(tag, clusterTopology)).ToArray();
 
                 requestExecutors[shardNumber] = RequestExecutor.CreateForShard(
                     urls,

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -113,18 +113,12 @@ namespace Raven.Server.Documents.Sharding
 
             if (DictionaryExtensions.KeysEqual(record.Sharding.Shards, _record.Sharding.Shards) == false)
             {
-                using (var se = ShardExecutor)
-                {
-                    ShardExecutor = new ShardExecutor(ServerStore, record, record.DatabaseName);
-                }
+                ShardExecutor = new ShardExecutor(ServerStore, record, record.DatabaseName);
             }
 
             if (EnumerableExtension.ElementsEqual(record.Sharding.Orchestrator.Topology.Members, _record.Sharding.Orchestrator.Topology.Members) == false)
             {
-                using (var ne = AllOrchestratorNodesExecutor)
-                {
-                    AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, record);
-                }
+                AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, record);
             }
 
             Indexes.Update(record, index);
@@ -136,15 +130,9 @@ namespace Raven.Server.Documents.Sharding
 
         private void OnUrlChange(DatabaseRecord record, long index)
         {
-            using (var se = ShardExecutor)
-            {
-                ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
-            }
+            ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
 
-            using (var ne = AllOrchestratorNodesExecutor)
-            {
-                AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
-            }
+            AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
         }
 
         public void UpdateUrls(long index) => DatabasesLandlord.NotifyFeaturesAboutStateChange(_record, index, _urlUpdateStateChange);
@@ -197,9 +185,15 @@ namespace Raven.Server.Documents.Sharding
 
             exceptionAggregator.Execute(() => Replication?.Dispose());
 
+
+            /*
+            we explicitly do not dispose the executors here to avoid possible memory invalidation
+            and we rely on the GC to dispose them
+
             exceptionAggregator.Execute(() => ShardExecutor?.Dispose());
 
             exceptionAggregator.Execute(() => AllOrchestratorNodesExecutor?.Dispose());
+            */
 
             exceptionAggregator.Execute(() => SubscriptionsStorage.Dispose());
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -188,15 +188,9 @@ namespace Raven.Server.Documents.Sharding
 
             exceptionAggregator.Execute(() => Replication?.Dispose());
 
-
-            /*
-            we explicitly do not dispose the executors here to avoid possible memory invalidation
-            and we rely on the GC to dispose them via the finalizer
-
             exceptionAggregator.Execute(() => ShardExecutor?.Dispose());
 
             exceptionAggregator.Execute(() => AllOrchestratorNodesExecutor?.Dispose());
-            */
 
             exceptionAggregator.Execute(() => SubscriptionsStorage.Dispose());
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -130,6 +130,9 @@ namespace Raven.Server.Documents.Sharding
 
         private void OnUrlChange(DatabaseRecord record, long index)
         {
+            // we explicitly do not dispose the old executors here to avoid possible memory invalidation and since this is expected to be rare.
+            // So we rely on the GC to dispose them via the finalizer
+            
             ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
 
             AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
@@ -188,7 +191,7 @@ namespace Raven.Server.Documents.Sharding
 
             /*
             we explicitly do not dispose the executors here to avoid possible memory invalidation
-            and we rely on the GC to dispose them
+            and we rely on the GC to dispose them via the finalizer
 
             exceptionAggregator.Execute(() => ShardExecutor?.Dispose());
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents.Sharding.NotificationCenter;
 using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;
@@ -114,6 +115,19 @@ namespace Raven.Server.Documents.Sharding
             Interlocked.Exchange(ref _record, record);
 
             RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
+        }
+
+        public void RefreshExecutors(long index)
+        {
+            using (var se = ShardExecutor)
+            {
+                ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
+            }
+
+            using (var ne = AllOrchestratorNodesExecutor)
+            {
+                AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
+            }
         }
 
         public string DatabaseName => _record.DatabaseName;

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -169,6 +169,7 @@ namespace Raven.Server.ServerWide
             [nameof(SourceMigrationCleanupCommand)] = 60_000,
             [nameof(PutShardedSubscriptionCommand)] = 60_000,
             [nameof(CreateNewShardCommand)] = 60_000,
+            [nameof(UpdatePrivateUrlsCommand)] = 60_000,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -169,7 +169,7 @@ namespace Raven.Server.ServerWide
             [nameof(SourceMigrationCleanupCommand)] = 60_000,
             [nameof(PutShardedSubscriptionCommand)] = 60_000,
             [nameof(CreateNewShardCommand)] = 60_000,
-            [nameof(UpdatePrivateUrlsCommand)] = 60_000,
+            [nameof(UpdateServerPublishedUrlsCommand)] = 60_000,
         };
 
         public static bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -640,6 +640,12 @@ namespace Raven.Server.ServerWide
                         }
                         break;
 
+                    case nameof(UpdatePrivateUrlsCommand):
+                        var command = (UpdatePrivateUrlsCommand)CommandBase.CreateFrom(cmd);
+                        command.Update(context, index);
+                        NotifyValueChanged(context, type, index);
+                        break;
+
                     default:
                         var massage = $"The command '{type}' is unknown and cannot be executed on server with version '{ServerVersion.FullVersion}'.{Environment.NewLine}" +
                                       "Updating this node version to match the rest should resolve this issue.";
@@ -2162,7 +2168,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public void DeleteItem<TTransaction>(TransactionOperationContext<TTransaction> context, string name)
+        public static void DeleteItem<TTransaction>(TransactionOperationContext<TTransaction> context, string name)
             where TTransaction : RavenTransaction
         {
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -640,8 +640,8 @@ namespace Raven.Server.ServerWide
                         }
                         break;
 
-                    case nameof(UpdatePrivateUrlsCommand):
-                        var command = (UpdatePrivateUrlsCommand)CommandBase.CreateFrom(cmd);
+                    case nameof(UpdateServerPublishedUrlsCommand):
+                        var command = (UpdateServerPublishedUrlsCommand)CommandBase.CreateFrom(cmd);
                         command.Update(context, index);
                         NotifyValueChanged(context, type, index);
                         break;

--- a/src/Raven.Server/ServerWide/Commands/UpdatePrivateUrlsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdatePrivateUrlsCommand.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Http;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Voron;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public class UpdatePrivateUrlsCommand : CommandBase
+    {
+        public const string ClusterUrlsKey = "cluster/urls";
+        
+        public string NodeTag;
+        public string PublicUrl;
+        public string PrivateUrl;
+
+        public UpdatePrivateUrlsCommand()
+        {
+        }
+
+        public UpdatePrivateUrlsCommand(string nodeTag, string publicUrl, string privateUrl, string raftId) : base(raftId)
+        {
+            NodeTag = nodeTag;
+            PublicUrl = publicUrl;
+            PrivateUrl = privateUrl;
+        }
+
+        public void Update(ClusterOperationContext context, long index)
+        {
+            var published = PublishedUrls.Read(context);
+            var urls = published.Urls;
+
+            if (urls.TryGetValue(NodeTag, out var value))
+            {
+                if (value.Index >= index)
+                    return; // try to update to old value
+
+                if (value.PrivateUrl == PrivateUrl && value.PublicUrl == PublicUrl)
+                    return; // same value
+            }
+
+            value ??= new UrlInfo();
+            value.PrivateUrl = PrivateUrl;
+            value.PublicUrl = PublicUrl;
+            value.Index = index;
+
+            urls[NodeTag] = value;
+
+            using (Slice.From(context.Allocator, ClusterUrlsKey, out var key))
+            using (var updated = context.ReadObject(published.ToJson(), "update-cluster-urls"))
+            {
+                ClusterStateMachine.UpdateValueForItemsTable(context, index, key, key, updated);
+            }
+        }
+
+        public override DynamicJsonValue ToJson(JsonOperationContext context)
+        {
+            var json = base.ToJson(context);
+            json[nameof(PublicUrl)] = PublicUrl;
+            json[nameof(PrivateUrl)] = PrivateUrl;
+            json[nameof(NodeTag)] = NodeTag;
+            return json;
+        }
+    }
+
+    public class PublishedUrls : IDynamicJson
+    {
+        private static Func<BlittableJsonReaderObject, PublishedUrls> _convertor = JsonDeserializationBase.GenerateJsonDeserializationRoutine<PublishedUrls>();
+
+        [JsonDeserializationStringDictionary(StringComparison.InvariantCultureIgnoreCase)]
+        public Dictionary<string, UrlInfo> Urls; // map node tag to private url
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Urls)] = DynamicJsonValue.Convert(Urls)
+            };
+        }
+
+        public static PublishedUrls Read(ClusterOperationContext context)
+        {
+            using (Slice.From(context.Allocator, UpdatePrivateUrlsCommand.ClusterUrlsKey, out var key))
+            {
+                var current = ClusterStateMachine.ReadInternal(context, out _, key);
+                if (current == null)
+                    return new PublishedUrls { Urls = new Dictionary<string, UrlInfo>(StringComparer.InvariantCultureIgnoreCase) };
+
+                return _convertor(current);
+            }
+        }
+
+        public static void Clear(ClusterOperationContext context) => ClusterStateMachine.DeleteItem(context, UpdatePrivateUrlsCommand.ClusterUrlsKey);
+
+        public string SelectUrl(string requestedTag, ClusterTopology clusterTopology)
+        {
+            if (Urls.TryGetValue(requestedTag, out var info))
+                return info.PrivateUrl;
+
+            return clusterTopology.GetUrlFromTag(requestedTag);
+        }
+    }
+
+    public class UrlInfo : IDynamicJson
+    {
+        public string PublicUrl;
+        public string PrivateUrl;
+        public long Index;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(PublicUrl)] = PublicUrl,
+                [nameof(PrivateUrl)] = PrivateUrl,
+                [nameof(Index)] = Index,
+            };
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -270,7 +270,8 @@ namespace Raven.Server.ServerWide
             [nameof(StartBucketMigrationCommand)] = GenerateJsonDeserializationRoutine<StartBucketMigrationCommand>(),
             [nameof(SourceMigrationSendCompletedCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationSendCompletedCommand>(),
             [nameof(DestinationMigrationConfirmCommand)] = GenerateJsonDeserializationRoutine<DestinationMigrationConfirmCommand>(),
-            [nameof(SourceMigrationCleanupCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationCleanupCommand>()
+            [nameof(SourceMigrationCleanupCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationCleanupCommand>(),
+            [nameof(UpdatePrivateUrlsCommand)] = GenerateJsonDeserializationRoutine<UpdatePrivateUrlsCommand>()
         };
     }
 }

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.ServerWide
             [nameof(SourceMigrationSendCompletedCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationSendCompletedCommand>(),
             [nameof(DestinationMigrationConfirmCommand)] = GenerateJsonDeserializationRoutine<DestinationMigrationConfirmCommand>(),
             [nameof(SourceMigrationCleanupCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationCleanupCommand>(),
-            [nameof(UpdatePrivateUrlsCommand)] = GenerateJsonDeserializationRoutine<UpdatePrivateUrlsCommand>()
+            [nameof(UpdateServerPublishedUrlsCommand)] = GenerateJsonDeserializationRoutine<UpdateServerPublishedUrlsCommand>()
         };
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1276,7 +1276,7 @@ namespace Raven.Server.ServerWide
                         if (orchestrator.IsCompletedSuccessfully == false)
                             continue;
 
-                        orchestrator.Result.RefreshExecutors(index);
+                        orchestrator.Result.UpdateUrls(index);
                     }
                     
                     break;

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -144,9 +144,13 @@ namespace Raven.Server.ServerWide
 
         private bool ShardingCustomValidationCallback(HttpRequestMessage message, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
         {
+            // We only care about the certificate that the orchestrator going to use and the shard is going to respond
+            // In most cases is simply going to be the same certificate
+
             if (cert.Thumbprint == _serverStore.Server.Certificate.Certificate.Thumbprint)
                 return true;
 
+            // Here we handle the case of the server certificate replacement 
             if (cert.GetPublicKeyPinningHash() == _serverStore.Server.Certificate.Certificate.GetPublicKeyPinningHash())
                 return true;
 

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -803,7 +803,7 @@ namespace Raven.Server.Web.Authentication
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
-                ServerStore.Cluster.DeleteItem(context, CertificateReplacement.CertificateReplacementDoc);
+                ClusterStateMachine.DeleteItem(context, CertificateReplacement.CertificateReplacementDoc);
                 tx.Commit();
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20025

### Additional description

Shard executor was using the public urls to access the shards, which is slow & expensive (in the cloud) so we need a way to access the private IPs of the shards.
We need to expose the private IP of each node, so the orchestrator can be aware of the private IPs of the shards.

The idea is that each node upon start-up will register his private IP in the cluster (since it can be changed after restart)  
We also add a new configuration option `ServerUrl.Cluster` which is the private IP that the user must fill.

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Simple case was verified by manual testing, but require more manual testing on the cloud

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO).

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- No UI work is needed
