### PR TITLE
RavenDB-20064 - Fix compare exchange tombstone cleaner to delete up to min raft of all shards backups

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -693,7 +693,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 if (state != null)
                 {
                     DevelopmentHelper.ToDo(DevelopmentHelper.Feature.Cluster, DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal,
-                        "handle this after RavenDB-20064 is fixed");
+                        "remove this after RavenDB-20150 is fixed");
                     // if (state.DatabaseTopology.Count != state.Current.Count) // we have a state change, do not remove anything
                     // return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -27,6 +27,7 @@ using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide.Maintenance
 {
@@ -280,28 +281,26 @@ namespace Raven.Server.ServerWide.Maintenance
                             var cleanupCommandsForDatabase = GetUnusedAutoIndexes(mergedState);
                                 cleanUnusedAutoIndexesCommands.AddRange(cleanupCommandsForDatabase);
                         }
-
+                        
                         if (cleanupTombstones)
                         {
-                            foreach (var shardToState in mergedState.States)
+                            var cmd = GetCompareExchangeTombstonesToCleanup(database, mergedState, context, out var cleanupState);
+                            switch (cleanupState)
                             {
-                                var cmd = GetCompareExchangeTombstonesToCleanup(shardToState.Value.Name, shardToState.Value, context, out var cleanupState);
-                                switch (cleanupState)
-                                {
-                                    case CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState:
-                                        _hasMoreTombstones = true;
-                                        break;
-                                    case CompareExchangeTombstonesCleanupState.HasMoreTombstones:
-                                        Debug.Assert(cmd != null);
-                                        cleanCompareExchangeTombstonesCommands.Add(cmd);
-                                        break;
-                                    case CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus:
-                                    case CompareExchangeTombstonesCleanupState.NoMoreTombstones:
-                                        break;
+                                case CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState:
+                                    _hasMoreTombstones = true;
+                                    break;
+                                case CompareExchangeTombstonesCleanupState.HasMoreTombstones:
+                                    Debug.Assert(cmd != null);
+                                    Console.WriteLine($"added clean command max raft: {cmd.MaxRaftIndex}");
+                                    cleanCompareExchangeTombstonesCommands.Add(cmd);
+                                    break;
+                                case CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus:
+                                case CompareExchangeTombstonesCleanupState.NoMoreTombstones:
+                                    break;
 
-                                    default:
-                                        throw new NotSupportedException($"Not supported state: '{cleanupState}'.");
-                                }
+                                default:
+                                    throw new NotSupportedException($"Not supported state: '{cleanupState}'.");
                             }
                         }
                     }
@@ -326,7 +325,6 @@ namespace Raven.Server.ServerWide.Maintenance
                     var result = await _server.SendToLeaderAsync(cmd);
                     await _server.Cluster.WaitForIndexNotification(result.Index);
                     var hasMore = (bool)result.Result;
-
                     _hasMoreTombstones |= hasMore;
                 }
 
@@ -600,8 +598,9 @@ namespace Raven.Server.ServerWide.Maintenance
             return cleanupCommands;
         }
 
-        internal CleanCompareExchangeTombstonesCommand GetCompareExchangeTombstonesToCleanup(string databaseName, DatabaseObservationState state, ClusterOperationContext context, out CompareExchangeTombstonesCleanupState cleanupState)
+        internal CleanCompareExchangeTombstonesCommand GetCompareExchangeTombstonesToCleanup(string databaseName, MergedDatabaseObservationState mergedState, ClusterOperationContext context, out CompareExchangeTombstonesCleanupState cleanupState)
         {
+            Debug.Assert(ShardHelper.IsShardName(databaseName) == false, "Compare exchanges are put in cluster under sharded database name, so can't delete them from under shard name");
             const int amountToDelete = 8192;
 
             if (_server.Cluster.HasCompareExchangeTombstones(context, databaseName) == false)
@@ -610,8 +609,8 @@ namespace Raven.Server.ServerWide.Maintenance
                 return null;
             }
 
-            cleanupState = GetMaxCompareExchangeTombstonesEtagToDelete(context, databaseName, state, out long maxEtag);
-
+            cleanupState = GetMaxCompareExchangeTombstonesEtagToDelete(context, databaseName, mergedState, out long maxEtag);
+            
             return cleanupState == CompareExchangeTombstonesCleanupState.HasMoreTombstones
                 ? new CleanCompareExchangeTombstonesCommand(databaseName, maxEtag, amountToDelete, RaftIdGenerator.NewId())
                 : null;
@@ -624,15 +623,15 @@ namespace Raven.Server.ServerWide.Maintenance
             InvalidPeriodicBackupStatus,
             NoMoreTombstones
         }
-
-        private CompareExchangeTombstonesCleanupState GetMaxCompareExchangeTombstonesEtagToDelete<TRavenTransaction>(TransactionOperationContext<TRavenTransaction> context, string databaseName, DatabaseObservationState state, out long maxEtag) where TRavenTransaction : RavenTransaction
+        
+        private CompareExchangeTombstonesCleanupState GetMaxCompareExchangeTombstonesEtagToDelete<TRavenTransaction>(TransactionOperationContext<TRavenTransaction> context, string databaseName, MergedDatabaseObservationState mergedState, out long maxEtag) where TRavenTransaction : RavenTransaction
         {
             List<long> periodicBackupTaskIds;
             maxEtag = long.MaxValue;
 
-            if (state?.RawDatabase != null)
+            if (mergedState.RawDatabase != null)
             {
-                periodicBackupTaskIds = state.RawDatabase.PeriodicBackupsTaskIds;
+                periodicBackupTaskIds = mergedState.RawDatabase.PeriodicBackupsTaskIds;
             }
             else
             {
@@ -640,70 +639,79 @@ namespace Raven.Server.ServerWide.Maintenance
                     periodicBackupTaskIds = rawRecord.PeriodicBackupsTaskIds;
             }
 
-            if (periodicBackupTaskIds != null && periodicBackupTaskIds.Count > 0)
+            foreach (var (shardNumber, state) in mergedState.States)
             {
-                foreach (var taskId in periodicBackupTaskIds)
+                if (periodicBackupTaskIds != null && periodicBackupTaskIds.Count > 0)
                 {
-                    var singleBackupStatus = _server.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(databaseName, taskId));
-                    if (singleBackupStatus == null)
-                        continue;
-
-                    if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastFullBackupInternal), out DateTime? lastFullBackupInternal) == false || lastFullBackupInternal == null)
+                    foreach (var taskId in periodicBackupTaskIds)
                     {
-                        // never backed up yet
-                        if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastIncrementalBackupInternal), out DateTime? lastIncrementalBackupInternal) == false || lastIncrementalBackupInternal == null)
+                        //if sharded, we have to get backup status by shard name
+                        var shardName = state?.Name ?? ShardHelper.ToShardName(databaseName, shardNumber);
+                        var singleBackupStatus = _server.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(shardName, taskId));
+                        if (singleBackupStatus == null)
                             continue;
-                    }
 
-                    if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastRaftIndex), out BlittableJsonReaderObject lastRaftIndexBlittable) == false ||
-                        lastRaftIndexBlittable == null)
-                    {
-                        if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.Error), out BlittableJsonReaderObject error) == false || error != null)
+                        if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastFullBackupInternal), out DateTime? lastFullBackupInternal) == false ||
+                            lastFullBackupInternal == null)
                         {
-                            // backup errored on first run (lastRaftIndex == null) => cannot remove ANY tombstones
-                            return CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus;
+                            // never backed up yet
+                            if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastIncrementalBackupInternal), out DateTime? lastIncrementalBackupInternal) ==
+                                false || lastIncrementalBackupInternal == null)
+                                continue;
                         }
 
