### PR TITLE
RavenDB-19985 Switch to FluentFTP

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -366,6 +366,27 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public string CertificateFileName { get; set; }
 
+        public FtpSettings()
+        {
+        }
+
+        internal FtpSettings(FtpSettings settings)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            Url = settings.Url;
+            Port = settings.Port;
+            UserName = settings.UserName;
+            Password = settings.Password;
+            CertificateAsBase64 = settings.CertificateAsBase64;
+            CertificateFileName = settings.CertificateFileName;
+            Disabled = settings.Disabled;
+
+            if (settings.GetBackupConfigurationScript != null)
+                GetBackupConfigurationScript = new GetBackupConfigurationScript(settings.GetBackupConfigurationScript);
+        }
+
         public override bool HasSettings()
         {
             if (base.HasSettings())

--- a/src/Raven.Server/Documents/PeriodicBackup/RavenFtpClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/RavenFtpClient.cs
@@ -10,9 +10,11 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using FluentFTP;
 using Raven.Client.Documents.Operations.Backups;
 
 namespace Raven.Server.Documents.PeriodicBackup
@@ -65,36 +67,35 @@ namespace Raven.Server.Documents.PeriodicBackup
             var url = CreateNestedFoldersIfNeeded(folderName);
             url += $"/{fileName}";
 
-            var request = CreateFtpWebRequest(url, WebRequestMethods.Ftp.UploadFile, keepAlive: true);
-            var readBuffer = new byte[DefaultBufferSize];
-
-            int count;
-            var requestStream = request.GetRequestStream();
-            while ((count = stream.Read(readBuffer, 0, readBuffer.Length)) != 0)
+            using (var client = CreateFtpClient(_url, keepAlive: true))
             {
-                requestStream.Write(readBuffer, 0, count);
+                var readBuffer = new byte[DefaultBufferSize];
 
-                Progress?.UploadProgress.ChangeState(UploadState.Uploading);
-                Progress?.UploadProgress.UpdateUploaded(count);
-                Progress?.OnUploadProgress();
-            }
+                int count;
+                while ((count = stream.Read(readBuffer, 0, readBuffer.Length)) != 0)
+                {
+                    client.UploadBytes(readBuffer, url, FtpRemoteExists.Resume);
 
-            requestStream.Flush();
-            requestStream.Close();
+                    Progress?.UploadProgress.ChangeState(UploadState.Uploading);
+                    Progress?.UploadProgress.UpdateUploaded(count);
+                    Progress?.OnUploadProgress();
+                }
 
-            Progress?.UploadProgress.ChangeState(UploadState.PendingResponse);
-            using (request.GetResponse())
-            {
-                Progress?.UploadProgress.ChangeState(UploadState.Done);
+                Progress?.UploadProgress.ChangeState(UploadState.PendingResponse);
+                if (client.FileExists(url))
+                {
+                    Progress?.UploadProgress.ChangeState(UploadState.Done);
+                }
             }
         }
 
         private string CreateNestedFoldersIfNeeded(string folderName)
         {
-            ExtractUrlAndDirectories(out var url, out var directories);
+            ExtractUrlAndDirectories(out var directories);
 
             // create the nested folders including the new folder
             directories.Add(folderName);
+            string url = "";
 
             foreach (var directory in directories)
             {
@@ -102,70 +103,63 @@ namespace Raven.Server.Documents.PeriodicBackup
                     continue;
 
                 url += $"/{directory}";
-                var request = CreateFtpWebRequest(url, WebRequestMethods.Ftp.MakeDirectory, keepAlive: false);
-
-                try
+                using (var client = CreateFtpClient(_url, keepAlive: false))
                 {
-                    var response = request.GetResponse();
-                    response.Close();
-                }
-                catch (WebException e)
-                {
-                    var response = (FtpWebResponse)e.Response;
-                    if (response.StatusCode == FtpStatusCode.ActionNotTakenFileUnavailable)
+                    try
                     {
-                        // folder already exists
-                        continue;
+                        if (!client.DirectoryExists($"/{directory}"))
+                            client.CreateDirectory($"/{directory}");
                     }
-
-                    throw;
+                    catch (Exception e)
+                    {
+                        throw new Exception();
+                    }
                 }
             }
 
             return url;
         }
 
