### PR TITLE
RavenDB-20121 reduce number of alerts during resharding

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1411,7 +1411,7 @@ namespace Raven.Server.Documents.Replication
             return null;
         }
 
-        private DatabaseOutgoingReplicationHandler GetOutgoingReplicationHandlerInstance(TcpConnectionInfo info, ReplicationNode node)
+        protected virtual DatabaseOutgoingReplicationHandler GetOutgoingReplicationHandlerInstance(TcpConnectionInfo info, ReplicationNode node)
         {
             if (Database == null)
                 return null;
@@ -1428,9 +1428,6 @@ namespace Raven.Server.Documents.Replication
                     break;
                 case ExternalReplication externalNode:
                     outgoingReplication = new OutgoingExternalReplicationHandler(this, Database, externalNode, info);
-                    break;
-                case BucketMigrationReplication migrationNode:
-                    outgoingReplication = new OutgoingMigrationReplicationHandler(this, ShardedDocumentDatabase.CastToShardedDocumentDatabase(Database), migrationNode, info);
                     break;
                 default:
                     throw new ArgumentException($"Unknown node type {node.GetType().FullName}");

--- a/src/Raven.Server/Documents/Replication/Stats/IncomingConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/IncomingConnectionInfo.cs
@@ -22,6 +22,8 @@ namespace Raven.Server.Documents.Replication.Stats
 
         public string RemoteIp { get; set; }
 
+        public ReplicationLatestEtagRequest.ReplicationType ReplicationsType { get; set; }
+
         public static IncomingConnectionInfo FromGetLatestEtag(ReplicationLatestEtagRequest message)
         {
             return new IncomingConnectionInfo
@@ -30,17 +32,20 @@ namespace Raven.Server.Documents.Replication.Stats
                 SourceUrl = message.SourceUrl,
                 SourceMachineName = message.SourceMachineName,
                 SourceDatabaseId = message.SourceDatabaseId,
-                SourceTag = message.SourceTag
+                SourceTag = message.SourceTag,
+                ReplicationsType = message.ReplicationsType
             };
         }
 
-        public override string ToString() => $"Incoming Connection Info ({nameof(SourceDatabaseId)} : {SourceDatabaseId}, {nameof(SourceDatabaseName)} : {SourceDatabaseName}, {nameof(SourceMachineName)} : {SourceMachineName})";
+        public override string ToString() => $"Incoming Connection Info for {ReplicationsType} replication ({nameof(SourceDatabaseId)} : {SourceDatabaseId}, {nameof(SourceDatabaseName)} : {SourceDatabaseName}, {nameof(SourceMachineName)} : {SourceMachineName})";
 
         public bool Equals(IncomingConnectionInfo other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return string.Equals(SourceDatabaseName, other.SourceDatabaseName, StringComparison.OrdinalIgnoreCase) && string.Equals(SourceUrl, other.SourceUrl, StringComparison.OrdinalIgnoreCase) && string.Equals(SourceMachineName, other.SourceMachineName, StringComparison.CurrentCultureIgnoreCase);
+            return string.Equals(SourceDatabaseName, other.SourceDatabaseName, StringComparison.OrdinalIgnoreCase) && 
+                   string.Equals(SourceUrl, other.SourceUrl, StringComparison.OrdinalIgnoreCase) && 
+                   string.Equals(SourceMachineName, other.SourceMachineName, StringComparison.CurrentCultureIgnoreCase);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20121

### Additional description

In replication it is prohibited to have more than 1 replication channel from the same source to the same destination.

But in resharding it is expected to have several replication channels open, so we bypass this assertion by providing a different guid to the destination. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- No UI work is needed
