### PR TITLE
RavenDB-20066 import & disk usage improvements 

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
@@ -310,7 +310,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
         public long ReadCount { get; set; }
         public bool Skipped { get; set; }
         public long ErroredCount { get; set; }
-        public long Size { get; set; }
+        public long SizeInBytes { get; set; }
 
         public virtual DynamicJsonValue ToJson()
         {
@@ -321,7 +321,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
                 [nameof(ReadCount)] = ReadCount,
                 [nameof(Skipped)] = Skipped,
                 [nameof(ErroredCount)] = ErroredCount,
-                [nameof(Size)] = Size
+                [nameof(SizeInBytes)] = SizeInBytes
             };
         }
 
@@ -331,8 +331,8 @@ public abstract class SmugglerProgressBase : IOperationProgress
             sb.Append($"Read: {ReadCount:#,#;;0}.");
             if (ErroredCount > 0) 
                 sb.Append($" Errored: {ErroredCount:#,#;;0}.");
-            if (Size > 0)
-                sb.Append($" Size: {new Size(Size).HumaneSize}.");
+            if (SizeInBytes > 0)
+                sb.Append($" Size: {new Size(SizeInBytes).HumaneSize}.");
 
             return sb.ToString();
         }

--- a/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
@@ -310,6 +310,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
         public long ReadCount { get; set; }
         public bool Skipped { get; set; }
         public long ErroredCount { get; set; }
+        public long Size { get; set; }
 
         public virtual DynamicJsonValue ToJson()
         {
@@ -319,14 +320,21 @@ public abstract class SmugglerProgressBase : IOperationProgress
                 [nameof(Processed)] = Processed,
                 [nameof(ReadCount)] = ReadCount,
                 [nameof(Skipped)] = Skipped,
-                [nameof(ErroredCount)] = ErroredCount
+                [nameof(ErroredCount)] = ErroredCount,
+                [nameof(Size)] = Size
             };
         }
 
         public override string ToString()
         {
-            return $"Read: {ReadCount:#,#;;0}. " +
-                   $"Errored: {ErroredCount:#,#;;0}.";
+            var sb = new StringBuilder();
+            sb.Append($"Read: {ReadCount:#,#;;0}.");
+            if (ErroredCount > 0) 
+                sb.Append($" Errored: {ErroredCount:#,#;;0}.");
+            if (Size > 0)
+                sb.Append($" Size: {new Size(Size).HumaneSize}.");
+
+            return sb.ToString();
         }
 
         internal void Start()
@@ -360,7 +368,13 @@ public abstract class SmugglerProgressBase : IOperationProgress
 
         public override string ToString()
         {
-            return $"{base.ToString()} Attachments: {Attachments}";
+            if (Attachments is { ReadCount: > 0 })
+            {
+                return $"{base.ToString()}" +
+                       $"{Environment.NewLine}Attachments: {Attachments}";
+            }
+
+            return base.ToString();
         }
     }
 
@@ -377,7 +391,10 @@ public abstract class SmugglerProgressBase : IOperationProgress
 
         public override string ToString()
         {
-            return $"Skipped: {SkippedCount}. {base.ToString()}";
+            if (SkippedCount > 0)
+                return $"Skipped: {SkippedCount}. {base.ToString()}";
+
+            return base.ToString();
         }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -61,13 +61,19 @@ namespace Raven.Client.Documents.Smuggler
             smugglerResult.Documents.SkippedCount += Documents.SkippedCount;
             smugglerResult.Documents.ReadCount += Documents.ReadCount;
             smugglerResult.Documents.ErroredCount += Documents.ErroredCount;
+            smugglerResult.Documents.Size += Documents.Size;
+
             smugglerResult.Documents.LastEtag = Math.Max(smugglerResult.Documents.LastEtag, Documents.LastEtag);
-            smugglerResult.Documents.Attachments = Documents.Attachments;
+            smugglerResult.Documents.Attachments.ReadCount += Documents.Attachments.ReadCount;
+            smugglerResult.Documents.Attachments.Size += Documents.Attachments.Size;
 
             smugglerResult.RevisionDocuments.ReadCount += RevisionDocuments.ReadCount;
             smugglerResult.RevisionDocuments.ErroredCount += RevisionDocuments.ErroredCount;
