### PR TITLE
RavenDB-19720 - Verify that deleting an orchestrator removes it from the `ShardedDatabasesCache`

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -707,6 +707,9 @@ namespace Raven.Server.Documents
 
         private ShardedDatabaseContext GetOrAddShardedDatabaseContext(StringSegment databaseName, RawDatabaseRecord databaseRecord)
         {
+            if (databaseRecord.Sharding.Orchestrator.Topology.RelevantFor(_serverStore.NodeTag) == false)
+                throw new DatabaseNotRelevantException($"Can't get or add orchestrator for database {databaseName} because it is not relevant on this node {_serverStore.NodeTag}");
+
             var newTask = new Task<ShardedDatabaseContext>(() => new ShardedDatabaseContext(_serverStore, databaseRecord));
             var currentTask = ShardedDatabasesCache.GetOrAdd(databaseName, newTask);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19720

### Additional description

Cluster Dashboard was showing node information after it was removed from orchestrators.
`GetOrAddShardedDatabaseContext` was missing a relevancy check for orchestrator on the node, so it always added it back to the `ShardedDatabaseCache` even after the remove command executed.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
