### PR TITLE
RavenDB-20063 - Inter-version testing between 5.4 & 6.0 non-sharded

### DIFF
--- a/test/Tests.Infrastructure/InterversionTest/UpgradeTestSuit.cs
+++ b/test/Tests.Infrastructure/InterversionTest/UpgradeTestSuit.cs
@@ -156,4 +156,61 @@ namespace Tests.Infrastructure.InterversionTest
             }
         }
     }
+
+    public class Version54X : UpgradeTestSuit
+    {
+        public Version54X(InterversionTestBase infrastructure) : base(infrastructure)
+        {
+        }
+
+        public override async Task TestClustering(List<DocumentStore> stores, string key)
+        {
+            using (var session = stores[0].OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var id = $"cluster/document/{Interlocked.Increment(ref ClusterDocumentNumber)}";
+                session.Advanced.RequestExecutor.DefaultTimeout = TimeSpan.FromSeconds(60);
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, "okay");
+                var user = new User
+                {
+                    Name = "Karmel"
+                };
+                await session.StoreAsync(user, id);
+                await session.SaveChangesAsync();
+
+                Assert.True(await Infrastructure.WaitForDocumentInClusterAsync<User>(
+                    id,
+                    u => u.Name.Equals("Karmel"),
+                    TimeSpan.FromSeconds(10),
+                    stores,
+                    stores[0].Database));
+            }
+        }
+
+        public override async Task TestReplication(List<DocumentStore> stores)
+        {
+            var user = new User
+            {
+                Name = "aviv",
+                Id = new Guid().ToString()
+            };
+
+            using (var session = stores[0].OpenAsyncSession())
+            {
+                session.Advanced.RequestExecutor.DefaultTimeout = TimeSpan.FromSeconds(60);
+
+                await session.StoreAsync(user, user.Id);
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await Infrastructure.WaitForDocumentInClusterAsync<User>(
+                user.Id,
+                u => u.Name.Equals("aviv"),
+                TimeSpan.FromSeconds(10),
+                stores,
+                stores[0].Database));
+        }
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20063/Inter-version-testing-between-5.4-6.0-non-sharded

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
