### PR TITLE
RavenDB-20136 Creating ETL task fail on Assertion

### DIFF
--- a/src/Raven.Server/Documents/ETL/ExtractedItem.cs
+++ b/src/Raven.Server/Documents/ETL/ExtractedItem.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.ETL
         {
             Etag = tombstone.Etag;
 
-            Debug.Assert(tombstone.Type == Tombstone.TombstoneType.Document || tombstone.Type == Tombstone.TombstoneType.Attachment);
+            Debug.Assert(tombstone.Type is Tombstone.TombstoneType.Document or Tombstone.TombstoneType.Attachment or Tombstone.TombstoneType.Revision or Tombstone.TombstoneType.Counter);
             DocumentId = tombstone.LowerId;
             Collection = collection;
 

--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -29,6 +29,7 @@ namespace SlowTests.Server.Documents.ETL
                 AddEtl(src, configuration, new RavenConnectionString {Name = "test", TopologyDiscoveryUrls = dst.Urls, Database = dst.Database,});
 
                 var etlDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 3);
+                var loadDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 2);
 
                 using (var session = src.OpenSession())
                 {
@@ -42,6 +43,8 @@ namespace SlowTests.Server.Documents.ETL
                     user.Name = "Gracjan";
                     session.SaveChanges();
                 }
+                
+                Assert.True(loadDone.Wait(TimeSpan.FromSeconds(3)));
                 
                 using (var session = dst.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.ETL;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL
+{
+    public class RavenDB_20136 : EtlTestBase
+    {
+
+        public RavenDB_20136(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async void DeletingDocumentWithRevisionsDoesntCorruptETLProcess()
+        {
+            using (var src = GetDocumentStore())
+            using (var dst = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, src.Database);
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = "test", Name = "aaa", Transforms = {new Transformation {Name = "S1", Collections = {"Users"}}}
+                };
+
+                AddEtl(src, configuration, new RavenConnectionString {Name = "test", TopologyDiscoveryUrls = dst.Urls, Database = dst.Database,});
+
+                var etlDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 3);
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.SaveChanges();
+                }
+                
+                using (var session = src.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Gracjan";
+                    session.SaveChanges();
+                }
+                
+                using (var session = dst.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                }
+                
+                using (var session = src.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+                
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(3)));
+                
+                using (var session = dst.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.Null(user);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20136/Creating-ETL-task-fail-on-Assertion

### Additional description

Deleting the document with revisions caused the ETL process to corrupt. The problematic `Debug.Assert` line (assuring that we have received a tombstone type known to us) in the `ExtractedItem` constructor has been updated, to include TombstoneType.Revisions & Counters as a valid ETL Tombstone to be replicated/filtered out.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
