### PR TITLE
RavenDB-18543 Missing HasRevisions flag when importing docs and revision independently

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -153,8 +153,9 @@ namespace Raven.Server.Documents
         LowerId = 1 << 1,
         Data = 1 << 4,
         ChangeVector = 1 << 5,
+        Flags = 1 << 6,
 
-        All = Id | LowerId | Data | ChangeVector
+        All = Id | LowerId | Data | ChangeVector | Flags
     }
 
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1549,9 +1549,11 @@ namespace Raven.Server.Documents
             if (fields.Contain(DocumentFields.ChangeVector))
                 result.ChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref tvr);
 
+            if (fields.Contain(DocumentFields.Flags))
+                result.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
+
             result.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
             result.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);
-            result.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
             result.StorageId = tvr.Id;
             result.TransactionMarker = TableValueToShort((int)DocumentsTable.TransactionMarker, nameof(DocumentsTable.TransactionMarker), ref tvr);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1463,9 +1463,13 @@ namespace Raven.Server.Smuggler.Documents
                             _database.DocumentsStorage.RevisionsStorage.Put(context, id, document.Data, document.Flags,
                                 document.NonPersistentFlags, document.ChangeVector, document.LastModified.Ticks);
 
-                            if (addHasRevisionsFlag.Contains(id) == false && document.Flags.Contain(DocumentFlags.HasRevisions))
+                            if (addHasRevisionsFlag.Contains(id) == false)
                             {
-                                addHasRevisionsFlag.Add(id);
+                                var actualDocument = _database.DocumentsStorage.Get(context, id, DocumentFields.Flags);
+                                if (actualDocument != null && actualDocument.Flags.Contain(DocumentFlags.HasRevisions) == false)
+                                {
+                                    addHasRevisionsFlag.Add(id);
+                                }
                             }
                         }
 

--- a/test/SlowTests/Issues/RavenDB-18543.cs
+++ b/test/SlowTests/Issues/RavenDB-18543.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Smuggler;
+using Constants = Raven.Client.Constants;
+using Tests.Infrastructure;
+using Raven.Server.Documents;
+using System.IO;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_18543 : RavenTestBase
+    {
+        public RavenDB_18543(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task DocumentsHasHasRevisionsFlag()
+        {
+            DoNotReuseServer();
+
+            var path = NewDataPath(forceCreateDir: true);
+            var exportDocsFile = Path.Combine(path, "exportDocs.ravendbdump");
+            var exportRevisionsFile = Path.Combine(path, "exportRevisions.ravendbdump");
+
+            using (var store = GetDocumentStore())
+            {
+                CreateSampleDataForTest(store);
+
+                var exportDocs = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions()
+                {
+                    OperateOnTypes = DatabaseItemType.Documents
+                }, exportDocsFile);
+                await exportDocs.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var exportRevisions = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions()
+                {
+                    OperateOnTypes = DatabaseItemType.RevisionDocuments
+                }, exportRevisionsFile);
+                await exportRevisions.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                string databaseName = GetDatabaseName();
+                Assert.NotEqual(store.Database, databaseName);
+
+                store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName)));
+
+                var importDocs = await store.Smuggler.ForDatabase(databaseName).ImportAsync(new DatabaseSmugglerImportOptions(), exportDocsFile);
+                await importDocs.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var importRevisions = await store.Smuggler.ForDatabase(databaseName).ImportAsync(new DatabaseSmugglerImportOptions(), exportRevisionsFile);
+                await importRevisions.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                using (var session = store.OpenSession(databaseName))
+                {
+                    var orders = session.Query<Order>().ToList();
+
+                    foreach (Order order in orders)
+                    {
+                        var metadata = session.Advanced.GetMetadataFor(order);
+                        var flagsValue = metadata[Constants.Documents.Metadata.Flags];
+                        Assert.NotNull(flagsValue);
+                        var flags = Enum.Parse<DocumentFlags>(flagsValue.ToString());
+                        Assert.True(flags.HasFlag(DocumentFlags.HasRevisions));
+                    }
+                }
+            }
+        }
+
+        private void CreateSampleDataForTest(DocumentStore store)
+        {
+            DatabaseItemType operateOnTypes = DatabaseItemType.Documents
+                                              | DatabaseItemType.RevisionDocuments
+                                              | DatabaseItemType.Attachments
+                                              | DatabaseItemType.CounterGroups
+                                              | DatabaseItemType.TimeSeries
+                                              | DatabaseItemType.Indexes
+                                              | DatabaseItemType.CompareExchange;
+
+            store.Maintenance.Send(new CreateSampleDataOperation(operateOnTypes: operateOnTypes));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18543/Missing-HasRevisions-flag-when-importing-docs-and-revision-independently

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing
