### PR TITLE
RavenDB-20091 - Sharding - OrchestratorTopology field in ModifyOrchestratorTopologyResult is a string

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/AddNodeToOrchestratorTopologyOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/AddNodeToOrchestratorTopologyOperation.cs
@@ -72,7 +72,7 @@ namespace Raven.Client.ServerWide.Sharding
     public class ModifyOrchestratorTopologyResult
     {
         public string Name { get; set; }
-        public string OrchestratorTopology { get; set; }
+        public OrchestratorTopology OrchestratorTopology { get; set; }
         public long RaftCommandIndex { get; set; }
     }
 }

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -293,7 +293,7 @@ namespace SlowTests.Sharding
                 var nodeInOrchestratorTopology = allNodes.First(x => record.Sharding.Orchestrator.Topology.Members.Contains(x));
 
                 //remove the node from orchestrator topology
-                store.Maintenance.Server.Send(new RemoveNodeFromOrchestratorTopologyOperation(store.Database, nodeInOrchestratorTopology));
+                var modifyResult = store.Maintenance.Server.Send(new RemoveNodeFromOrchestratorTopologyOperation(store.Database, nodeInOrchestratorTopology));
                 record = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)));
                 dbTopology = record.Sharding.Orchestrator.Topology;
                 Assert.Equal(nodeAmount - 1, dbTopology.Members.Count);
@@ -301,14 +301,20 @@ namespace SlowTests.Sharding
                 Assert.Equal(0, dbTopology.Promotables.Count);
                 Assert.Equal(0, dbTopology.Rehabs.Count);
                 
+                Assert.Equal(dbTopology.Members.Count, modifyResult.OrchestratorTopology.Members.Count);
+                Assert.Equal(dbTopology.Rehabs.Count, modifyResult.OrchestratorTopology.Rehabs.Count);
+                
                 //add node to orchestrator topology
-                store.Maintenance.Server.Send(new AddNodeToOrchestratorTopologyOperation(store.Database, nodeInOrchestratorTopology));
+                modifyResult = store.Maintenance.Server.Send(new AddNodeToOrchestratorTopologyOperation(store.Database, nodeInOrchestratorTopology));
                 record = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)));
                 dbTopology = record.Sharding.Orchestrator.Topology;
                 Assert.Equal(2, record.Sharding.Orchestrator.Topology.ReplicationFactor);
                 Assert.Equal(nodeAmount - 1, dbTopology.Members.Count);
                 Assert.Equal(1, dbTopology.Promotables.Count);
                 Assert.Equal(nodeInOrchestratorTopology, dbTopology.Promotables[0]);
+
+            	Assert.Equal(dbTopology.Members.Count, modifyResult.OrchestratorTopology.Members.Count);
+                Assert.Equal(dbTopology.Rehabs.Count, modifyResult.OrchestratorTopology.Rehabs.Count);
             }
         }
 

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -300,10 +300,10 @@ namespace SlowTests.Sharding
                 Assert.Equal(1, record.Sharding.Orchestrator.Topology.ReplicationFactor);
                 Assert.Equal(0, dbTopology.Promotables.Count);
                 Assert.Equal(0, dbTopology.Rehabs.Count);
-                
+
                 Assert.Equal(dbTopology.Members.Count, modifyResult.OrchestratorTopology.Members.Count);
                 Assert.Equal(dbTopology.Rehabs.Count, modifyResult.OrchestratorTopology.Rehabs.Count);
-                
+
                 //add node to orchestrator topology
                 modifyResult = store.Maintenance.Server.Send(new AddNodeToOrchestratorTopologyOperation(store.Database, nodeInOrchestratorTopology));
                 record = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)));
@@ -313,7 +313,7 @@ namespace SlowTests.Sharding
                 Assert.Equal(1, dbTopology.Promotables.Count);
                 Assert.Equal(nodeInOrchestratorTopology, dbTopology.Promotables[0]);
 
-            	Assert.Equal(dbTopology.Members.Count, modifyResult.OrchestratorTopology.Members.Count);
+                Assert.Equal(dbTopology.Members.Count, modifyResult.OrchestratorTopology.Members.Count);
                 Assert.Equal(dbTopology.Rehabs.Count, modifyResult.OrchestratorTopology.Rehabs.Count);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20091

### Additional description

Changed from string to the class

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
