### PR TITLE
RavenDB-20176 Create ` TermMatch` from numeric value.

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if DEBUG
@@ -11,6 +12,7 @@ using Sparrow.Compression;
 using Voron;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
+using Voron.Data.Fixed;
 using Voron.Data.PostingLists;
 
 namespace Corax;
@@ -24,7 +26,49 @@ public partial class IndexSearcher
     public TermMatch TermQuery(string field, Slice term, bool hasBoost = false) => TermQuery(FieldMetadataBuilder(field, hasBoost: hasBoost), term);
     public TermMatch TermQuery(Slice field, Slice term, bool hasBoost = false) => TermQuery(FieldMetadata.Build(field, default, default, default, default, hasBoost: hasBoost), term);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private unsafe long GetContainerIdOfNumericalTerm<TNumeric>(in FieldMetadata field, out FieldMetadata numericalField, TNumeric term)
+    {
+        long containerId = default;
+        numericalField = default;
+        if (typeof(TNumeric) == typeof(long))
+        {
+            numericalField = field.GetNumericFieldMetadata<long>(_transaction.Allocator);
+            using var set = _fieldsTree?.FixedTreeFor(numericalField.FieldName, sizeof(long));
+            if (set != null)
+            {
+                containerId = *(long*)set.ReadPtr((long)(object)term, out var length);
+                Debug.Assert(length == sizeof(long));
+            }
+
+        }
+        else if (typeof(TNumeric) == typeof(double))
+        {
+            numericalField = field.GetNumericFieldMetadata<double>(_transaction.Allocator);
+            using var set = _fieldsTree?.FixedTreeForDouble(numericalField.FieldName, sizeof(double));
+            if (set != null)
+            {
+                containerId = *(long*)set.ReadPtr((double)(object)term, out var length);
+                Debug.Assert(length == sizeof(long));
+            }
+        }
+
+        return containerId;
+    }
     
+    //Numerical TermMatch.
+    public unsafe TermMatch TermQuery<TNumeric>(in FieldMetadata field, TNumeric term, CompactTree termsTree = null)
+    {
+        var containerId = GetContainerIdOfNumericalTerm(field, out var numericalField, term);
+
+        if (containerId == 0)
+        {
+            return TermMatch.CreateEmpty(this, Allocator);
+        }
+
+        return TermQuery(numericalField, containerId, 1);
+    }
+
     public TermMatch TermQuery(FieldMetadata field, string term, CompactTree termsTree = null)
     {
         var terms = termsTree ?? _fieldsTree?.CompactTreeFor(field.FieldName);
@@ -109,7 +153,7 @@ public partial class IndexSearcher
         #endif
         return matches;
     }
-
+    
     internal TermMatch TermQuery(in FieldMetadata field, long containerId, double termRatioToWholeCollection)
     {
         TermMatch matches;
@@ -136,7 +180,23 @@ public partial class IndexSearcher
         return matches;
     }
 
