### PR TITLE
RavenDB-20212 Cannot build deb package for Ubuntu 22.04/arm64- Unable…

### DIFF
--- a/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
+++ b/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
@@ -9,7 +9,7 @@ COPY --from=qemu /usr/bin/qemu-${QEMU_ARCH}-static /usr/bin
 ARG DISTRO_VERSION_NAME
 ARG DISTRO_VERSION
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y dos2unix devscripts dh-make wget gettext-base lintian curl dh-systemd debhelper
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y dos2unix devscripts dh-make wget gettext-base lintian curl debhelper
 
 RUN apt update \ 
     && apt-get -y dist-upgrade \


### PR DESCRIPTION
fix deb build script