### PR TITLE
RavenDB-20059: `Failed to parse` on registering the behaviour function in a script engine when script contains `GlobalObject`

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -322,6 +322,8 @@ namespace Raven.Server.Documents.ETL
                 catch (JavaScriptParseException e)
                 {
                     HandleTransformationScriptParseException(stats, e);
+
+                    return transformer.GetTransformedResults();
                 }
 
                 var batchSize = 0;

--- a/test/SlowTests/Issues/RavenDB_20059.cs
+++ b/test/SlowTests/Issues/RavenDB_20059.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Threading.Tasks;
+using Raven.Client.Exceptions.Documents.Patching;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using SlowTests.Server.Documents.ETL;
 using Xunit;
 using Xunit.Abstractions;
@@ -58,6 +59,35 @@ function deleteDocumentsOfContractsBehavior(docId) {
                     Assert.NotNull(contract);
                     Assert.Equal(13, contract.Contact.AdditionalInfo);
                 }
+            }
+        }
+
+        [Fact]
+        public void WeStillShouldGetErrorWhenEtlProcessRunsBehaviorFunctionWithInvalidSyntax()
+        {
+            using (var srcStore = GetDocumentStore())
+            using (var destStore = GetDocumentStore())
+            {
+                var script =
+@"this.Contact = .;	
+loadToContractsTemp(this);
+function deleteDocumentsOfContractsBehavior(docId) {
+    return false;
+    }";
+                AddEtl(srcStore, destStore, new[] { "Contracts" }, script, out var config);
+
+                using (var session = srcStore.OpenSession())
+                {
+                    session.Store(new Contract { Contact = new Contact { AdditionalInfo = 10 } });
+                    session.SaveChanges();
+                }
+
+                EtlErrorInfo error = null;
+                WaitForValue(() => TryGetTransformationError(srcStore.Database, config, out error), true, timeout: TimeSpan.FromSeconds(15).Milliseconds);
+
+                Assert.NotNull(error);
+                Assert.True(error.Error.Contains($"{nameof(JavaScriptParseException)}: Failed to parse:"));
+                Assert.True(error.Error.Contains("Unexpected token ."));
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20059/Failed-to-parse-on-registering-the-behaviour-function-in-a-script-engine-when-script-contains-GlobalObject

### Additional description

In a previous [pull request](https://github.com/ravendb/ravendb/pull/15966), we fixed an issue that occurred when working with a script containing both a `GlobalObject` and a `behavior function` simultaneously. The issue was resolved by ignoring script validation during the initialization of the behavior function, which necessitated testing to ensure that if a user attempts to initialize an ETL task with a script containing a syntax error (in Studio, syntax is controlled by a different mechanism), they will be notified of the error.

As a result:

1. We improved the error handling mechanism for this type of issue;
2. We created a test that verifies the presence of a notification in the notification center when creating an ETL task with a script containing a syntax error.

Note that the comprehensive testing functionality, including checking for notifications in the notification center, has been implemented starting with `RavenDB v5.4`. Therefore, this work was carried out as part of a separate pull request.

### Type of change

- Test coverage 

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed