### PR TITLE
RavenDB-20101 Tuning for Sharding deployment during db creation

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -642,15 +642,15 @@
 
 <script type="text/html" id="manual-selection-sharded">
     <div class="bg-info padding no-margin" data-bind="visible: manualMode()">
-        <small>Orchestrator nodes</small>
-        <div class="checkbox">
+        <h3>Orchestrator nodes</h3>
+        <div class="checkbox checkbox-info margin-bottom-xxs">
             <input type="checkbox" id="toggle_all_in_cluster_sharded" class="styled" data-bind="checkboxTriple: $root.orchestratorSelectionState, event: { change: $root.orchestratorToggleSelectAll }">
             <label for="toggle_all_in_cluster_sharded"><i class="icon-cluster"></i><span>All cluster nodes</span></label>
         </div>
         <div data-bind="foreach: $root.clusterNodes">
-            <div class="checkbox checkbox-info" data-bind="validationOptions: { errorsAsTitle: false, insertMessages: false }">
+            <div class="checkbox checkbox-success padding-left-md" data-bind="validationOptions: { errorsAsTitle: false, insertMessages: false }">
                 <input class="styled" type="checkbox" data-bind="attr: { id: 'cluster_node_sharding_' + $index() }, checked: $parent.orchestrators, checkedValue: $data">
-                <label data-bind="attr: { for: 'cluster_node_sharding_' + $index() }">
+                <label class="text-success" data-bind="attr: { for: 'cluster_node_sharding_' + $index() }">
                     <i class="icon-cluster-node"></i><span data-bind="text: tag()"></span> &nbsp; <small data-bind="text: serverUrl()"></small>
                 </label>
             </div>
@@ -707,15 +707,15 @@
 
 <script type="text/html" id="manual-selection-non-sharded">
     <div class="bg-info padding no-margin" data-bind="visible: manualMode()">
-        <small>Available nodes</small>
-        <div class="checkbox">
+        <h3>Available nodes</h3>
+        <div class="checkbox checkbox-info margin-bottom-xxs">
             <input type="checkbox" id="toggle_all_in_cluster" class="styled" data-bind="checkboxTriple: $root.selectionState, event: { change: $root.toggleSelectAll }">
             <label for="toggle_all_in_cluster"><i class="icon-cluster"></i><span>All cluster nodes</span></label>
         </div>
         <div data-bind="foreach: $root.clusterNodes">
-            <div class="checkbox checkbox-info" data-bind="validationOptions: { errorsAsTitle: false, insertMessages: false }">
+            <div class="checkbox checkbox-success padding-left-md" data-bind="validationOptions: { errorsAsTitle: false, insertMessages: false }">
                 <input class="styled" type="checkbox" data-bind="attr: { id: 'cluster_node_' + $index() }, checked: $parent.nodes, checkedValue: $data">
-                <label data-bind="attr: { for: 'cluster_node_' + $index() }">
+                <label class="text-success" data-bind="attr: { for: 'cluster_node_' + $index() }">
                     <i class="icon-cluster-node"></i><span data-bind="text: tag()"></span> &nbsp; <small data-bind="text: serverUrl()"></small>
                 </label>
             </div>

--- a/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
@@ -340,7 +340,7 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
     }
     &.collapse-menu #main-menu {
         overflow: visible;
-        z-index: 999;
+        z-index: 1001;
         .btn-expand-menu {
             display: block;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20101/Ability-to-fine-tune-sharding-deployment-during-db-creation

### Additional description

Small tuning; also fixed main menu z-index

### Type of change
- Optimization

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