+            smugglerResult.RevisionDocuments.Size += RevisionDocuments.Size;
             smugglerResult.RevisionDocuments.LastEtag = Math.Max(smugglerResult.RevisionDocuments.LastEtag, RevisionDocuments.LastEtag);
             smugglerResult.RevisionDocuments.Attachments = RevisionDocuments.Attachments;
+            smugglerResult.RevisionDocuments.Attachments.ReadCount += RevisionDocuments.Attachments.ReadCount;
+            smugglerResult.RevisionDocuments.Attachments.Size += RevisionDocuments.Attachments.Size;
 
             smugglerResult.Counters.ReadCount += Counters.ReadCount;
             smugglerResult.Counters.ErroredCount += Counters.ErroredCount;
@@ -75,6 +81,8 @@ namespace Raven.Client.Documents.Smuggler
 
             smugglerResult.TimeSeries.ReadCount += TimeSeries.ReadCount;
             smugglerResult.TimeSeries.ErroredCount += TimeSeries.ErroredCount;
+            smugglerResult.TimeSeries.Size += TimeSeries.Size;
+
             smugglerResult.TimeSeries.LastEtag = Math.Max(smugglerResult.TimeSeries.LastEtag, TimeSeries.LastEtag);
 
             smugglerResult.Identities.ReadCount += Identities.ReadCount;

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -61,19 +61,19 @@ namespace Raven.Client.Documents.Smuggler
             smugglerResult.Documents.SkippedCount += Documents.SkippedCount;
             smugglerResult.Documents.ReadCount += Documents.ReadCount;
             smugglerResult.Documents.ErroredCount += Documents.ErroredCount;
-            smugglerResult.Documents.Size += Documents.Size;
+            smugglerResult.Documents.SizeInBytes += Documents.SizeInBytes;
 
             smugglerResult.Documents.LastEtag = Math.Max(smugglerResult.Documents.LastEtag, Documents.LastEtag);
             smugglerResult.Documents.Attachments.ReadCount += Documents.Attachments.ReadCount;
-            smugglerResult.Documents.Attachments.Size += Documents.Attachments.Size;
+            smugglerResult.Documents.Attachments.SizeInBytes += Documents.Attachments.SizeInBytes;
 
             smugglerResult.RevisionDocuments.ReadCount += RevisionDocuments.ReadCount;
             smugglerResult.RevisionDocuments.ErroredCount += RevisionDocuments.ErroredCount;
-            smugglerResult.RevisionDocuments.Size += RevisionDocuments.Size;
+            smugglerResult.RevisionDocuments.SizeInBytes += RevisionDocuments.SizeInBytes;
             smugglerResult.RevisionDocuments.LastEtag = Math.Max(smugglerResult.RevisionDocuments.LastEtag, RevisionDocuments.LastEtag);
             smugglerResult.RevisionDocuments.Attachments = RevisionDocuments.Attachments;
             smugglerResult.RevisionDocuments.Attachments.ReadCount += RevisionDocuments.Attachments.ReadCount;
-            smugglerResult.RevisionDocuments.Attachments.Size += RevisionDocuments.Attachments.Size;
+            smugglerResult.RevisionDocuments.Attachments.SizeInBytes += RevisionDocuments.Attachments.SizeInBytes;
 
             smugglerResult.Counters.ReadCount += Counters.ReadCount;
             smugglerResult.Counters.ErroredCount += Counters.ErroredCount;
@@ -81,7 +81,7 @@ namespace Raven.Client.Documents.Smuggler
 
             smugglerResult.TimeSeries.ReadCount += TimeSeries.ReadCount;
             smugglerResult.TimeSeries.ErroredCount += TimeSeries.ErroredCount;
-            smugglerResult.TimeSeries.Size += TimeSeries.Size;
+            smugglerResult.TimeSeries.SizeInBytes += TimeSeries.SizeInBytes;
 
             smugglerResult.TimeSeries.LastEtag = Math.Max(smugglerResult.TimeSeries.LastEtag, TimeSeries.LastEtag);
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -316,7 +316,7 @@ public unsafe class ShardedDocumentsStorage : DocumentsStorage
         using (Slice.External(allocator, buffer, buffer.Length, out var keySlice))
         using (Slice.External(allocator, buffer, buffer.Length - sizeof(long), out var prefix))
         {
-            foreach (var result in table.SeekForwardFromPrefix(dynamicIndex, keySlice, prefix, skip))
+            foreach (var result in table.SeekByPrefix(dynamicIndex, prefix, keySlice, skip))
             {
                 yield return result;
                 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -260,7 +260,7 @@ namespace Raven.Server.Smuggler.Documents
                     if (_options.OperateOnTypes.HasFlag(DatabaseItemType.Attachments))
                     {
                         progress.Attachments.ReadCount += item.Attachments.Count;
-                        progress.Attachments.Size += item.Attachments.Sum(x => x.Stream.Length);
+                        progress.Attachments.SizeInBytes += item.Attachments.Sum(x => x.Stream.Length);
 
                     }
                     else

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -257,13 +257,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (item.Attachments != null)
                 {
-                    if (_options.OperateOnTypes.HasFlag(DatabaseItemType.Attachments))
-                    {
-                        progress.Attachments.ReadCount += item.Attachments.Count;
-                        progress.Attachments.SizeInBytes += item.Attachments.Sum(x => x.Stream.Length);
-
-                    }
-                    else
+                    if (_options.OperateOnTypes.HasFlag(DatabaseItemType.Attachments) == false)
                         progress.Attachments.Skipped = true;
                 }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -257,7 +258,11 @@ namespace Raven.Server.Smuggler.Documents
                 if (item.Attachments != null)
                 {
                     if (_options.OperateOnTypes.HasFlag(DatabaseItemType.Attachments))
+                    {
                         progress.Attachments.ReadCount += item.Attachments.Count;
+                        progress.Attachments.Size += item.Attachments.Sum(x => x.Stream.Length);
+
+                    }
                     else
                         progress.Attachments.Skipped = true;
                 }

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -408,7 +408,7 @@ namespace Raven.Server.Smuggler.Documents
                     }
 
                     if (item.Document != null) 
-                        result.Documents.Size += item.Document.Data.Size;
+                        result.Documents.SizeInBytes += item.Document.Data.Size;
 
                     if (item.Attachments != null)
                     {
@@ -417,7 +417,7 @@ namespace Raven.Server.Smuggler.Documents
                             if (attachment.Stream != null)
                             {
                                 result.Documents.Attachments.ReadCount++;
-                                result.Documents.Attachments.Size += attachment.Stream.Length;
+                                result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
                             }
                         }
                     }
@@ -511,7 +511,7 @@ namespace Raven.Server.Smuggler.Documents
                     result.RevisionDocuments.ReadCount++;
 
                     if (item.Document != null)
-                        result.RevisionDocuments.Size += item.Document.Data.Size;
+                        result.RevisionDocuments.SizeInBytes += item.Document.Data.Size;
 
                     if (item.Attachments != null)
                     {
@@ -520,7 +520,7 @@ namespace Raven.Server.Smuggler.Documents
                             if (attachment.Stream != null)
                             {
                                 result.Documents.Attachments.ReadCount++;
-                                result.Documents.Attachments.Size += attachment.Stream.Length;
+                                result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
                             }
                         }
                     }
@@ -865,10 +865,10 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     _token.ThrowIfCancellationRequested();
                     result.TimeSeries.ReadCount += ts.Segment.NumberOfEntries;
-                    result.TimeSeries.Size += ts.Segment.NumberOfBytes;
+                    result.TimeSeries.SizeInBytes += ts.Segment.NumberOfBytes;
 
                     if (result.TimeSeries.ReadCount % 1000 == 0)
-                        AddInfoToSmugglerResult(result, $"Time series entries {result.TimeSeries}");
+                        AddInfoToSmugglerResult(result, $"Time Series entries {result.TimeSeries}");
 
                     result.TimeSeries.LastEtag = ts.Etag;
 

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -407,11 +407,24 @@ namespace Raven.Server.Smuggler.Documents
                         result.Documents.ReadCount++;
                     }
 
