### PR TITLE
RavenDB-20041 Explain that Document Defaults override the Conflicting Document Defaults

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/revisions.ts
@@ -281,7 +281,8 @@ class revisions extends viewModelBase {
                               <li><small>This is the default revision configuration for <strong>conflicting documents only</strong>.</small></li>
                               <li><small>When enabled, a revision is created for each conflicting item.</small></li>
                               <li><small>A revision is also created for the conflict resolution document.</small></li>
-                              <li><small>When a collection specific configuration is defined, it <strong>overrides</strong> these defaults.</li>
+                              <li><small>When Document Defaults or a collection-specific configuration is defined,<br/>
+                                         they <strong>override</strong> the Conflicting Document Defaults.</li>
                           </ul>`,
                 html: true
             });
@@ -410,7 +411,7 @@ class revisions extends viewModelBase {
                 content: `<ul class="margin-top margin-top-xs">
                               <li><small>This is the default revision configuration for all <strong>non-conflicting documents</strong>.</small></li>
                               <li><small>When enabled, a revision is created for all non-conflicting documents.</small></li>
-                              <li><small>When a collection specific configuration is defined, it <strong>overrides</strong> these defaults.</li>
+                              <li><small>When a collection specific configuration is defined, it <strong>overrides</strong> these defaults.</small></li>
                           </ul>`,
                 html: true
             });


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20041/Explain-that-Document-Defaults-override-the-Conflicting-Document-Defaults

### Additional description
Added explanation in tooltip:
```
When Document Defaults or a collection-specific configuration is defined,
they override the Conflicting Document Defaults.
```

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
