### PR TITLE
RavenDB-19998 - Sharding - Deleting orchestrator doesn't change orchestrator topology's replication factor

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -152,6 +152,8 @@ namespace Raven.Client.ServerWide
             Stamp = topology.Stamp;
             PriorityOrder = topology.PriorityOrder;
             NodesModifiedAt = topology.NodesModifiedAt;
+
+            ReplicationFactor = topology.ReplicationFactor;
         }
     }
 

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -154,6 +154,7 @@ namespace Raven.Client.ServerWide
             NodesModifiedAt = topology.NodesModifiedAt;
 
             ReplicationFactor = topology.ReplicationFactor;
+            DynamicNodesDistribution = topology.DynamicNodesDistribution;
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19998

### Additional description

`Update()` function in `OrchestratorTopology` class was missing update of `ReplicationFactor`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
