### PR TITLE
RDoc-2397 Document 6.0 docker Linux image breaking changes in readmes

### DIFF
--- a/docker/readme.md
+++ b/docker/readme.md
@@ -9,7 +9,7 @@
 
 ### What's new
 RavenDB `v6.0` docker image has been adjusted to run under **a non-root user**, providing far better security.
-Containers are now using RavenDB *.deb package*. More information about how to deal with the breaking changes in the **migration from 5.4 image** section.
+Containers are now using RavenDB *.deb package*. More information about how to deal with the breaking changes in the [**migration from 5.4 image**](#what-migration-process-from-54-image-looks-like) section.
 
 
 ### Image tags

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -161,7 +161,7 @@ Data is stored in a different directory, and needs to be migrated or linked upon
 
 We highly recommend migrating your data from legacy data directory to the new one `/var/lib/ravendb/data/`.
 
-However, running the server using `run-server.sh`, which is a default entrypoint for the container, causes to run `link-legacy-datadir.sh` script. It checks whether RavenDB data is stored under legacy data directory. If so, it tries to create symlink to the new data directory. If the permissions are insufficent for the 'ravendb' user (which is running the container) it is going to fail with an appropriate error message.
+However, running the server using `run-server.sh`, which is a default entry point for the container, causes to run `link-legacy-datadir.sh` script. It checks whether RavenDB data is stored under legacy data directory. If so, it tries to create symlink to the new data directory. If the permissions are insufficent for the 'ravendb' user (which is running the container) it is going to fail with an appropriate error message.
 
 ##### How to run as different UID?
 To run with a different UID or GID, you need to build the Ubuntu image yourself with these build args (both are optional):

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -8,7 +8,7 @@
     - based on Windows Nanoserver image (run using Windows containers). 
 
 ### What's new
-RavenDB `v6.0` docker image includes **switching to a non-root user**, providing far better security.
+RavenDB `v6.0` docker image has been adjusted to run under **a non-root user**, providing far better security.
 Containers are now using RavenDB *.deb package*. More information about how to deal with the breaking changes in the **migration from 5.4 image** section.
 
 
@@ -157,17 +157,18 @@ Mount it as a docker volume and use `--config-path PATH_TO_CONFIG` command line 
 
 ##### What migration process from 5.4 image looks like?
 
-Data is stored in a different directory, and needs to be migrated or linked on the update. The container is now using the .deb package, which is well documented [here](https://github.com/ravendb/ravendb/blob/v5.4/scripts/linux/pkg/linux-packaging.md). The link describes new filesystem locations and permissions. 
+Data is stored in a different directory, and needs to be migrated or linked upon update. The container is now using the .deb package, which is well documented [here](https://ravendb.net/docs/article-page/latest/csharp/start/installation/gnu-linux/deb). The link describes new filesystem locations and permissions. 
 
 We highly recommend migrating your data from legacy data directory to the new one `/var/lib/ravendb/data/`.
 
-However, running the server using `run-server.sh`, which is an entrypoint for the container, causes to run `link-legacy-datadir.sh` script. It checks whether there is data stored in the legacy data directory. If so, it tries to create symlink with the new data directory. If the permissions are insufficent for the 'ravendb' user (which is running the container) it'll fail with appropriate error message.
+However, running the server using `run-server.sh`, which is a default entrypoint for the container, causes to run `link-legacy-datadir.sh` script. It checks whether RavenDB data is stored under legacy data directory. If so, it tries to create symlink to the new data directory. If the permissions are insufficent for the 'ravendb' user (which is running the container) it is going to fail with an appropriate error message.
 
 ##### How to run as different UID?
-To run with different UID or GID, you need to build the appropriate ubuntu image with these build args (both are optional):
+To run with a different UID or GID, you need to build the Ubuntu image yourself with these build args (both are optional):
 
 ` --build-arg "RAVEN_USER_ID=999" --build-arg "RAVEN_GROUP_ID=999"`
 
 The `ravendb` user will use the following UID/GID, it's being set in the .deb package post-installation process.
 
+The default UID and GID are 999.
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDoc-2397/Document-6.0-docker-Linux-image-breaking-changes-in-readmes-and-docs

### Additional description

A documentation updates for [this PR](https://github.com/ravendb/ravendb/pull/15857) that solved [this issue](https://issues.hibernatingrhinos.com/issue/RavenDB-18888/Running-as-a-non-root-user-in-Linux-containers) (running v6.0 container on non-root user)

### How risky is the change?

- Not relevant

