### PR TITLE
RavenDB_19548: edited SelectMemberAccess and TranslateSelectBodyToJs methods to include Raw RavenQuery without 'new' keyword

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2393,6 +2393,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     AddToFieldsToFetch(ToJs(call), "cmpxchg");
                     return;
                 }
+
+                if (IsRawCall(call))
+                {
+                    HandleSelectRaw(call, lambdaExpression);
+                    return;
+                }
             }
 
             var expressionInfo = GetMember(body);
@@ -2574,6 +2580,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     fieldToFetch.Alias = null;
                 }
             }
+
             if (_declareBuilder != null)
                 AddReturnStatementToOutputFunction(body);
         }
@@ -2631,6 +2638,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
             AddToFieldsToFetch(path, alias);
         }
 
+        private void HandleSelectRaw(MethodCallExpression callExpression, LambdaExpression lambdaExpression)
+        {
+            AddFromAlias(lambdaExpression.Parameters[0].Name);
+            _declareBuilder ??= new StringBuilder();
+            AddReturnStatementToOutputFunction(callExpression);
+        }
 
         private string GetSelectPathOrConstantValue(MemberExpression member)
         {
@@ -2964,11 +2977,11 @@ The recommended method is to use full text search (mark the field as Analyzed an
         private string TranslateSelectBodyToJs(Expression expression)
         {
             var sb = new StringBuilder();
-
-            sb.Append("{ ");
-
+          
             if (expression is NewExpression newExpression)
             {
+                sb.Append("{ ");
+
                 for (int index = 0; index < newExpression.Arguments.Count; index++)
                 {
                     var name = GetSelectPath(newExpression.Members[index]);
@@ -2977,7 +2990,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     {
                         if (index > 0)
                             sb.Append(", ");
-                        
+
                         _jsProjectionNames.Add(name);
                         sb.Append(name).Append(" : ").Append(TranslateSelectBodyToJs(newExpression.Arguments[index]));
                     }
@@ -2990,6 +3003,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (expression is MemberInitExpression mie)
             {
+                sb.Append("{ ");
+
                 for (int index = 0; index < mie.Bindings.Count; index++)
                 {
                     var field = mie.Bindings[index] as MemberAssignment;
@@ -3001,22 +3016,26 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     {
                         if (index > 0)
                             sb.Append(", ");
-                        
+
                         _jsProjectionNames.Add(name);
                         sb.Append(name).Append(" : ").Append(TranslateSelectBodyToJs(field.Expression));
                         continue;
                     }
-                   
+
                     AddJsProjection(name, field.Expression, sb, index != 0);
-                    
+
                 }
             }
-            
-            if (expression is MemberExpression memberExpression)
-                AddJsProjection(memberExpression.Member.Name, memberExpression, sb, false);
 
+            if (expression is MemberExpression or MethodCallExpression)
+            { 
+                if (IsRawOrTimeSeriesCall(expression, out string script) == false)
+                    script = ToJs(expression);
+                
+                sb.Append(script);
+                return sb.ToString();
+            }
             sb.Append(" }");
-
             return sb.ToString();
         }
 
@@ -3094,12 +3113,15 @@ The recommended method is to use full text search (mark the field as Analyzed an
         private bool IsRawOrTimeSeriesCall(Expression expression, out string script)
         {
             script = null;
-
             if (!(expression is MethodCallExpression mce))
                 return false;
-
+            
             if (IsRawCall(mce))
             {
+
+                if (typeof(T).IsPrimitive || typeof(T) == typeof(string))
+                    throw new NotSupportedException($"Unsupported parameter type {expression.Type.Name}. Primitive types/string types are not allowed in Raw<T>() method.");
+
                 if (mce.Arguments.Count == 1)
                 {
                     script = (mce.Arguments[0] as ConstantExpression)?.Value.ToString();

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2999,6 +2999,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         AddJsProjection(name, newExpression.Arguments[index], sb, index != 0);
                     }
                 }
+                sb.Append(" }");
             }
 
             if (expression is MemberInitExpression mie)
@@ -3025,6 +3026,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     AddJsProjection(name, field.Expression, sb, index != 0);
 
                 }
+                sb.Append(" }");
             }
 
             if (expression is MemberExpression or MethodCallExpression)
@@ -3033,9 +3035,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     script = ToJs(expression);
                 
                 sb.Append(script);
-                return sb.ToString();
             }
-            sb.Append(" }");
+
             return sb.ToString();
         }
 

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2574,6 +2574,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     fieldToFetch.Alias = null;
                 }
             }
+            if (_declareBuilder != null)
+                AddReturnStatementToOutputFunction(body);
         }
 
         private void AddFromAliasOrRenameArgument(ref string arg)
