### PR TITLE
RavenDB-20140 The update of `Single` in `IndexWriter` has to include frequency changes.

### DIFF
--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -159,6 +159,11 @@ public static class EntryIdEncodings
 
     private static readonly short[] FrequencyTable = Enumerable.Range(0, byte.MaxValue).Select(i => FrequencyReconstructionFromQuantizationFromFunction(i)).ToArray();
 
+    internal static long QuantizeAndDequantize(short frequency)
+    {
+        return FrequencyReconstructionFromQuantization(FrequencyQuantization(frequency));
+    }
+    
     internal static long FrequencyQuantization(short frequency)
     {
         if (Lzcnt.IsSupported)

--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -370,16 +370,15 @@ public class RavenIntegration : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void UpdatingField(Options options)
+    public void CanUpdateSingleWhenFrequencyIsChangingLevel(Options options)
     {
-        string initial = "12345";
-        string dataGenerator(int i) => string.Join(" ", Enumerable.Range(0, i).Select(i => initial));
-
+        const string initial = "12345";
+        string DataGenerator(int i) => string.Join(" ", Enumerable.Range(0, i).Select(i => initial));
         using var store = GetDocumentStore(options);
         DtoForDynamics docToModify;
         using (var session = store.OpenSession())
         {
-            docToModify = new DtoForDynamics() {Tag = dataGenerator(17)};
+            docToModify = new DtoForDynamics() {Tag = DataGenerator(17)};
             session.Store(docToModify);
             session.SaveChanges();
         }
@@ -390,15 +389,14 @@ public class RavenIntegration : RavenTestBase
         using (var session = store.OpenSession())
         {
             var doc = session.Load<DtoForDynamics>(docToModify.Id);
-            doc.Tag = dataGenerator(1);
+            doc.Tag = DataGenerator(1);
             session.SaveChanges();
         }
 
         Indexes.WaitForIndexing(store);
         WaitForUserToContinueTheTest(store);
     }
-
-
+    
     private class SearchIndex : AbstractIndexCreationTask<DtoForDynamics>
     {
         public SearchIndex()

--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -379,7 +379,7 @@ public class RavenIntegration : RavenTestBase
         DtoForDynamics docToModify;
         using (var session = store.OpenSession())
         {
-            docToModify = new DtoForDynamics() {Tag = dataGenerator(100)};
+            docToModify = new DtoForDynamics() {Tag = dataGenerator(17)};
             session.Store(docToModify);
             session.SaveChanges();
         }
@@ -390,20 +390,12 @@ public class RavenIntegration : RavenTestBase
         using (var session = store.OpenSession())
         {
             var doc = session.Load<DtoForDynamics>(docToModify.Id);
-            doc.Tag = dataGenerator(99);
+            doc.Tag = dataGenerator(1);
             session.SaveChanges();
         }
 
-        using (var session = store.OpenSession())
-        {
-            var doc = session.Load<DtoForDynamics>(docToModify.Id);
-            doc.Tag = dataGenerator(98);
-            session.SaveChanges();
-        }
-
-        Indexes.WaitForIndexing(store, allowErrors: true);
+        Indexes.WaitForIndexing(store);
         WaitForUserToContinueTheTest(store);
-        IndexErrors[] errors = Indexes.WaitForIndexingErrors(store, new[] {index.IndexName});
     }
 
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20140

### Additional description

The old codebase wasn't compatible with frequency quantizations.  

### Type of change

- Regression bug fix


### How risky is the change?
 
- Moderate 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