-        private void ExtractUrlAndDirectories(out string url, out List<string> dirs)
+        private void ExtractUrlAndDirectories(out List<string> dirs)
         {
             var uri = new Uri(_url);
 
             dirs = uri.AbsolutePath.TrimStart('/').TrimEnd('/').Split("/").ToList();
-            var port = _port ?? (uri.Port > 0 ? uri.Port : DefaultFtpPort);
-            if (port < 1 || port > 65535)
-                throw new ArgumentException("Port number range: 1-65535");
-
-            url = $"{uri.Scheme}://{uri.Host}:{port}";
         }
 
-        private FtpWebRequest CreateFtpWebRequest(string url, string method, bool keepAlive)
+        internal FtpClient CreateFtpClient(string url, bool keepAlive)
         {
-#pragma warning disable SYSLIB0014
-            var request = (FtpWebRequest)WebRequest.Create(new Uri(url));
-#pragma warning restore SYSLIB0014
-            request.Method = method;
-
-            request.Credentials = new NetworkCredential(_userName, _password);
-            request.EnableSsl = _useSsl;
+            var client = new FtpClient(url);
+            client.Config.ConnectTimeout = -1;
+            client.Credentials = new NetworkCredential(_userName, _password);
             if (_useSsl)
             {
                 var byteArray = Convert.FromBase64String(_certificateAsBase64);
 
                 try
                 {
-                    var x509Certificate = new X509Certificate(byteArray);
-                    request.ClientCertificates = new X509CertificateCollection(new[] { x509Certificate });
+                    var x509Certificate = new X509Certificate2(byteArray);
+                    client.Config.EncryptionMode = FtpEncryptionMode.Explicit;
+                    client.Config.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
+                    client.Config.ClientCertificates.Add(x509Certificate);
+                    client.ValidateCertificate += (control, e) =>
+                    {
+                        e.Accept = e.PolicyErrors == SslPolicyErrors.None;
+                    };
                 }
                 catch (Exception e)
                 {
                     throw new ArgumentException($"This is not a valid certificate, file name: {_certificateFileName}", e);
                 }
             }
-                
-            request.UsePassive = true;
-            request.UseBinary = true;
-            request.KeepAlive = keepAlive;
 
-            return request;
+            client.Config.SocketKeepAlive = keepAlive;
+            if (_port != null)
+                client.Port = (int)_port;
+            else
+                client.Port = DefaultFtpPort;
+            client.Connect();
+            return client;
         }
 
         public void TestConnection()
@@ -173,29 +167,21 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_useSsl && string.IsNullOrWhiteSpace(_certificateAsBase64))
                 throw new ArgumentException("Certificate must be provided when using ftp with SSL!");
 
-            ExtractUrlAndDirectories(out var url, out _);
-            var request = CreateFtpWebRequest(url, WebRequestMethods.Ftp.ListDirectory, keepAlive: false);
-
-            try
+            using (var client = CreateFtpClient(_url, keepAlive: false))
             {
-                var response = request.GetResponse();
-                response.Close();
-            }
-            catch (WebException e)
-            {
-                var response = (FtpWebResponse)e.Response;
-                if (response.StatusCode == FtpStatusCode.ActionNotTakenFileUnavailable)
+                try
                 {
-                    // folder doesn't exist
-                    return;
+                    client.Connect();
                 }
-
-                throw;
-            }
-            catch (AuthenticationException e)
-            {
-                throw new AuthenticationException("Make sure that you provided the correct certificate " +
-                                                  "and that the url matches the one that is defined in it", e);
+                catch (AuthenticationException e)
+                {
+                    throw new AuthenticationException("Make sure that you provided the correct certificate " +
+                                                      "and that the url matches the one that is defined in it", e);
+                }
+                catch (Exception e)
+                {
+                    throw new Exception();
+                }
             }
         }
     }

--- a/src/Raven.Server/Documents/PeriodicBackup/RavenFtpClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/RavenFtpClient.cs
@@ -110,9 +110,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                         if (!client.DirectoryExists($"/{directory}"))
                             client.CreateDirectory($"/{directory}");
                     }
-                    catch (Exception e)
+                    catch (WebException e)
                     {
-                        throw new Exception();
+                        throw ;
                     }
                 }
             }
@@ -178,9 +178,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                     throw new AuthenticationException("Make sure that you provided the correct certificate " +
                                                       "and that the url matches the one that is defined in it", e);
                 }
-                catch (Exception e)
+                catch (WebException e)
                 {
-                    throw new Exception();
+                    throw;
                 }
             }
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
     {
         private readonly RavenFtpClient _client;
 
-        protected override string Name => "Ftp";
+        protected override string Name => "FTP";
 
         public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client)
             : base(parameters)

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -162,6 +162,7 @@
     <PackageReference Include="Confluent.Kafka" Version="2.1.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="DasMulli.Win32.ServiceUtils.Signed" Version="1.1.0" />
+    <PackageReference Include="FluentFTP" Version="46.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             await using (var serviceProvider = services.BuildServiceProvider())
             {
                 var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
-                ftpServerHost.StartAsync(CancellationToken.None).Wait();
+                await ftpServerHost.StartAsync(CancellationToken.None);
                 var settings = new FtpSettings
                 {
                     Url = "ftp://127.0.0.1",
@@ -47,7 +47,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var isExist = CheckFile(settings.Url, "testFolder", "testFile", client);
                     Assert.Equal(true, isExist);
                 }
-                ftpServerHost.StopAsync(CancellationToken.None).Wait();
+                await ftpServerHost.StopAsync(CancellationToken.None);
             }
         }
 
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             await using (var serviceProvider = services.BuildServiceProvider())
             {
                 var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
-                ftpServerHost.StartAsync(CancellationToken.None).Wait();
+                await ftpServerHost.StartAsync(CancellationToken.None);
                 var settings = new FtpSettings
                 {
                     Url = "ftp://127.0.0.1",
@@ -87,7 +87,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(true, isExist);
                 }
 
-                ftpServerHost.StopAsync(CancellationToken.None).Wait();
+                await ftpServerHost.StopAsync(CancellationToken.None);
             }
         }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
@@ -1,0 +1,124 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentFTP;
+using FubarDev.FtpServer;
+using FubarDev.FtpServer.FileSystem.InMemory;
+using Microsoft.Extensions.DependencyInjection;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    public class Ftp : CloudBackupTestBase
+    {
+        public Ftp(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [FtpFact]
+        public async Task CanUploadFile()
+        {
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                ftpServerHost.StartAsync(CancellationToken.None).Wait();
+                var settings = new FtpSettings
+                {
+                    Url = "ftp://127.0.0.1",
+                    UserName = "anonymous",
+                    Password = "itay@ravendb.net"
+                };
+                using (var client = new RavenFtpClient(settings))
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc")))
+                {
+                    client.UploadFile("testFolder", "testFile", stream);
+                    var isExist = CheckFile(settings.Url, "testFolder", "testFile", client);
+                    Assert.Equal(true, isExist);
+                }
+                ftpServerHost.StopAsync(CancellationToken.None).Wait();
+            }
+        }
+
+        [FtpFact]
+        public async Task CanUploadBackup()
+        {
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                ftpServerHost.StartAsync(CancellationToken.None).Wait();
+                var settings = new FtpSettings
+                {
+                    Url = "ftp://127.0.0.1",
+                    UserName = "anonymous",
+                    Password = "itay@ravendb.net"
+                };
+                using (var client = new RavenFtpClient(settings))
+                using (var store = GetDocumentStore())
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User { Name = "itay" }, "users/1");
+                        session.SaveChanges();
+                    }
+                    var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest");
+                    var backupId = Backup.UpdateConfigAndRunBackup(Server, config, store);
+                    var backupResult = (BackupResult)store.Maintenance.Send(new GetOperationStateOperation(await Backup.GetBackupOperationIdAsync(store, backupId))).Result;
+                    var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                    var status = await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store,  expectedEtag: lastEtag);
+                    var isExist = CheckBackupFile(settings.Url, status.FolderName, client);
+                    Assert.NotNull(backupResult);
+                    Assert.Equal(UploadState.Done, backupResult.FtpBackup.UploadProgress.UploadState);
+                    Assert.Equal(true, isExist);
+                }
+
+                ftpServerHost.StopAsync(CancellationToken.None).Wait();
+            }
+        }
+
+        private bool CheckFile(string url, string folderName, string fileName, RavenFtpClient client)
+        {
+            using (var ftpClient = client.CreateFtpClient(url, keepAlive: true))
+            {
+                if (ftpClient.FileExists("/" + folderName + "/" + fileName))
+                    return true;
+            }
+            return false;
+        }
+
+        private bool CheckBackupFile(string url, string backupName, RavenFtpClient client)
+        {
+            using (var ftpClient = client.CreateFtpClient(url, keepAlive: true))
+            {
+                var items = ftpClient.GetListing();
+                items.OrderBy(i => i.Modified);
+                foreach (var item in items)
+                {
+                    if (item.Type == FtpObjectType.Directory)
+                    {
+                        if (item.FullName.Contains(backupName))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Ftp.cs
@@ -1,15 +1,17 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.InMemory;
 using Microsoft.Extensions.DependencyInjection;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -33,21 +35,27 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             await using (var serviceProvider = services.BuildServiceProvider())
             {
                 var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
-                await ftpServerHost.StartAsync(CancellationToken.None);
-                var settings = new FtpSettings
+                try
                 {
-                    Url = "ftp://127.0.0.1",
-                    UserName = "anonymous",
-                    Password = "itay@ravendb.net"
-                };
-                using (var client = new RavenFtpClient(settings))
-                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc")))
-                {
-                    client.UploadFile("testFolder", "testFile", stream);
-                    var isExist = CheckFile(settings.Url, "testFolder", "testFile", client);
-                    Assert.Equal(true, isExist);
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    var settings = new FtpSettings
+                    {
+                        Url = "ftp://127.0.0.1:21/testing2",
+                        UserName = "anonymous",
+                        Password = "itay@ravendb.net"
+                    };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc")))
+                    {
+                        client.UploadFile("testFolder", "testFile", stream);
+                        var isExist = CheckFile(settings.Url, "testFolder", "testFile", client);
+                        Assert.Equal(true, isExist);
+                    }
                 }
-                await ftpServerHost.StopAsync(CancellationToken.None);
+                finally
+                {
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
             }
         }
 
@@ -61,41 +69,268 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             await using (var serviceProvider = services.BuildServiceProvider())
             {
                 var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
-                await ftpServerHost.StartAsync(CancellationToken.None);
-                var settings = new FtpSettings
+                try
                 {
-                    Url = "ftp://127.0.0.1",
-                    UserName = "anonymous",
-                    Password = "itay@ravendb.net"
-                };
-                using (var client = new RavenFtpClient(settings))
-                using (var store = GetDocumentStore())
-                {
-                    using (var session = store.OpenSession())
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    var settings = new FtpSettings
                     {
-                        session.Store(new User { Name = "itay" }, "users/1");
-                        session.SaveChanges();
+                        Url = "ftp://127.0.0.1:21/internal",
+                        UserName = "anonymous",
+                        Password = "itay@ravendb.net"
+                    };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var store = GetDocumentStore())
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User { Name = "itay" }, "users/1");
+                            session.SaveChanges();
+                        }
+                        var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest");
+                        var backupId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                        var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                        var status = await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, expectedEtag: lastEtag);
+                        var backupResult = (BackupResult)store.Maintenance.Send(new GetOperationStateOperation(await Backup.GetBackupOperationIdAsync(store, backupId))).Result;
+                        var isExist = CheckBackupFile(settings.Url, status.FolderName, client);
+                        Assert.NotNull(backupResult);
+                        Assert.Equal(UploadState.Done, backupResult.FtpBackup.UploadProgress.UploadState);
+                        Assert.Equal(true, isExist);
                     }
-                    var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest");
-                    var backupId = Backup.UpdateConfigAndRunBackup(Server, config, store);
-                    var backupResult = (BackupResult)store.Maintenance.Send(new GetOperationStateOperation(await Backup.GetBackupOperationIdAsync(store, backupId))).Result;
-                    var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
-                    var status = await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store,  expectedEtag: lastEtag);
-                    var isExist = CheckBackupFile(settings.Url, status.FolderName, client);
-                    Assert.NotNull(backupResult);
-                    Assert.Equal(UploadState.Done, backupResult.FtpBackup.UploadProgress.UploadState);
-                    Assert.Equal(true, isExist);
                 }
+                finally
+                {
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
+            }
+        }
 
