### PR TITLE
RavenDB-19843 Added sorting by ticks when dates are involved

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -712,6 +712,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         sortOptions = SortField.DOUBLE;
                         fieldName += Constants.Documents.Indexing.Fields.RangeFieldSuffixDouble;
                         break;
+                    case OrderByFieldType.Implicit:
+                        if (index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(fieldName))
+                        {
+                            sortOptions = SortField.LONG;
+                            fieldName += Constants.Documents.Indexing.Fields.TimeFieldSuffix;
+                        }
+                        break;
                 }
 
                 sortArray[sortIndex++] = new SortField(fieldName, sortOptions, field.Ascending == false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19843/Lucene-order-by-ticks-when-field-contains-dates.

### Additional description

It was added to v5.4 here https://github.com/ravendb/ravendb/pull/15654, but probably got lost when merging.


### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured
- Can be reverted by configuration option

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes.
Querying with order by date field

### UI work

- No UI work is needed
