### PR TITLE
RavenDB-19241 - Sharding - Handle writes to the wrong shard - call directly on startup and after resharding

### DIFF
--- a/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
@@ -34,11 +34,5 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Sharding.OrchestratorTimeoutInMin", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting OrchestratorTimeout { get; set; }
-
-        [DefaultValue(10 * 60)]
-        [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Sharding.PeriodicDocumentsMigrationIntervalInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        [Description("Time (in seconds) between periodic documents migration.")]
-        public TimeSetting PeriodicDocumentsMigrationInterval { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -376,7 +376,6 @@ namespace Raven.Server.Documents
 
                 OnDatabaseRecordChanged(record);
                 InitializeCompareExchangeStorage();
-                InitializeAndStartDocumentsMigration();
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
@@ -389,6 +388,7 @@ namespace Raven.Server.Documents
                 EtlLoader.Initialize(record);
 
                 TombstoneCleaner.Start();
+                InitializeAndStartDocumentsMigration();
 
                 try
                 {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1040,7 +1040,7 @@ namespace Raven.Server.Documents
             exceptionAggregator.ThrowIfNeeded();
         }
 
-        protected virtual void DisposeBackgroundWorkers(ExceptionAggregator exceptionAggregator)
+        private void DisposeBackgroundWorkers(ExceptionAggregator exceptionAggregator)
         {
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing ExpiredDocumentsCleaner");
             exceptionAggregator.Execute(() =>

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -330,7 +330,7 @@ namespace Raven.Server.Documents
             CompareExchangeStorage.Initialize(Name);
         }
 
-        protected virtual void InitializeAndStartPeriodicDocumentsMigrator()
+        protected virtual void InitializeAndStartDocumentsMigration()
         {
         }
 
@@ -376,7 +376,7 @@ namespace Raven.Server.Documents
 
                 OnDatabaseRecordChanged(record);
                 InitializeCompareExchangeStorage();
-                InitializeAndStartPeriodicDocumentsMigrator();
+                InitializeAndStartDocumentsMigration();
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             await ServerStore.EnsureNotPassiveAsync();
 
             var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(Database);
-            await database.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+            await database.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
         }

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -27,6 +27,7 @@ namespace Raven.Server.Documents.Sharding.Background
                 int bucket = -1;
                 int moveToShard = -1;
                 bool found = false;
+                bool monitorTaken = false;
                 try
                 {
                     _cts.Token.ThrowIfCancellationRequested();
@@ -34,6 +35,7 @@ namespace Raven.Server.Documents.Sharding.Background
                     if (Monitor.TryEnter(this, 250) == false)
                         return;
 
+                    monitorTaken = true;
                     if (_database.ServerStore.Sharding.HasActiveMigrations(_database.ShardedDatabaseName))
                         return;
 
@@ -72,7 +74,8 @@ namespace Raven.Server.Documents.Sharding.Background
                 }
                 finally
                 {
-                    Monitor.Exit(this);
+                    if (monitorTaken)
+                        Monitor.Exit(this);
                 }
 
                 if (found)

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Sharding.Background
                 {
                     _token.ThrowIfCancellationRequested();
 
-                    Monitor.TryEnter(this, 250, ref monitorTaken);
+                    Monitor.TryEnter(this, 0, ref monitorTaken);
                     if (monitorTaken == false)
                         return;
 
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Sharding.Background
 
                             foreach (var bucketStats in bucketStatistics)
                             {
-                                if (bucketStats.NumberOfDocuments <= 0)
+                                if (bucketStats.NumberOfDocuments == 0)
                                     continue;
 
                                 bucket = bucketStats.Bucket;
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Sharding.Background
             }
         }
 
-        private async ValueTask MoveDocumentsToShardAsync(int bucket, int moveToShard)
+        private async Task MoveDocumentsToShardAsync(int bucket, int moveToShard)
         {
             var cmd = new StartBucketMigrationCommand(bucket, _database.ShardNumber, moveToShard, _database.ShardedDatabaseName,
                 $"{Guid.NewGuid()}/{bucket}");
@@ -101,10 +101,6 @@ namespace Raven.Server.Documents.Sharding.Background
             await _database.ServerStore.SendToLeaderAsync(cmd);
         }
 
-        public void Dispose()
-        {
-            Monitor.Enter(this);
-            Monitor.Exit(this);
-        }
+        public void Dispose() => Monitor.Enter(this);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Server.ServerWide.Commands.Sharding;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Sharding.Background
 {
@@ -21,22 +22,21 @@ namespace Raven.Server.Documents.Sharding.Background
 
         internal async Task ExecuteMoveDocumentsAsync()
         {
-            _cts.Token.ThrowIfCancellationRequested();
-
-            if (Monitor.TryEnter(this, 250) == false)
-                return;
-
-            if (_database.ServerStore.Sharding.HasActiveMigrations(_database.ShardedDatabaseName))
-                return;
-
             try
             {
                 int bucket = -1;
                 int moveToShard = -1;
                 bool found = false;
-
                 try
                 {
+                    _cts.Token.ThrowIfCancellationRequested();
+
+                    if (Monitor.TryEnter(this, 250) == false)
+                        return;
+
+                    if (_database.ServerStore.Sharding.HasActiveMigrations(_database.ShardedDatabaseName))
+                        return;
+
                     using (_database.ShardedDocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (context.OpenReadTransaction())
                     {

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Sharding.Background
 
                             foreach (var bucketStats in bucketStatistics)
                             {
-                                if (bucketStats.NumberOfDocuments == 0)
+                                if (bucketStats.NumberOfDocuments <= 0)
                                     continue;
 
                                 bucket = bucketStats.Bucket;

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -32,10 +32,10 @@ namespace Raven.Server.Documents.Sharding.Background
                 {
                     _cts.Token.ThrowIfCancellationRequested();
 
-                    if (Monitor.TryEnter(this, 250) == false)
+                    Monitor.TryEnter(this, 250, ref monitorTaken);
+                    if (monitorTaken == false)
                         return;
 
-                    monitorTaken = true;
                     if (_database.ServerStore.Sharding.HasActiveMigrations(_database.ShardedDatabaseName))
                         return;
 

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -76,6 +76,11 @@ namespace Raven.Server.Documents.Sharding
             _mergedChangeVectors.Clear();
         }
 
+        public void ClearBucketStatsOnFailure(IPagerLevelTransactionState _)
+        {
+            _values.Clear();
+            _mergedChangeVectors.Clear();
+        }
 
         private ByteStringContext.InternalScope MergeStats(Transaction tx, Tree tree, Documents.BucketStats inMemoryStats, Slice keySlice, int bucket, out Documents.BucketStats stats, out Slice mergedCvSlice)
         {

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -141,8 +141,9 @@ public class ShardedDocumentDatabase : DocumentDatabase
                 // cleanup values
                 t = DeleteBucketAsync(process.Bucket, process.MigrationIndex, process.LastSourceChangeVector);
 
-                t.ContinueWith(_ =>
+                t?.ContinueWith(_ =>
                 {
+                    t.RunSynchronously();
                     _ = DocumentsMigrator.ExecuteMoveDocumentsAsync();
                 });
             }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -49,7 +49,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
     protected override void InitializeAndStartDocumentsMigration()
     {
         DocumentsMigrator = new ShardedDocumentsMigrator(this);
-        Task.Run(DocumentsMigrator.ExecuteMoveDocumentsAsync);
+        _ = DocumentsMigrator.ExecuteMoveDocumentsAsync();
     }
 
     protected override DocumentsStorage CreateDocumentsStorage(Action<string> addToInitLog)
@@ -147,7 +147,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
             if (t != null)
             {
                 _confirmations[index] = t;
-                t.ContinueWith(__ => _confirmations.TryRemove(process.MigrationIndex, out _));
+                t.ContinueWith(__ => _confirmations.TryRemove(index, out _));
             }
         }
     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -168,18 +168,6 @@ public class ShardedDocumentDatabase : DocumentDatabase
         return batchCollector;
     }
 
-    protected override void DisposeBackgroundWorkers(ExceptionAggregator exceptionAggregator)
-    {
-        base.DisposeBackgroundWorkers(exceptionAggregator);
-
-        ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing ShardedPeriodicDocumentsMigrator");
-        exceptionAggregator.Execute(() =>
-        {
-            DocumentsMigrator?.Dispose();
-        });
-        ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposed ShardedPeriodicDocumentsMigrator");
-    }
-
     protected class ShardedClusterTransactionBatchCollector : ClusterTransactionBatchCollector
     {
         private readonly ShardedDocumentDatabase _database;

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -130,12 +130,10 @@ public class ShardedDocumentDatabase : DocumentDatabase
 
             if (process.SourceShard == ShardNumber && process.Status == MigrationStatus.OwnershipTransferred)
             {
-                bool alreadyExist = false;
                 index = (long)Hashing.XXHash64.CalculateRaw(process.LastSourceChangeVector ?? $"No docs for {process.MigrationIndex}");
 
                 if (_confirmations.TryGetValue(index, out t))
                 {
-                    alreadyExist = true;
                     if (t.IsCompleted == false)
                         continue;
                 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -143,13 +143,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
                 // cleanup values
                 t = DeleteBucketAsync(process.Bucket, process.MigrationIndex, process.LastSourceChangeVector);
 
-                if (alreadyExist == false)
-                {
-                    t.ContinueWith(_ =>
-                    {
-                        _ = DocumentsMigrator.ExecuteMoveDocumentsAsync();
-                    });
-                }
+                t.ContinueWith(__ => DocumentsMigrator.ExecuteMoveDocumentsAsync());
             }
 
             if (t != null)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -30,6 +30,8 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     private readonly ShardedDocumentDatabase _documentDatabase;
 
+    public Action<IPagerLevelTransactionState> OnFailure { get; protected set; }
+
     static ShardedDocumentsStorage()
     {
         using (StorageEnvironment.GetStaticContext(out var ctx))
@@ -44,6 +46,7 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
         _documentDatabase = documentDatabase;
         _bucketStats = new BucketStatsHolder();
 
+        OnFailure += _bucketStats.ClearBucketStatsOnFailure;
         OnBeforeCommit += _bucketStats.UpdateBucketStatsTreeBeforeCommit;
     }
 

--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -16,7 +16,6 @@ using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
-using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;

--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -26,14 +26,14 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Sharding.BucketMigration
 {
-    public class PeriodicDocumentsMigrationTests : ReplicationTestBase
+    public class DocumentsMigrationTests : ReplicationTestBase
     {
-        public PeriodicDocumentsMigrationTests(ITestOutputHelper output) : base(output)
+        public DocumentsMigrationTests(ITestOutputHelper output) : base(output)
         {
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_SimpleCase()
+        public async Task DocumentsMigratorShouldWork_SimpleCase()
         {
             using (var store = Sharding.GetDocumentStore())
             {
@@ -56,7 +56,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -77,7 +77,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_MultipleWrongBuckets()
+        public async Task DocumentsMigratorShouldWork_MultipleWrongBuckets()
         {
             Server.ServerStore.Sharding.BlockPrefixedSharding = false;
             using var store = Sharding.GetDocumentStore(new Options
@@ -98,7 +98,6 @@ namespace SlowTests.Sharding.BucketMigration
                             Shards = new List<int> { 2 }
                         }
                     };
-                    record.Settings[RavenConfiguration.GetKey(x => x.Sharding.PeriodicDocumentsMigrationInterval)] = 1.ToString();
                 }
             });
 
@@ -131,7 +130,7 @@ namespace SlowTests.Sharding.BucketMigration
                 session.SaveChanges();
             }
 
-            await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+            await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             Assert.True(WaitForValue(() =>
             {
@@ -151,7 +150,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_ClusterCase()
+        public async Task DocumentsMigratorShouldWork_ClusterCase()
         {
             var dbName = GetDatabaseName();
             var (nodes, leader) = await CreateRaftCluster(3);
@@ -187,7 +186,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -208,7 +207,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [RavenFact(RavenTestCategory.Subscriptions | RavenTestCategory.Sharding)]
-        public async Task PeriodicDocumentsMigratorShouldWork_SubscriptionsCase()
+        public async Task DocumentsMigratorShouldWork_SubscriptionsCase()
         {
             using var store = Sharding.GetDocumentStore();
             using (var session = store.OpenSession())
@@ -229,7 +228,7 @@ namespace SlowTests.Sharding.BucketMigration
                 session.SaveChanges();
             }
 
-            await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+            await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             var id = await store.Subscriptions.CreateAsync<User>();
             var users = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -266,7 +265,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_ExternalReplicationShardedAndNonSharded()
+        public async Task DocumentsMigratorShouldWork_ExternalReplicationShardedAndNonSharded()
         {
             using (var source = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -296,7 +295,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -317,7 +316,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded()
+        public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded()
         {
             using (var source = Sharding.GetDocumentStore())
             using (var dest = Sharding.GetDocumentStore())
@@ -347,7 +346,7 @@ namespace SlowTests.Sharding.BucketMigration
                     session.SaveChanges();
                 }
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -368,7 +367,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded2()
+        public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded2()
         {
             using (var source = Sharding.GetDocumentStore())
             using (var dest = Sharding.GetDocumentStore())
@@ -398,7 +397,7 @@ namespace SlowTests.Sharding.BucketMigration
                 await SetupReplicationAsync(dest, source);
                 await EnsureReplicatingAsync(dest, source);
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {
@@ -419,7 +418,7 @@ namespace SlowTests.Sharding.BucketMigration
         }
 
         [Fact]
-        public async Task PeriodicDocumentsMigratorShouldWork_ExternalReplicationFromShardedToShardedWithConflict()
+        public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToShardedWithConflict()
         {
             using (var source = Sharding.GetDocumentStore())
             using (var dest = Sharding.GetDocumentStore())
@@ -470,7 +469,7 @@ namespace SlowTests.Sharding.BucketMigration
                 b1.Mend();
                 b2.Mend();
 
-                await db.PeriodicDocumentsMigrator.ExecuteMoveDocumentsAsync();
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
                 Assert.True(WaitForValue(() =>
                 {

--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -129,10 +129,10 @@ namespace SlowTests.Sharding.BucketMigration
                 session.SaveChanges();
             }
 
-            await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
-
-            Assert.True(WaitForValue(() =>
+            await AssertWaitForValueAsync(async () =>
             {
+                await db.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
                 using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, wrongShard)))
                 {
                     var u2 = session.Load<User>("users/2");
@@ -145,7 +145,7 @@ namespace SlowTests.Sharding.BucketMigration
 
                     return true;
                 }
-            }, true, 30_000, 333));
+            }, true, 30_000, 333);
         }
 
         [Fact]


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19241/Sharding-Handle-writes-to-the-wrong-shard

### Additional description

Fixing PR comments of https://github.com/ravendb/ravendb/pull/15848


### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
