### PR TITLE
RavenDB-18164 - Group By fields should have a consistent order

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AutoIndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/AutoIndexDefinition.cs
@@ -20,6 +20,8 @@ namespace Raven.Client.Documents.Indexes
 
         public Dictionary<string, AutoIndexFieldOptions> GroupByFields { get; set; }
 
+        public List<string> GroupByFieldNames { get; set; }
+
         public IndexDefinitionCompareDifferences Compare(AutoIndexDefinition other)
         {
             if (other == null)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -381,7 +381,7 @@ namespace Raven.Server.Documents.Indexes
                     })
                     .ToArray();
 
-                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, indexDeployment, definition.ClusterState, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+                var result = new AutoMapReduceIndexDefinition(definition.Collection, mapFields, groupByFields, definition.GroupByFieldNames, indexDeployment, definition.ClusterState, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
                 if (definition.Priority.HasValue)
                     result.Priority = definition.Priority.Value;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -134,6 +134,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             }
             writer.WriteEndArray();
 
+            writer.WriteComma();
+
             writer.WritePropertyName((nameof(GroupByFieldNames)));
             writer.WriteStartArray();
             first = true;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Extensions;
-using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Documents.Indexes.Auto; 
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
@@ -21,14 +21,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public List<string> GroupByFieldNames { get; }
 
-        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState, long? indexVersion = null)
+        public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, List<string> groupByFieldNames, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState, long? indexVersion = null)
             : base(AutoIndexNameFinder.FindMapReduceIndexName(collection, mapFields, groupByFields), collection, mapFields, deploymentMode, clusterState, indexVersion)
         {
             OrderedGroupByFields = groupByFields.OrderBy(x => x.Name, StringComparer.Ordinal).ToArray();
 
             GroupByFields = groupByFields.ToDictionary(x => x.Name, x => x, StringComparer.Ordinal);
 
-            GroupByFieldNames = groupByFields.Select(x => x.Name).ToList();
+            GroupByFieldNames = groupByFieldNames;
 
             MapAndGroupByFields = new Dictionary<string, AutoIndexField>(MapFields.Count + GroupByFields.Count);
 
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         // For Legacy test
         public AutoMapReduceIndexDefinition(string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, long? indexVersion = null)
-            : this(collection, mapFields, groupByFields, deploymentMode: null, clusterState: null, indexVersion)
+            : this(collection, mapFields, groupByFields, groupByFieldNames: null, deploymentMode: null, clusterState: null, indexVersion)
         {
 
         }
@@ -265,7 +265,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
                 field.Id = fieldId++;
             }
             
-            return new AutoMapReduceIndexDefinition(collection, mapFields, groupByFields, deploymentMode: null, clusterState: null, version)
+            return new AutoMapReduceIndexDefinition(collection, mapFields, groupByFields, groupByFieldNames: null, deploymentMode: null, clusterState: null, version)
             {
                 LockMode = lockMode,
                 Priority = priority,

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -278,14 +278,21 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
                 field.Id = fieldId++;
             }
 
+            List<string> groupByFieldNames;
+
             if (reader.TryGet(nameof(GroupByFieldNames), out jsonArray) == false)
-                throw new InvalidOperationException("No persisted group by field names");
-
-            var groupByFieldNames = new List<string>();
-
-            foreach (var groupByField in jsonArray)
             {
-                groupByFieldNames.Add(groupByField.ToString());
+                // the fields don't exist for indexes that were imported from a dump prior to 6.0
+                groupByFieldNames = groupByFields.Select(x => x.Name).ToList();
+            }
+            else
+            {
+                groupByFieldNames = new List<string>();
+
+                foreach (var groupByField in jsonArray)
+                {
+                    groupByFieldNames.Add(groupByField.ToString());
+                }
             }
 
             return new AutoMapReduceIndexDefinition(collection, mapFields, groupByFields, groupByFieldNames, deploymentMode: null, clusterState: null, version)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
