### PR TITLE
RavenDB-19482 Add alias to query when using ProjectInto with reserved keyword

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3928,8 +3928,16 @@ The recommended method is to use full text search (mark the field as Analyzed an
             var i = 0;
             foreach (var fieldToFetch in FieldsToFetch)
             {
-                fields[i] = fieldToFetch.Name;
-                projections[i] = fieldToFetch.Alias ?? fieldToFetch.Name;
+                var fieldName = fieldToFetch.Name;
+                var fieldAlias = fieldToFetch.Alias;
+
+                if (_isProjectInto)
+                {
+                    HandleKeywordsIfNeeded(ref fieldName, ref fieldAlias);
+                }
+                
+                fields[i] = fieldName;
+                projections[i] = fieldAlias ?? fieldName;
 
                 i++;
             }

--- a/test/SlowTests/Issues/RavenDB-19482.cs
+++ b/test/SlowTests/Issues/RavenDB-19482.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19482 : RavenTestBase
+{
+    public RavenDB_19482(ITestOutputHelper output) : base(output)
+    {
+    }
+    private class MyUser
+    {
+        public string Name { get; set; }
+        public string Order { get; set; }
+    }
+
+    [Fact]
+    public void Can_Project_Into()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string name = "Grisha";
+            const string order = "orders/1";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new MyUser
+                {
+                    Name = name,
+                    Order = order
+                });
+                session.SaveChanges();
+            }
+            
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<MyUser>().ProjectInto<MyUser>();
+                
+                var result = query.ToList();
+
+                Assert.Equal(name, result[0].Name);
+                Assert.Equal(order, result[0].Order);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19482/Projection-with-reserved-keywords-doesnt-work

### Additional description

We want to add alias to query when using ProjectInto<Type>(), and Type has property name that's a reserved keyword (e.g. Order)

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
