### PR TITLE
RavenDB-20110 - Import or restore of unsupported feature should be sk…

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -51,6 +51,9 @@ namespace Raven.Client.Documents.Smuggler
                                                               DatabaseItemType.Identities |
                                                               DatabaseItemType.Subscriptions;
 
+        internal const DatabaseRecordItemType ShardingNotSupportedDatabaseSmugglerOptions = DatabaseRecordItemType.HubPullReplications | 
+                                                                                            DatabaseRecordItemType.SinkPullReplications;
+
         private const int DefaultMaxStepsForTransformScript = 10 * 1000;
 
         public DatabaseSmugglerOptions()

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -52,7 +52,9 @@ namespace Raven.Client.Documents.Smuggler
                                                               DatabaseItemType.Subscriptions;
 
         internal const DatabaseRecordItemType ShardingNotSupportedDatabaseSmugglerOptions = DatabaseRecordItemType.HubPullReplications | 
-                                                                                            DatabaseRecordItemType.SinkPullReplications;
+                                                                                            DatabaseRecordItemType.SinkPullReplications |
+                                                                                            DatabaseRecordItemType.PostgreSQLIntegration |
+                                                                                            DatabaseRecordItemType.QueueEtls;
 
         private const int DefaultMaxStepsForTransformScript = 10 * 1000;
 

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public async ValueTask<IAsyncDisposable> InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
         {
-            options.OperateOnDatabaseRecordTypes &= ~(DatabaseRecordItemType.HubPullReplications | DatabaseRecordItemType.SinkPullReplications);
+            options.OperateOnDatabaseRecordTypes &= ~DatabaseSmugglerOptions.ShardingNotSupportedDatabaseSmugglerOptions;
             _options = options;
 
             // we will send decrypted data to the shards

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -44,6 +44,7 @@ namespace Raven.Server.Smuggler.Documents
 
         public async ValueTask<IAsyncDisposable> InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
         {
+            options.OperateOnDatabaseRecordTypes &= ~(DatabaseRecordItemType.HubPullReplications | DatabaseRecordItemType.SinkPullReplications);
             _options = options;
 
             // we will send decrypted data to the shards

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -44,7 +44,6 @@ namespace Raven.Server.Smuggler.Documents
 
         public async ValueTask<IAsyncDisposable> InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
         {
-            options.OperateOnDatabaseRecordTypes &= ~DatabaseSmugglerOptions.ShardingNotSupportedDatabaseSmugglerOptions;
             _options = options;
 
             // we will send decrypted data to the shards

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -91,6 +91,10 @@ namespace Raven.Server.Smuggler.Documents
         protected override bool ShouldSkipIndex(IndexDefinitionAndType index, out string msg)
         {
             msg = null;
+
+            if (index.Type == IndexType.AutoMap || index.Type == IndexType.AutoMapReduce)
+                return false;
+
             var definition = (IndexDefinition)index.IndexDefinition;
 
             if (definition.OutputReduceToCollection != null)

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
@@ -48,6 +49,18 @@ namespace Raven.Server.Smuggler.Documents
             {
                 return await ProcessDatabaseRecordInternalAsync(result, action);
             }
+        }
+
+        protected override bool ShouldSkipIndex(IndexDefinitionAndType index)
+        {
+            if (index.Type is IndexType.MapReduce or IndexType.AutoMapReduce)
+                return true;
+
+            var definition = (IndexDefinition)index.IndexDefinition;
+            if (definition.DeploymentMode is IndexDeploymentMode.Rolling)
+                return true;
+
+            return false;
         }
 
         protected override async Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType)

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -93,9 +93,9 @@ namespace Raven.Server.Smuggler.Documents
             msg = null;
             var definition = (IndexDefinition)index.IndexDefinition;
 
-            if (index.Type is IndexType.MapReduce or IndexType.AutoMapReduce)
+            if (definition.OutputReduceToCollection != null)
             {
-                msg = $"Skipped index '{definition.Name}'. Map-Reduce is currently not supported in Sharding";
+                msg = $"Skipped index '{definition.Name}'. Map-Reduce output documents feature is currently not supported in Sharding";
                 return true;
             }
 

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -667,6 +667,9 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
+                    if (ShouldSkipIndex(index))
+                        continue;
+
                     if (OnIndexAction != null)
                     {
                         OnIndexAction(index);
@@ -746,7 +749,7 @@ namespace Raven.Server.Smuggler.Documents
             return result.Indexes;
         }
 
-
+        protected virtual bool ShouldSkipIndex(IndexDefinitionAndType index) => false;
 
         protected virtual Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType) =>
             ProcessIdentitiesInternalAsync(result, buildType, _destination.Identities());

--- a/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
@@ -466,18 +466,9 @@ namespace SlowTests.Sharding.Backup
                     Assert.Equal("tempDatabase", record.ExternalReplications[0].Database);
                     Assert.Equal(true, record.ExternalReplications[0].Disabled);
 
-                    Assert.Equal(1, record.SinkPullReplications.Count);
-                    Assert.Equal("sinkDatabase", record.SinkPullReplications[0].Database);
-                    Assert.Equal("hub", record.SinkPullReplications[0].HubName);
-                    Assert.Equal((string)null, record.SinkPullReplications[0].CertificatePassword);
-                    Assert.Equal(privateKey, record.SinkPullReplications[0].CertificateWithPrivateKey);
-                    Assert.Equal(true, record.SinkPullReplications[0].Disabled);
-
-                    Assert.Equal(1, record.HubPullReplications.Count);
-                    Assert.Equal(new TimeSpan(3), record.HubPullReplications.First().DelayReplicationFor);
-                    Assert.Equal("hub", record.HubPullReplications.First().Name);
-                    Assert.Equal(true, record.HubPullReplications.First().Disabled);
-
+                    Assert.Equal(0, record.SinkPullReplications.Count);
+                    Assert.Equal(0, record.HubPullReplications.Count);
+              
                     Assert.Equal(1, record.RavenEtls.Count);
                     Assert.Equal("Etl", record.RavenEtls.First().Name);
                     Assert.Equal("ConnectionName", record.RavenEtls.First().ConnectionStringName);

--- a/test/SlowTests/Sharding/Issues/RavenDB_20110.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20110.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20110 : RavenTestBase
+    {
+        public RavenDB_20110(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
+        public async Task ShouldSkipUnsupportedFeaturesInShardingOnImport()
+        {
+            var file = GetTempFileName();
+            try
+            {
+                using (var store1 = GetDocumentStore())
+                using (var store2 = Sharding.GetDocumentStore())
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = "Name1" }, "users/1");
+                        await session.StoreAsync(new User { Name = "Name2" }, "users/2");
+
+                        await session.SaveChangesAsync();
+                    }
+
+                    await store1.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition {Name = "t", Mode = PullReplicationMode.HubToSink, Disabled = true}));
+
+                    var record = await store1.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store1.Database));
+                    Assert.Equal(1, record.HubPullReplications.Count);
+                 
+                    var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    record = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store2.Database));
+                    Assert.Equal(0, record.HubPullReplications.Count);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_20110.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20110.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Operations.Integrations.PostgreSQL;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -18,8 +22,8 @@ namespace SlowTests.Sharding.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
-        public async Task ShouldSkipUnsupportedFeaturesInShardingOnImport()
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding | RavenTestCategory.Replication)]
+        public async Task ShouldSkipUnsupportedFeaturesInShardingOnImport_HubSinkReplication()
         {
             var file = GetTempFileName();
             try
@@ -35,11 +39,11 @@ namespace SlowTests.Sharding.Issues
                         await session.SaveChangesAsync();
                     }
 