-    public long NumberOfDocumentsUnderSpecificTerm(FieldMetadata binding, string term)
+    public long NumberOfDocumentsUnderSpecificTerm<TData>(FieldMetadata binding, TData term)
+    {
+        if (typeof(TData) == typeof(long))
+        {
+            var containerId = GetContainerIdOfNumericalTerm(binding, out var numericalField, (long)(object)term);
+            return NumberOfDocumentsUnderSpecificTerm(containerId);
+        }
+        if (typeof(TData) == typeof(double))
+        {
+            var containerId = GetContainerIdOfNumericalTerm(binding, out var numericalField, (double)(object)term);
+            return NumberOfDocumentsUnderSpecificTerm(containerId);
+        }
+            
+        return NumberOfDocumentsUnderSpecificTerm(binding, (string)(object)term);
+    }
+    
+    private long NumberOfDocumentsUnderSpecificTerm(FieldMetadata binding, string term)
     {
         var terms = _fieldsTree?.CompactTreeFor(binding.FieldName);
         if (terms == null)
@@ -158,23 +218,28 @@ public partial class IndexSearcher
         return NumberOfDocumentsUnderSpecificTerm(tree, term.AsReadOnlySpan());
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private long NumberOfDocumentsUnderSpecificTerm(CompactTree tree, ReadOnlySpan<byte> term)
     {
         if (tree.TryGetValue(term, out var value) == false)
             return 0;
 
-        
-        if ((value & (long)TermIdMask.Set) != 0)
+        return NumberOfDocumentsUnderSpecificTerm(value);
+    }
+    
+    private long NumberOfDocumentsUnderSpecificTerm(long containerId)
+    {
+        if ((containerId & (long)TermIdMask.Set) != 0)
         {
-            var setId = EntryIdEncodings.GetContainerId(value);
+            var setId = EntryIdEncodings.GetContainerId(containerId);
             var setStateSpan = Container.Get(_transaction.LowLevelTransaction, setId).ToSpan();
             ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             return setState.NumberOfEntries;
         }
         
-        if ((value & (long)TermIdMask.Small) != 0)
+        if ((containerId & (long)TermIdMask.Small) != 0)
         {
-            var smallSetId = EntryIdEncodings.GetContainerId(value);
+            var smallSetId = EntryIdEncodings.GetContainerId(containerId);
             var small = Container.Get(_transaction.LowLevelTransaction, smallSetId);
             var itemsCount = ZigZagEncoding.Decode<int>(small.ToSpan(), out var len);
 

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -251,7 +251,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     public TermMatch EmptyMatch() => TermMatch.CreateEmpty(this, Allocator);
 
-    public long GetEntriesAmountInField(FieldMetadata field)
+    public long GetTermAmountInField(FieldMetadata field)
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxAndQueries.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxAndQueries.cs
@@ -61,7 +61,12 @@ public class CoraxAndQueries : CoraxBooleanQueryBase
                 break;
 
             //We're always do TermMatch (true and NOT (X))
-            IQueryMatch second = IndexSearcher.TermQuery(query.Field, query.TermAsString);
+            IQueryMatch second = query.Term switch
+            {
+                long l => IndexSearcher.TermQuery(query.Field, l),
+                double d => IndexSearcher.TermQuery(query.Field, d),
+                _ => IndexSearcher.TermQuery(query.Field, query.TermAsString),
+            };
 
             if (query.Operation is UnaryMatchOperation.NotEquals)
             {

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -189,6 +189,30 @@ namespace FastTests.Corax
         }
 
         [Fact]
+        public void CanDoNumericalTermMatch()
+        {
+            _entries = new List<Entry>();
+            _entries.Add(new Entry() {Id = $"entries/0", LongValue = 0, DoubleValue = 0.0, TextualValue = "abc" });
+            IndexEntries();
+            
+            using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+            using var searcher = new IndexSearcher(Env);
+            var match0 = searcher.TermQuery(_doubleItemFieldMetadata, 0.0D);
+            var ids = new long[16];
+            Assert.Equal(1, match0.Fill(ids)); //match one doc
+
+            var match1 = searcher.TermQuery(_doubleItemFieldMetadata, 0L);
+            Assert.Equal(1, match1.Fill(ids)); //match one doc
+            
+            //Lets assert also longs:
+            var match2 = searcher.TermQuery(_longItemFieldMetadata, 0.0D);
+            Assert.Equal(1, match2.Fill(ids)); //match one doc
+
+            var match3 = searcher.TermQuery(_longItemFieldMetadata, 0L);
+            Assert.Equal(1, match3.Fill(ids)); //match one doc
+        }
+        
+        [Fact]
         public void MultiTermMatchWithTermMatch()
         {
             PrepareData();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20176 

### Additional description

This PR allows getting `containerId` from `PrefixSizeTree` instead of `CompactTree` in the case when we query numbers. 
This allows users to match docs like:
```json
{
    "Number": 11.5
}
```
with query like
```
[...] where Number == 11
```


### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
