### PR TITLE
RavenDB-19843 Removed unnecessary assert in test and updated configuration option description

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -458,7 +458,7 @@ namespace Raven.Server.Config.Categories
             ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex { get; set; }
         
-        [Description("Sort by ticks when field contains dates. Null dates are returned at the end with this option enabled.")]
+        [Description("Sort by ticks when field contains dates. When sorting in descending order, null dates are returned at the end with this option enabled.")]
         [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]

--- a/test/SlowTests/Issues/RavenDB-19843.cs
+++ b/test/SlowTests/Issues/RavenDB-19843.cs
@@ -19,9 +19,6 @@ public class RavenDB_19843 : RavenTestBase
     [InlineData(false)]
     public void CheckIfNullDatesAreReturnedLastWithConfigOptionEnabled(bool configEnabled)
     {
-        //guardian to set different config for 6_0
-        Assert.True(Raven.Server.Documents.Indexes.IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion < 60_000);
-
         using (var store = GetDocumentStore(new Options
                {
                    ModifyDatabaseRecord = r =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19843/Lucene-order-by-ticks-when-field-contains-dates.

### Additional description

Removed unnecessary assert in test and updated configuration option description

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
