### PR TITLE
RavenDB-20170 fix NRE during importing of old dump

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1377,7 +1377,7 @@ namespace Raven.Server.Smuggler.Documents
                     result.DatabaseRecord.QueueEtlsUpdated = true;
                 }
 
-                if (databaseRecord.IndexesHistory.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.IndexesHistory))
+                if (databaseRecord.IndexesHistory?.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.IndexesHistory))
                 {
                     if (_log.IsInfoEnabled)
                         _log.Info("Configuring Indexes History configuration from smuggler");

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -1949,6 +1949,21 @@ namespace SlowTests.Smuggler
         }
 
         [Fact]
+        public async Task CanImportLegacyDatabaseRecordWithoutErrors()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await using (var stream = GetDump("RavenDB_11664.1.ravendbdump"))
+                {
+                    var operation = await store.Smuggler.ForDatabase(store.Database).ImportAsync(new DatabaseSmugglerImportOptions(), stream);
+                    var importResult = (SmugglerResult)await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    Assert.DoesNotContain(importResult.Messages, m => m.Contains("ERROR"));
+                }
+            }
+        }
+
+        [Fact]
         public async Task Keep_The_Same_Document_Id_After_Counters_Import()
         {
             var file = GetTempFileName();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20170

### Additional description

was introduce during the indexes history issue

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
