### PR TITLE
RavenDB-19836 Uncaught TypeError: Cannot read properties of null (rea…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -1222,9 +1222,14 @@ class indexPerformance extends viewModelBase {
                     countsDetails += `<div class="tooltip-li">Average Document Size: <div class="value">${generalUtils.formatBytesToSize(parentStats.DocumentsSize.SizeInBytes / parentStats.InputCount)}</div></div>`;
                 }
 
-                countsDetails += `<div class="tooltip-li">Managed Allocations (accumulated): <div class="value">${parentStats.AllocatedManagedBytes.HumaneSize}</div></div>`;
-                countsDetails += `<div class="tooltip-li">Unmanaged Allocations: <div class="value">${parentStats.AllocatedUnmanagedBytes.HumaneSize}</div></div>`;
-
+                if (parentStats.AllocatedManagedBytes) {
+                    countsDetails += `<div class="tooltip-li">Managed Allocations (accumulated): <div class="value">${parentStats.AllocatedManagedBytes.HumaneSize}</div></div>`;
+                }
+                
+                if (parentStats.AllocatedUnmanagedBytes) {
+                    countsDetails += `<div class="tooltip-li">Unmanaged Allocations: <div class="value">${parentStats.AllocatedUnmanagedBytes.HumaneSize}</div></div>`;
+                }
+                
                 if (element.DurationInMs > 0) {
                     const durationInSec = element.DurationInMs / 1000;
                     countsDetails += `<div class="tooltip-li">Processed Data Speed: <div class="value">${generalUtils.formatBytesToSize(parentStats.DocumentsSize.SizeInBytes / durationInSec)}/sec</div></div>`;


### PR DESCRIPTION
…ding 'HumaneSize')

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19836 

### Additional description

Conditionally render allocations on index performance page. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### UI work

- No UI work is needed
