### PR TITLE
RavenDB-19664

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2540,9 +2540,12 @@ more responsive application.
             bool isProjectInto)
         {
             var metadata = json.GetMetadata();
-            var changeVector = metadata.GetChangeVector();
-            //MapReduce indexes return reduce results that don't have @id property
-            metadata.TryGetId(out string id);
+
+            string changeVector = null;
+
+            //MapReduce indexes return reduce results that don't have @id property and @change-vector
+            if (metadata.TryGetId(out string id))
+                changeVector = metadata.GetChangeVector();
 
             return new StreamResult<T>
             {
@@ -2557,9 +2560,12 @@ more responsive application.
         {
             var json = enumerator.Current;
             var metadata = json.GetMetadata();
-            var changeVector = metadata.GetChangeVector();
-            //MapReduce indexes return reduce results that don't have @id property
-            metadata.TryGetId(out string id);
+
+            string changeVector = null;
+
+            //MapReduce indexes return reduce results that don't have @id property and @change-vector
+            if (metadata.TryGetId(out string id))
+                changeVector = metadata.GetChangeVector();
 
             var result = new TimeSeriesStreamResult<T>
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19664

### Additional description

We should not retrieve @change-vector if there is no @id field. Due to backward compatibility, we cannot change the server-side which is sending back the null @change-vector, but for correctness we should change the code here, so in future (7.0?) we might change that.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
