### PR TITLE
RavenDB-20245 Avoid mixing different values in @index_metadata tree

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -9,9 +9,10 @@ namespace Corax
         public const string NullValue = "NULL_VALUE";
         public const string EmptyString = "EMPTY_STRING";
         public const string IndexMetadata = "@index_metadata";
+        public const string IndexTimeFields = "@index_time_fields";
         public const string DocumentBoost = "@document_boost";
         
-        public static readonly Slice NullValueSlice, EmptyStringSlice, IndexMetadataSlice, DocumentBoostSlice;
+        public static readonly Slice NullValueSlice, EmptyStringSlice, IndexMetadataSlice, DocumentBoostSlice, IndexTimeFieldsSlice;
 
         static Constants()
         {
@@ -21,6 +22,7 @@ namespace Corax
                 Slice.From(ctx, EmptyString, ByteStringType.Immutable, out EmptyStringSlice);
                 Slice.From(ctx, IndexMetadata, ByteStringType.Immutable, out IndexMetadataSlice);
                 Slice.From(ctx, DocumentBoost, ByteStringType.Immutable, out DocumentBoostSlice);
+                Slice.From(ctx, IndexTimeFields, ByteStringType.Immutable, out IndexTimeFieldsSlice);
             }
         }
         
@@ -44,7 +46,7 @@ namespace Corax
         public static class IndexWriter
         {
             // This is the schema version for the indexes. 
-            public const long SchemaVersion = 54_005;
+            public const long SchemaVersion = 54_006;
             
             
             public static ReadOnlySpan<byte> DoubleTreeSuffix => DoubleTreeSuffixBytes.AsSpan();
@@ -54,7 +56,7 @@ namespace Corax
             private static readonly byte[] LongTreeSuffixBytes = new byte[]  { (byte)'-', (byte)'L' };
 
             
-            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice, TimeFieldsSlice, NumberOfTermsInIndex;
+            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice, NumberOfTermsInIndex;
             public const int IntKnownFieldMask = unchecked((int)0x80000000);
             public const short ShortKnownFieldMask = unchecked((short)0x8000);
             public const byte ByteKnownFieldMask = unchecked((byte)0x80);
@@ -70,7 +72,6 @@ namespace Corax
                     Slice.From(ctx, "SuggestionFields", ByteStringType.Immutable, out SuggestionsFieldsSlice);
                     Slice.From(ctx, "IndexVersion", ByteStringType.Immutable, out IndexVersionSlice);
                     Slice.From(ctx, "DynamicFieldsAnalyzers", ByteStringType.Immutable, out DynamicFieldsAnalyzersSlice);
-                    Slice.From(ctx, "TimeFieldsSlice", ByteStringType.Immutable, out TimeFieldsSlice);
                     Slice.From(ctx, "NumberOfTermsInIndex", ByteStringType.Immutable, out NumberOfTermsInIndex);
                 }
             }

--- a/src/Corax/Utils/TimeFields.cs
+++ b/src/Corax/Utils/TimeFields.cs
@@ -14,18 +14,12 @@ public static class TimeFields
     {
         var fieldsNames = new HashSet<string>();
 
-        var metadataTree = tx.ReadTree(Constants.IndexMetadata);
-        if (metadataTree != null)
+        var timeFieldsTree = tx.ReadTree(Constants.IndexTimeFieldsSlice);
+        if (timeFieldsTree != null)
         {
-            using var iterator = metadataTree.MultiRead(Constants.IndexWriter.TimeFieldsSlice);
-            if (iterator.Seek(Slices.BeforeAllKeys))
-            {
-                do
-                {
-                    fieldsNames.Add(iterator.CurrentKey.ToString());
-                } while (iterator.MoveNext());
-            }
-                
+            using var iterator = timeFieldsTree.MultiRead(Constants.IndexTimeFieldsSlice);
+            while (iterator.MoveNext())
+                fieldsNames.Add(iterator.CurrentKey.ToString());
         }
 
         return fieldsNames;
@@ -35,13 +29,12 @@ public static class TimeFields
     {
         if (tx.IsWriteTransaction == false)
             throw new InvalidDataException("Tried to write fields names but got non write transaction.");
-        
+
         if (fieldsNames == null || fieldsNames.Count == 0)
             return;
 
-        using var metadataTree = tx.CreateTree(Constants.IndexMetadata);
-        
+        using var indexTimeFieldsTree = tx.CreateTree(Constants.IndexTimeFieldsSlice);
         foreach (var field in fieldsNames)
-            metadataTree.MultiAdd(Constants.IndexWriter.TimeFieldsSlice, field);
+            indexTimeFieldsTree.MultiAdd(Constants.IndexTimeFieldsSlice, field);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20245 

### Additional description

Avoid mixing different values in @index_metadata tree

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

-Current tests should test it well.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
