### PR TITLE
RavenDB-19886 always use the same URI for order finalization in LetsEncrypt

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -368,10 +368,12 @@ namespace Raven.Server.Commercial
                 CSR = Jws.Base64UrlEncoded(csr.CreateSigningRequest())
             }, token);
 
+            var finalizeLocation = response.Location;
+
             while (true)
             {
                 // post-as-get (https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380)
-                (response, responseText) = await SendAsync<Order>(HttpMethod.Post, response.Location, string.Empty, token);
+                (response, responseText) = await SendAsync<Order>(HttpMethod.Post, finalizeLocation, string.Empty, token);
 
                 if (response.Status == "valid")
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19886

### Additional description

The `response.Location` needs to come from the finalization request, not from status check responses - it is null then.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
