### PR TITLE
RavenDB-20087 Indicate node tag in the exported csv file for documents and query

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Exceptions.Documents;
-using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Documents.Queries;
 using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide;
@@ -103,7 +101,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
                 // set the exported file name prefix
                 var fileNamePrefix = query.Metadata.IsCollectionQuery ? query.Metadata.CollectionName + "_collection" : "query_result";
-                fileNamePrefix = $"{RequestHandler.DatabaseName}_{fileNamePrefix}";
+                fileNamePrefix = $"{RequestHandler.DatabaseName}_{ServerStore.NodeTag}_{fileNamePrefix}";
 
                 var fromSharded = RequestHandler.GetBoolFromHeaders(Constants.Headers.Sharded) ?? false;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20087/Indicate-cluster-node-and-shard-if-sharded-in-the-exported-csv-file-for-documents-and-query

### Additional description

If is a single shard view, the database name will simply be "{dbName}${shardNumber}", so there is no changes.
The only change is adding a node tag to the file name.

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
