### PR TITLE
RavenDB-19611 - Block support for queue ETLs in sharding

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.ETL;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
@@ -7,6 +9,21 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
     {
         public OngoingTasksHandlerProcessorForAddEtl([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override void AssertIsEtlTypeSupported(EtlType type)
+        {
+            switch (type)
+            {
+                case EtlType.Raven:
+                case EtlType.Sql:
+                case EtlType.Olap:
+                case EtlType.ElasticSearch:
+                case EtlType.Queue:
+                    return;
+                default:
+                    throw new NotSupportedException($"Unknown ETL type {type}");
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using JetBrains.Annotations;
-using Raven.Client.Documents.Operations.ETL;
+﻿using JetBrains.Annotations;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
@@ -9,21 +7,6 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
     {
         public OngoingTasksHandlerProcessorForAddEtl([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
-        }
-
-        protected override void AssertIsEtlTypeSupported(EtlType type)
-        {
-            switch (type)
-            {
-                case EtlType.Raven:
-                case EtlType.Sql:
-                case EtlType.Olap:
-                case EtlType.ElasticSearch:
-                case EtlType.Queue:
-                    return;
-                default:
-                    throw new NotSupportedException($"Unknown ETL type {type}");
-            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedQueueEtlHandlerProcessorForPostScriptTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/ShardedQueueEtlHandlerProcessorForPostScriptTest.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.ETL;
 using Raven.Server.Documents.ETL.Providers.Queue.Test;
@@ -12,6 +13,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.ETL
     {
         public ShardedQueueEtlHandlerProcessorForPostScriptTest([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+            throw new NotSupportedInShardingException("Queue ETLs are currently not supported in sharding");
         }
 
         protected override TestQueueEtlScript GetTestEtlScript(BlittableJsonReaderObject json) => JsonDeserializationServer.TestQueueEtlScript(json);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
@@ -1,4 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
 using Raven.Server.ServerWide.Context;
 
@@ -8,6 +11,21 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
     {
         public ShardedOngoingTasksHandlerProcessorForAddEtl([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override void AssertIsEtlTypeSupported(EtlType type)
+        {
+            switch (type)
+            {
+                case EtlType.Raven:
+                case EtlType.Sql:
+                case EtlType.Olap:
+                case EtlType.ElasticSearch:
+                case EtlType.Queue:
+                    throw new NotSupportedInShardingException("Queue ETLs are currently not supported in sharding");
+                default:
+                    throw new NotSupportedException($"Unknown ETL type {type}");
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
 {
@@ -13,19 +15,12 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override void AssertIsEtlTypeSupported(EtlType type)
+        protected override void AssertCanAddOrUpdateEtl(ref BlittableJsonReaderObject etlConfiguration)
         {
-            switch (type)
-            {
-                case EtlType.Raven:
-                case EtlType.Sql:
-                case EtlType.Olap:
-                case EtlType.ElasticSearch:
-                case EtlType.Queue:
-                    throw new NotSupportedInShardingException("Queue ETLs are currently not supported in sharding");
-                default:
-                    throw new NotSupportedException($"Unknown ETL type {type}");
-            }
+            if(EtlConfiguration<ConnectionString>.GetEtlType(etlConfiguration) == EtlType.Queue)
+                throw new NotSupportedInShardingException("Queue ETLs are currently not supported in sharding");
+
+            base.AssertCanAddOrUpdateEtl(ref etlConfiguration);
         }
     }
 }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.ETL.Providers.Queue;
 using Raven.Server.Documents.ETL.Providers.Queue.Test;
@@ -67,6 +68,19 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             Assert.Equal(order.Id, "orders/1-A");
             Assert.Equal(order.OrderLinesCount, 2);
             Assert.Equal(order.TotalCost, 10);
+        }
+    }
+
+    [RequiresRabbitMqRetryFact]
+    public void ShardedRabbitMqEtlNotSupported()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var error = Assert.ThrowsAny<NotSupportedInShardingException>(() =>
+            {
+                SetupQueueEtlToRabbitMq(store, DefaultScript, DefaultCollections);
+            });
+            Assert.Contains("Queue ETLs are currently not supported in sharding", error.Message);
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19611

### Additional description

Throwing `NotSupportedInSharding` for adding kafka and rabbitMq tasks.
Also throwing for script testing queue ETLs in a sharded database.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
