### PR TITLE
RavenDB-20107 - It takes over a minute to test replication connection…

### DIFF
--- a/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
@@ -13,6 +13,7 @@ namespace Raven.Client.ServerWide.Commands
         private readonly string _dbId;
         private readonly long _etag;
         private readonly bool _fromReplication;
+        private readonly string _senderUrl;
 
         public GetTcpInfoCommand(string tag)
         {
@@ -25,11 +26,21 @@ namespace Raven.Client.ServerWide.Commands
             _dbName = dbName;
         }
 
+        internal GetTcpInfoCommand(string senderUrl, string tag, string dbName = null) : this(tag, dbName)
+        {
+            _senderUrl = senderUrl;
+        }
+
         internal GetTcpInfoCommand(string tag, string dbName, string dbId, long etag) : this(tag, dbName)
         {
             _dbId = dbId;
             _etag = etag;
             _fromReplication = true;
+        }
+
+        internal GetTcpInfoCommand(string senderUrl, string tag, string dbName, string dbId, long etag) : this(tag, dbName, dbId, etag)
+        { 
+            _senderUrl = senderUrl;
         }
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
@@ -46,6 +57,11 @@ namespace Raven.Client.ServerWide.Commands
                     url += $"&from-outgoing={_dbId}&etag={_etag}";
                 }
             }
+            if (_senderUrl != null)
+            {
+                url += $"&senderUrl={_senderUrl}";
+            }
+
             RequestedNode = node;
             var request = new HttpRequestMessage
             {

--- a/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetTcpInfoCommand.cs
@@ -56,10 +56,10 @@ namespace Raven.Client.ServerWide.Commands
                 {
                     url += $"&from-outgoing={_dbId}&etag={_etag}";
                 }
-            }
-            if (_senderUrl != null)
-            {
-                url += $"&senderUrl={_senderUrl}";
+                if (_senderUrl != null)
+                {
+                    url += $"&senderUrl={Uri.EscapeDataString(_senderUrl)}";
+                }
             }
 
             RequestedNode = node;

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -249,7 +249,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 using (var cts = new CancellationTokenSource(ServerStore.Engine.TcpConnectionTimeout))
                 {
-                    var info = await ReplicationUtils.GetTcpInfoAsync(url, null, "PingTest", ServerStore.Engine.ClusterCertificate, cts.Token);
+                    var info = await ReplicationUtils.GetServerTcpInfoAsync(url, "PingTest", ServerStore.Engine.ClusterCertificate, cts.Token);
                     result.TcpInfo.TcpInfoTime = sp.ElapsedMilliseconds;
 
                     using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1629,7 +1629,7 @@ namespace Raven.Server.Documents.Replication
             using (var requestExecutor = RequestExecutor.Create(exNode.ConnectionString.TopologyDiscoveryUrls, exNode.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
-                var cmd = new GetTcpInfoCommand(_server.Server.WebUrl, ExternalReplicationTag, database, Database.DbId.ToString(), Database.ReadLastEtag());
+                var cmd = new GetTcpInfoCommand(_server.GetNodeHttpServerUrl(), ExternalReplicationTag, database, Database.DbId.ToString(), Database.ReadLastEtag());
                 try
                 {
                     requestExecutor.ExecuteWithCancellationToken(cmd, ctx, _shutdownToken);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1629,7 +1629,7 @@ namespace Raven.Server.Documents.Replication
             using (var requestExecutor = RequestExecutor.Create(exNode.ConnectionString.TopologyDiscoveryUrls, exNode.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
-                var cmd = new GetTcpInfoCommand(ExternalReplicationTag, database, Database.DbId.ToString(), Database.ReadLastEtag());
+                var cmd = new GetTcpInfoCommand(_server.Server.WebUrl, ExternalReplicationTag, database, Database.DbId.ToString(), Database.ReadLastEtag());
                 try
                 {
                     requestExecutor.ExecuteWithCancellationToken(cmd, ctx, _shutdownToken);

--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.NotificationCenter.Handlers
         {
             if (certificate != null)
             {
-                var tcpConnection = ReplicationUtils.GetTcpInfo(_nodeUrl, null, $"{nameof(ProxyWebSocketConnection)} to {_nodeUrl}", certificate, _cts.Token);
+                var tcpConnection = ReplicationUtils.GetServerTcpInfo(_nodeUrl, $"{nameof(ProxyWebSocketConnection)} to {_nodeUrl}", certificate, _cts.Token);
 
                 var expectedCert = CertificateLoaderUtil.CreateCertificate(Convert.FromBase64String(tcpConnection.Certificate));
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3637,7 +3637,7 @@ namespace Raven.Server.ServerWide
             {
                 cts.CancelAfter(_parent.TcpConnectionTimeout);
 
-                info = await ReplicationUtils.GetTcpInfoAsync(url, null, "Cluster", certificate, cts.Token);
+                info = await ReplicationUtils.GetServerTcpInfoAsync(url, "Cluster", certificate, cts.Token);
             }
             
             TcpClient tcpClient = null;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         using (var timeout = new CancellationTokenSource(tcpTimeout))
                         using (var combined = CancellationTokenSource.CreateLinkedTokenSource(_token, timeout.Token))
                         {
-                            tcpConnection = ReplicationUtils.GetTcpInfo(Url, null, "Supervisor", _parent._server.Server.Certificate.Certificate, combined.Token);
+                            tcpConnection = ReplicationUtils.GetServerTcpInfo(Url, "Supervisor", _parent._server.Server.Certificate.Certificate, combined.Token);
                             if (tcpConnection == null)
                             {
                                 continue;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3331,7 +3331,7 @@ namespace Raven.Server.ServerWide
 
                 using (var cts = new CancellationTokenSource(Server.Configuration.Cluster.OperationTimeout.AsTimeSpan))
                 {
-                    connectionInfo = ReplicationUtils.GetTcpInfoAsync(url, database, "Test-Connection", Server.Certificate.Certificate,
+                    connectionInfo = ReplicationUtils.GetTcpInfoAsync(Server.WebUrl, url, database, "Test-Connection", Server.Certificate.Certificate,
                         cts.Token);
                 }
                 Task timeoutTask = await Task.WhenAny(timeout, connectionInfo);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3331,7 +3331,7 @@ namespace Raven.Server.ServerWide
 
                 using (var cts = new CancellationTokenSource(Server.Configuration.Cluster.OperationTimeout.AsTimeSpan))
                 {
-                    connectionInfo = ReplicationUtils.GetTcpInfoAsync(GetNodeHttpServerUrl(), url, database, "Test-Connection", Server.Certificate.Certificate,
+                    connectionInfo = ReplicationUtils.GetDatabaseTcpInfoAsync(GetNodeHttpServerUrl(), url, database, "Test-Connection", Server.Certificate.Certificate,
                         cts.Token);
                 }
                 Task timeoutTask = await Task.WhenAny(timeout, connectionInfo);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3331,7 +3331,7 @@ namespace Raven.Server.ServerWide
 
                 using (var cts = new CancellationTokenSource(Server.Configuration.Cluster.OperationTimeout.AsTimeSpan))
                 {
-                    connectionInfo = ReplicationUtils.GetTcpInfoAsync(Server.WebUrl, url, database, "Test-Connection", Server.Certificate.Certificate,
+                    connectionInfo = ReplicationUtils.GetTcpInfoAsync(GetNodeHttpServerUrl(), url, database, "Test-Connection", Server.Certificate.Certificate,
                         cts.Token);
                 }
                 Task timeoutTask = await Task.WhenAny(timeout, connectionInfo);

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -19,35 +19,20 @@ namespace Raven.Server.Utils
             return AsyncHelpers.RunSync(() => GetTcpInfoForInternalReplicationAsync(url, databaseName, databaseId, etag, tag, certificate, localNodeTag, token));
         }
 
-        public static TcpConnectionInfo GetTcpInfo(string url, string databaseName, string databaseId, long etag, string tag, X509Certificate2 certificate, CancellationToken token)
+        public static TcpConnectionInfo GetServerTcpInfo(string url, string tag, X509Certificate2 certificate, CancellationToken token)
         {
-            return AsyncHelpers.RunSync(() => GetTcpInfoAsync(url, databaseName, databaseId, etag, tag, certificate, token));
+            return AsyncHelpers.RunSync(() => GetServerTcpInfoAsync(url, tag, certificate, token));
         }
 
-        public static TcpConnectionInfo GetTcpInfo(string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
+        public static async Task<TcpConnectionInfo> GetServerTcpInfoAsync(string url, string tag, X509Certificate2 certificate, CancellationToken token)
         {
-            return AsyncHelpers.RunSync(() => GetTcpInfoAsync(url, databaseName, tag, certificate, token));
-        }
-
-        public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
-        {
-            return await GetTcpInfoAsync(url, databaseName, null, default, tag, certificate, token);
-        }
-
-        public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string senderUrl, string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
-        {
-            return await GetTcpInfoAsync(senderUrl, url, databaseName, null, default, tag, certificate, token);
-        }
-
-        public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, string databaseName, string databaseId, long etag, string tag, X509Certificate2 certificate, CancellationToken token)
-        {
-            var getTcpInfoCommand = databaseId == null ? new GetTcpInfoCommand(tag, databaseName) : new GetTcpInfoCommand(tag, databaseName, databaseId, etag);
+            var getTcpInfoCommand = new GetTcpInfoCommand(tag);
             return await GetTcpInfoAsync(url, getTcpInfoCommand, certificate, token);
         }
 
-        public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string senderUrl, string url, string databaseName, string databaseId, long etag, string tag, X509Certificate2 certificate, CancellationToken token)
+        public static async Task<TcpConnectionInfo> GetDatabaseTcpInfoAsync(string senderUrl, string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
         {
-            var getTcpInfoCommand = databaseId == null ? new GetTcpInfoCommand(senderUrl, tag, databaseName) : new GetTcpInfoCommand(senderUrl, tag, databaseName, databaseId, etag);
+            var getTcpInfoCommand = new GetTcpInfoCommand(senderUrl, tag, databaseName);
             return await GetTcpInfoAsync(url, getTcpInfoCommand, certificate, token);
         }
 

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -29,11 +29,6 @@ namespace Raven.Server.Utils
             return AsyncHelpers.RunSync(() => GetTcpInfoAsync(url, databaseName, tag, certificate, token));
         }
 
-        public static TcpConnectionInfo GetTcpInfo(string senderUrl, string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
-        {
-            return AsyncHelpers.RunSync(() => GetTcpInfoAsync(senderUrl, url, databaseName, tag, certificate, token));
-        }
-
         public static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, string databaseName, string tag, X509Certificate2 certificate, CancellationToken token)
         {
             return await GetTcpInfoAsync(url, databaseName, null, default, tag, certificate, token);

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandlerForDatabase.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandlerForDatabase.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Web.System
 
         private bool CanConnectViaPrivateTcpUrl()
         {
-            var senderUrl = GetStringQueryString("senderUrl", false);
+            var senderUrl = GetStringQueryString("senderUrl", required: false);
             if (string.IsNullOrEmpty(senderUrl))
                 return true;
 

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandlerForDatabase.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandlerForDatabase.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Web.System
         [RavenAction("/databases/*/info/tcp", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public async Task Get()
         {
-            var forExternalUse = CanConnectViaPrivateTcpUrl() == false;
+            var forExternalUse = CanConnectViaPublicClusterTcpUrl() == false;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
@@ -21,7 +21,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private bool CanConnectViaPrivateTcpUrl()
+        private bool CanConnectViaPublicClusterTcpUrl()
         {
             var senderUrl = GetStringQueryString("senderUrl", required: false);
             if (string.IsNullOrEmpty(senderUrl))


### PR DESCRIPTION
… in between 5.4 -> 6.0 servers in the same cloud region

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20107/It-takes-over-a-minute-to-test-replication-connection-in-between-5.4-6.0-servers-in-the-same-cloud-region

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
