### PR TITLE
RavenDB-19744 - Sharding - Patch by query with identity will generate…

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1126,20 +1126,18 @@ namespace Raven.Server.Documents.Patch
                     return id;
 
                 var originalId = (args[1].AsObject() as BlittableObjectInstance)?.DocumentId;
-                if (originalId != null)
-                {
-                    var builder = new StringBuilder(id);
-                    var index = originalId.IndexOf('$');
-                    if (index != -1)
-                        originalId = originalId[index..originalId.Length];
-                    else
-                        builder.Append('$');
+                var builder = new StringBuilder(id);
+                var index = originalId.IndexOf('$');
+                if (index != -1)
+                    originalId = originalId[index..originalId.Length];
+                else
+                    builder.Append('$');
 
-                    builder.Append(originalId + '$' + _database.IdentityPartsSeparator);
-                    id = builder.ToString();
-                }
-                
-                return id;
+                builder.Append(originalId)
+                    .Append('$')
+                    .Append(_database.IdentityPartsSeparator);
+
+                return builder.ToString();
             }
 
             private static void AssertValidId()

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1125,19 +1125,8 @@ namespace Raven.Server.Documents.Patch
                 if (id?[^1] != _database.IdentityPartsSeparator)
                     return id;
 
-                var originalId = (args[1].AsObject() as BlittableObjectInstance)?.DocumentId;
-                var builder = new StringBuilder(id);
-                var index = originalId.IndexOf('$');
-                if (index != -1)
-                    originalId = originalId[index..originalId.Length];
-                else
-                    builder.Append('$');
-
-                builder.Append(originalId)
-                    .Append('$')
-                    .Append(_database.IdentityPartsSeparator);
-
-                return builder.ToString();
+                var originalId = (args[1].AsObject() as BlittableObjectInstance)!.DocumentId;
+                return ShardHelper.GenerateStickyId(id, originalId, _database.IdentityPartsSeparator);
             }
 
             private static void AssertValidId()

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1088,7 +1088,7 @@ namespace Raven.Server.Documents.Patch
                     reader = JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, args[1].AsObject(), usageMode: BlittableJsonDocumentBuilder.UsageMode.ToDisk);
 
                     if (_database is ShardedDocumentDatabase)
-                        id = GenerateIdForShard(args, id);
+                        id = GenerateIdForShard(id);
 
                     var put = _database.DocumentsStorage.Put(
                         _docsCtx,
@@ -1120,13 +1120,12 @@ namespace Raven.Server.Documents.Patch
                 }
             }
 
-            private string GenerateIdForShard(JsValue[] args, string id)
+            private string GenerateIdForShard(string id)
             {
                 if (id?[^1] != _database.IdentityPartsSeparator)
                     return id;
 
-                var originalId = (args[1].AsObject() as BlittableObjectInstance)!.DocumentId;
-                return ShardHelper.GenerateStickyId(id, originalId, _database.IdentityPartsSeparator);
+                return ShardHelper.GenerateStickyId(id, OriginalDocumentId, _database.IdentityPartsSeparator);
             }
 
             private static void AssertValidId()

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -373,6 +373,11 @@ namespace Raven.Server.Utils
 
         public static (int ShardNumber, int Bucket) GetShardNumberAndBucketForIdentity(ShardingConfiguration configuration, TransactionOperationContext context, string id, char identityPartsSeparator)
         {
+            return GetShardNumberAndBucketForIdentity(configuration, context.Allocator, id, identityPartsSeparator);
+        }
+
+        public static (int ShardNumber, int Bucket) GetShardNumberAndBucketForIdentity(ShardingConfiguration configuration, ByteStringContext allocator, string id, char identityPartsSeparator)
+        {
             // the expected id format here is users/$BASE26$/
             // so we cut the '$/' from the end to detect shard number based on BASE26 part
             Debug.Assert(id[^1] == identityPartsSeparator, $"id[^1] != {identityPartsSeparator} for {id}");
@@ -380,7 +385,7 @@ namespace Raven.Server.Utils
             var actualId = id.AsSpan(0, id.Length - 2);
             var actualIdAsString = actualId.ToString();
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Pawel, DevelopmentHelper.Severity.Normal, "RavenDB-19086 Optimize this");
-            return GetShardNumberAndBucketFor(configuration, context.Allocator, actualIdAsString);
+            return GetShardNumberAndBucketFor(configuration, allocator, actualIdAsString);
         }
 
         public static int GetShardNumberFor(ShardingConfiguration configuration, TransactionOperationContext context, string id, char identityPartsSeparator)

--- a/test/SlowTests/Sharding/Issues/RavenDB_19744.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19744.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_19744 : RavenTestBase
+    {
+        public RavenDB_19744(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Sharding)]
+        public async Task PatchByQueryOnShardedDbShouldGenerateIdsInTheCorrectShard()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+                var operation = await store.Operations.SendAsync(new PatchByQueryOperation("from Orders update { put(\"orders/\", this) }"));
+                var result = await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromMinutes(1));
+                Assert.Equal(830, result.Total);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_19744.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19744.cs
@@ -21,9 +21,15 @@ namespace SlowTests.Sharding.Issues
             {
                 await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
+                // all document Ids in 'Orders' collection don't contain a '$suffix'
                 var operation = await store.Operations.SendAsync(new PatchByQueryOperation("from Orders update { put(\"orders/\", this) }"));
                 var result = await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromMinutes(1));
                 Assert.Equal(830, result.Total);
+
+                // some document Ids in 'Orders' collection contains a '$suffix'
+                operation = await store.Operations.SendAsync(new PatchByQueryOperation("from Orders update { put(\"orders/\", this) }"));
+                result = await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromMinutes(1));
+                Assert.Equal(1660, result.Total);
             }
         }
     }


### PR DESCRIPTION
… ids not in the correct shard

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19744/Sharding-Patch-by-query-with-identity-will-generate-ids-not-in-the-correct-shard

### Additional description

@ayende @ppekrol @karmeli87 We need to decide how we want to handle this issue.
_Background:_
Patch by query with identity operation run on each shard; therefore, generating a sticky ID is not enough to solve this (we may get a sticky ID belonging to shard 2, but we try writing the document to shard 1).

The options we have considered so far:
* Generate sticky IDs until suits the shard (inefficient? but the trivial option) - current PR relies on this option.
* Create separate structure `<bucket, stickyId>`; for example:
                1 : /$DEYFH$/
		2: /$WPRNG$/
		...
	  and extract a sticky Id by the shard's bucket range.
* Pull a random document from the database and generate a new ID that includes the suffix of this document ID; for example: pull document `"users/1"` -> create Id: `"users/0000001-A$users/1"` (we probably don't want this...).


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
