### PR TITLE
RavenDB-20134 - handle the EP `/databases/*/admin/backup`

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
@@ -4,6 +4,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
+using Sparrow.Extensions;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
@@ -27,6 +28,7 @@ namespace Raven.Client.Documents.Operations.Backups
 
         internal class BackupCommand : RavenCommand<OperationIdResult<StartBackupOperationResult>>
         {
+            private readonly DateTime? _startTime;
             public override bool IsReadRequest => false;
             private readonly DocumentConventions _conventions;
             private readonly BackupConfiguration _backupConfiguration;
@@ -39,12 +41,21 @@ namespace Raven.Client.Documents.Operations.Backups
                 _operationId = operationId;
             }
 
+            internal BackupCommand(DocumentConventions conventions, BackupConfiguration backupConfiguration, DateTime startTime, long? operationId = null) : 
+                this(conventions, backupConfiguration, operationId)
+            {
+                _startTime = startTime;
+            }
+
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                url = $"{node.Url}/databases/{node.Database}/admin/backup";
+                url = $"{node.Url}/databases/{node.Database}/admin/backup?";
 
                 if (_operationId.HasValue)
-                    url += $"?operationId={_operationId}";
+                    url += $"&operationId={_operationId}";
+
+                if (_startTime.HasValue)
+                    url += $"&startTime={_startTime.Value.GetDefaultRavenFormat()}";
 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -24,19 +24,19 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override void ScheduleBackup(BackupConfiguration backupConfiguration, long operationId, string backupName, Stopwatch sw, OperationCancelToken token)
+        protected override void ScheduleBackup(BackupConfiguration backupConfiguration, long operationId, string backupName, Stopwatch sw, DateTime startTime, OperationCancelToken token)
         {
             var backupParameters = new BackupParameters
             {
                 RetentionPolicy = null,
-                StartTimeUtc = SystemTime.UtcNow,
+                StartTimeUtc = startTime,
                 IsOneTimeBackup = true,
                 BackupStatus = new PeriodicBackupStatus { TaskId = -1 },
                 OperationId = operationId,
                 BackupToLocalFolder = BackupConfiguration.CanBackupUsing(backupConfiguration.LocalSettings),
                 IsFullBackup = true,
                 TempBackupPath = BackupUtils.GetBackupTempPath(RequestHandler.Database.Configuration, "OneTimeBackupTemp"),
-                Name = backupName
+                Name = backupName,
             };
 
             var backupTask = new BackupTask(RequestHandler.Database, backupParameters, backupConfiguration, Logger);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
@@ -17,14 +18,15 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override void ScheduleBackup(BackupConfiguration backupConfiguration, long operationId, string backupName, Stopwatch sw, OperationCancelToken token)
+        protected override void ScheduleBackup(BackupConfiguration backupConfiguration, long operationId, string backupName, Stopwatch sw, DateTime startTime, OperationCancelToken token)
         {
             var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(
                 operationId,
                 OperationType.DatabaseBackup,
                 $"Manual backup for database: {RequestHandler.DatabaseName}",
                 detailedDescription: null,
-                commandFactory: (context, shardNumber) => new BackupOperation.BackupCommand(RequestHandler.ShardExecutor.Conventions, backupConfiguration, operationId),
+                commandFactory: (context, shardNumber) => new BackupOperation.
+                    BackupCommand(RequestHandler.ShardExecutor.Conventions, backupConfiguration, startTime, operationId),
                 token);
 
             var _ = t.ContinueWith(_ =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20134

### Additional description

Pass the backup start time to the `/databases/*/admin/backup` EP to ensure identical time in the file name for all shards

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
