### PR TITLE
RavenDB-19522 Add alias to query if nested path starts from keyword

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -703,10 +703,20 @@ namespace Raven.Client.Documents.Linq
 
             var propertyName = GetPropertyName(result.Path, expression.NodeType);
 
+            if(_aliasKeywords.Any(s => propertyName.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0))
+                propertyName = AddAliasIfNeeded(propertyName);
+            
             return new ExpressionInfo(propertyName, result.MemberType, result.IsNestedPath, result.Args)
             {
                 MaybeProperty = result.MaybeProperty
             };
+        }
+
+        private string AddAliasIfNeeded(string propertyName)
+        {
+            var fromAlias = $"{DefaultAliasPrefix}{_aliasesCount++}";
+            AddFromAlias(fromAlias);
+            return $"{fromAlias}.{propertyName}";
         }
 
         private string GetPropertyName(string selectPath, ExpressionType type)

--- a/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
+++ b/src/Raven.Client/Documents/Queries/QueryFieldUtil.cs
@@ -1,9 +1,29 @@
 ﻿using System.Text;
+using System;
+using System.Collections.Generic;
 
 namespace Raven.Client.Documents.Queries
 {
     public static class QueryFieldUtil
     {
+        private static readonly HashSet<string> AliasKeywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "AS",
+            "SELECT",
+            "WHERE",
+            "GROUP",
+            "ORDER",
+            "INCLUDE",
+            "UPDATE",
+            "LIMIT",
+            "OFFSET"
+        };
+
+        public static bool IsKeyword(int start, int end, StringBuilder sb)
+        {
+            return AliasKeywords.Contains(sb.ToString(start, end - start - 1));
+        }
+        
         public static string EscapeIfNecessary(string name)
         {
             return EscapeIfNecessary(name, isPath: false);
@@ -44,6 +64,13 @@ namespace Raven.Client.Documents.Queries
                         sb.Insert(i, '\'');
                         i++;
                     }
+                    
+                    if (IsKeyword(lastTermStart, i + 1, sb))
+                    {
+                        sb.Insert(lastTermStart, '\'');
+                        i++;
+                        sb.Insert(i, '\'');
+                    }
 
                     lastTermStart = i+1;
                     continue;
@@ -64,7 +91,7 @@ namespace Raven.Client.Documents.Queries
 
             return sb.ToString();
 
-                bool ShouldEscape(string s)
+            bool ShouldEscape(string s)
             {
                 var escape = false;
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -740,8 +740,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         public void WhereIn(string fieldName, IEnumerable<object> values, bool exact = false)
         {
             AssertMethodIsCurrentlySupported(nameof(WhereIn));
-            
-            fieldName = EnsureValidFieldName(fieldName, isNestedPath: false);
+
+            var nestedPath = fieldName.Contains('.');
+            fieldName = EnsureValidFieldName(fieldName, isNestedPath: nestedPath);
 
             var tokens = GetCurrentWhereTokens();
             AppendOperatorIfNeeded(tokens);

--- a/test/SlowTests/Issues/RavenDB-19522.cs
+++ b/test/SlowTests/Issues/RavenDB-19522.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19522 : RavenTestBase
+{
+    public RavenDB_19522(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private class Dto
+    {
+        public GroupObject Group { get; set; }
+    }
+
+    private class GroupObject
+    {
+        public string Name { get; set; }
+    }
+    
+    [RavenFact(RavenTestCategory.Querying)]
+    public void CheckIfKeywordFirstInNestedPathIsHandledCorrectly()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var g1 = new GroupObject() { Name = "CoolName1" };
+                var g2 = new GroupObject() { Name = "CoolName2" };
+                var g3 = new GroupObject() { Name = "CoolName3" };
+
+                var d1 = new Dto() { Group = g1 };
+                var d2 = new Dto() { Group = g2 };
+                var d3 = new Dto() { Group = g3 };
+                
+                session.Store(d1);
+                session.Store(d2);
+                session.Store(d3);
+                
+                session.SaveChanges();
+                
+                var result = session.Query<Dto>()
+                    .Where(dto => dto.Group.Name.In(new string[] { "CoolName1", "CoolName2" })).Customize(x => x.WaitForNonStaleResults()).ToList();
+                
+                Assert.Equal("CoolName1", result[0].Group.Name);
+                Assert.Equal("CoolName2", result[1].Group.Name);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19522/Property-named-Group-not-escaped-in-Linq-query-to-RQL-conversion

### Additional description

We want AbstractDocumentQuery.EnsureValidFieldName to escape keywords in nested path, and RavenQueryProviderProcessor.GetMember to add alias to query that has keyword as first member of nested path. 

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
