### PR TITLE
RavenDB-20055 Cluster dashboard does not show time when hovering over…

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/clusterDashboard/lineChart.ts
+++ b/src/Raven.Studio/typescript/models/resources/clusterDashboard/lineChart.ts
@@ -97,7 +97,7 @@ export class lineChart {
             .attr("y2", this.height)
             .style("stroke-opacity", 0);
         
-        this.tooltip = d3.select(".tooltip");
+        this.tooltip = d3.select(".cluster-dashboard-tooltip");
         
         if (this.opts.tooltipProvider || this.opts.onMouseMove) {
             this.setupValuesPreview();

--- a/src/Raven.Studio/wwwroot/App/views/resources/clusterDashboard.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/clusterDashboard.html
@@ -14,7 +14,7 @@
             <i class="icon-plus"></i>
         </button>
     </div>
-    <div class="tooltip" style="opacity: 0; display: none">
+    <div class="tooltip cluster-dashboard-tooltip" style="opacity: 0; display: none">
     </div>
     <style type="text/css" id="cluster-dashboard-node-styles">
         /* this stylesheet is generated automatically based on cluster topology */


### PR DESCRIPTION
… graphs while Server Dashboard did - fixed styles clash

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20055

### Additional description

Fixed tooltip on cluster dashboard 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### UI work

- No UI work is needed
