### PR TITLE
RavenDB-20237 Fxing the issue that the encryption key wasn't provided to Configuration storage

### DIFF
--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -77,8 +77,8 @@ exit 0";
                     var lines = File.ReadAllLines(outputFile);
                     Assert.Equal(10, lines.Length);
                     Assert.True(lines[0].Contains($"{DirectoryExecUtils.EnvironmentType.System} {SystemDbName} {options.BasePath} {options.TempPath} {options.JournalPath}"));
-                    Assert.True(lines[1].Contains($"{DirectoryExecUtils.EnvironmentType.Configuration} {store.Database} {options.BasePath} {options.TempPath} {options.JournalPath}"));
-                    Assert.True(lines[2].Contains($"{DirectoryExecUtils.EnvironmentType.Database} {store.Database} {options.BasePath} {options.TempPath} {options.JournalPath}"));
+                    Assert.True(lines[1].Contains($"{DirectoryExecUtils.EnvironmentType.Database} {store.Database} {options.BasePath} {options.TempPath} {options.JournalPath}"));
+                    Assert.True(lines[2].Contains($"{DirectoryExecUtils.EnvironmentType.Configuration} {store.Database} {options.BasePath} {options.TempPath} {options.JournalPath}"));
 
                     var indexes = documentDatabase.IndexStore.GetIndexes().ToArray();
 
@@ -151,8 +151,8 @@ exit 0";
                 var docsEnvOptions = documentDatabase.DocumentsStorage.Environment.Options;
 
                 Assert.True(lines[0].Contains($"{DirectoryExecUtils.EnvironmentType.System} {SystemDbName} {systemEnvOptions.BasePath} {systemEnvOptions.TempPath} {systemEnvOptions.JournalPath}"));
-                Assert.True(lines[1].Contains($"{DirectoryExecUtils.EnvironmentType.Configuration} {store.Database} {configEnvOptions.BasePath} {configEnvOptions.TempPath} {configEnvOptions.JournalPath}"));
-                Assert.True(lines[2].Contains($"{DirectoryExecUtils.EnvironmentType.Database} {store.Database} {docsEnvOptions.BasePath} {docsEnvOptions.TempPath} {docsEnvOptions.JournalPath}"));
+                Assert.True(lines[1].Contains($"{DirectoryExecUtils.EnvironmentType.Database} {store.Database} {docsEnvOptions.BasePath} {docsEnvOptions.TempPath} {docsEnvOptions.JournalPath}"));
+                Assert.True(lines[2].Contains($"{DirectoryExecUtils.EnvironmentType.Configuration} {store.Database} {configEnvOptions.BasePath} {configEnvOptions.TempPath} {configEnvOptions.JournalPath}"));
 
                 var indexes = documentDatabase.IndexStore.GetIndexes().ToArray();
 

--- a/test/SlowTests/Issues/RavenDB_20237.cs
+++ b/test/SlowTests/Issues/RavenDB_20237.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20237 : RavenTestBase
+{
+    public RavenDB_20237(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Encryption)]
+    public async Task MustProvideEncryptionKeyToAllDbStorages()
+    {
+        Encryption.EncryptedServer(out var certificates, out var databaseName);
+
+        using (var store = GetDocumentStore(new Options
+               {
+                   ModifyDatabaseName = _ => databaseName,
+                   ClientCertificate = certificates.ServerCertificate.Value,
+                   AdminCertificate = certificates.ServerCertificate.Value,
+                   Encrypted = true
+               }))
+        {
+            Index index = new Index();
+            await index.ExecuteAsync(store);
+
+            var database = await GetDatabase(databaseName);
+
+            Assert.NotNull(database.MasterKey);
+
+            Assert.True(database.ConfigurationStorage.Environment.Options.Encryption.IsEnabled);
+            Assert.Equal(database.MasterKey, database.ConfigurationStorage.Environment.Options.Encryption.MasterKey);
+
+            var indexInstance = database.IndexStore.GetIndex(index.IndexName);
+
+            Assert.True(indexInstance._environment.Options.Encryption.IsEnabled);
+            Assert.Equal(database.MasterKey, indexInstance._environment.Options.Encryption.MasterKey);
+        }
+    }
+
+    private class Index : AbstractIndexCreationTask<User>
+    {
+        public Index()
+        {
+            Map = users => from u in users select new {u.Name};
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20237/Encryption-key-isnt-provided-to-Configuration-storage

### Additional description

The issue was that we moved the load of the encryption key to database initialization (https://github.com/ravendb/ravendb/pull/13883) but options of Configuration storage was created in ctor of DocumentDatabase instance so we didn't have the encryption key yet.

This caused issue with loading an existing, encrypted 5.4 database on 6.0.

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
 - 
### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
