### PR TITLE
RavenDB-20143: Indexes malfunction on the LicenseTracking database

### DIFF
--- a/src/Corax/IndexWriter.Debug.cs
+++ b/src/Corax/IndexWriter.Debug.cs
@@ -16,7 +16,7 @@ namespace Corax
 
             public IndexTermDumper(Tree tree, Slice field)
             {
-                _writer = File.AppendText(tree.Name.ToString() + fieldId);
+                _writer = File.AppendText(tree.Name.ToString() + field.ToString());
             }
 #else
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
@@ -37,7 +37,10 @@ namespace Corax.Queries
             {
                 var termSlice = termScope.Key.Decoded();
                 if (!termSlice.Contains(contains))
+                {
+                    termScope.Dispose();
                     continue;
+                }
 
                 term = _searcher.TermQuery(_field, termScope.Key, _tree);
                 return true;

--- a/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
@@ -39,7 +39,10 @@ namespace Corax.Queries
             {
                 var termSlice = termScope.Key.Decoded();
                 if (termSlice.EndsWith(suffix) == false)
+                {
+                    termScope.Dispose();
                     continue;
+                }
 
                 term = _searcher.TermQuery(_field, termScope.Key, _tree);
                 return true;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
@@ -38,7 +38,10 @@ namespace Corax.Queries
             {
                 var termSlice = termScope.Key.Decoded();
                 if (termSlice.Contains(contains))
+                {
+                    termScope.Dispose();
                     continue;
+                }
 
                 term = _searcher.TermQuery(_field, termScope.Key, _tree);
                 return true;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
@@ -43,7 +43,10 @@ namespace Corax.Queries
             {
                 var termSlice = termScope.Key.Decoded();
                 if (termSlice.EndsWith(suffix))
+                {
+                    termScope.Dispose();
                     continue;
+                }
 
                 term = _searcher.TermQuery(_field, termScope.Key, _tree);
                 return true;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
@@ -40,7 +40,10 @@ namespace Corax.Queries
             {
                 var termSlice = termScope.Key.Decoded();
                 if (termSlice.StartsWith(startWith))
+                {
+                    termScope.Dispose();
                     continue;
+                }
 
                 term = _searcher.TermQuery(_field, termScope.Key, _tree);
                 return true;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -870,7 +870,7 @@ namespace Voron.Data.CompactTrees
                 // TODO: Check if the valueBufferLength is bigger, shouldn't we be able to just update if the encoding is actually smaller?
                 if (len == valueBufferLength)
                 {
-                    Debug.Assert(valueBufferLength <= sizeof(long));
+                    Debug.Assert(valueBufferLength <= 10);
                     Unsafe.CopyBlockUnaligned(valuePtr, valueBufferPtr, (uint)valueBufferLength);
                     return;
                 }

--- a/test/FastTests/Voron/PostingLists/PostingListTests.cs
+++ b/test/FastTests/Voron/PostingLists/PostingListTests.cs
@@ -218,7 +218,7 @@ namespace FastTests.Voron.Sets
                     for (int i = 0; i < size; i++)
                     {
                         var rname = (int)(uint)random.Next();
-                        if (!uniqueKeys.Contains(rname))
+                        if (!uniqueKeys.Contains(rname) && rname != 0)
                         {
                             uniqueKeys.Add(rname);
                             inTreeKeys.Add(rname);

--- a/test/FastTests/Voron/PostingLists/PostingListTests.cs
+++ b/test/FastTests/Voron/PostingLists/PostingListTests.cs
@@ -189,7 +189,7 @@ namespace FastTests.Voron.Sets
         
         [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(73014, 35)]
-        public void CanDeleteAndInsertInRandomOrder(int seed, int size)
+        public void CanDeleteAndInsertInRandomOrder(int seed, int size, int iterations = 4)
         {
             static void Shuffle(int[] list, Random rng)
             {
@@ -210,7 +210,7 @@ namespace FastTests.Voron.Sets
 
             int name = random.Next();
 
-            for (int iter = 0; iter < 4; iter++)
+            for (int iter = 0; iter < iterations; iter++)
             {
                 using (var wtx = Env.WriteTransaction())
                 {
@@ -254,7 +254,7 @@ namespace FastTests.Voron.Sets
 
                 using (var rtx = Env.ReadTransaction())
                 {
-                    var matches = new long[size * 4];
+                    var matches = new long[inTreeKeys.Count];
                     var set = rtx.OpenPostingList($"Set({name})");
                     set.Iterate().Fill(matches, out int read);
                     Assert.Equal(inTreeKeys.Count, read);

--- a/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
+++ b/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.CompactTrees;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.CompactTrees
+{
+    public class FuzzyUpsertsTests : StorageTest
+    {
+
+        public FuzzyUpsertsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> Configuration =>
+            new List<object[]>
+            {
+                new object[] { 500000, Random.Shared.Next(), 4096 },
+                new object[] { 100000, Random.Shared.Next(), 1024 },
+                new object[] { 10000, Random.Shared.Next(), 64 },
+            };
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [MemberData("Configuration")]
+        public void RandomUpsertsWithoutRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        {
+            var currentState = new Dictionary<long, long>();
+            var keys = new List<long>();
+            var rnd = new Random(randomSeed);
+
+            var transactions = treeSize / transactionSize;
+
+            // Initializing the tree with random writes. Depending on the tree size, it may
+            // cause the creation of new dictionaries and transitioning pages. 
+            int i = 0;
+            while ( i < transactions + 1 )
+            {
+                int itemsToInsert = (i < transactions) ? transactionSize : treeSize % transactionSize;
+                using (var wtx = Env.WriteTransaction())
+                {
+                    var tree = CompactTree.Create(wtx.LowLevelTransaction, "test");
+                    for (int j = 0; j < itemsToInsert; j++)
+                    {
+                        long item = Math.Abs((long)rnd.Next() + rnd.Next());
+
+                        keys.Add(item);
+                        currentState[item] = item;
+                        tree.Add(item.ToString(), item);
+                    }
+                    wtx.Commit();
+                }
+
+                i++;
+            }
+
+            // Run 10 batches of random upserts. 
+            for (int batches = 0; batches < 10; batches++)
+            {
+                using (var wtx = Env.WriteTransaction())
+                {
+                    var tree = CompactTree.Create(wtx.LowLevelTransaction, "test");
+                    for (int j = 0; j < treeSize; j++)
+                    {
+                        long key = keys[rnd.Next(keys.Count)];
+                        long value = Math.Abs((long)rnd.Next() + rnd.Next());
+
+                        currentState[key] = value;
+                        tree.Add(key.ToString(), value);
+                    }
+                    wtx.Commit();
+                }
+
+                using (var rtx = Env.ReadTransaction())
+                {
+                    var tree = CompactTree.Create(rtx.LowLevelTransaction, "test");
+
+                    foreach (var key in keys)
+                    {
+                        // We need to ensure the element IS there, and that it also has the right value
+                        Assert.True(tree.TryGetValue(key.ToString(), out var r));
+                        Assert.Equal(currentState[key], r);
+                    }
+                }
+            }
+        }
+
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [MemberData("Configuration")]
+        public void RandomUpsertsWithRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        {
+            var currentState = new Dictionary<long, long>();
+            var currentKeys = new List<long>();
+            var rnd = new Random(randomSeed);
+
+            var transactions = treeSize / transactionSize;
+
+            // Initializing the tree with random writes. Depending on the tree size, it may
+            // cause the creation of new dictionaries and transitioning pages. 
+            int i = 0;
+            while (i < transactions + 1)
+            {
+                int itemsToInsert = (i < transactions) ? transactionSize : treeSize % transactionSize;
+                using (var wtx = Env.WriteTransaction())
+                {
+                    var tree = CompactTree.Create(wtx.LowLevelTransaction, "test");
+                    for (int j = 0; j < itemsToInsert; j++)
+                    {
+                        long item = Math.Abs((long)rnd.Next() + rnd.Next());
+
+                        currentKeys.Add(item);
+                        currentState[item] = item;
+                        tree.Add(item.ToString(), item);
+                    }
+                    wtx.Commit();
+                }
+
+                i++;
+            }
+
+            var removedKeys = new HashSet<long>();
+
+            // Run 10 batches of random upserts. 
+            for (int batches = 0; batches < 10; batches++)
+            {
+                using (var wtx = Env.WriteTransaction())
+                {
+                    var tree = CompactTree.Create(wtx.LowLevelTransaction, "test");
+                    for (int j = 0; j < treeSize; j++)
+                    {
+                        long key = currentKeys[rnd.Next(currentKeys.Count)];
+
+                        // We will remove 1% of the inserts if we haven't remove it already... 
+                        if (rnd.Next(100) <= 1 && !removedKeys.Contains(key))
+                        {
+                            Assert.True(tree.TryRemove(key.ToString(), out long oldValue));
+
+                            // Ensure that the last known value is a match
+                            Assert.Equal(currentState[key], oldValue);
+                            removedKeys.Add(key);
+                        }
+                        else if (!removedKeys.Contains(key))
+                        {
+                            // Do an upsert instead.
+                            long value = Math.Abs((long)rnd.Next() + rnd.Next());
+
+                            currentState[key] = value;
+                            tree.Add(key.ToString(), value);
+                        }
+                    }
+                    wtx.Commit();
+                }
+
+                using (var rtx = Env.ReadTransaction())
+                {
+                    var tree = CompactTree.Create(rtx.LowLevelTransaction, "test");
+
+                    foreach (var key in currentKeys)
+                    {
+                        if (removedKeys.Contains(key))
+                        {
+                            Assert.False(tree.TryGetValue(key.ToString(), out var _));
+                        }
+                        else
+                        {
+                            // We need to ensure the element IS there, and that it also has the right value
+                            Assert.True(tree.TryGetValue(key.ToString(), out var r));
+                            Assert.Equal(currentState[key], r);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/PostingListTestsExtended.cs
+++ b/test/SlowTests/Voron/PostingListTestsExtended.cs
@@ -26,10 +26,14 @@ public class PostingListTestsExtended : NoDisposalNoOutputNeeded
     [InlineData(1337, 200000)]
     [InlineData(1064156071, 796)]
     [InlineData(511767612, 4172)]
+    [InlineData(439188321, 502627)]
+    [InlineData(506431817, 2)]
+    [InlineData(391060845, 31707323)]
+    [InlineData(1477187726, 1828658)]
     [MemberData("Configuration")]
     public void CanDeleteAndInsertInRandomOrder(int seed, int size)
     {
         using var testClass = new FastTests.Voron.Sets.PostingListTests(Output);
-        testClass.CanDeleteAndInsertInRandomOrder(seed, size);
+        testClass.CanDeleteAndInsertInRandomOrder(seed, size, 10);
     }
 }

--- a/test/SlowTests/Voron/PostingListTestsExtended.cs
+++ b/test/SlowTests/Voron/PostingListTestsExtended.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,9 +11,22 @@ public class PostingListTestsExtended : NoDisposalNoOutputNeeded
     public PostingListTestsExtended(ITestOutputHelper output) : base(output)
     {
     }
-    
+
+
+    public static IEnumerable<object[]> Configuration =>
+        new List<object[]>
+        {
+            new object[] { Random.Shared.Next(), Random.Shared.Next(20000000)},
+            new object[] { Random.Shared.Next(), Random.Shared.Next(2000000)},
+            new object[] { Random.Shared.Next(), Random.Shared.Next(200000)},
+            new object[] { Random.Shared.Next(), Random.Shared.Next(20000)},
+        };
+
     [RavenTheory(RavenTestCategory.Voron)]
     [InlineData(1337, 200000)]
+    [InlineData(1064156071, 796)]
+    [InlineData(511767612, 4172)]
+    [MemberData("Configuration")]
     public void CanDeleteAndInsertInRandomOrder(int seed, int size)
     {
         using var testClass = new FastTests.Voron.Sets.PostingListTests(Output);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20143

### Additional description
This PR doesn't fix the immediate issue of the LicenseTracking indexes, and at the same time wires up a test which will fail because it uncovers a deeper issue in how PostingLists are merged/split when they are big enough (LicenseTracking). Since we are also investigating space consumption issues on the PostingList, it is important that this fixes be applied ASAP even if we know that some configurations of the fuzzying test `CanDeleteAndInsertInRandomOrder` will fail consistently. 

### Type of change
- Bug fix

### How risky is the change?
- Moderate 

### Backward compatibility
- Ensured. We need to update the index schema. 

### Is it platform specific issue?
- No