### PR TITLE
HRINT-3153 Add label if changes are only in Studio dir

### DIFF
--- a/.github/workflows/studioLabel.yml
+++ b/.github/workflows/studioLabel.yml
@@ -11,7 +11,16 @@ jobs:
     name: Label
     runs-on: windows-latest
     steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '!src/Raven.Studio/**/*'
+
       - uses: actions/checkout@v2
+        if: steps.changes.outputs.src != 'true'
+        
       - name: Set Label
         env:
           githubOwner: ${{ github.event.pull_request.base.repo.owner.login }}
@@ -19,5 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPlus_ReadyToRunExcludeList: 'System.Security.Cryptography.X509Certificates'
           Raven_Enable_Per_Test_Logging: 'true'
-        if: contains(github.event.pull_request.labels.*.name, env.newLabel) == false && (startsWith( github.event.pull_request.base.ref, 'v' ) || startsWith( github.event.pull_request.base.ref, 'feature' ))
+        if: steps.changes.outputs.src != 'true' && contains(github.event.pull_request.labels.*.name, env.newLabel) == false && (startsWith( github.event.pull_request.base.ref, 'v' ) || startsWith( github.event.pull_request.base.ref, 'feature' ))
         run: ./scripts/githubActions/set_github_label.ps1 -owner ${{env.githubOwner}} -repo ${{env.repoName}} -pullRequestId ${{ github.event.pull_request.number }} -label "Studio"
+        
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-3153

### Additional description

Run workflow if changes were made **only** in `Studio` folder.

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing
Labels added by workflow depending on changed files location:
https://github.com/hiddenshadow21/ravendb/pull/19
https://github.com/hiddenshadow21/ravendb/pull/18

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
