### PR TITLE
RavenDB-20134 : Sharding - Backup - use the same date for all shard backup folders

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
@@ -1,7 +1,9 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
+using Sparrow.Extensions;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
@@ -29,6 +31,7 @@ namespace Raven.Client.Documents.Operations.Backups
             private readonly bool? _isFullBackup;
             private readonly long _taskId;
             private readonly long? _operationId;
+            private readonly DateTime? _startTime;
 
             public StartBackupCommand(bool? isFullBackup, long taskId)
             {
@@ -36,11 +39,10 @@ namespace Raven.Client.Documents.Operations.Backups
                 _taskId = taskId;
             }
 
-            internal StartBackupCommand(bool? isFullBackup, long taskId, long operationId) : this(isFullBackup, taskId)
+            internal StartBackupCommand(bool? isFullBackup, long taskId, long operationId, DateTime? startTime = null) : this(isFullBackup, taskId)
             {
-                _isFullBackup = isFullBackup;
-                _taskId = taskId;
                 _operationId = operationId;
+                _startTime = startTime;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
@@ -51,6 +53,8 @@ namespace Raven.Client.Documents.Operations.Backups
                     url += $"&isFullBackup={_isFullBackup}";
                 if (_operationId.HasValue)
                     url += $"&operationId={_operationId}";
+                if (_startTime.HasValue)
+                    url += $"&startTime={_startTime.Value.GetDefaultRavenFormat()}";
 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Backups;
 using Sparrow.Json;
@@ -13,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected abstract ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId);
+        protected abstract ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
 
         protected abstract long GetNextOperationId();
 
@@ -22,8 +23,9 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             var taskId = RequestHandler.GetLongQueryString("taskId");
             var isFullBackup = RequestHandler.GetBoolValueQueryString("isFullBackup", required: false) ?? true;
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
+            var startTime = RequestHandler.GetDateTimeQueryString("startTime", required: false);
 
-            var isResponsibleNode = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId);
+            var isResponsibleNode = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId, startTime);
 
             if (isResponsibleNode)
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             return RequestHandler.Database.Operations.GetNextOperationId();
         }
 
-        protected override async ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId)
+        protected override async ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime)
         {
             // task id == raft index
             // we must wait here to ensure that the task was actually created on this node
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
 
             if (nodeTag == ServerStore.NodeTag)
             {
-                RequestHandler.Database.PeriodicBackupRunner.StartBackupTask(taskId, isFullBackup, operationId);
+                RequestHandler.Database.PeriodicBackupRunner.StartBackupTask(taskId, isFullBackup, operationId, startTime);
                 return true;
             }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -316,14 +316,14 @@ namespace Raven.Server.Documents.PeriodicBackup
             return _database.WhoseTaskIsIt(topology, periodicBackup.Configuration, backupStatus, keepTaskOnOriginalMemberNode: true);
         }
 
-        public long StartBackupTask(long taskId, bool isFullBackup, long? operationId = null)
+        public long StartBackupTask(long taskId, bool isFullBackup, long? operationId = null, DateTime? startTimeUtc = null)
         {
             if (_periodicBackups.TryGetValue(taskId, out var periodicBackup) == false)
             {
                 throw new InvalidOperationException($"Backup task id: {taskId} doesn't exist");
             }
 
-            return CreateBackupTask(periodicBackup, isFullBackup, SystemTime.UtcNow, operationId);
+            return CreateBackupTask(periodicBackup, isFullBackup, startTimeUtc ?? SystemTime.UtcNow, operationId);
         }
 
         public async Task DelayAsync(long taskId, TimeSpan delay, X509Certificate2 clientCert, CancellationToken token)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20134

### Additional description

- we want the date part in backup folder names to be identical for all shards, so that users can choose a single `RestorePoint` for all shards when restoring a sharded database via Studio
- a sharded periodic backup task will use the same 'startTime' for all shards when it is triggered by the backup-frequency (since periodic backup configuration is identical for all shards)
-  problem was with a sharded periodic backup task that is triggered by a `BackupNow` operation - each shard used it's own start time, and the generated backup folders names had a slightly different date
- modified sharded `BackupNow` to use the same date for all shards - the orchestrator will set the 'startTime' and pass it to all the shards 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio