### PR TITLE
RavenDB-20220

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -631,9 +631,11 @@ namespace Raven.Client.Documents.Session.Operations
                 if (_builderContext.AllocatedMemory > 4 * 1024 * 1024 ||
                     _docsCountOnCachedRenewSession > _maxDocsCountOnCachedRenewSession)
                 {
+                    _builder.Dispose();
                     _builderContext.Reset();
                     _builderContext.Renew();
                     _docsCountOnCachedRenewSession = 0;
+                    _builder = new BlittableJsonDocumentBuilder(_builderContext, BlittableJsonDocumentBuilder.UsageMode.ToDisk, "readArray/singleResult", _parser, _state);
                     return;
                 }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
-using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Commands.Streaming;
 using Raven.Server.Documents.Queries;
@@ -16,7 +14,7 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Queries
 {
-    internal class ShardedQueryStreamProcessor : AbstractShardedQueryProcessor<PostQueryStreamCommand, StreamResult, (IEnumerator<BlittableJsonReaderObject>, StreamQueryStatistics)>
+    internal class ShardedQueryStreamProcessor : AbstractShardedQueryProcessor<PostQueryStreamCommand, StreamResult, ShardedStreamQueryResult>
     {
         private readonly string _debug;
         private readonly bool _ignoreLimit;
@@ -45,7 +43,7 @@ namespace Raven.Server.Documents.Sharding.Queries
                 throw new NotSupportedInShardingException("Includes and Loads are not supported in sharded streaming queries");
         }
 
-        public override Task<(IEnumerator<BlittableJsonReaderObject>, StreamQueryStatistics)> ExecuteShardedOperations(QueryTimingsScope scope)
+        public override Task<ShardedStreamQueryResult> ExecuteShardedOperations(QueryTimingsScope scope)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Handle continuation token in streaming");
 

--- a/src/Raven.Server/Documents/Sharding/Streaming/YieldShardStreamResults.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/YieldShardStreamResults.cs
@@ -30,7 +30,7 @@ public class YieldShardStreamResults : IAsyncEnumerator<BlittableJsonReaderObjec
         if (await _readingState.ReadAsync() == false)
             _readingState.ThrowInvalidJson();
 
-        if (_readingState.CurrentTokenType == JsonParserToken.EndArray)
+        if (_readingState.CurrentTokenType is JsonParserToken.EndArray or JsonParserToken.EndObject)
             return false;
 
         Current = await _readingState.ReadObjectAsync();
@@ -77,7 +77,7 @@ public class YieldShardStreamResults : IAsyncEnumerator<BlittableJsonReaderObjec
         // need to read to end of the array
         while (await MoveNextAsync())
         {
-                        
+
         }
     }
 }


### PR DESCRIPTION
- synced MergedEnumerator and MergedAsyncEnumerator code
- dispose internal enumerators when they are empty
- we need to dispose merged enumerator when streaming
- we need to dispose builder before resetting and renewing context to return allocated memory from that generation
- we need to create new instance of builder after resetting and renewing context because it needs to allocate memory from appropriate generation

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20220