### PR TITLE
RavenDB-19589 Indicate cluster node and shard (if sharded) in exported file names

### DIFF
--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.spec.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.spec.ts
@@ -1,0 +1,64 @@
+﻿import DatabaseUtils from "components/utils/DatabaseUtils";
+
+describe("DatabaseUtils", function () {
+
+    describe("formatNameForFile", function () {
+
+        it("throw when databaseName equal null", () => {
+            
+            expect(() => DatabaseUtils.formatNameForFile(
+                null,
+                {
+                    nodeTag: "A",
+                    shardNumber: 2
+                }
+            )).toThrow(Error("Must specify databaseName"));
+        });
+        
+        it("correct format when not sharded", () => {
+            
+            const result = DatabaseUtils.formatNameForFile(
+                "dbName",
+                null
+            );
+            
+            expect(result).toEqual("dbName")
+        });
+
+        it("correct format when specified location without shardNumber", () => {
+            
+            const result = DatabaseUtils.formatNameForFile(
+                "dbName",
+                {
+                    nodeTag: "C",
+                    shardNumber: null
+                }
+            );
+
+            expect(result).toEqual("dbName_C")
+        });
+
+        it("correct format when specified location with shardNumber", () => {
+
+            const result = DatabaseUtils.formatNameForFile(
+              "dbName",
+              {
+                  nodeTag: "D",
+                  shardNumber: 0
+              }
+            );
+
+            expect(result).toEqual("dbName_D_shard_0")
+        });
+        
+        it("correct format when sharded without specified location", () => {
+            
+            const result = DatabaseUtils.formatNameForFile(
+                "dbName$3",
+                null
+            );
+
+            expect(result).toEqual("dbName_shard_3")
+        });
+    });
+});

--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
@@ -9,6 +9,24 @@ export default class DatabaseUtils {
         return DatabaseUtils.shardGroupKey(name) + " (shard #" + DatabaseUtils.shardNumber(name) + ")";
     }
 
+    static formatNameForFile(databaseName: string, location?: databaseLocationSpecifier) {
+        if (!databaseName) {
+            throw new Error("Must specify databaseName");
+        }
+
+        if (location) {
+            return `${databaseName}_${location.nodeTag}${
+                location?.shardNumber != null ? `_shard_${location.shardNumber}` : ""
+            }`;
+        }
+
+        if (DatabaseUtils.isSharded(databaseName)) {
+            return DatabaseUtils.shardGroupKey(databaseName) + "_shard_" + DatabaseUtils.shardNumber(databaseName);
+        }
+
+        return databaseName;
+    }
+
     static isSharded(name: string) {
         return name.includes("$");
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -14,6 +14,7 @@ import fileImporter = require("common/fileImporter");
 import moment = require("moment");
 import shardViewModelBase from "viewmodels/shardViewModelBase";
 import database from "models/resources/database";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 type rTreeLeaf = {
     minX: number;
@@ -1455,7 +1456,9 @@ class indexPerformance extends shardViewModelBase {
         if (this.isImport()) {
             exportFileName = this.importFileName().substring(0, this.importFileName().lastIndexOf('.'));
         } else {
-            exportFileName = `indexPerf of ${this.db.name} ${moment().format("YYYY-MM-DD HH-mm")}`; 
+            const detailedDatabaseName = DatabaseUtils.formatNameForFile(this.db.name, this.location);
+            
+            exportFileName = `indexPerf of ${detailedDatabaseName} ${moment().format("YYYY-MM-DD HH-mm")}`; 
         }
 
         const keysToIgnore: Array<keyof IndexingPerformanceStatsWithCache | keyof IndexingPerformanceOperationWithParent> = [
@@ -1466,6 +1469,7 @@ class indexPerformance extends shardViewModelBase {
             "WaitOperation",
             "DetailsExcludingWaitTime"
         ];
+        
         fileDownloader.downloadAsJson(this.data, exportFileName + ".json", exportFileName, (key, value) => {
             if (_.includes(keysToIgnore, key)) {
                 return undefined;

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
@@ -2,6 +2,7 @@ import dbLiveIOStatsWebSocketClient = require("common/dbLiveIOStatsWebSocketClie
 import ioStatsGraph = require("models/database/status/ioStatsGraph");
 import shardViewModelBase from "viewmodels/shardViewModelBase";
 import database from "models/resources/database";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 class ioStats extends shardViewModelBase {
     
@@ -13,8 +14,10 @@ class ioStats extends shardViewModelBase {
     constructor(db: database, location: databaseLocationSpecifier) {
         super(db, location);
 
+        const detailedDatabaseName = DatabaseUtils.formatNameForFile(db.name, location);
+
         this.graph = new ioStatsGraph(
-            () => `database-${this.db.name}`,
+            () => `database-${detailedDatabaseName}`,
             ["Documents", "Index", "Configuration"],
             true,
             (onUpdate, cutOff) => new dbLiveIOStatsWebSocketClient(this.db, this.location, onUpdate, cutOff));

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -19,6 +19,7 @@ import shardViewModelBase from "viewmodels/shardViewModelBase";
 import database from "models/resources/database";
 import TaskUtils from "components/utils/TaskUtils";
 import EtlType = Raven.Client.Documents.Operations.ETL.EtlType;
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 type treeActionType = "toggleTrack" | "trackItem" | "gapItem" | "previewEtlScript" |
                       "subscriptionErrorItem" | "subscriptionPendingItem" | "subscriptionConnectionItem" | "previewSubscriptionQuery";
@@ -2292,7 +2293,9 @@ class ongoingTasksStats extends shardViewModelBase {
         if (this.isImport()) {
             exportFileName = this.importFileName().substring(0, this.importFileName().lastIndexOf('.'));
         } else {
-            exportFileName = `OngoingTasksStats of ${this.db.name} ${moment().format("YYYY-MM-DD HH-mm")}`;
+            const detailedDatabaseName = DatabaseUtils.formatNameForFile(this.db.name, this.location);
+
+            exportFileName = `OngoingTasksStats of ${detailedDatabaseName} ${moment().format("YYYY-MM-DD HH-mm")}`;
         }
 
         const keysToIgnore: Array<keyof performanceBaseWithCache> = ["StartedAsDate", "CompletedAsDate"];

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
@@ -26,8 +26,8 @@ import viewHelpers = require("common/helpers/view/viewHelpers");
 import accessManager = require("common/shell/accessManager");
 import shardViewModelBase from "viewmodels/shardViewModelBase";
 import database from "models/resources/database";
-import shardedDatabase from "models/resources/shardedDatabase";
 import { shardingTodo } from "common/developmentHelper";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 class editReplicationHubTask extends shardViewModelBase {
 
@@ -549,8 +549,9 @@ class editReplicationHubTask extends shardViewModelBase {
 
         let fileName = includeAccessInfo ? "hubAccessConfiguration" : "hubConfiguration";
         const accessName = includeAccessInfo ? this.editedReplicationAccessItem().replicationAccessName() + "-" : "";
+        const detailedDatabaseName = DatabaseUtils.formatNameForFile(databaseName, this.location);
         
-        fileName = `${fileName}-${hubTaskItem.taskName()}-${accessName}${databaseName}.json`;
+        fileName = `${fileName}-${hubTaskItem.taskName()}-${accessName}${detailedDatabaseName}.json`;
         
         fileDownloader.downloadAsJson(configurationToExport, fileName);
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
@@ -17,6 +17,7 @@ import defaultAceCompleter = require("common/defaultAceCompleter");
 import setupEncryptionKey = require("viewmodels/resources/setupEncryptionKey");
 import viewHelpers = require("common/helpers/view/viewHelpers");
 import shardViewModelBase from "viewmodels/shardViewModelBase";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 class exportDatabase extends shardViewModelBase {
 
@@ -114,9 +115,10 @@ class exportDatabase extends shardViewModelBase {
     }
 
     private setupDefaultExportFilename(): void {
-        const dbName = this.db.name;
         const date = moment().format("YYYY-MM-DD HH-mm");
-        this.model.exportFileName(`Dump of ${dbName} ${date}`);
+        const detailedDatabaseName = DatabaseUtils.formatNameForFile(this.db.name, this.location);
+        
+        this.model.exportFileName(`Dump of ${detailedDatabaseName} ${date}`);
     }
 
     private initializeObservables(): void {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19589/Indicate-cluster-node-and-shard-if-sharded-in-exported-file-names

### Additional description

The name of file has been adjusted for:
- export edit replication hub task
- export database
- export index performance
- export io statistics
- export ongoing tasks stats

### Type of change

- New feature

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
