### PR TITLE
RavenDB-20115 - High unmanged memory during deletion of a document with a lot of revisions

### DIFF
--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -719,6 +719,11 @@ namespace Sparrow.Server
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get { return (int)(End - Current); }
             }
+
+            public override string ToString()
+            {
+                return $"{nameof(Start)}: {(long)Start}, {nameof(End)}: {(long)End}, {nameof(Size)}: {Size}, {nameof(SizeLeft)}: {SizeLeft}";
+            }
         }
 
         // Log₂(MinBlockSizeInBytes)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -230,6 +230,9 @@ namespace Voron.Data.Tables
 
         public void ForgetAboutCompressed(long id)
         {
+            if (_tx.CachedDecompressedBuffersByStorageId == null)
+                return;
+
             if (_tx.CachedDecompressedBuffersByStorageId.Remove(id, out var t))
             {
                 _tx.Allocator.Release(ref t);
@@ -433,7 +436,7 @@ namespace Voron.Data.Tables
             var ptr = DirectReadRaw(id, out int size, out bool compressed);
 
             if (compressed)
-                _tx.CachedDecompressedBuffersByStorageId?.Remove(id);
+                ForgetAboutCompressed(id);
 
             ByteStringContext<ByteStringMemoryCache>.InternalScope decompressValue = default;
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -228,17 +228,6 @@ namespace Voron.Data.Tables
             return DirectReadDecompress(id, result, ref size);
         }
 
-        public void ForgetAboutCompressed(long id)
-        {
-            if (_tx.CachedDecompressedBuffersByStorageId == null)
-                return;
-
-            if (_tx.CachedDecompressedBuffersByStorageId.Remove(id, out var t))
-            {
-                _tx.Allocator.Release(ref t);
-            }
-        }
-
         private byte* DirectReadDecompress(long id, byte* directRead, ref int size)
         {
             if (_tx.CachedDecompressedBuffersByStorageId.TryGetValue(id, out var t))
@@ -436,7 +425,7 @@ namespace Voron.Data.Tables
             var ptr = DirectReadRaw(id, out int size, out bool compressed);
 
             if (compressed)
-                ForgetAboutCompressed(id);
+                _tx.ForgetAbout(id);
 
             ByteStringContext<ByteStringMemoryCache>.InternalScope decompressValue = default;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20115/High-unmanged-memory-during-deletion-of-a-document-with-a-lot-of-revisions

### Additional description

Release the memory of the allocated compressed value (and not just update the in-memory state).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing
