### PR TITLE
RavenDB-20202: Cluster node health check issue when experiencing a timeout and topology update simultaneously.

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -125,8 +125,9 @@ namespace Raven.Client.Http
             var state = _state;
             var preferredNode = GetPreferredNodeInternal(state);
             return (preferredNode.Index, preferredNode.Node, state.Topology?.Etag??-2);
-            
         }
+
+        internal int[] GetNodeSelectorFailures => _state.Failures;
 
         private static ValueTuple<int, ServerNode> UnlikelyEveryoneFaultedChoice(NodeSelectorState state)
         {

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -177,12 +177,13 @@ namespace Raven.Client.Http
             return GetPreferredNode();
         }
 
-        public void RestoreNodeIndex(int nodeIndex)
+        public void RestoreNodeIndex(ServerNode node)
         {
             var state = _state;
-            if (state.Failures.Length <= nodeIndex)
-                return; // the state was changed and we no longer have it?
-
+            var nodeIndex = state.Nodes.IndexOf(node);
+            if (nodeIndex == -1)
+                return;
+            
             while (true)
             {
                 var stateFailure = state.Failures[nodeIndex];

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Http
             return (preferredNode.Index, preferredNode.Node, state.Topology?.Etag??-2);
         }
 
-        internal int[] GetNodeSelectorFailures => _state.Failures;
+        internal int[] NodeSelectorFailures => _state.Failures;
 
         private static ValueTuple<int, ServerNode> UnlikelyEveryoneFaultedChoice(NodeSelectorState state)
         {

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2338,9 +2338,9 @@ namespace Raven.Client.Http
                 _requestExecutor = requestExecutor;
             }
 
-            internal int[] GetNodeSelectorFailures => _requestExecutor._nodeSelector.GetNodeSelectorFailures;
-            internal ConcurrentDictionary<ServerNode, Lazy<NodeStatus>> GetFailedNodesTimers => _requestExecutor._failedNodesTimers;
-            internal (int Index, ServerNode Node) GetPreferredNode => _requestExecutor._nodeSelector.GetPreferredNode();
+            internal int[] NodeSelectorFailures => _requestExecutor._nodeSelector.NodeSelectorFailures;
+            internal ConcurrentDictionary<ServerNode, Lazy<NodeStatus>> FailedNodesTimers => _requestExecutor._failedNodesTimers;
+            internal (int Index, ServerNode Node) PreferredNode => _requestExecutor._nodeSelector.GetPreferredNode();
         }
     }
 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2330,7 +2330,6 @@ namespace Raven.Client.Http
         {
             private readonly RequestExecutor _requestExecutor;
 
-            internal TestingStuff() { }
             internal TestingStuff(RequestExecutor requestExecutor)
             {
                 _requestExecutor = requestExecutor;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1939,6 +1939,9 @@ namespace Raven.Server.Documents
 
                 return new DisposableAction(() => Subscription_ActionToCallAfterRegisterSubscriptionConnection = null);
             }
+
+            internal ManualResetEvent DatabaseRecordLoadHold;
+            internal ManualResetEvent HealthCheckHold;
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminConfigurationHandler.cs
@@ -79,6 +79,8 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/record", "GET", AuthorizationStatus.DatabaseAdmin)]
         public async Task GetDatabaseRecord()
         {
+            Database.ForTestingPurposes?.DatabaseRecordLoadHold?.WaitOne();
+
             await SendDatabaseRecord(Database.Name, ServerStore, HttpContext, ResponseBodyStream());
         }
 

--- a/src/Raven.Server/Documents/Handlers/StatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/StatsHandler.cs
@@ -56,6 +56,8 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/healthcheck", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public Task DatabaseHealthCheck()
         {
+            Database.ForTestingPurposes?.HealthCheckHold?.WaitOne();
+
             NoContentStatus();
             return Task.CompletedTask;
         }

--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -96,7 +96,7 @@ public class RavenDB_20202 : ClusterTestBase
             WaitForValue(() =>
             {
                 // Assert that there are no health check timers for failed nodes
-                var failedNodesTimers = store.GetRequestExecutor().ForTestingPurposesOnly().GetFailedNodesTimers;
+                var failedNodesTimers = store.GetRequestExecutor().ForTestingPurposesOnly().FailedNodesTimers;
                 return failedNodesTimers.Count;
             }, 
                 expectedVal: 0, 
@@ -104,11 +104,11 @@ public class RavenDB_20202 : ClusterTestBase
                 interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
 
             // Assert that there are no failures in the node selector state
-            var nodeSelectorFailures = store.GetRequestExecutor().ForTestingPurposesOnly().GetNodeSelectorFailures;
+            var nodeSelectorFailures = store.GetRequestExecutor().ForTestingPurposesOnly().NodeSelectorFailures;
             Assert.Equal(new[] { 0, 0, 0 }, nodeSelectorFailures);
 
             // Assert that we're back to the first node 
-            var preferredNode = store.GetRequestExecutor().ForTestingPurposesOnly().GetPreferredNode;
+            var preferredNode = store.GetRequestExecutor().ForTestingPurposesOnly().PreferredNode;
             Assert.Equal(0, preferredNode.Index);
             Assert.Equal("A", preferredNode.Node.ClusterTag);
         }

--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -100,8 +100,8 @@ public class RavenDB_20202 : ClusterTestBase
                 return failedNodesTimers.Count;
             }, 
                 expectedVal: 0, 
-                timeout: TimeSpan.FromMinutes(1).Milliseconds, 
-                interval: TimeSpan.FromSeconds(1).Milliseconds);
+                timeout: Convert.ToInt32(TimeSpan.FromMinutes(1).TotalMilliseconds), 
+                interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
 
             // Assert that there are no failures in the node selector state
             var nodeSelectorFailures = store.GetRequestExecutor().ForTestingPurposesOnly().GetNodeSelectorFailures;

--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -26,8 +26,6 @@ public class RavenDB_20202 : ClusterTestBase
     public async Task ShouldGettingBackToTheNodeAfterExperiencingTimeoutAndTopologyUpdateSimultaneously()
     {
         const string databaseName = "testDb";
-        const string userName = "RavenDB-20202";
-        const string userId = "user/1";
         const int clusterSize = 3;
         var timeOut = TimeSpan.FromSeconds(5);
 

--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20202 : ClusterTestBase
+{
+    public RavenDB_20202(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public async Task ShouldGettingBackToTheNodeAfterExperiencingTimeoutAndTopologyUpdateSimultaneously()
+    {
+        const string databaseName = "testDb";
+        const string userName = "RavenDB-20202";
+        const string userId = "user/1";
+        const int clusterSize = 3;
+        var timeOut = TimeSpan.FromSeconds(5);
+
+        var (nodes, leaderServer) = await CreateRaftCluster(clusterSize);
+        await CreateDatabaseInCluster(databaseName, 3, leaderServer.WebUrl);
+
+        using (var store = new DocumentStore
+        {
+            Urls = new[] { leaderServer.WebUrl },
+            Database = databaseName,
+            Conventions = new DocumentConventions { RequestTimeout = timeOut, }
+        }.Initialize())
+        {
+            List<string> originalNodesOrder = new() { "A", "B", "C" };
+            await store.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(store.Database, originalNodesOrder));
+
+            var databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            Assert.Equal(originalNodesOrder, databaseRecordWithEtag.Topology.Members);
+
+            // We'll hold database settings load and health check executions for nodes 'A' and 'B' only
+            foreach (var node in nodes.Where(node => node.ServerStore.NodeTag is "A" or "B"))
+            {
+                var db = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+                Assert.NotNull(db);
+                var forTestingPurposes = db.ForTestingPurposesOnly();
+
+                forTestingPurposes.DatabaseRecordLoadHold = new ManualResetEvent(false);
+                forTestingPurposes.HealthCheckHold = new ManualResetEvent(false);
+            }
+
+            // We'll get TimeOutException for the first two nodes and be prepared to create
+            // a specific condition while experiencing a timeout and topology update simultaneously.
+            store.Maintenance.Send(new GetDatabaseSettingsOperation(store.Database));
+
+            // Let's force topology update
+            // Set a new order of nodes
+            var newNodesOrder = new List<string>(originalNodesOrder);
+            newNodesOrder.Shuffle();
+            await store.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(store.Database, newNodesOrder));
+            databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            Assert.Equal(newNodesOrder, databaseRecordWithEtag.Topology.Members);
+
+            //And revert to the original nodes order back
+            await store.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(store.Database, originalNodesOrder));
+            databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            Assert.Equal(originalNodesOrder, databaseRecordWithEtag.Topology.Members);
+
+            // We'll hold database settings load for the last node 'C' (but health check still allowed to execute)
+            var nodeC = nodes.Single(node => node.ServerStore.NodeTag is "C");
+            var nodeCdb = await nodeC.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+            Assert.NotNull(nodeCdb);
+            nodeCdb.ForTestingPurposesOnly().DatabaseRecordLoadHold = new ManualResetEvent(false);
+
+            var error = Assert.Throws<AllTopologyNodesDownException>(() => store.Maintenance.Send(new GetDatabaseSettingsOperation(store.Database)));
+            Assert.Contains($"`GET /databases/{databaseName}/admin/record` to all configured nodes in the topology, none of the attempt succeeded.", error.Message);
+
+            // Now we'll allow all waiting threads to proceed
+            foreach (var node in nodes)
+            {
+                var db = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+                Assert.NotNull(db);
+                var forTestingPurposes = db.ForTestingPurposesOnly();
+                forTestingPurposes.DatabaseRecordLoadHold?.Set();
+                forTestingPurposes.HealthCheckHold?.Set();
+            }
+
+            // Wait 25s (time with buffer) for timers to execute callbacks; expect no failed nodes/timers after it
+            await Task.Delay(25_000);
+
+            // Assert that there are no failures in the node selector state
+            var nodeSelectorFailures = store.GetRequestExecutor().ForTestingPurposesOnly().GetNodeSelectorFailures;
+            Assert.Equal(new[] { 0, 0, 0 }, nodeSelectorFailures);
+
+            // Assert that there are no health check timers for failed nodes
+            var failedNodesTimers = store.GetRequestExecutor().ForTestingPurposesOnly().GetFailedNodesTimers;
+            Assert.Equal(0, failedNodesTimers.Count);
+
+            // Assert that we're back to the first node 
+            var preferredNode = store.GetRequestExecutor().ForTestingPurposesOnly().GetPreferredNode;
+            Assert.Equal(0, preferredNode.Index);
+            Assert.Equal("A", preferredNode.Node.ClusterTag);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20202/Cluster-node-health-check-issue-when-experiencing-a-timeout-and-topology-update-simultaneously.

### Additional description

The issue occurs when one of the nodes in the cluster becomes unavailable. The affected node is marked as failed in the node selector, and a health check timer is spawned to recheck the node's health after a specified period. Then, when the following events happen simultaneously:

1. An attempt is made to execute a command in the cluster, but none of the nodes respond, resulting in a timeout exception.
2. A topology update is performed.
3. A node health check is initiated to identify a healthy node.

A race condition arises where, after the topology update, we still have a "failed" flag on one of the nodes. However, the health check procedure for this node is not started due to the topology change.

As a result, the affected node is ignored when selecting a node for query execution because it has the "failed" flag, which is not cleared since the health check procedure has not been initiated.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- A test has been added that proves the fix is effective

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed