### PR TITLE
RavenDB-20100 Avoid hanging read transaction on restore of incremental backups

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -509,7 +509,7 @@ namespace Raven.Client.Documents.Smuggler
 
             internal void Start()
             {
-                StartTime = SystemTime.UtcNow;
+                StartTime ??= SystemTime.UtcNow;
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -111,6 +111,10 @@ namespace Raven.Server.Smuggler.Documents.Data
         ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
 
         ValueTask WriteTombstoneKeyAsync(string key);
+
+        bool MaybeFlush();
+
+        Task FlushAsync();
     }
 
     public interface IDatabaseRecordActions : IAsyncDisposable

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDocumentActions : INewDocumentActions, IAsyncDisposable
     {
-        ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress);
+        ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<Task> beforeFlushing = null);
 
         ValueTask WriteTombstoneAsync(Tombstone tombstone, SmugglerProgressBase.CountsWithLastEtag progress);
 
@@ -112,9 +112,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         ValueTask WriteTombstoneKeyAsync(string key);
 
-        bool MaybeFlush();
-
-        Task FlushAsync();
+        ValueTask FlushAsync();
     }
 
     public interface IDatabaseRecordActions : IAsyncDisposable

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IDocumentActions : INewDocumentActions, IAsyncDisposable
     {
-        ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<Task> beforeFlushing = null);
+        ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<ValueTask> beforeFlushing = null);
 
         ValueTask WriteTombstoneAsync(Tombstone tombstone, SmugglerProgressBase.CountsWithLastEtag progress);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
@@ -300,7 +299,7 @@ namespace Raven.Server.Smuggler.Documents
                     _command.DocumentCollectionMismatchHandler = item => _duplicateDocsHandler.AddDocument(item);
             }
 
-            public ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<Task> beforeFlushing)
+            public ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<ValueTask> beforeFlushing)
             {
                 if (item.Attachments != null)
                 {
@@ -513,7 +512,7 @@ namespace Raven.Server.Smuggler.Documents
                 _revisionDeleteCommand = null;
             }
 
-            private ValueTask HandleBatchOfDocumentsIfNecessaryAsync(Func<Task> beforeFlush)
+            private ValueTask HandleBatchOfDocumentsIfNecessaryAsync(Func<ValueTask> beforeFlush)
             {
                 var commandSize = _command.GetCommandAllocationSize();
                 var prevDoneAndHasEnough = commandSize > Constants.Size.Megabyte && _prevCommandTask.IsCompleted;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Smuggler.Documents
             EnsureStepProcessed(result.Counters, skipped);
             EnsureStepProcessed(result.Tombstones, skipped);
             EnsureStepProcessed(result.Conflicts, skipped);
-            EnsureStepProcessed(result.Indexes,  indexesSkipped ?? skipped);
+            EnsureStepProcessed(result.Indexes, indexesSkipped ?? skipped);
             EnsureStepProcessed(result.Identities, skipped);
             EnsureStepProcessed(result.CompareExchange, skipped);
             EnsureStepProcessed(result.CompareExchangeTombstones, skipped);
@@ -682,8 +682,8 @@ namespace Raven.Server.Smuggler.Documents
             await using (var compareExchangeActions = _destination.CompareExchange(context, BackupKind, withDocuments: true))
             {
                 List<string> legacyIdsToDelete = null;
-                Func<Task> beforeFlush = compareExchangeActions == null ? null : async () => await compareExchangeActions.FlushAsync();
-                
+                Func<ValueTask> beforeFlush = compareExchangeActions == null ? null : compareExchangeActions.FlushAsync;
+
                 await foreach (DocumentItem item in _source.GetDocumentsAsync(_options.Collections, documentActions))
                 {
                     _token.ThrowIfCancellationRequested();
@@ -761,7 +761,7 @@ namespace Raven.Server.Smuggler.Documents
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
                         continue;
                     }
-                        
+
                     await documentActions.WriteDocumentAsync(item, result.Documents, beforeFlush);
                 }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -760,7 +760,7 @@ namespace Raven.Server.Smuggler.Documents
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
                         continue;
                     }
-                    if (compareExchangeActions.MaybeFlush()) // we don't want to keep the cmp xng transaction open for too long
+                    if (compareExchangeActions?.MaybeFlush() == true) // we don't want to keep the cmp xng transaction open for too long
                         await compareExchangeActions.FlushAsync();
                     await documentActions.WriteDocumentAsync(item, result.Documents);
                 }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -760,7 +760,8 @@ namespace Raven.Server.Smuggler.Documents
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
                         continue;
                     }
-
+                    if (compareExchangeActions.MaybeFlush()) // we don't want to keep the cmp xng transaction open for too long
+                        await compareExchangeActions.FlushAsync();
                     await documentActions.WriteDocumentAsync(item, result.Documents);
                 }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
-using NuGet.Protocol;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
@@ -28,7 +27,6 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.Util;
 using Raven.Server.Config;
-using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.PeriodicBackup;
@@ -39,7 +37,6 @@ using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Web.System;
-using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -1197,7 +1194,7 @@ namespace Raven.Server.Smuggler.Documents
                 _filterMetadataProperty = filterMetadataProperty;
             }
 
-            public ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<Task> beforeFlush)
+            public ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<ValueTask> beforeFlush)
             {
                 if (item.Attachments != null)
                     throw new NotSupportedException();

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1437,6 +1437,16 @@ namespace Raven.Server.Smuggler.Documents
             {
                 throw new NotSupportedException();
             }
+
+            public bool MaybeFlush()
+            {
+                return false;
+            }
+
+            public Task FlushAsync()
+            {
+                return Task.CompletedTask;
+            }
         }
 
         private abstract class StreamActionsBase : IAsyncDisposable


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20100 

### Additional description

During restore of multiple files (incremental backup) we may leave a compare exchange operation alive while we are writing many transactions. That leaves a transaction open, which prevent flushing to disk.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

