### PR TITLE
RavenDB-20033 Create JSONL endpoint also for documents streaming

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Streaming/IStreamResultsWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/IStreamResultsWriter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.Handlers.Streaming;
+
+public interface IStreamResultsWriter<in T> : IAsyncDisposable
+{
+    void StartResponse();
+    
+    void StartResults();
+    
+    void EndResults();
+    
+    ValueTask AddResultAsync(T res, CancellationToken token);
+    
+    void EndResponse();
+}

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamJsonlResultsWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamJsonlResultsWriter.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Json;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Streaming;
+
+public class StreamJsonlResultsWriter : IStreamResultsWriter<Document>
+{
+    private readonly AsyncBlittableJsonTextWriter _writer;
+    private readonly JsonOperationContext _context;
+
+    public StreamJsonlResultsWriter(Stream stream, JsonOperationContext context)
+    {
+        _context = context;
+        _writer = new AsyncBlittableJsonTextWriter(context, stream);
+    }
+    
+    public ValueTask DisposeAsync()
+    {
+        return _writer.DisposeAsync();
+    }
+
+    public void StartResponse()
+    {
+    }
+
+    public void StartResults()
+    {
+    }
+
+    public void EndResults()
+    {
+    }
+    
+    public async ValueTask AddResultAsync(Document res, CancellationToken token)
+    {
+        _writer.WriteDocument(_context, res, metadataOnly: false);
+        _writer.WriteNewLine();
+        await _writer.MaybeFlushAsync(token);
+    }
+
+    public void EndResponse()
+    {
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamResultsWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamResultsWriter.cs
@@ -1,0 +1,62 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Json;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Streaming;
+
+public class StreamResultsWriter : IStreamResultsWriter<Document>
+{
+    private readonly AsyncBlittableJsonTextWriter _writer;
+    private readonly JsonOperationContext _context;
+    private bool _first = true;
+    
+
+    public StreamResultsWriter(Stream stream, JsonOperationContext context)
+    {
+        _context = context;
+        _writer = new AsyncBlittableJsonTextWriter(context, stream);
+    }
+    
+    public ValueTask DisposeAsync()
+    {
+        return _writer.DisposeAsync();
+    }
+
+    public void StartResponse()
+    {
+        _writer.WriteStartObject();
+    }
+
+    public void StartResults()
+    {
+        _writer.WritePropertyName("Results");
+        _writer.WriteStartArray();
+    }
+
+    public void EndResults()
+    {
+        _writer.WriteEndArray();
+    }
+
+    public async ValueTask AddResultAsync(Document res, CancellationToken token)
+    {
+        if (_first == false)
+        {
+            _writer.WriteComma();
+        }
+        else
+        {
+            _first = false;
+        }
+        
+        _writer.WriteDocument(_context, res, metadataOnly: false);
+        await _writer.MaybeFlushAsync(token);
+    }
+
+    public void EndResponse()
+    {
+        _writer.WriteEndObject();
+    }
+}

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -220,7 +220,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Dashboard\Server\" />
-    <Folder Include="Documents\Streaming" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Validate'">
     <Optimize>true</Optimize>

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -220,6 +220,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Dashboard\Server\" />
+    <Folder Include="Documents\Streaming" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Validate'">
     <Optimize>true</Optimize>

--- a/test/SlowTests/Issues/RavenDB-20033.cs
+++ b/test/SlowTests/Issues/RavenDB-20033.cs
@@ -1,0 +1,77 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20033 : RavenTestBase
+{
+    
+    public RavenDB_20033(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private string LoadDocumentsUrlGenerator(IDocumentStore store, int keys_range_min, int keys_range_max, string format)
+    {
+        StringBuilder str = new($"{store.Urls[0]}/databases/{store.Database}/streams/docs?&");
+        for(int i = keys_range_min; i < keys_range_max; i++)
+            str.Append($"id=users%2F{i}&");
+        str.Append($"format={format}");
+        return str.ToString();
+    }
+
+    private string ThrowStreamIsEmpty() => throw new InvalidDataException("stream is empty");
+    
+    [Fact]
+    public async Task JsonlDocumentsLoadStreamReturnsCorrectData()
+    {
+        var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        for (int i = 0; i < 10; i++)
+        {
+            session.Store(new User {Id = $"User/{i}", Name = $"Gracjan{i}"});
+        }
+        session.SaveChanges();
+        using var client = new HttpClient();
+        string jsonResult;
+        await using (var stream = await client.GetStreamAsync(LoadDocumentsUrlGenerator(store, 0, 10, "json")))
+        {
+            using TextReader tr = new StreamReader(stream);
+            jsonResult = await tr.ReadToEndAsync();
+            Assert.NotEmpty(jsonResult);
+        }
+        var standardOutput = JsonConvert.DeserializeObject(jsonResult) as JObject;
+        Assert.NotNull(standardOutput);
+
+        await using var jsonlStream = await client.GetStreamAsync(LoadDocumentsUrlGenerator(store, 0, 10, "jsonl"));
+        using var jsonlReader = new StreamReader(jsonlStream);
+        
+        var standardResults = standardOutput["Results"] as JArray;
+        Assert.NotNull(standardResults);
+
+        foreach (var child in standardResults.Children())
+        {
+            var standardResult = child as JObject;
+            var jsonlResult = JsonConvert.DeserializeObject(await jsonlReader.ReadLineAsync() ?? ThrowStreamIsEmpty()) as JObject;
+            Assert.NotNull(standardResult);
+            Assert.NotNull(jsonlResult);
+            
+            Assert.Equal(standardResult["Name"], jsonlResult!["Name"]);
+            Assert.Equal(standardResult["LastName"], jsonlResult["LastName"]);
+            Assert.Equal(standardResult["AddressId"], jsonlResult["AddressId"]);
+            Assert.Equal(standardResult["Count"], jsonlResult["Count"]);
+            Assert.Equal(standardResult["@metadata"], jsonlResult["@metadata"]);
+        }
+        
+        Assert.Empty(await jsonlReader.ReadLineAsync() ?? string.Empty);
+    }
+                
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20033/Create-JSONL-endpoint-also-for-documents-streaming

### Additional description

I've created a document streaming endpoint that returns the JSONL formatted results.
 [JSONL](https://jsonlines.org/) is a format of JSON data where every line is a valid JSON object. It will be needed for implementing streaming in the python client. The same solution might be used in the node.js client. 

During implementation, I've refactored the code responsible for writing to stream. I've added a new interface, a base for the writers performing load-documents-stream writing. Doing so provides a possibility to handle other formats ([like the csv in the query streaming](https://github.com/ravendb/ravendb/blob/95714bf7870ebd99bc9c45bad171bf19baa655ac/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs#L308-L314)) in the future. The interface is similar to the[ query streaming writer interface](https://github.com/ravendb/ravendb/blob/1411d7a9b6f1b170108c0f255f39540d896c3203/src/Raven.Server/Documents/Queries/IStreamQueryResultWriter.cs), and in the future, they may be consolidated in some way.  

I've added a test that confirms that the feature works.


### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
