### PR TITLE
RavenDB-19063 -  Sharding - Certificates - Handle Change

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Sharding.Executors
             if (requestExecutors == null)
                 return;
 
-            foreach (var executor in _requestExecutors.Values)
+            foreach (var executor in requestExecutors.Values)
             {
                 try
                 {

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -211,7 +211,7 @@ namespace SlowTests.Authentication
             }
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Certificates | RavenTestCategory.Sharding)]
         public async Task CertificateReplaceSharded()
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
@@ -250,7 +250,7 @@ namespace SlowTests.Authentication
                 }
 
                 //trigger cert refresh
-                await requestExecutor.HttpClient.PostAsync(Uri.EscapeDataString($"{nodes[0].WebUrl}/admin/certificates/letsencrypt/force-renew"), null);
+                await requestExecutor.HttpClient.PostAsync($"{nodes[0].WebUrl}/admin/certificates/letsencrypt/force-renew", null);
                 
                 await Task.WhenAll(replaceTasks.Values.Select(x => x.WaitAsync()).ToArray());
                 

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -250,7 +250,7 @@ namespace SlowTests.Authentication
                 }
 
                 //trigger cert refresh
-                await requestExecutor.HttpClient.PostAsync(Uri.EscapeUriString($"{nodes[0].WebUrl}/admin/certificates/letsencrypt/force-renew"), null);
+                await requestExecutor.HttpClient.PostAsync(Uri.EscapeDataString($"{nodes[0].WebUrl}/admin/certificates/letsencrypt/force-renew"), null);
                 
                 await Task.WhenAll(replaceTasks.Values.Select(x => x.WaitAsync()).ToArray());
                 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19063

### Additional description

Making sure that renewing a lets encrypt certificate triggers refresh of shard executors to have the new cert as well.
Fixed bug where the existing shard executors were disposed instead of the old ones.

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
