### PR TITLE
RavenDB-19984 Fix for getting collection name | Adding new functionality for IndexMerger.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
         public bool IsFanout { get; set; }
 
-        public string Collection { get; set; }
+        public string[] Collections { get; set; }
         public InvocationExpressionSyntax InvocationExpression { get; set; }
         public IndexDefinition Index => _index;
         public bool IsMapReduceOrMultiMap { get; set; }

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexVisitor.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             _indexData = indexData;
             indexData.NumberOfFromClauses = 0;
             indexData.SelectExpressions = new();
-            _indexData.Collection = null;
+            _indexData.Collections = null;
         }
 
         public override SyntaxNode VisitQueryExpression(QueryExpressionSyntax node)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19984
### Additional description

-Adding a new visitor to retrieve the collection name
-Get the correct inner member when the field is nested 
-Adding new types of syntax for `Rewriter`


### Type of change

- Bug fix
- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
