### PR TITLE
RavenDB-20176 Guardians for `Double` tree. (Corax's TermMatch)

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -50,11 +50,14 @@ public partial class IndexSearcher
         {
             numericalField = field.GetNumericFieldMetadata<double>(_transaction.Allocator);
             using var set = _fieldsTree?.FixedTreeForDouble(numericalField.FieldName, sizeof(double));
-            var ptr = set.ReadPtr((double)(object)term, out var length);
-            if (ptr != null)
+            if (set != null)
             {
-                containerId = *(long*)ptr;
-                Debug.Assert(length == sizeof(long));
+                var ptr = set.ReadPtr((double)(object)term, out var length);
+                if (ptr != null)
+                {
+                    containerId = *(long*)ptr;
+                    Debug.Assert(length == sizeof(double));
+                }
             }
         }
 

--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -405,4 +405,23 @@ public class RavenIntegration : RavenTestBase
             Index(i => i.Tag, FieldIndexing.Search);
         }
     }
+    
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TermMatchCanQueryOnDoubleTermThatDoesntExists(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Doc{Name = "Maciej", BoostFactor = 11.5f});
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Doc>().Where(i => i.BoostFactor == 0f).ToList();
+            Assert.Empty(results);
+        }
+    }
+
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20176 

### Additional description

When a term doesn't exist in a double tree got nullptr.

### Type of change

- Regression bug fix


### How risky is the change?

- Low 
- Moderate 
- High
- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