-                await ftpServerHost.StopAsync(CancellationToken.None);
+        [FtpFact]
+        public async Task CanUploadBackupsWithDeletion()
+        {
+            BackupConfigurationHelper.SkipMinimumBackupAgeToKeepValidation = true;
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                try
+                {
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    var settings = new FtpSettings { Url = "ftp://127.0.0.1:21/internal", UserName = "anonymous", Password = "itay@ravendb.net" };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var store = GetDocumentStore())
+                    {
+                        var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest",
+                            retentionPolicy: new RetentionPolicy { MinimumBackupAgeToKeep = TimeSpan.FromSeconds(15) });
+                        var backupId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                        for (int i = 0; i < 3; i++)
+                        {
+                            using (var session = store.OpenSession())
+                            {
+                                session.Store(new User { Name = "itay" });
+                                session.SaveChanges();
+                            }
+
+                            var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                            await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, expectedEtag: lastEtag, timeout: 120000);
+                        }
+                        await Task.Delay(TimeSpan.FromSeconds(15) + TimeSpan.FromSeconds(3));
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User { Name = "itay" });
+                            await session.SaveChangesAsync();
+                        }
+                        var etag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                        await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, isFullBackup: true, expectedEtag: etag, timeout: 120000);
+                        var folders = client.GetFolders();
+                        var foundFolders = 0;
+                        for (int i = 0; i < folders.Count; i++)
+                        {
+                            var isExist = folders[i].Contains("CanUploadBackupsWithDeletion");
+                            if (isExist)
+                                foundFolders++;
+                        }
+                        Assert.Equal(1, foundFolders);
+                    }
+                }
+                finally
+                {
+                    BackupConfigurationHelper.SkipMinimumBackupAgeToKeepValidation = false;
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
+            }
+        }
+
+        [FtpFact]
+        public async Task CanUploadFileOnEncrypted()
+        {
+            CertificateUtils.CreateCertificateAuthorityCertificate("auth", out var caKey, out var caName);
+            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey("admin", caName, caKey, true, false,
+                DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
+            var cert = new X509Certificate2(certBytes);
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.Configure<AuthTlsOptions>(cfg => cfg.ServerCertificate = cert);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                try
+                {
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    
+                    var settings = new FtpSettings
+                    {
+                        Url = "ftps://127.0.0.1:21/internal",
+                        UserName = "anonymous",
+                        Password = "itay@ravendb.net",
+                        CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
+                    };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc")))
+                    {
+                        client.UploadFile("testFolder", "testFile", stream);
+                        var isExist = CheckFile(settings.Url, "testFolder", "testFile", client);
+                        Assert.Equal(true, isExist);
+                    }
+                }
+                finally
+                {
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
+            }
+        }
+
+        [FtpFact]
+        public async Task CanUploadBackupOnEncrypted()
+        {
+            CertificateUtils.CreateCertificateAuthorityCertificate("auth", out var caKey, out var caName);
+            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey("admin", caName, caKey, true, false,
+                DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
+            var cert = new X509Certificate2(certBytes);
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.Configure<AuthTlsOptions>(cfg => cfg.ServerCertificate = cert);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                try
+                {
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    var settings = new FtpSettings
+                    {
+                        Url = "ftps://127.0.0.1",
+                        UserName = "anonymous",
+                        Password = "itay@ravendb.net",
+                        CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
+                    };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var store = GetDocumentStore())
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User { Name = "itay" }, "users/1");
+                            session.SaveChanges();
+                        }
+                        var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest");
+                        var backupId = Backup.UpdateConfigAndRunBackup(Server, config, store);
+                        var backupResult = (BackupResult)store.Maintenance.Send(new GetOperationStateOperation(await Backup.GetBackupOperationIdAsync(store, backupId))).Result;
+                        var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                        var status = await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, expectedEtag: lastEtag);
+                        var isExist = CheckBackupFile(settings.Url, status.FolderName, client);
+                        Assert.NotNull(backupResult);
+                        Assert.Equal(UploadState.Done, backupResult.FtpBackup.UploadProgress.UploadState);
+                        Assert.Equal(true, isExist);
+                    }
+                }
+                finally
+                {
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
+            }
+        }
+
+        [FtpFact]
+        public async Task CanUploadBackupsWithDeletionOnEncrypted()
+        {
+            CertificateUtils.CreateCertificateAuthorityCertificate("auth", out var caKey, out var caName);
+            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey("admin", caName, caKey, true, false,
+                DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
+            var cert = new X509Certificate2(certBytes);
+            BackupConfigurationHelper.SkipMinimumBackupAgeToKeepValidation = true;
+            var services = new ServiceCollection();
+            services.Configure<InMemoryFileSystemOptions>(opt => opt.KeepAnonymousFileSystem = true);
+            services.Configure<AuthTlsOptions>(cfg => cfg.ServerCertificate = cert);
+            services.AddFtpServer(builder => builder.UseInMemoryFileSystem().EnableAnonymousAuthentication());
+            services.Configure<FtpServerOptions>(opt => opt.ServerAddress = "127.0.0.1");
+            await using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var ftpServerHost = serviceProvider.GetRequiredService<IFtpServerHost>();
+                try
+                {
+                    await ftpServerHost.StartAsync(CancellationToken.None);
+                    var settings = new FtpSettings { 
+                        Url = "ftps://127.0.0.1:21/internal",
+                        UserName = "anonymous",
+                        Password = "itay@ravendb.net",
+                        CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
+                    };
+                    using (var client = new RavenFtpClient(settings))
+                    using (var store = GetDocumentStore())
+                    {
+                        var config = Backup.CreateBackupConfiguration(ftpSettings: settings, name: "ftpBackupTest",
+                            retentionPolicy: new RetentionPolicy { MinimumBackupAgeToKeep = TimeSpan.FromSeconds(15) });
+                        var backupId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                        for (int i = 0; i < 3; i++)
+                        {
+                            using (var session = store.OpenSession())
+                            {
+                                session.Store(new User { Name = "itay" });
+                                session.SaveChanges();
+                            }
+
+                            var lastEtag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                            await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, expectedEtag: lastEtag, timeout: 120000);
+                        }
+                        await Task.Delay(TimeSpan.FromSeconds(15) + TimeSpan.FromSeconds(3));
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User { Name = "itay" });
+                            await session.SaveChangesAsync();
+                        }
+                        var etag = store.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                        await Backup.RunBackupAndReturnStatusAsync(Server, backupId, store, isFullBackup: true, expectedEtag: etag, timeout: 120000);
+                        var folders = client.GetFolders();
+                        var foundFolders = 0;
+                        for (int i = 0; i < folders.Count; i++)
+                        {
+                            var isExist = folders[i].Contains("CanUploadBackupsWithDeletion");
+                            if (isExist)
+                                foundFolders++;
+                        }
+                        Assert.Equal(1, foundFolders);
+                    }
+                }
+                finally
+                {
+                    BackupConfigurationHelper.SkipMinimumBackupAgeToKeepValidation = false;
+                    await ftpServerHost.StopAsync(CancellationToken.None);
+                }
             }
         }
 
         private bool CheckFile(string url, string folderName, string fileName, RavenFtpClient client)
         {
-            using (var ftpClient = client.CreateFtpClient(url, keepAlive: true))
+            var outputUrl = GetUrlAndFolders(url, out string path);
+
+            using (var ftpClient = client.CreateFtpClient(outputUrl, keepAlive: true))
             {
-                if (ftpClient.FileExists("/" + folderName + "/" + fileName))
+                if (ftpClient.FileExists(path + "/" + folderName + "/" + fileName))
                     return true;
             }
             return false;
@@ -103,22 +338,38 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
         private bool CheckBackupFile(string url, string backupName, RavenFtpClient client)
         {
-            using (var ftpClient = client.CreateFtpClient(url, keepAlive: true))
+            var outputUrl = GetUrlAndFolders(url, out var path);
+
+            using (var ftpClient = client.CreateFtpClient(outputUrl, keepAlive: false))
             {
-                var items = ftpClient.GetListing();
-                items.OrderBy(i => i.Modified);
-                foreach (var item in items)
-                {
-                    if (item.Type == FtpObjectType.Directory)
-                    {
-                        if (item.FullName.Contains(backupName))
-                        {
-                            return true;
-                        }
-                    }
-                }
+                if (ftpClient.FileExists(path + "/" + backupName))
+                    return true;
             }
             return false;
+        }
+
+        private string GetUrlAndFolders(string url, out string path)
+        {
+            if (url.StartsWith("ftps", StringComparison.OrdinalIgnoreCase))
+            {
+                url = url.Replace("ftps://", "ftp://", StringComparison.OrdinalIgnoreCase);
+            }
+            var uri = new Uri(url);
+
+            var dirs = uri.AbsolutePath.TrimStart('/').TrimEnd('/').Split("/").ToList();
+
+            url = $"{uri.Scheme}://{uri.Host}";
+
+            path = string.Empty;
+            foreach (var directory in dirs)
+            {
+                if (directory == string.Empty)
+                    continue;
+
+                path += $"/{directory}";
+            }
+
+            return url;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/FtpBasicTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/FtpBasicTests.cs
@@ -19,9 +19,9 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.PeriodicBackup
 {
-    public class Ftp : CloudBackupTestBase
+    public class FtpBasicTests : CloudBackupTestBase
     {
-        public Ftp(ITestOutputHelper output) : base(output)
+        public FtpBasicTests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/FtpBasicTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/FtpBasicTests.cs
@@ -188,7 +188,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Password = "itay@ravendb.net",
                         CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
                     };
-                    Environment.SetEnvironmentVariable("isTesting", "true");
                     using (var client = new RavenFtpClient(settings))
                     using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc")))
                     {
@@ -228,7 +227,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Password = "itay@ravendb.net",
                         CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
                     };
-                    Environment.SetEnvironmentVariable("isTesting", "true");
                     using (var client = new RavenFtpClient(settings))
                     using (var store = GetDocumentStore(options: new Options
                            {
@@ -282,7 +280,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Password = "itay@ravendb.net",
                         CertificateAsBase64 = Convert.ToBase64String(cert.Export(X509ContentType.Cert))
                     };
-                    Environment.SetEnvironmentVariable("isTesting", "true");
                     using (var client = new RavenFtpClient(settings))
                     using (var store = GetDocumentStore(options: new Options
                            {
@@ -336,10 +333,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var ftpClient = client.CreateFtpClient(outputUrl, keepAlive: true))
             {
-                if (ftpClient.FileExists(path + "/" + folderName + "/" + fileName))
-                    return true;
+                return ftpClient.FileExists(path + "/" + folderName + "/" + fileName);
             }
-            return false;
         }
 
         private bool CheckBackupFile(string url, string backupName, RavenFtpClient client)

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -156,6 +156,9 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="FubarDev.FtpServer" Version="3.1.2" />
+    <PackageReference Include="FubarDev.FtpServer.FileSystem.DotNet" Version="3.1.2" />
+    <PackageReference Include="FubarDev.FtpServer.FileSystem.InMemory" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/test/Tests.Infrastructure/FtpFactAttribute.cs
+++ b/test/Tests.Infrastructure/FtpFactAttribute.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.Backups;
+using Xunit;
+
+namespace Tests.Infrastructure
+{
+    public class FtpFactAttribute : FactAttribute
+    {
+        private const string FtpCredentialEnvironmentVariable = "FTP_CREDENTIAL";
+
+        private static readonly FtpSettings _ftpSettings;
+
+        public static FtpSettings FtpSettings => new FtpSettings(_ftpSettings);
+
+        private static readonly string ParsingError;
+
+        private static readonly bool EnvVariableMissing;
+
+        static FtpFactAttribute()
+        {
+            var ftpSettingsString = Environment.GetEnvironmentVariable(FtpCredentialEnvironmentVariable);
+            if (ftpSettingsString == null)
+            {
+                EnvVariableMissing = true;
+                return;
+            }
+
+            try
+            {
+                _ftpSettings = JsonConvert.DeserializeObject<FtpSettings>(ftpSettingsString);
+            }
+            catch (Exception e)
+            {
+                ParsingError = e.ToString();
+            }
+        }
+
+        public FtpFactAttribute([CallerMemberName] string memberName = "")
+        {
+            if (RavenTestHelper.IsRunningOnCI)
+                return;
+
+            if (EnvVariableMissing)
+            {
+                Skip = $"Test is missing '{FtpCredentialEnvironmentVariable}' environment variable.";
+                return;
+            }
+
+            if (string.IsNullOrEmpty(ParsingError) == false)
+            {
+                Skip = $"Failed to parse the Ftp settings, error: {ParsingError}";
+                return;
+            }
+
+            if (_ftpSettings == null)
+            {
+                Skip = $"Ftp {memberName} tests missing {nameof(FtpSettings)}.";
+                return;
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -134,7 +134,7 @@ namespace FastTests
 
             public PeriodicBackupConfiguration CreateBackupConfiguration(string backupPath = null, BackupType backupType = BackupType.Backup, bool disabled = false, string fullBackupFrequency = "0 0 1 1 *",
                 string incrementalBackupFrequency = null, long? taskId = null, string mentorNode = null, BackupEncryptionSettings backupEncryptionSettings = null, AzureSettings azureSettings = null,
-                GoogleCloudSettings googleCloudSettings = null, S3Settings s3Settings = null, RetentionPolicy retentionPolicy = null, string name = null)
+                GoogleCloudSettings googleCloudSettings = null, S3Settings s3Settings = null, FtpSettings ftpSettings = null, RetentionPolicy retentionPolicy = null, string name = null)
             {
                 var config = new PeriodicBackupConfiguration()
                 {
@@ -161,6 +161,8 @@ namespace FastTests
                     config.GoogleCloudSettings = googleCloudSettings;
                 if (s3Settings != null)
                     config.S3Settings = s3Settings;
+                if (ftpSettings != null)
+                    config.FtpSettings = ftpSettings;
                 if (retentionPolicy != null)
                     config.RetentionPolicy = retentionPolicy;
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -98,7 +98,7 @@ namespace FastTests
             LicenseManager.AddLicenseStatusToLicenseLimitsException = true;
             RachisStateMachine.EnableDebugLongCommit = true;
             RavenServer.SkipCertificateDispose = true;
-
+            RavenFtpClient.ValidateAnyCertificate = true;
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();
             ZstdLib.CreateDictionaryException = message => new VoronErrorException(message);
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -24,16 +24,16 @@ public static class Program
     {
         Console.WriteLine(Process.GetCurrentProcess().Id);
 
-        /*for (int i = 0; i < 1000; i++)
+        for (int i = 0; i < 1000; i++)
         {
-            Console.WriteLine($"Starting to run {i}");*/
+            Console.WriteLine($"Starting to run {i}");
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new FtpBasicTests(testOutputHelper))
+                using (var test = new ReshardingTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.CanUploadBackupsWithDeletionOnEncrypted();
+                    await test.RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration();
                 }
             }
             catch (Exception e)
@@ -43,6 +43,6 @@ public static class Program
                 Console.ForegroundColor = ConsoleColor.White;
                 return;
             }
-        // }
+        }
     }
 }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -8,6 +8,7 @@ using RachisTests.DatabaseCluster;
 using Raven.Server.Utils;
 using SlowTests.Cluster;
 using SlowTests.Issues;
+using SlowTests.Server.Documents.PeriodicBackup;
 using SlowTests.Sharding.Cluster;
 
 namespace Tryouts;
@@ -23,16 +24,16 @@ public static class Program
     {
         Console.WriteLine(Process.GetCurrentProcess().Id);
 
-        for (int i = 0; i < 1000; i++)
+        /*for (int i = 0; i < 1000; i++)
         {
-            Console.WriteLine($"Starting to run {i}");
+            Console.WriteLine($"Starting to run {i}");*/
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ReshardingTests(testOutputHelper))
+                using (var test = new FtpBasicTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration();
+                    await test.CanUploadBackupsWithDeletionOnEncrypted();
                 }
             }
             catch (Exception e)
@@ -42,6 +43,6 @@ public static class Program
                 Console.ForegroundColor = ConsoleColor.White;
                 return;
             }
-        }
+        // }
     }
 }

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -8,7 +8,6 @@ using RachisTests.DatabaseCluster;
 using Raven.Server.Utils;
 using SlowTests.Cluster;
 using SlowTests.Issues;
-using SlowTests.Server.Documents.PeriodicBackup;
 using SlowTests.Sharding.Cluster;
 
 namespace Tryouts;
@@ -30,10 +29,10 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new Ftp(testOutputHelper))
+                using (var test = new ReshardingTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.CanUploadBackupOnEncrypted();
+                    await test.RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration();
                 }
             }
             catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -33,7 +33,7 @@ public static class Program
                 using (var test = new Ftp(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.CanUploadBackup();
+                    await test.CanUploadBackupOnEncrypted();
                 }
             }
             catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -8,6 +8,7 @@ using RachisTests.DatabaseCluster;
 using Raven.Server.Utils;
 using SlowTests.Cluster;
 using SlowTests.Issues;
+using SlowTests.Server.Documents.PeriodicBackup;
 using SlowTests.Sharding.Cluster;
 
 namespace Tryouts;
@@ -29,10 +30,10 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ReshardingTests(testOutputHelper))
+                using (var test = new Ftp(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration();
+                    await test.CanUploadBackup();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19985/Switch-to-FluentFTP

### Additional description

First test current functionality by creating 2 slow tests and then after those passed, migrate the raven ftp client to use FluentFTP library and tested using those 2 slow tests with some minor changes to use FluentFTP commands

### Type of change
- Task

### How risky is the change?
- Low 

### Is it platform specific issue?

- Yes, v6.0 and above

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### UI work
- No UI work is needed