+                    if (item.Document != null) 
+                        result.Documents.Size += item.Document.Data.Size;
+
+                    if (item.Attachments != null)
+                    {
+                        foreach (var attachment in item.Attachments)
+                        {
+                            if (attachment.Stream != null)
+                            {
+                                result.Documents.Attachments.ReadCount++;
+                                result.Documents.Attachments.Size += attachment.Stream.Length;
+                            }
+                        }
+                    }
+
                     if (result.Documents.ReadCount % 1000 == 0)
                     {
-                        var message = $"Read {result.Documents.ReadCount:#,#;;0} documents.";
-                        if (result.Documents.Attachments.ReadCount > 0)
-                            message += $" Read {result.Documents.Attachments.ReadCount:#,#;;0} attachments.";
+                        var message = $"Documents: {result.Documents}"; 
                         AddInfoToSmugglerResult(result, message);
                     }
 
@@ -497,8 +510,23 @@ namespace Raven.Server.Smuggler.Documents
                     _token.ThrowIfCancellationRequested();
                     result.RevisionDocuments.ReadCount++;
 
+                    if (item.Document != null)
+                        result.RevisionDocuments.Size += item.Document.Data.Size;
+
+                    if (item.Attachments != null)
+                    {
+                        foreach (var attachment in item.Attachments)
+                        {
+                            if (attachment.Stream != null)
+                            {
+                                result.Documents.Attachments.ReadCount++;
+                                result.Documents.Attachments.Size += attachment.Stream.Length;
+                            }
+                        }
+                    }
+
                     if (result.RevisionDocuments.ReadCount % 1000 == 0)
-                        AddInfoToSmugglerResult(result, $"Read {result.RevisionDocuments.ReadCount:#,#;;0} revision documents.");
+                        AddInfoToSmugglerResult(result, $"Revisions {result.RevisionDocuments}");
 
                     if (item.Document == null)
                     {
@@ -837,9 +865,10 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     _token.ThrowIfCancellationRequested();
                     result.TimeSeries.ReadCount += ts.Segment.NumberOfEntries;
+                    result.TimeSeries.Size += ts.Segment.NumberOfBytes;
 
                     if (result.TimeSeries.ReadCount % 1000 == 0)
-                        AddInfoToSmugglerResult(result, $"Read {result.TimeSeries.ReadCount:#,#;;0} time series.");
+                        AddInfoToSmugglerResult(result, $"Time series entries {result.TimeSeries}");
 
                     result.TimeSeries.LastEtag = ts.Etag;
 

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -401,14 +401,13 @@ namespace Raven.Server.Smuggler.Documents
                     if (isPreV4Revision)
                     {
                         result.RevisionDocuments.ReadCount++;
+                        result.RevisionDocuments.SizeInBytes += item.Document.Data.Size;
                     }
                     else
                     {
                         result.Documents.ReadCount++;
-                    }
-
-                    if (item.Document != null) 
                         result.Documents.SizeInBytes += item.Document.Data.Size;
+                    }
 
                     if (item.Attachments != null)
                     {
@@ -416,8 +415,16 @@ namespace Raven.Server.Smuggler.Documents
                         {
                             if (attachment.Stream != null)
                             {
-                                result.Documents.Attachments.ReadCount++;
-                                result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
+                                if (isPreV4Revision)
+                                {
+                                    result.RevisionDocuments.Attachments.ReadCount++;
+                                    result.RevisionDocuments.Attachments.SizeInBytes += attachment.Stream.Length;
+                                }
+                                else
+                                {
+                                    result.Documents.Attachments.ReadCount++;
+                                    result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
+                                }
                             }
                         }
                     }
@@ -519,8 +526,8 @@ namespace Raven.Server.Smuggler.Documents
                         {
                             if (attachment.Stream != null)
                             {
-                                result.Documents.Attachments.ReadCount++;
-                                result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
+                                result.RevisionDocuments.Attachments.ReadCount++;
+                                result.RevisionDocuments.Attachments.SizeInBytes += attachment.Stream.Length;
                             }
                         }
                     }

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -120,7 +120,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 ErroredCount: items.reduce((p, c) => p + c.ErroredCount, 0),
                 Skipped: items.every(x => x.Skipped),
                 Processed: items.some(x => x.Processed),
