### PR TITLE
RavenDB-20029 Temporary patch to reduce errors on system with only cgroup2

### DIFF
--- a/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
+++ b/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
@@ -12,9 +12,12 @@ namespace Sparrow.Platform.Posix
     {
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(KernelVirtualFileSystemUtils).FullName);
         private static readonly ConcurrentSet<string> IsOldFileAlert = new ConcurrentSet<string>();
+        private static readonly ConcurrentSet<string> MissingCgroupFiles = new ConcurrentSet<string>();
 
         public static long? ReadNumberFromCgroupFile(string fileName)
         {
+            if (MissingCgroupFiles.Contains(fileName))
+                return null;
             try
             {
                 var txt = File.ReadAllText(fileName);
@@ -26,6 +29,9 @@ namespace Sparrow.Platform.Posix
             }
             catch (Exception e)
             {
+                if(e is DirectoryNotFoundException)
+                    MissingCgroupFiles.Add(fileName);
+                
                 if (IsOldFileAlert.TryAdd(fileName) && Logger.IsOperationsEnabled)
                 {
                     Logger.Operations($"Unable to read and parse '{fileName}', will not respect container's limit", e);

--- a/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
+++ b/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
@@ -18,6 +18,7 @@ namespace Sparrow.Platform.Posix
         {
             if (MissingCgroupFiles.Contains(fileName))
                 return null;
+            
             try
             {
                 var txt = File.ReadAllText(fileName);
@@ -29,7 +30,7 @@ namespace Sparrow.Platform.Posix
             }
             catch (Exception e)
             {
-                if(e is DirectoryNotFoundException)
+                if (e is DirectoryNotFoundException)
                     MissingCgroupFiles.Add(fileName);
                 
                 if (IsOldFileAlert.TryAdd(fileName) && Logger.IsOperationsEnabled)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20029/Exceptions-opening-cgroup-info-mountpoints-on-Ubuntu-22.04

### Additional description

There was a change in the Cgroup API that lead to a lot of IO errors.
A proper fix will be to identify the relevant version which will be added later.
This fix is temporary to reduce the errors and will be removed when a proper fix will be added.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- Yes, Linux


### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
