### PR TITLE
RavenDB-19747 - block having a two digit shard number

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2875,6 +2875,9 @@ namespace Raven.Server.ServerWide
 
                 foreach (var (shardNumber, shardTopology) in record.Sharding.Shards)
                 {
+                    if (shardNumber > 9)
+                        throw new InvalidOperationException($"A two digit shard number ${shardNumber} is currently not supported");
+
                     InitializeTopology(shardTopology);
                 }
 

--- a/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
@@ -291,7 +291,10 @@ namespace Raven.Server.Web.System
                     node ??= FindFitNodeForDatabase(database, newShardTopology, databaseRecord.IsEncrypted, clusterTopology);
                     newShardTopology.Members.Add(node);
                 }
-                
+
+                if (newChosenShardNumber > 9)
+                    throw new InvalidOperationException($"A two digit shard number ${newChosenShardNumber} is currently not supported");
+
                 var update = new CreateNewShardCommand(database, newChosenShardNumber, newShardTopology, SystemTime.UtcNow, raftRequestId);
 
                 var (newIndex, _) = await ServerStore.SendToLeaderAsync(update);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19747

### Additional description

Two digit shard is blocked for now until tested properly.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
