### PR TITLE
RavenDB-15330 - Put raft commands with `DontCareId` in the history log as well

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1496,12 +1496,10 @@ namespace Raven.Server.Rachis
             {
                 var newGuid = $"DontCare/{term}-{lastIndex}";
                 cmd.Modifications = new DynamicJsonValue { [nameof(CommandBase.UniqueRequestId)] = newGuid };
-                BlittableJsonReaderObject newCmd;
-                using (cmd)
+                using (var old = cmd)
                 {
-                    newCmd = context.ReadObject(cmd, newGuid);
+                    cmd = context.ReadObject(cmd, newGuid);
                 }
-                cmd = newCmd;
             }
             
             using (table.Allocate(out TableValueBuilder tvb))

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1494,12 +1494,14 @@ namespace Raven.Server.Rachis
             var guid = LogHistory.GetGuidFromCommand(cmd);
             if (guid == RaftIdGenerator.DontCareId)
             {
-                var newGuid = $"DontCare/{lastIndex}";
+                var newGuid = $"DontCare/{term}-{lastIndex}";
                 cmd.Modifications = new DynamicJsonValue { [nameof(CommandBase.UniqueRequestId)] = newGuid };
+                BlittableJsonReaderObject newCmd;
                 using (cmd)
                 {
-                    cmd = context.ReadObject(cmd, newGuid);
+                    newCmd = context.ReadObject(cmd, newGuid);
                 }
+                cmd = newCmd;
             }
             
             using (table.Allocate(out TableValueBuilder tvb))

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -134,6 +134,11 @@ namespace Raven.Server.Rachis
             if (guid == null) // shouldn't happened in new cluster version!
                 return;
 
+            if (guid == RaftIdGenerator.DontCareId)
+            {
+                guid = $"DontCare/{index}";
+            }
+
             var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
             var type = GetTypeFromCommand(cmd);
 

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -134,9 +134,6 @@ namespace Raven.Server.Rachis
             if (guid == null) // shouldn't happened in new cluster version!
                 return;
 
-            if (guid == RaftIdGenerator.DontCareId)
-                return;
-
             var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
             var type = GetTypeFromCommand(cmd);
 

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -135,9 +135,7 @@ namespace Raven.Server.Rachis
                 return;
 
             if (guid == RaftIdGenerator.DontCareId)
-            {
                 return;
-            }
 
             var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
             var type = GetTypeFromCommand(cmd);

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -136,7 +136,7 @@ namespace Raven.Server.Rachis
 
             if (guid == RaftIdGenerator.DontCareId)
             {
-                guid = $"DontCare/{index}";
+                return;
             }
 
             var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);

--- a/test/SlowTests/Issues/RavenDB-15330.cs
+++ b/test/SlowTests/Issues/RavenDB-15330.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Util;
+using Raven.Server.Config;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands.Indexes;
+using Raven.Server.ServerWide.Commands.Subscriptions;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using SlowTests.Rolling;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_15330 : ClusterTestBase
+{
+    public RavenDB_15330(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Command_With_DontCareId_Should_Be_Committed()
+    {
+        DebuggerAttachedTimeout.DisableLongTimespan = true;
+        var server = GetNewServer();
+        using var store = GetDocumentStoreForRollingIndexes(new RavenTestBase.Options
+        {
+            ModifyDatabaseRecord =
+                record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndex)] = "5",
+            Server = server,
+            ReplicationFactor = 1,
+        });
+
+        await store.ExecuteIndexAsync(new SomeRollingIndex());
+
+        var result = await server.ServerStore.SendToLeaderAsync(new PutRollingIndexCommand(store.Database, nameof(SomeRollingIndex),
+            DateTime.UtcNow, RaftIdGenerator.DontCareId));
+
+        using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            var historyLog = server.ServerStore.Engine.LogHistory.GetHistoryLogs(context);
+            bool contain = false;
+            foreach (var djv in historyLog)
+            {
+                if (djv!=null && 
+                    djv["Type"] != null && djv["Type"].ToString() == nameof(PutRollingIndexCommand) && 
+                    djv["State"]!=null && djv["State"].ToString() == "Committed")
+                {
+                    contain = true;
+                    break;
+                }
+            }
+            Assert.True(contain);
+        }
+    }
+
+    private class SomeRollingIndex : AbstractIndexCreationTask<Order>
+    {
+        public SomeRollingIndex()
+        {
+            Map = orders => from order in orders
+                select new
+                {
+                    order.Company,
+                };
+
+            DeploymentMode = IndexDeploymentMode.Rolling;
+        }
+    }
+
+}
+

--- a/test/SlowTests/Issues/RavenDB-15330.cs
+++ b/test/SlowTests/Issues/RavenDB-15330.cs
@@ -33,7 +33,6 @@ public class RavenDB_15330 : ClusterTestBase
     [Fact]
     public async Task Command_With_DontCareId_Should_Be_Committed()
     {
-        DoNotReuseServer();
         var typeProp = nameof(RachisLogHistory.LogHistoryColumn.Type);
         var stateProp = nameof(RachisLogHistory.LogHistoryColumn.State);
         var indexProp = nameof(RachisLogHistory.LogHistoryColumn.Index);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15330/Put-raft-commands-with-DontCareId-in-the-history-log-as-well

### Additional description

Put raft commands with `DontCareId` in the history log as well

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