-                        continue;
-                    }
+                        if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastRaftIndex), out BlittableJsonReaderObject lastRaftIndexBlittable) == false ||
+                            lastRaftIndexBlittable == null)
+                        {
+                            if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.Error), out BlittableJsonReaderObject error) == false || error != null)
+                            {
+                                // backup errored on first run (lastRaftIndex == null) => cannot remove ANY tombstones
+                                return CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus;
+                            }
 
-                    if (lastRaftIndexBlittable.TryGet(nameof(PeriodicBackupStatus.LastEtag), out long? lastRaftIndex) == false || lastRaftIndex == null)
-                    {
-                        continue;
-                    }
-
-                    if (lastRaftIndex < maxEtag)
-                        maxEtag = lastRaftIndex.Value;
-
-                    if (maxEtag == 0)
-                        return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
-                }
-            }
-
-            if (state != null)
-            {
-                if (state.DatabaseTopology.Count != state.Current.Count) // we have a state change, do not remove anything
-                    return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
-
-                foreach (var node in state.DatabaseTopology.AllNodes)
-                {
-                    if (state.Current.TryGetValue(node, out var nodeReport) == false)
-                        continue;
-
-                    if (nodeReport.Report.TryGetValue(state.Name, out var report) == false)
-                        continue;
-
-                    foreach (var kvp in report.LastIndexStats)
-                    {
-                        var lastIndexedCompareExchangeReferenceTombstoneEtag = kvp.Value.LastIndexedCompareExchangeReferenceTombstoneEtag;
-                        if (lastIndexedCompareExchangeReferenceTombstoneEtag == null)
                             continue;
+                        }
 
-                        if (lastIndexedCompareExchangeReferenceTombstoneEtag < maxEtag)
-                            maxEtag = lastIndexedCompareExchangeReferenceTombstoneEtag.Value;
+                        if (lastRaftIndexBlittable.TryGet(nameof(PeriodicBackupStatus.LastEtag), out long? lastRaftIndex) == false || lastRaftIndex == null)
+                        {
+                            continue;
+                        }
+
+                        if (lastRaftIndex < maxEtag)
+                            maxEtag = lastRaftIndex.Value;
 
                         if (maxEtag == 0)
                             return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+                    }
+                }
+
+                if (state != null)
+                {
+                    DevelopmentHelper.ToDo(DevelopmentHelper.Feature.Cluster, DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal,
+                        "handle this after RavenDB-20064 is fixed");
+                    // if (state.DatabaseTopology.Count != state.Current.Count) // we have a state change, do not remove anything
+                    // return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
+
+                    foreach (var node in state.DatabaseTopology.AllNodes)
+                    {
+                        if (state.Current.TryGetValue(node, out var nodeReport) == false)
+                            continue;
+
+                        if (nodeReport.Report.TryGetValue(state.Name, out var report) == false)
+                            continue;
+
+                        foreach (var kvp in report.LastIndexStats)
+                        {
+                            var lastIndexedCompareExchangeReferenceTombstoneEtag = kvp.Value.LastIndexedCompareExchangeReferenceTombstoneEtag;
+                            if (lastIndexedCompareExchangeReferenceTombstoneEtag == null)
+                                continue;
+
+                            if (lastIndexedCompareExchangeReferenceTombstoneEtag < maxEtag)
+                                maxEtag = lastIndexedCompareExchangeReferenceTombstoneEtag.Value;
+
+                            if (maxEtag == 0)
+                                return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+                        }
                     }
                 }
             }
@@ -815,6 +823,8 @@ namespace Raven.Server.ServerWide.Maintenance
         {
             public static MergedDatabaseObservationState Empty = new MergedDatabaseObservationState();
             private readonly bool _isShardedState;
+            public readonly Dictionary<int, DatabaseObservationState> States;
+            public readonly RawDatabaseRecord RawDatabase;
 
             public MergedDatabaseObservationState(RawDatabaseRecord record)
             {
@@ -849,12 +859,14 @@ namespace Raven.Server.ServerWide.Maintenance
 
                 if (_isShardedState == false)
                     throw new InvalidOperationException($"The database {state.Name} is sharded (shard: {shardNumber}), but was initialized as a regular one.");
-
+                
                 States[shardNumber] = state;
             }
 
-            public readonly Dictionary<int, DatabaseObservationState> States;
-            public readonly RawDatabaseRecord RawDatabase;
+            public static MergedDatabaseObservationState GetEmpty()
+            {
+                return new MergedDatabaseObservationState();
+            }
         }
 
         internal class DatabaseObservationState

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -291,8 +291,7 @@ namespace Raven.Server.ServerWide.Maintenance
                                     _hasMoreTombstones = true;
                                     break;
                                 case CompareExchangeTombstonesCleanupState.HasMoreTombstones:
-                                    Debug.Assert(cmd != null);
-                                    Console.WriteLine($"added clean command max raft: {cmd.MaxRaftIndex}");
+                                    Debug.Assert(cmd != null, $"Expected to get command {nameof(CleanCompareExchangeTombstonesCommand)} but it was null");
                                     cleanCompareExchangeTombstonesCommands.Add(cmd);
                                     break;
                                 case CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus:
@@ -600,7 +599,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         internal CleanCompareExchangeTombstonesCommand GetCompareExchangeTombstonesToCleanup(string databaseName, MergedDatabaseObservationState mergedState, ClusterOperationContext context, out CompareExchangeTombstonesCleanupState cleanupState)
         {
-            Debug.Assert(ShardHelper.IsShardName(databaseName) == false, "Compare exchanges are put in cluster under sharded database name, so can't delete them from under shard name");
+            Debug.Assert(ShardHelper.IsShardName(databaseName) == false, $"Compare exchanges are put in cluster under sharded database name, so can't delete them from under shard name {databaseName}");
             const int amountToDelete = 8192;
 
             if (_server.Cluster.HasCompareExchangeTombstones(context, databaseName) == false)

--- a/src/Sparrow/Utils/DevelopmentHelper.cs
+++ b/src/Sparrow/Utils/DevelopmentHelper.cs
@@ -15,7 +15,8 @@ internal static class DevelopmentHelper
 
     internal enum Feature
     {
-        Sharding
+        Sharding,
+        Cluster
     }
 
     internal enum TeamMember

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
+using Raven.Server.Documents;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
@@ -141,6 +142,17 @@ public partial class RavenTestBase
                     }
                 }
             }
+        }
+        public virtual Task<DocumentDatabase> GetAnyDocumentDatabaseInstanceFor(IDocumentStore store, List<RavenServer> cluster, string database = null)
+        {
+            foreach (var node in cluster)
+            {
+                var db = node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+                if (db != null)
+                    return db;
+            }
+
+            return null;
         }
 
         public long LastRaftIndexForCommand(RavenServer server, string commandType)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -56,18 +56,6 @@ namespace FastTests
             return Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
         }
 
-        protected virtual Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(IDocumentStore store, List<RavenServer> cluster, string database = null)
-        {
-            foreach (var node in cluster)
-            {
-                var db = node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
-                if (db != null)
-                    return db;
-            }
-
-            return null;
-        }
-
         public bool WaitForDocument<T>(IDocumentStore store,
             string docId,
             Func<T, bool> predicate,

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -56,6 +56,18 @@ namespace FastTests
             return Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
         }
 
+        protected virtual Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(IDocumentStore store, List<RavenServer> cluster, string database = null)
+        {
+            foreach (var node in cluster)
+            {
+                var db = node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+                if (db != null)
+                    return db;
+            }
+
+            return null;
+        }
+
         public bool WaitForDocument<T>(IDocumentStore store,
             string docId,
             Func<T, bool> predicate,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20064

### Additional description

Fixed the compare exchange tombstone cleaner code so that we calculate the minimal raft index (represents the last point of backup) between all the shards. Since backups are local for each shard.
Cleaner then only deletes the tombstones in cluster up to that shared index.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
