### PR TITLE
RavenDB-19590 Disabled not supported import for sharded database

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importCollectionFromCsv.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importCollectionFromCsv.html
@@ -1,5 +1,11 @@
 <div class="importDatabase ">
-    <div class="panel">
+    <div class="panel padding padding-md" data-bind="visible: $root.activeDatabase().isSharded()">
+        <h2 class="text-warning"><i class="icon-info"></i> Feature not available</h2>
+        <p class="margin-top margin-lg">
+            Import documents from a CSV file into a collection is not available for sharded databases.
+        </p>
+    </div>
+    <div class="panel" data-bind="visible: !$root.activeDatabase().isSharded()">
         <div class="panel-body">
             <form class="flex-form" data-bind="submit: importCsv">
                 <h3>Import documents from a CSV file into a collection</h3>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -1,5 +1,11 @@
 <div class="importDatabase absolute-fill flex-vertical sql-migration">
-    <div class="panel" data-bind="if: inFirstStep, visible: inFirstStep">
+    <div class="panel padding padding-md" data-bind="visible: $root.activeDatabase().isSharded()">
+        <h2 class="text-warning"><i class="icon-info"></i> Feature not available</h2>
+        <p class="margin-top margin-lg">
+            Import documents from a SQL database into the current RavenDB database is not available for sharded databases.
+        </p>
+    </div>
+    <div class="panel" data-bind="if: inFirstStep, visible: !$root.activeDatabase().isSharded() && inFirstStep">
         <div class="panel-body">
             <form class="flex-form" data-bind="submit: nextStep">
                 <h3>Import documents from a SQL database into the current RavenDB database</h3>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateDatabase.html
@@ -1,5 +1,11 @@
 <div class="migrate-database">
-    <div class="panel">
+    <div class="panel padding padding-md" data-bind="visible: $root.activeDatabase().isSharded()">
+        <h2 class="text-warning"><i class="icon-info"></i> Feature not available</h2>
+        <p class="margin-top margin-lg">
+            Migrate data from another database is not available for sharded databases.
+        </p>
+    </div>
+    <div class="panel" data-bind="visible: !$root.activeDatabase().isSharded()">
         <div class="panel-body">
             <form class="flex-form" data-bind="submit: migrateDb" autocomplete="off">
                 <div class="row">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/migrateRavenDbDatabase.html
@@ -1,5 +1,11 @@
 <div class="migrate-ravendb-database">
-    <div class="panel">
+    <div class="panel padding padding-md" data-bind="visible: $root.activeDatabase().isSharded()">
+        <h2 class="text-warning"><i class="icon-info"></i> Feature not available</h2>
+        <p class="margin-top margin-lg">
+            Migrate data from another RavenDB Server is not available for sharded databases.
+        </p>
+    </div>
+    <div class="panel" data-bind="visible: !$root.activeDatabase().isSharded()">
         <div class="panel-body">
             <form class="flex-form" data-bind="submit: migrateDb" autocomplete="off">
                 <div class="row">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19590/Disabled-not-supported-import-for-sharded-database

### Additional description

Is sharded database import disabled for:
- From RavenDB Server
- From CSV File
- From SQL
- From NoSQL

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/224766523-cd85e2d8-2796-452b-9988-a597f450b456.png)