@@ -3009,6 +3011,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     
                 }
             }
+            
+            if (expression is MemberExpression memberExpression)
+                AddJsProjection(memberExpression.Member.Name, memberExpression, sb, false);
 
             sb.Append(" }");
 

--- a/test/SlowTests/Issues/RavenDB_19548.cs
+++ b/test/SlowTests/Issues/RavenDB_19548.cs
@@ -48,9 +48,13 @@ namespace SlowTests.Issues
                         let ret = RavenQuery.Raw<int>("result.Id.length")
                         select new { userIdLength = ret };
 
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn { userIdLength : ret };\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+                    RavenTestHelper.AssertEqualRespectingNewLines(
+                        @"declare function output(result) {
+	var ret = result.Id.length;
+	return { userIdLength : ret };
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
+
                 }
 
                 /*
@@ -79,9 +83,13 @@ namespace SlowTests.Issues
                         let ret = RavenQuery.Raw<object>("result.Id.length")
                         select new { myval = ret };
 
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn { myval : ret };\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+
+                    RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(result) {
+	var ret = result.Id.length;
+	return { myval : ret };
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
+                    
                 }
 
                 /* should work:
@@ -93,9 +101,11 @@ namespace SlowTests.Issues
                         let ret = RavenQuery.Raw<object>("{ retval : result.Id.length}")
                         select ret;
 
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\tvar ret = { retval : result.Id.length};\r\n\treturn ret;\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+                    RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(result) {
+	var ret = { retval : result.Id.length};
+	return ret;
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
                 }
 
                 /* shouldn't work:
@@ -107,10 +117,12 @@ namespace SlowTests.Issues
                     var asyncDocumentQuery = from result in session.Query<User>()
                         let ret = RavenQuery.Raw<object>("result.Id.length")
                         select ret;
-
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn ret;\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+                    
+                      RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(result) {
+	var ret = result.Id.length;
+	return ret;
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 
                     var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
                     Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",
@@ -124,10 +136,11 @@ namespace SlowTests.Issues
                 {
                     var asyncDocumentQuery = from result in session.Query<User>()
                         select RavenQuery.Raw<object>("{ retval : result.Id.length }");
-
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\treturn { retval : result.Id.length };\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+                    
+                      RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(result) {
+	return { retval : result.Id.length };
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
                 }
 
                 /* shouldn't work:
@@ -139,9 +152,10 @@ namespace SlowTests.Issues
                     var asyncDocumentQuery = from result in session.Query<User>()
                         select RavenQuery.Raw<object>("result.Id.length");
 
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\treturn result.Id.length;\r\n}\r\nfrom 'Users' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
+                      RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(result) {
+	return result.Id.length;
+}
+from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 
                     var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
                     Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",

--- a/test/SlowTests/Issues/RavenDB_19548.cs
+++ b/test/SlowTests/Issues/RavenDB_19548.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
 
                     Action act = () => asyncDocumentQuery.ToString();
                     var exception = Assert.Throws<NotSupportedException>(act);
-                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method without wrapping them as an object.",
+                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method.",
                         exception.InnerException.Message);
                 }
 
@@ -112,6 +112,9 @@ namespace SlowTests.Issues
                         "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn ret;\r\n}\r\nfrom 'Users' as result select output(result)"
                         , asyncDocumentQuery.ToString());
 
+                    var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
+                    Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",
+                        exception.Result.Message);
                 }
 
                 /* should work:
@@ -139,6 +142,10 @@ namespace SlowTests.Issues
                     Assert.Equal(
                         "declare function output(result) {\r\n\treturn result.Id.length;\r\n}\r\nfrom 'Users' as result select output(result)"
                         , asyncDocumentQuery.ToString());
+
+                    var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
+                    Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",
+                        exception.Result.Message);
                 }
 
                 /* shouldn't work:
@@ -152,7 +159,7 @@ namespace SlowTests.Issues
 
                     Action act = () => asyncDocumentQuery.ToString();
                     var exception = Assert.Throws<NotSupportedException>(act);
-                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method without wrapping them as an object.",
+                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method.",
                         exception.InnerException.Message);
                 }
 

--- a/test/SlowTests/Issues/RavenDB_19548.cs
+++ b/test/SlowTests/Issues/RavenDB_19548.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -16,85 +18,159 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task TestCase()
+        public async Task RawRavenQueryProjectionWithoutNewKeyword()
         {
             using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenAsyncSession())
                 {
-                    await session.StoreAsync(new TestObj { Name = "Omer", Prop1 = "123456", Prop2 = "12", Birthday = new DateTime(1994, 3, 22) });
+                    await session.StoreAsync(new User { Name = "Omer", Id = "123456", Age = "28", Birthday = new DateTime(1994, 3, 22) });
                     await session.SaveChangesAsync();
                 }
 
+                /* should work:
+                * simple linq select
+                */
                 using (var session = store.OpenAsyncSession())
                 {
-                    var asyncDocumentQuery = from result in session.Query<TestObj>() select result.Prop1.Length;
-                    Assert.Equal(6, await asyncDocumentQuery.SingleAsync());
-                    Assert.Equal("from 'TestObjs' select Prop1.Length"
+                    var asyncDocumentQuery = from result in session.Query<User>() select result.Id.Length;
+
+                    Assert.Equal("from 'Users' select Id.Length"
                         , asyncDocumentQuery.ToString());
                 }
 
-
+                /* should work:
+                 * primitive type with 'select new'
+                 */
                 using (var session = store.OpenAsyncSession())
                 {
-                    var asyncDocumentQuery = from result in session.Query<TestObj>()
-                                             let ret = RavenQuery.Raw<int>("result.Prop1.length")
-                                             select ret;
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        let ret = RavenQuery.Raw<int>("result.Id.length")
+                        select new { userIdLength = ret };
 
-                    var i = await asyncDocumentQuery.SingleAsync();
-                    Assert.Equal(6, i);
-                    Assert.Equal("declare function output(result) {\r\n\tvar ret = result.Prop1.length;\r\n\treturn { ret : ret };\r\n}\r\nfrom 'TestObjs' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
-
-                }
-
-                using (var session = store.OpenAsyncSession())
-                {
-                    var asyncDocumentQuery = from result in session.Query<TestObj>()
-                                             let ret = RavenQuery.Raw<int>("result.Prop1.length")
-                                             let ret2 = RavenQuery.Raw<int>("result.Prop2.length")
-                                             let x = ret + ret2
-                                             select x;
-
-                    var i = await asyncDocumentQuery.SingleAsync();
-                    Assert.Equal(8, i);
-                    Assert.Equal("declare function output(result) {\r\n\tvar ret = result.Prop1.length;\r\n\tvar ret2 = result.Prop2.length;\r\n\tvar x = ret+ret2;\r\n\treturn { x : x };\r\n}\r\nfrom 'TestObjs' as result select output(result)"
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn { userIdLength : ret };\r\n}\r\nfrom 'Users' as result select output(result)"
                         , asyncDocumentQuery.ToString());
                 }
 
+                /*
+                 * shouldn't work:
+                 * primitive type without 'select new' (just 'select').
+                 * client throws nested exception InvalidOperationException(NotSupportedException)
+                 */
                 using (var session = store.OpenAsyncSession())
                 {
-                    var asyncDocumentQuery = from result in session.Query<TestObj>()
-                                             let ret = RavenQuery.Raw<string>("result.Name.substr(0,3)")
-                                             select ret;
-
-                    var queryResult = await asyncDocumentQuery.ToListAsync();
-                    Assert.Equal("Ome", queryResult[0]);
-                    Assert.Equal("declare function output(result) {\r\n\tvar ret = result.Name.substr(0,3);\r\n\treturn { ret : ret };\r\n}\r\nfrom 'TestObjs' as result select output(result)"
-                        , asyncDocumentQuery.ToString());
-                }
-
-                using (var session = store.OpenAsyncSession())
-                {
-                    var asyncDocumentQuery = from result in session.Query<TestObj>()
-                        let ret = RavenQuery.Raw<DateTime>("new Date(Date.parse(result.Birthday))")
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        let ret = RavenQuery.Raw<int>("result.Id.length")
                         select ret;
 
-                    var queryResult = await asyncDocumentQuery.ToListAsync();
-                    Assert.Equal(new DateTime(1994, 3, 22), queryResult[0].Date);
-                    Assert.Equal(
-                        "declare function output(result) {\r\n\tvar ret = new Date(Date.parse(result.Birthday));\r\n\treturn { ret : ret };\r\n}\r\nfrom 'TestObjs' as result select output(result)",
-                        asyncDocumentQuery.ToString());
+                    Action act = () => asyncDocumentQuery.ToString();
+                    var exception = Assert.Throws<NotSupportedException>(act);
+                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method without wrapping them as an object.",
+                        exception.InnerException.Message);
                 }
+
+                /* should work:
+                 * object type X 'select new'
+                 */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        let ret = RavenQuery.Raw<object>("result.Id.length")
+                        select new { myval = ret };
+
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn { myval : ret };\r\n}\r\nfrom 'Users' as result select output(result)"
+                        , asyncDocumentQuery.ToString());
+                }
+
+                /* should work:
+                 * object type X 'select' with JS object inside Raw() function
+                 */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        let ret = RavenQuery.Raw<object>("{ retval : result.Id.length}")
+                        select ret;
+
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\tvar ret = { retval : result.Id.length};\r\n\treturn ret;\r\n}\r\nfrom 'Users' as result select output(result)"
+                        , asyncDocumentQuery.ToString());
+                }
+
+                /* shouldn't work:
+                 * object type X 'select'  
+                 * server throws InvalidOperationException: "Query returning a single function call result must return an object"
+                 */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        let ret = RavenQuery.Raw<object>("result.Id.length")
+                        select ret;
+
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\tvar ret = result.Id.length;\r\n\treturn ret;\r\n}\r\nfrom 'Users' as result select output(result)"
+                        , asyncDocumentQuery.ToString());
+
+                }
+
+                /* should work:
+                 * object type X 'select function' with JS object inside
+                 */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        select RavenQuery.Raw<object>("{ retval : result.Id.length }");
+
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\treturn { retval : result.Id.length };\r\n}\r\nfrom 'Users' as result select output(result)"
+                        , asyncDocumentQuery.ToString());
+                }
+
+                /* shouldn't work:
+                 * object type X 'select function'
+                 * server throws InvalidOperationException: "Query returning a single function call result must return an object"
+                 */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        select RavenQuery.Raw<object>("result.Id.length");
+
+                    Assert.Equal(
+                        "declare function output(result) {\r\n\treturn result.Id.length;\r\n}\r\nfrom 'Users' as result select output(result)"
+                        , asyncDocumentQuery.ToString());
+                }
+
+                /* shouldn't work:
+                * primitive type X 'select function'
+                * client throws nested exception InvalidOperationException(NotSupportedException)
+                */
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<User>()
+                        select RavenQuery.Raw<int>("result.Id.length");
+
+                    Action act = () => asyncDocumentQuery.ToString();
+                    var exception = Assert.Throws<NotSupportedException>(act);
+                    Assert.Equal("Unsupported parameter type Int32. Primitive types/string types are not allowed in Raw<T>() method without wrapping them as an object.",
+                        exception.InnerException.Message);
+                }
+
+
             }
