### PR TITLE
RavenDB-20252 Database stats  - values are hidden when value is zero

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/IndexesDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/IndexesDatabaseStats.tsx
@@ -155,9 +155,9 @@ function IndexStatistics(props: { indexName: string; database: database }) {
                             <DetailsBlock index={index}>
                                 {(data) => (
                                     <>
-                                        {data.mappedPerSecondRate > 1
+                                        {data.mappedPerSecondRate > 0.01
                                             ? genUtils.formatNumberToStringFixed(data.mappedPerSecondRate, 2)
-                                            : ""}
+                                            : "0"}
                                     </>
                                 )}
                             </DetailsBlock>
@@ -192,9 +192,9 @@ function IndexStatistics(props: { indexName: string; database: database }) {
                                     <DetailsBlock index={index}>
                                         {(data) => (
                                             <>
-                                                {data.reducedPerSecondRate > 1
+                                                {data.reducedPerSecondRate > 0.01
                                                     ? genUtils.formatNumberToStringFixed(data.reducedPerSecondRate, 2)
-                                                    : ""}
+                                                    : "0"}
                                             </>
                                         )}
                                     </DetailsBlock>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20252 

### Additional description

Show indexing rate even when it is slow. 
