### PR TITLE
RavenDB-20111 fix a leak on TcpConnectionOptions 

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -14,7 +14,6 @@ using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Sparrow.Utils;
 using Voron;
 
@@ -79,15 +78,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
             catch (Exception e)
             {
                 batch?.BatchSent?.TrySetException(e);
-                try
-                {
-                    _tcpConnectionOptions.Dispose();
-                }
-                catch
-                {
-                    // nothing we can do
-                }
-
                 throw;
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -102,13 +102,21 @@ namespace Raven.Server.Documents.Sharding
 
                     AddAndStartIncomingInstance(shardedIncomingHandler);
                 }
-                catch (Exception)
+                catch
                 {
+                    try
+                    {
+                        shardedIncomingHandler.Dispose();
+                    }
+                    catch
+                    {
+                        // do nothing
+                    }
                     try
                     {
                         tcpConnectionOptions.Dispose();
                     }
-                    catch (Exception)
+                    catch
                     {
                         // do nothing
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20111

### Additional description

need properly to dispose the `ShardedOutgoingReplicationHandler` upon initial error

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- No UI work is needed
