### PR TITLE
RavenDB-20092 - fixed OrchestratorTimeoutInMinutes setting is showing 0 in studio

### DIFF
--- a/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Config.Categories
     {
         public ShardingConfiguration()
         {
-            OrchestratorTimeoutInMin = new TimeSetting(Timeout.InfiniteTimeSpan);
+            OrchestratorTimeout = new TimeSetting(Timeout.InfiniteTimeSpan);
         }
 
         [Description("The compression level to use when sending import streams to shards during smuggler import")]
@@ -33,7 +33,7 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(DefaultValueSetInConstructor)]
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Sharding.OrchestratorTimeoutInMin", ConfigurationEntryScope.ServerWideOnly)]
-        public TimeSetting OrchestratorTimeoutInMin { get; set; }
+        public TimeSetting OrchestratorTimeout { get; set; }
 
         [DefaultValue(10 * 60)]
         [TimeUnit(TimeUnit.Seconds)]

--- a/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ShardingConfiguration.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Config.Categories
     {
         public ShardingConfiguration()
         {
-            OrchestratorTimeoutInMinutes = new TimeSetting(Timeout.InfiniteTimeSpan);
+            OrchestratorTimeoutInMin = new TimeSetting(Timeout.InfiniteTimeSpan);
         }
 
         [Description("The compression level to use when sending import streams to shards during smuggler import")]
@@ -32,8 +32,8 @@ namespace Raven.Server.Config.Categories
         [Description("Enable the timeout of the orchestrator's requests to the shards")]
         [DefaultValue(DefaultValueSetInConstructor)]
         [TimeUnit(TimeUnit.Minutes)]
-        [ConfigurationEntry("Sharding.OrchestratorTimeoutInMinutes", ConfigurationEntryScope.ServerWideOnly)]
-        public TimeSetting OrchestratorTimeoutInMinutes { get; set; }
+        [ConfigurationEntry("Sharding.OrchestratorTimeoutInMin", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting OrchestratorTimeoutInMin { get; set; }
 
         [DefaultValue(10 * 60)]
         [TimeUnit(TimeUnit.Seconds)]

--- a/src/Raven.Server/Config/ConfigurationEntryMetadata.cs
+++ b/src/Raven.Server/Config/ConfigurationEntryMetadata.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Config
                         return configurationValueAsSize.GetValue(SizeUnit.Value).ToString();
                     case ConfigurationEntryType.Time:
                         var configurationValueAsTime = (TimeSetting)configurationValue;
-                        return configurationValueAsTime.GetValue(TimeUnit.Value).ToString();
+                        return configurationValueAsTime.GetValueAsString(TimeUnit.Value);
                     default:
                         throw new NotSupportedException($"Type '{Type}' is not supported.");
                 }

--- a/src/Raven.Server/Config/Settings/TimeSetting.cs
+++ b/src/Raven.Server/Config/Settings/TimeSetting.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 
 namespace Raven.Server.Config.Settings
 {
@@ -67,6 +68,16 @@ namespace Raven.Server.Config.Settings
                 default:
                     throw new ArgumentOutOfRangeException(nameof(requestedUnit), requestedUnit, "Unknown TimeUnit value");
             }
+        }
+
+        public string GetValueAsString(TimeUnit requestedUnit)
+        {
+            if (AsTimeSpan.Equals(Timeout.InfiniteTimeSpan))
+            {
+                return "Infinite";
+            }
+
+            return GetValue(requestedUnit).ToString();
         }
     }
 

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Sharding.Executors
                 HttpPooledConnectionLifetime = DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime,
                 UseHttpCompression = store.Configuration.Sharding.ShardExecutorUseHttpCompression,
                 UseHttpDecompression = store.Configuration.Sharding.ShardExecutorUseHttpDecompression,
-                GlobalHttpClientTimeout = store.Configuration.Sharding.OrchestratorTimeoutInMinutes.AsTimeSpan
+                GlobalHttpClientTimeout = store.Configuration.Sharding.OrchestratorTimeoutInMin.AsTimeSpan
             };
 
             _requestExecutors = CreateExecutors();

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Sharding.Executors
                 HttpPooledConnectionLifetime = DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime,
                 UseHttpCompression = store.Configuration.Sharding.ShardExecutorUseHttpCompression,
                 UseHttpDecompression = store.Configuration.Sharding.ShardExecutorUseHttpDecompression,
-                GlobalHttpClientTimeout = store.Configuration.Sharding.OrchestratorTimeoutInMin.AsTimeSpan
+                GlobalHttpClientTimeout = store.Configuration.Sharding.OrchestratorTimeout.AsTimeSpan
             };
 
             _requestExecutors = CreateExecutors();

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -201,7 +201,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             Query.Metadata.IndexName,
             canReadFromCache: ExistingResultEtag != null,
             _raftUniqueRequestId,
-            RequestHandler.ServerStore.Configuration.Sharding.OrchestratorTimeoutInMinutes.AsTimeSpan);
+            RequestHandler.ServerStore.Configuration.Sharding.OrchestratorTimeoutInMin.AsTimeSpan);
     }
 
     protected virtual void AssertQueryExecution()

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -201,7 +201,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             Query.Metadata.IndexName,
             canReadFromCache: ExistingResultEtag != null,
             _raftUniqueRequestId,
-            RequestHandler.ServerStore.Configuration.Sharding.OrchestratorTimeoutInMin.AsTimeSpan);
+            RequestHandler.ServerStore.Configuration.Sharding.OrchestratorTimeout.AsTimeSpan);
     }
 
     protected virtual void AssertQueryExecution()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20092

### Additional description

Code was taking only the relevant part of the `TimeSpan` according to the configured time unit. In this case - minutes. But the default setting was `-1 ms` (Infinite). Which resulted in the `Minutes` part being 0.
Changed so now there is a comparison check to `Infinite` and returning a string value accordingly.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
