### PR TITLE
RavenDB-19250 Sharding Backup/Restore

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -32,6 +32,7 @@
         <div>Notes:</div>
         <ul>
             <li><small>An incremental Snapshot is the same as an incremental Backup</small></li>
+            <li><small>An incremental Snapshot is not supported in sharded databases</small></li>
         </ul>`;
     
     static readonly backupAgeInfo = 

--- a/src/Raven.Studio/typescript/models/resources/creation/backupCredentials.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/backupCredentials.ts
@@ -16,6 +16,7 @@ export abstract class restoreSettings {
     fetchRestorePointsCommand: () => commandBase;
 
     abstract getFolderPathOptions(): JQueryPromise<string[]>;
+    abstract getShardingFolderPathOptions(backupDirectory: string): JQueryPromise<string[]>;
     
     abstract getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,
                                                 backupLocation: string): Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase
@@ -45,6 +46,10 @@ export class localServerCredentials extends restoreSettings {
 
     getFolderPathOptions() {
         return super.getFolderPathOptionsByCommand(getFolderPathOptionsCommand.forServerLocal(this.backupDirectory(), true))
+    }
+
+    getShardingFolderPathOptions(backupDirectory: string) {
+        return super.getFolderPathOptionsByCommand(getFolderPathOptionsCommand.forServerLocal(backupDirectory, true))
     }
     
     getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,
@@ -133,6 +138,10 @@ export class amazonS3Credentials extends restoreSettings {
         return this.getFolderPathOptionsByCommand(getFolderPathOptionsCommand.forCloudBackup(this.toDto(), "S3"));
     }
 
+    getShardingFolderPathOptions(backupDirectory: string): JQueryPromise<string[]> {
+        throw new Error("Amazon S3 is currently not supported for sharded database restore");
+    }
+
     getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,
                                        backupLocation: string) {
         const amazonS3Configuration = baseConfiguration as Raven.Client.Documents.Operations.Backups.RestoreFromS3Configuration;
@@ -207,6 +216,10 @@ export class azureCredentials extends restoreSettings {
     getFolderPathOptions() {
         return super.getFolderPathOptionsByCommand(getFolderPathOptionsCommand.forCloudBackup(this.toDto(), "Azure"))
     }
+
+    getShardingFolderPathOptions(backupDirectory: string): JQueryPromise<string[]> {
+        throw new Error("Azure is currently not supported for sharded database restore");
+    }
     
     getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,
                                        backupLocation: string) {
@@ -266,6 +279,10 @@ export class googleCloudCredentials extends restoreSettings {
 
     getFolderPathOptions() {
         return this.getFolderPathOptionsByCommand(getFolderPathOptionsCommand.forCloudBackup(this.toDto(), "GoogleCloud"))
+    }
+
+    getShardingFolderPathOptions(backupDirectory: string): JQueryPromise<string[]> {
+        throw new Error("Google is currently not supported for sharded database restore");
     }
     
     getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,
@@ -390,6 +407,10 @@ export class ravenCloudCredentials extends restoreSettings {
     getFolderPathOptions() {
         // Folder options are not relevant when source is the 'RavenDB Cloud Link'.. 
         return $.Deferred<string[]>().reject();
+    }
+
+    getShardingFolderPathOptions(backupDirectory: string): JQueryPromise<string[]> {
+        throw new Error("Raven cloud is currently not supported for sharded database restore");
     }
     
     getConfigurationForRestoreDatabase(baseConfiguration: Raven.Client.Documents.Operations.Backups.RestoreBackupConfigurationBase,

--- a/src/Raven.Studio/typescript/models/resources/creation/shardingRestoreBackupDirectory.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/shardingRestoreBackupDirectory.ts
@@ -1,0 +1,12 @@
+﻿
+export default class shardingRestoreBackupDirectory {
+    nodeTag: KnockoutObservable<string>;
+    directoryPath: KnockoutObservable<string>;
+    directoryPathOptions: KnockoutObservableArray<string>
+
+    constructor() {
+        this.directoryPath = ko.observable("");
+        this.nodeTag = ko.observable("");
+        this.directoryPathOptions = ko.observableArray();
+    }
+}

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -91,7 +91,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
             return false;
         }
         
-        return type.includes("ShardedSmugglerResult") || type.includes("ShardedBackupResult");
+        return type.includes("ShardedSmugglerResult") || type.includes("ShardedBackupResult") || type.includes("ShardedRestoreResult");
     }
     
     private static isShardedProgress(value: object): value is ShardedSmugglerProgress {
@@ -101,7 +101,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
             return false;
         }
         
-        return type.includes("ShardedSmugglerProgress") || type.includes("ShardedBackupProgress");
+        return type.includes("ShardedSmugglerProgress") || type.includes("ShardedBackupProgress") || type.includes("ShardedRestoreResult");
     }
     
     private static isShardedBackupResult(value: object): value is ShardedBackupResult {
@@ -206,7 +206,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 const backupCount = (status as BackupProgress).SnapshotBackup;
 
                 // skip it this case means it is not backup progress object or it is backup of non-binary data
-                if (!backupCount.Skipped) {
+                if (backupCount && backupCount.Skipped) {
                     result.push(this.mapToExportListItem("Backed up files", backupCount));
                 }
             }
@@ -215,7 +215,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 const restoreCounts = (status as RestoreProgress).SnapshotRestore;
                 
                 // skip it this case means it is not restore progress object or it is restore of non-binary data 
-                if (!restoreCounts.Skipped) {
+                if (restoreCounts && restoreCounts.Skipped) {
                     result.push(this.mapToExportListItem("Preparing restore", restoreCounts));
                 }
             }
@@ -381,7 +381,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
     }
 
     private static mapUploadItem(backupType: string, backupStatus: CloudUploadStatus): uploadListItem | null {
-        if (backupStatus.Skipped) {
+        if (!backupStatus || backupStatus.Skipped) {
             return null;
         }
 
@@ -470,6 +470,10 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
     }
 
     private mapToExportListItem(name: string, item: Counts, isNested = false): smugglerListItem {
+        if (!item) {
+            return null;
+        }
+        
         let stage: smugglerListItemStatus = "processing";
         
         if (item.Skipped) {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -134,6 +134,10 @@ class editPeriodicBackupTask extends shardViewModelBase {
         if (this.configuration() instanceof periodicBackupConfiguration) {
             document.getElementById("taskName").focus();
         }
+
+        if (this.db.isSharded()) {
+            this.configuration().backupType("Backup");
+        }
     }
 
     attached() {

--- a/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
@@ -433,6 +433,7 @@ class createDatabase extends dialogViewModelBase {
             case "newDatabase":
                 return _.without(sections, restoreSection);
             case "restore":
+                sections.find(x => x.id === "replicationAndSharding").name = "Replication";
                 return _.without(sections);
         }
     }

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -33,7 +33,7 @@
                 <label class="control-label col-sm-4 col-lg-2">Backup Type <i class="required"></i> <small><i class="backup-info icon-info text-info"></i></small></label>
                 <div class="col-sm-4" data-bind="validationOptions: { insertMessages: false }">
                     <div class="dropdown btn-block">
-                        <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
+                        <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown" data-bind="disable: $root.db.isSharded()">
                             <span data-bind="text: backupType() || 'Select backup type..'"></span>
                             <span class="caret"></span>
                         </button>

--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -113,7 +113,10 @@
             <div class="form-group flex-horizontal">
                 <div class="position-relative">
                     <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                        <span><i class="icon-node text-success"></i><span data-bind="textInput: $parent.shardingBackupDirectories()[$index()].nodeTag()"><span>Node tag</span></span></span>
+                        <span>
+                            <i class="icon-node text-success"></i>
+                            <span>Node <span data-bind="text: $parent.shardingBackupDirectories()[$index()].nodeTag()"></span></span>
+                        </span>
                         <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" data-bind="foreach: $root.clusterNodes">

--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -73,9 +73,9 @@
         <h3>Backup Source Configuration</h3>
         <div class="form-group row" data-bind="validationElement: source">
             <div class="col-md-4">
-                <label class="control-label">Source</label>
+                <label class="control-label" data-bind="text: enableSharding() ? localServerCredentials().backupStorageTypeText : 'Source'"></label>
             </div>
-            <div class="col-md-8">
+            <div class="col-md-8" data-bind="visible: !enableSharding()">
                 <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
                     <span data-bind="text: $root.findRestoreSourceLabel(source())"></span>
                     <span class="caret"></span>
@@ -101,9 +101,52 @@
             </div>
         </div>
 
+        <!-- Sharding -->
+        
+        <div class="toggle">
+            <input class="styled" type="checkbox" id="restore_sharded_db" data-bind="checked: enableSharding">
+            <label for="restore_sharded_db">Enable sharding</label>
+        </div>
+        
+        <div data-bind="visible: enableSharding, foreach: shardingBackupDirectories">
+            <div class="form-group flex-horizontal margin-top-xs">
+                <span>Shard #<span data-bind="text: $index()"></span></span>
+                <div class="dropdown btn-block" style="width: 150px;">
+                    <input type="text" class="form-control dropdown-toggle"
+                           data-bind="textInput: $parent.shardingBackupDirectories()[$index()].nodeTag()"
+                           data-toggle="dropdown" placeholder="Node tag" />
+                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                    <ul class="dropdown-menu" data-bind="foreach: $root.clusterNodes">
+                        <li data-bind="click: $parents[1].setShardingDirectoryNodeTag.bind($parent, $parentContext.$index(), $data.tag())">
+                            <a href="#" data-bind="text: $data.tag"></a>
+                        </li>
+                    </ul>
+                </div>
+                
+                <div class="dropdown btn-block">
+                    <input type="text" class="form-control dropdown-toggle"
+                           data-bind="textInput: $parent.shardingBackupDirectories()[$index()].directoryPath()"
+                           data-toggle="dropdown" placeholder="Enter backup directory path" />
+                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                    <ul class="dropdown-menu" data-bind="foreach: $data.directoryPathOptions">
+                        <li data-bind="click: $parents[1].setShardingDirectoryPath.bind($parent, $parentContext.$index(), $data)">
+                            <a href="#" data-bind="text: $data"></a>
+                        </li>
+                    </ul>
+                </div>
+                <button type="button" class="btn btn-danger" data-bind="click: $parent.removeShardingDirectoryPath.bind($parent, $index())">
+                    Remove
+                </button>
+            </div>
+        </div>
+
+        <button type="button" class="btn btn-info margin-bottom-xs margin-top-xs" data-bind="visible: enableSharding,click: addShardingDirectoryPath">
+            <i class="icon-backup" /> Add shard backup folder
+        </button>
+        
         <!-- Local Directory -->
 
-        <div class="form-group row" data-bind="validationOptions: { insertMessages: false }, validationElement: localServerCredentials().backupDirectory, visible: source() === localServerCredentials().backupStorageType">
+        <div class="form-group row" data-bind="validationOptions: { insertMessages: false }, validationElement: localServerCredentials().backupDirectory, visible: source() === localServerCredentials().backupStorageType && !enableSharding()">
             <div class="col-md-4">
                 <label class="control-label">Backup Directory<i class="required"></i></label>
             </div>
@@ -424,7 +467,7 @@
             <input class="styled" type="checkbox" id="skip-indexes-import" data-bind="checked: skipIndexes">
             <label for="skip-indexes-import">Skip indexes</label>
         </div>
-        <div class="form-group row" data-bind="validationOptions: { insertMessages: false }, validationElement: selectedRestorePoint">
+        <div class="form-group row" data-bind="validationOptions: { insertMessages: false }, validationElement: selectedRestorePoint, visible: !enableSharding()">
             <div class="col-md-4">
                 <label class="control-label">Restore Point</label>
             </div>

--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -103,19 +103,19 @@
 
         <!-- Sharding -->
         
-        <div class="toggle">
+        <div class="toggle margin-bottom-sm">
             <input class="styled" type="checkbox" id="restore_sharded_db" data-bind="checked: enableSharding">
             <label for="restore_sharded_db">Enable sharding</label>
         </div>
         
         <div data-bind="visible: enableSharding, foreach: shardingBackupDirectories">
-            <div class="form-group flex-horizontal margin-top-xs">
-                <span>Shard #<span data-bind="text: $index()"></span></span>
-                <div class="dropdown btn-block" style="width: 150px;">
-                    <input type="text" class="form-control dropdown-toggle"
-                           data-bind="textInput: $parent.shardingBackupDirectories()[$index()].nodeTag()"
-                           data-toggle="dropdown" placeholder="Node tag" />
-                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+            <span class="margin-top-sm margin-bottom-xs"><i class="icon-shard text-info" title="Shard"></i> #<span data-bind="text: $index()"></span></span>
+            <div class="form-group flex-horizontal">
+                <div class="position-relative">
+                    <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
+                        <span><i class="icon-node text-success"></i><span data-bind="textInput: $parent.shardingBackupDirectories()[$index()].nodeTag()"><span>Node tag</span></span></span>
+                        <span class="caret"></span>
+                    </button>
                     <ul class="dropdown-menu" data-bind="foreach: $root.clusterNodes">
                         <li data-bind="click: $parents[1].setShardingDirectoryNodeTag.bind($parent, $parentContext.$index(), $data.tag())">
                             <a href="#" data-bind="text: $data.tag"></a>
@@ -134,8 +134,8 @@
                         </li>
                     </ul>
                 </div>
-                <button type="button" class="btn btn-danger" data-bind="click: $parent.removeShardingDirectoryPath.bind($parent, $index())">
-                    Remove
+                <button type="button" class="btn btn-danger margin-left-xs" data-bind="click: $parent.removeShardingDirectoryPath.bind($parent, $index())">
+                    <i class="icon-trash"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19250/Sharding-Backup-Restore

### Additional description

Backup UI remains almost unchanged. Only it will not be possible to take a snapshot for a sharded database.

In the case of restore, you will be able to specify separate paths for each shard folder.

### Type of change

- New feature

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://user-images.githubusercontent.com/47967925/227955277-55e1014e-3e3c-4624-9d4e-97a9e47f4436.png)