-                    await store1.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition {Name = "t", Mode = PullReplicationMode.HubToSink, Disabled = true}));
+                    await store1.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition { Name = "t", Mode = PullReplicationMode.HubToSink, Disabled = true }));
 
                     var record = await store1.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store1.Database));
                     Assert.Equal(1, record.HubPullReplications.Count);
-                 
+
                     var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
@@ -53,6 +57,51 @@ namespace SlowTests.Sharding.Issues
             finally
             {
                 File.Delete(file);
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding | RavenTestCategory.PostgreSql)]
+        public async Task ShouldSkipUnsupportedFeaturesInShardingOnImport_PostgreSqlIntegration()
+        {
+            using (var srcStore = GetDocumentStore())
+            using (var dstStore = Sharding.GetDocumentStore())
+            {
+                srcStore.Maintenance.Send(new ConfigurePostgreSqlOperation(new PostgreSqlConfiguration
+                {
+                    Authentication = new PostgreSqlAuthenticationConfiguration()
+                    {
+                        Users = new List<PostgreSqlUser>()
+                        {
+                            new PostgreSqlUser()
+                            {
+                                Username = "arek",
+                                Password = "foo!@22"
+                            }
+                        }
+                    }
+                }));
+
+                var record = await srcStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(srcStore.Database));
+
+                Assert.NotNull(record.Integrations);
+                Assert.NotNull(record.Integrations.PostgreSql);
+                Assert.Equal(1, record.Integrations.PostgreSql.Authentication.Users.Count);
+
+                Assert.Contains("arek", record.Integrations.PostgreSql.Authentication.Users.First().Username);
+                Assert.Contains("foo!@22", record.Integrations.PostgreSql.Authentication.Users.First().Password);
+
+                var exportFile = GetTempFileName();
+
+                var exportOperation = await srcStore.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportFile);
+                await exportOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var operation = await dstStore.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                record = await dstStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dstStore.Database));
+
+                Assert.Null(record.Integrations);
             }
         }
     }


### PR DESCRIPTION
…ipped and warned about

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20110/Import-or-restore-of-unsupported-feature-should-be-skipped-and-warned-about

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
