### PR TITLE
RavenDB-20186 return appropriate number of indexes in /studio-tasks/databases endpoint

### DIFF
--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -907,12 +907,27 @@ namespace Raven.Server.ServerWide
             get
             {
                 if (_materializedRecord != null)
-                    return _materializedRecord.Indexes?.Count ?? 0;
+                    return (_materializedRecord.Indexes?.Count ?? 0) + (_materializedRecord.AutoIndexes?.Count ?? 0);
 
                 if (_countOfIndexes == null)
                 {
                     _countOfIndexes = 0;
                     if (_record.TryGet(nameof(DatabaseRecord.Indexes), out BlittableJsonReaderObject obj) && obj != null)
+                    {
+                        var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
+                        for (var i = 0; i < obj.Count; i++)
+                        {
+                            obj.GetPropertyByIndex(i, ref propertyDetails);
+
+                            if (propertyDetails.Value == null)
+                                continue;
+
+                            if (propertyDetails.Value is BlittableJsonReaderObject)
+                                _countOfIndexes++;
+                        }
+                    }
+
+                    if (_record.TryGet(nameof(DatabaseRecord.AutoIndexes), out obj) && obj != null)
                     {
                         var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
                         for (var i = 0; i < obj.Count; i++)

--- a/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabases.cs
+++ b/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabases.cs
@@ -150,7 +150,7 @@ internal class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesHandlerP
                 HasRefreshConfiguration = record.RefreshConfiguration != null,
                 HasRevisionsConfiguration = record.RevisionsConfiguration != null,
                 DeletionInProgress = record.DeletionInProgress,
-                IndexesCount = record.Indexes?.Count
+                IndexesCount = record.CountOfIndexes
             };
 
             if (record.IsSharded)


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-20186/Endpoint-studio-tasks-databases-indexes-count-should-take-auto-indexes-into-account