### PR TITLE
RavenDB-20247 - fix int overflow

### DIFF
--- a/src/Sparrow.Server/Meters/GeneralWaitPerformanceMetrics.cs
+++ b/src/Sparrow.Server/Meters/GeneralWaitPerformanceMetrics.cs
@@ -23,7 +23,7 @@ namespace Sparrow.Server.Meters
             };
 
             var pos = Interlocked.Increment(ref BufferPos);
-            var adjustedTail = pos % Buffer.Length;
+            var adjustedTail = (int)(pos % Buffer.Length);
 
             if (Interlocked.CompareExchange(ref Buffer[adjustedTail], meterItem, null) == null)
                 return;

--- a/src/Sparrow.Server/Meters/PerformanceMetrics.cs
+++ b/src/Sparrow.Server/Meters/PerformanceMetrics.cs
@@ -29,10 +29,10 @@ namespace Sparrow.Server.Meters
         }
 
         protected readonly MeterItem[] Buffer;
-        protected int BufferPos = -1;
+        protected long BufferPos = -1;
 
         private readonly SummerizedItem[] _summerizedBuffer;
-        private int _summerizedPos = -1;
+        private long _summerizedPos = -1;
 
         protected DatabasePerformanceMetrics.MetricType Type;
 

--- a/src/Sparrow.Server/Meters/TransactionPerformanceMetrics.cs
+++ b/src/Sparrow.Server/Meters/TransactionPerformanceMetrics.cs
@@ -88,7 +88,7 @@ namespace Sparrow.Server.Meters
             _tail = null;
 
             var pos = Interlocked.Increment(ref BufferPos);
-            var adjustedTail = pos % Buffer.Length;
+            var adjustedTail = (int)(pos % Buffer.Length);
 
             if (Interlocked.CompareExchange(ref Buffer[adjustedTail], meterItem, null) == null)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20247/IndexOutOfRangeException-in-write-transaction

### Additional description

Fix int overflow when we reach more than 2 billion transactions (for a single database).

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing
