### PR TITLE
RavenDB-20074 Change default value of Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved to true

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -460,7 +460,7 @@ namespace Raven.Server.Config.Categories
         public Size MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndex { get; set; }
         
         [Description("Sort by ticks when field contains dates. When sorting in descending order, null dates are returned at the end with this option enabled.")]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool OrderByTicksAutomaticallyWhenDatesAreInvolved { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20074/Change-default-value-of-Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved-to-true

### Additional description

6.0 default behavior update for https://issues.hibernatingrhinos.com/issue/RavenDB-19843/Lucene-order-by-ticks-when-field-contains-dates.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured. Can be turned off using configuration option

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### Is there any existing behavior change of other features due to this change?

- Yes. Querying with order by date field

### UI work

- No UI work is needed