@@ -13,6 +13,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto;
 
 public class AutoMapReduceIndexResultsAggregator
 {
+    protected Action<DynamicJsonValue> ModifyOutputToStore;
+
     internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, TransactionOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
     {
         var aggregatedResultsByReduceKey = new Dictionary<BlittableJsonReaderObject, Dictionary<string, PropertyResult>>(ReduceKeyComparer.Instance);
@@ -67,6 +69,8 @@ public class AutoMapReduceIndexResultsAggregator
 
         foreach (var aggregate in aggregationResult.Value)
             djv[aggregate.Key] = aggregate.Value.ResultValue;
+
+        ModifyOutputToStore?.Invoke(djv);
 
         return djv;
     }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/ReduceMapResultsOfAutoIndex.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Threading;
-using Raven.Client.Documents.Indexes;
-using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
-using Sparrow;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 {

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public Dictionary<string, DynamicQueryMappingItem> GroupByFields { get; private set; }
 
-        public GroupByField[] GroupBy { get; set; }
+        public List<string> GroupByFieldNames { get; private set; }
 
         public bool IsGroupBy { get; private set; }
 
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                     return indexField;
                 }).ToArray(),
-                groupByFieldNames: GroupBy.Select(x => x.Name.Value).ToList(),
+                GroupByFieldNames,
                 deploymentMode: null, clusterState: null);
         }
 
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             if (query.Metadata.IsGroupBy)
             {
                 result.IsGroupBy = true;
-                result.GroupBy = query.Metadata.GroupBy;
+                result.GroupByFieldNames = query.Metadata.GroupBy.Select(x => x.Name.Value).ToList();
                 result.GroupByFields = CreateGroupByFields(query, mapFields);
 
                 foreach (var field in mapFields)
@@ -310,8 +310,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 mapping.IsGroupBy = true;
 
                 var mapReduceDefinition = (AutoMapReduceIndexDefinition)definition;
-
                 mapping.GroupByFields = new Dictionary<string, DynamicQueryMappingItem>(StringComparer.Ordinal);
+                mapping.GroupByFieldNames = new List<string>();
 
                 foreach (var field in mapReduceDefinition.GroupByFields)
                 {
@@ -322,6 +322,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         isSpecifiedInWhere: true,
                         isFullTextSearch: autoField.Indexing.HasFlag(AutoFieldIndexing.Search),
                         isExactSearch: autoField.Indexing.HasFlag(AutoFieldIndexing.Exact));
+
+                    mapping.GroupByFieldNames.Add(field.Key);
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -22,6 +22,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public Dictionary<string, DynamicQueryMappingItem> GroupByFields { get; private set; }
 
+        public GroupByField[] GroupBy { get; set; }
+
         public bool IsGroupBy { get; private set; }
 
         public List<Index> SupersededIndexes;
@@ -120,7 +122,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     indexField.HasSuggestions = field.HasSuggestions;
 
                     return indexField;
-                }).ToArray(), deploymentMode: null, clusterState: null);
+                }).ToArray(),
+                groupByFieldNames: GroupBy.Select(x => x.Name.Value).ToList(),
+                deploymentMode: null, clusterState: null);
         }
 
         internal void ExtendMappingBasedOn(AutoIndexDefinitionBaseServerSide definitionOfExistingIndex)