+
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Age { get; set; }
+            public DateTime Birthday { get; set; }
+            public string Name { get; set; }
         }
     }
-    class TestObj
-    {
-        public string Id { get; set; }
-        public string Prop1 { get; set; }
-        public string Prop2 { get; set; }
-        public DateTime Birthday { get; set; }
-        public string Name { get; set; }
-    }
+
+
 }
+
+

--- a/test/SlowTests/Issues/RavenDB_19548.cs
+++ b/test/SlowTests/Issues/RavenDB_19548.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19548 : RavenTestBase
+    {
+        public RavenDB_19548(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task TestCase()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new TestObj { Name = "Omer", Prop1 = "123456", Prop2 = "12", Birthday = new DateTime(1994, 3, 22) });
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>() select result.Prop1.Length;
+                    Console.WriteLine(asyncDocumentQuery);
+                    Assert.Equal(6, await asyncDocumentQuery.SingleAsync());
+                }
+
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                                             let ret = RavenQuery.Raw<int>("result.Prop1.length")
+                                             select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+
+                    var i = await asyncDocumentQuery.SingleAsync();
+                    Assert.Equal(6, i);
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                                             let ret = RavenQuery.Raw<int>("result.Prop1.length")
+                                             let ret2 = RavenQuery.Raw<int>("result.Prop2.length")
+                                             let x = ret + ret2
+                                             select x;
+
+                    Console.WriteLine(asyncDocumentQuery);
+
+                    var i = await asyncDocumentQuery.SingleAsync();
+                    Assert.Equal(8, i);
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                                             let ret = RavenQuery.Raw<string>("result.Name.substr(0,3)")
+                                             select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+                    var queryResult = await asyncDocumentQuery.ToListAsync();
+
+                    Assert.Equal("Ome", queryResult[0]);
+
+
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var asyncDocumentQuery = from result in session.Query<TestObj>()
+                                             let ret = RavenQuery.Raw<DateTime>("new Date(Date.parse(result.Birthday))")
+                                             select ret;
+
+                    Console.WriteLine(asyncDocumentQuery);
+                    var queryResult = await asyncDocumentQuery.ToListAsync();
+
+                    Assert.Equal(new DateTime(1994, 3, 22), queryResult[0].Date);
+
+
+                }
+            }
+        }
+    }
+    class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop1 { get; set; }
+        public string Prop2 { get; set; }
+        public DateTime Birthday { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
…methods to include Raw RavenQuery without 'new' keyword

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19548/When-using-RavenQuery.Raw-without-select-new-...-the-query-dosent-include-the-raw-Raw-content

### Additional description

edited SelectMemberAccess and TranslateSelectBodyToJs methods to include Raw RavenQuery without 'new' keyword

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
