### PR TITLE
RavenDB-20014 Throw when projection is done twice via (Async)DocumentQuery

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1992,7 +1992,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                             _insideSelect--;
                             
                             if (initialSelect == 0 && initialCount > 0 && FieldsToFetch.Count != initialCount)
-                                throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
+                                QueryData.ThrowProjectionIsAlreadyDone();
                         }
                         break;
                     }
@@ -2536,7 +2536,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         private void VisitSelect(Expression operand)
         {
             if (FieldsToFetch is {Count: > 0})
-                ThrowProjectionIsAlreadyDone();
+                QueryData.ThrowProjectionIsAlreadyDone();
 
             var lambdaExpression = operand as LambdaExpression;
             var body = lambdaExpression != null ? lambdaExpression.Body : operand;
@@ -2577,11 +2577,6 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
         }
         
-        private static void ThrowProjectionIsAlreadyDone()
-        {
-            throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
-        }
-
         private void SelectCall(Expression body, LambdaExpression lambdaExpression)
         {
             FieldsToFetch?.Clear();

--- a/src/Raven.Client/Documents/Queries/QueryData.cs
+++ b/src/Raven.Client/Documents/Queries/QueryData.cs
@@ -44,5 +44,10 @@ namespace Raven.Client.Documents.Queries
         {
             return new QueryData(new[] { func }, Array.Empty<string>(), alias, isCustomFunction: true);
         }
+        
+        internal static void ThrowProjectionIsAlreadyDone()
+        {
+            throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -569,6 +569,9 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
+            if (IsProjectInto || FieldsToFetchToken is {Projections.Length: > 0})
+                QueryData.ThrowProjectionIsAlreadyDone();
+            
             var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -39,6 +39,9 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
+            if (IsProjectInto || FieldsToFetchToken is {Projections.Length: > 0})
+                QueryData.ThrowProjectionIsAlreadyDone();
+            
             var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => Conventions.GetConvertedPropertyNameFor(x)).ToArray();
             var fields = propertyInfos.Select(p => Conventions.GetConvertedPropertyNameFor(p)).ToArray();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20014

### Additional description

Another PR from the multi-projection saga. This PR will block this behavior in `DocumentQuery`.

### Type of change

- New feature

### How risky is the change?

-
- Moderate 


### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