@@ -232,6 +236,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             if (query.Metadata.IsGroupBy)
             {
                 result.IsGroupBy = true;
+                result.GroupBy = query.Metadata.GroupBy;
                 result.GroupByFields = CreateGroupByFields(query, mapFields);
 
                 foreach (var field in mapFields)

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedAutoMapReduceIndexResultsAggregator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedAutoMapReduceIndexResultsAggregator.cs
@@ -1,0 +1,18 @@
+﻿using Raven.Client;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Sharding.Queries;
+
+public class ShardedAutoMapReduceIndexResultsAggregator : AutoMapReduceIndexResultsAggregator
+{
+    private static readonly DynamicJsonValue DummyDynamicJsonValue = new();
+
+    public ShardedAutoMapReduceIndexResultsAggregator()
+    {
+        ModifyOutputToStore = djv =>
+        {
+            djv[Constants.Documents.Metadata.Key] = DummyDynamicJsonValue;
+        };
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -20,6 +20,8 @@ namespace Raven.Server.Documents.Sharding.Queries;
 
 public class ShardedMapReduceQueryResultsMerger
 {
+    private static readonly ShardedAutoMapReduceIndexResultsAggregator Aggregator = new();
+
     protected readonly List<BlittableJsonReaderObject> CurrentResults;
     private readonly ShardedDatabaseContext.ShardedIndexesContext _indexesContext;
     private readonly string _indexName;
@@ -92,6 +94,6 @@ public class ShardedMapReduceQueryResultsMerger
     internal virtual AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
     {
         BlittableJsonReaderObject currentlyProcessedResult = null;
-        return ReduceMapResultsOfAutoIndex.Aggregator.AggregateOn(CurrentResults, indexDefinition, Context, null, ref currentlyProcessedResult, Token);
+        return Aggregator.AggregateOn(CurrentResults, indexDefinition, Context, null, ref currentlyProcessedResult, Token);
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
@@ -82,6 +82,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
                 Collection = definition.Collections.First(),
                 MapFields = CreateFields(definition.MapFields.ToDictionary(x => x.Key, x => x.Value.As<AutoIndexField>())),
                 GroupByFields = indexType == IndexType.AutoMap ? null : CreateFields(((AutoMapReduceIndexDefinition)definition).GroupByFields),
+                GroupByFieldNames = indexType == IndexType.AutoMap ? null : ((AutoMapReduceIndexDefinition)definition).GroupByFieldNames,
                 Priority = definition.Priority,
                 Name = definition.Name,
                 Type = indexType,

--- a/test/FastTests/Server/Documents/Indexing/FullTextSearchOnAutoIndex.cs
+++ b/test/FastTests/Server/Documents/Indexing/FullTextSearchOnAutoIndex.cs
@@ -16,7 +16,7 @@ namespace FastTests.Server.Documents.Indexing
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanUseFullTextSearchInAutoIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -60,7 +60,7 @@ namespace FastTests.Server.Documents.Indexing
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanUseFullTextSearchInAutoMapReduceIndex(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/GroupByMultipleFields.cs
+++ b/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/GroupByMultipleFields.cs
@@ -14,8 +14,8 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
         {
         }
 
-        [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Group_by_multiple_fields(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -257,7 +257,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Select_composite_group_by_key(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/FastTests/Sharding/Queries/BasicShardedMapReduceQueryTests.cs
+++ b/test/FastTests/Sharding/Queries/BasicShardedMapReduceQueryTests.cs
@@ -387,6 +387,7 @@ limit 1, 1")
 
                     Assert.Equal(1, autoLinqQueryResult.Count);
                     Assert.Equal("Grisha", autoLinqQueryResult[0].Name);
+                    Assert.Equal("Kotler", autoLinqQueryResult[0].LastName);
                     Assert.Equal(21, autoLinqQueryResult[0].Sum);
 
                     var autoIndexResult = session.Query<User>(stats.IndexName)
@@ -396,6 +397,7 @@ limit 1, 1")
 
                     Assert.Equal(1, autoIndexResult.Count);
                     Assert.Equal("Grisha", autoIndexResult[0].Name);
+                    Assert.Equal("Kotler", autoIndexResult[0].LastName);
                     Assert.Equal(21, autoIndexResult[0].Count);
 
                     autoIndexResult = session.Query<User>(stats.IndexName)
@@ -406,6 +408,7 @@ limit 1, 1")
 
                     Assert.Equal(1, autoIndexResult.Count);
                     Assert.Equal("Grisha", autoIndexResult[0].Name);
+                    Assert.Equal("Kotler", autoIndexResult[0].LastName);
                     Assert.Equal(21, autoIndexResult[0].Count);
 
                     autoIndexResult = session.Query<User>(stats.IndexName)
@@ -416,6 +419,7 @@ limit 1, 1")
 
                     Assert.Equal(1, autoIndexResult.Count);
                     Assert.Equal("Jane", autoIndexResult[0].Name);
+                    Assert.Equal("Doe", autoIndexResult[0].LastName);
                     Assert.Equal(30, autoIndexResult[0].Count);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-18545.cs
+++ b/test/SlowTests/Issues/RavenDB-18545.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task QuotationForGroupInAlias()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task QuotationForGroupInAlias(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 CancellationToken cancellationToken = CancellationToken.None;
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Issues/RavenDB_8240.cs
+++ b/test/SlowTests/Issues/RavenDB_8240.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void Can_group_by_constant_in_static_index()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_group_by_constant_in_static_index(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var indexes = new List<AbstractIndexCreationTask>()
                 {

--- a/test/SlowTests/Issues/RavenDB_8728.cs
+++ b/test/SlowTests/Issues/RavenDB_8728.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Util;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void Can_sum_or_group_by_list_count()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_sum_or_group_by_list_count(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -77,10 +79,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void Can_sum_or_group_by_array_length()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_sum_or_group_by_array_length(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var createdAt = SystemTime.UtcNow;
 

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using FastTests;
 using Raven.Client.Documents.Operations;
 using Raven.Server.Config;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,10 +15,11 @@ namespace SlowTests.Server.Documents.Indexing.Auto
         {
         }
 
-        [Fact]
-        public void CanQueryOnCaseSensitiveFields()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanQueryOnCaseSensitiveFields(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -43,13 +45,13 @@ namespace SlowTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Fact]
-        public void ShouldExtendMappingDueToCaseSensitiveFields()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldExtendMappingDueToCaseSensitiveFields(Options options)
         {
-            using (var store = GetDocumentStore(new Options
-            {
-                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.TimeBeforeDeletionOfSupersededAutoIndex)] = "0"
-            }))
+            options.ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.TimeBeforeDeletionOfSupersededAutoIndex)] = "0";
+
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -89,10 +91,11 @@ namespace SlowTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Fact]
-        public void CanQueryOnCaseSensitiveGroupByFields()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanQueryOnCaseSensitiveGroupByFields(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -137,10 +140,11 @@ namespace SlowTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Fact]
-        public void CanQueryOnCaseSensitiveFields_UsingSearch()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanQueryOnCaseSensitiveFields_UsingSearch(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
+++ b/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
@@ -90,8 +90,8 @@ namespace SlowTests.Server.Documents.Indexing
             }
         }
 
-        [Theory]
-        [RavenData]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanUseExactInAutoMapReduceIndex(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Sharding/Queries/ShardedMapReduceTests.cs
+++ b/test/SlowTests/Sharding/Queries/ShardedMapReduceTests.cs
@@ -63,6 +63,8 @@ namespace SlowTests.Sharding.Queries
                 operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), tempFileName);
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
+                await Indexes.WaitForIndexingAsync(store2);
+
                 using (var session = store2.OpenAsyncSession())
                 {
                     var result = await session.Query<User>(indexName)

--- a/test/SlowTests/Sharding/Queries/ShardedMapReduceTests.cs
+++ b/test/SlowTests/Sharding/Queries/ShardedMapReduceTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Smuggler;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Queries
+{
+    public class ShardedMapReduceTests : RavenTestBase
+    {
+        public ShardedMapReduceTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Indexes | RavenTestCategory.Smuggler)]
+        public async Task Can_Export_And_Import_Auto_Map_Reduce_Index()
+        {
+            using (var store1 = Sharding.GetDocumentStore())
+            using (var store2 = Sharding.GetDocumentStore(new Options
+                   {
+                       ModifyDatabaseName = _ => store1.Database + "_restored"
+                   }))
+            {
+                string indexName = null;
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/1");
+                    await session.StoreAsync(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/2");
+                    await session.StoreAsync(new User { Name = "Grisha", LastName = "Kotler", Count = 21 }, "users/3$3");
+                    await session.StoreAsync(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/4$3");
+                    await session.SaveChangesAsync();
+
+                    var result = await session.Query<User>()
+                        .Statistics(out var stats)
+                        .GroupBy(x => new { x.Name, x.LastName }).Select(x => new
+                        {
+                            Name = x.Key.Name,
+                            LastName = x.Key.LastName,
+                            Sum = x.Sum(u => u.Count)
+                        })
+                        .Take(1)
+                        .ToListAsync();
+
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("Grisha", result[0].Name);
+                    Assert.Equal("Kotler", result[0].LastName);
+                    Assert.Equal(21, result[0].Sum);
+
+                    indexName = stats.IndexName;
+                }
+
+                string tempFileName = GetTempFileName();
+
+                var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), tempFileName);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), tempFileName);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                using (var session = store2.OpenAsyncSession())
+                {
+                    var result = await session.Query<User>(indexName)
+                        .Take(1)
+                        .As<AutoMapReduceResult>()
+                        .ToListAsync();
+
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("Grisha", result[0].Name);
+                    Assert.Equal("Kotler", result[0].LastName);
+                    Assert.Equal(21, result[0].Count);
+                }
+            }
+        }
+
+        private class AutoMapReduceResult
+        {
+            public string Name { get; set; }
+            public string LastName { get; set; }
+            public int Count { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18164/Query-against-a-map-reduce-index-should-get-all-the-results

### Additional description

Group by queries which creates an auto map-reduce index and static indexes preserve the order of the `Group By` fields.
The same should apply when querying an auto map-reduce index directly.

This is important because we are modifying the query before sending it to the shards.
A query like: `from 'AutoMapReduce` limit 1`
We are going to send the query and adding the group by fields as order by fields: `from 'AutoMapReduce` order by Employee, Company limit 1`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