-                Size: items.reduce((p, c) => p + c.Size, 0),
+                SizeInBytes: items.reduce((p, c) => p + c.SizeInBytes, 0),
                 StartTime: null,
             }
         }

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -120,7 +120,8 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 ErroredCount: items.reduce((p, c) => p + c.ErroredCount, 0),
                 Skipped: items.every(x => x.Skipped),
                 Processed: items.some(x => x.Processed),
-                StartTime: null
+                Size: items.reduce((p, c) => p + c.Size, 0),
+                StartTime: null,
             }
         }
         

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -146,6 +146,14 @@ namespace Sparrow.Json.Parsing
             return (count == amountToCopy, (int)amountToCopy);
         }
 
+        public (bool Done, int BytesRead) Copy(Stream dest, int count)
+        {
+            var amountToCopy = Math.Min(count, _bufSize - _pos);
+            dest.Write(new Span<byte>(_inputBuffer + _pos, (int)amountToCopy));
+            _pos += (uint)amountToCopy;
+            return (count == amountToCopy, (int)amountToCopy);
+        }
+
         public (bool Done, int BytesRead) Skip(int count)
         {
             var amountToCopy = Math.Min(count, _bufSize - _pos);

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -69,7 +69,7 @@ namespace FastTests.Voron.Tables
 
                 bool gotValues = false;
 
-                foreach (var reader in docs.SeekForwardFrom(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, 0))
+                foreach (var reader in docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, Slices.Empty, 0))
                 {
                     AssertKey(id, etag, reader.Key);
 
@@ -116,7 +116,7 @@ namespace FastTests.Voron.Tables
             {
                 var docs = tx.OpenTable(DocsSchema, "docs");
 
-                var reader = docs.SeekForwardFrom(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, 0);
+                var reader = docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, Slices.Empty, 0);
                 Assert.Empty(reader);
             }
         }
@@ -154,7 +154,7 @@ namespace FastTests.Voron.Tables
                 var docs = tx.OpenTable(DocsSchema, "docs");
 
                 bool gotValues = false;
-                foreach (var reader in docs.SeekForwardFrom(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, 0))
+                foreach (var reader in docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, Slices.Empty, 0))
                 {
                     AssertKey(id, etag: 2, reader.Key);
 
@@ -197,7 +197,7 @@ namespace FastTests.Voron.Tables
                 var docs = tx.OpenTable(DocsSchema, "docs");
 
                 long count = 0;
-                foreach (var item in docs.SeekForwardFrom(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, 0))
+                foreach (var item in docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, Slices.Empty, 0))
                 {
                     var handle = item.Result;
                     
@@ -271,7 +271,7 @@ namespace FastTests.Voron.Tables
 
                     long prevEtag = -1;
                     long count = 0;
-                    foreach (var reader in docs.SeekForwardFromPrefix(DocsSchema.DynamicKeyIndexes[IndexName], keySlice, prefix, skip: 0))
+                    foreach (var reader in docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], prefix, keySlice, 0))
                     {
                         var b = *(int*)reader.Key.Content.Ptr;
                         Assert.Equal(bucketToCheck, b);
@@ -360,7 +360,7 @@ namespace FastTests.Voron.Tables
                 var docs = tx.OpenTable(DocsSchema, "docs");
 
                 bool gotValues = false;
-                foreach (var reader in docs.SeekForwardFrom(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, 0))
+                foreach (var reader in docs.SeekByPrefix(DocsSchema.DynamicKeyIndexes[IndexName], Slices.BeforeAllKeys, Slices.Empty, 0))
                 {
                     AssertKey(id, etag: 123456789L, reader.Key);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20066 

### Additional description

- Add size to the import messages
- Remove redundant buffer when reading an attachment stream
- Make the dynamic index a single tree and reduce disk access
 
![image](https://user-images.githubusercontent.com/6377808/229337475-0aaab2d5-2ff8-4d3c-a46b-438b162c8254.png)

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

Change the way we store the dynamic index, so prior sharded databases will break.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing
- Prior to the change importing 1.2B records took 19 hours, after the change only 10

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
