### PR TITLE
RavenDB_19548: edited SelectMemberAccess and TranslateSelectBodyToJs …

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2574,6 +2574,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     fieldToFetch.Alias = null;
                 }
             }
+            if (_declareBuilder != null)
+                AddReturnStatementToOutputFunction(body);
         }
 
         private void AddFromAliasOrRenameArgument(ref string arg)
@@ -3010,6 +3012,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 }
             }
 
+            if (expression is MemberExpression memberExpression)
+                AddJsProjection(memberExpression.Member.Name, memberExpression, sb, false);
+            
             sb.Append(" }");
 
             return sb.ToString();

--- a/test/SlowTests/Issues/RavenDB-19548.cs
+++ b/test/SlowTests/Issues/RavenDB-19548.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.Bugs.Caching.UseCachingInLazyTests;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19548 : RavenTestBase
+    {
+        public RavenDB_19548(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task TestCase()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new TestObj { Name = "Omer", Prop1 = "123456", Prop2 = "12", Birthday = new DateTime(1994, 3, 22) });
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>() select result.Prop1.Length;
+                    Console.WriteLine(asyncDocumentQuery);
+                    Assert.Equal(6, await asyncDocumentQuery.SingleAsync());
+                }
+
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                        let ret = RavenQuery.Raw<int>("result.Prop1.length")
+                        select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+
+                    var i = await asyncDocumentQuery.SingleAsync();
+                    Assert.Equal(6, i);
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                        let ret = RavenQuery.Raw<int>("result.Prop1.length")
+                        let ret2 = RavenQuery.Raw<int>("result.Prop2.length")
+                        let x = ret + ret2
+                        select x;
+
+                    Console.WriteLine(asyncDocumentQuery);
+
+                    var i = await asyncDocumentQuery.SingleAsync();
+                    Assert.Equal(8, i);
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                        let ret = RavenQuery.Raw<string>("result.Name.substr(0,3)")
+                        select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+                    var queryResult = await asyncDocumentQuery.ToListAsync();
+                   
+                    Assert.Equal("Ome", queryResult[0]);
+
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                        let ret = RavenQuery.Raw<DateTime>("new Date(Date.parse(result.Birthday))")
+                        select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+                    var queryResult = await asyncDocumentQuery.ToListAsync();
+
+                    Assert.Equal(new DateTime(1994, 3, 22), queryResult[0].Date);
+
+
+                }
+            }
+        }
+    }
+    class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop1 { get; set; }
+        public string Prop2 { get; set; }
+        public DateTime Birthday { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
…methods to include Raw RavenQuery without 'new' keyword

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19548/When-using-RavenQuery.Raw-without-select-new-...-the-query-dosent-include-the-raw-Raw-content

### Additional description

edited SelectMemberAccess and TranslateSelectBodyToJs methods to include Raw RavenQuery without 'new' keyword

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
