### PR TITLE
RavenDB-20130 - change intervesion test from 5.2 to 5.4

### DIFF
--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -481,11 +481,11 @@ namespace InterversionTests
         }
 
         [Fact]
-        public async Task SingleSubscriptionMixedClusterEnsureAcknowledgeFallsBackToV52Behavior_RavenDB_17764()
+        public async Task SingleSubscriptionMixedClusterEnsureDocumentResend54()
         {
-            var proccess526List = await CreateCluster(new string[] { "5.2.6", "5.2.6" });
+            var proccess526List = await CreateCluster(new string[] { "5.4.101", "5.4.101" });
             await UpgradeServerAsync("current", proccess526List[0]);
-
+            
             using (var store53 = await GetStore(proccess526List[0].Url, proccess526List[0].Process, null,
                        new InterversionTestOptions() { ReplicationFactor = 2, CreateDatabase = true }))
             {
@@ -561,7 +561,7 @@ namespace InterversionTests
         [Fact]
         public async Task SingleSubscriptionMixedClusterStartAgainFromSpecificChangeVector()
         {
-            var proccess526List = await CreateCluster(new string[] { "5.2.6", "5.2.6" });
+            var proccess526List = await CreateCluster(new string[] { "5.4.101", "5.4.101" });
             await UpgradeServerAsync("current", proccess526List[0]);
 
             using (var store53 = await GetStore(proccess526List[0].Url, proccess526List[0].Process, null,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20130

### Additional description

We don't support subscription in mixed cluster of 5.2 and 6
Updated the interversion tests from 5.2 to 5.4

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
