### PR TITLE
RavenDB-20248 Appending alias to OrderBy if needed, and ordering field is compound

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3148,6 +3148,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         {
             FromAlias = RenameAliasIfNeeded(alias);
             DocumentQuery.AddFromAliasToWhereTokens(FromAlias);
+            DocumentQuery.AddAliasToOrderByTokens(FromAlias);
         }
 
         private void AddAliasToIncludeTokensIfNeeded()

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3148,7 +3148,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         {
             FromAlias = RenameAliasIfNeeded(alias);
             DocumentQuery.AddFromAliasToWhereTokens(FromAlias);
-            DocumentQuery.AddAliasToOrderByTokens(FromAlias);
+            DocumentQuery.AddFromAliasToOrderByTokens(FromAlias);
         }
 
         private void AddAliasToIncludeTokensIfNeeded()

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3148,6 +3148,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         {
             FromAlias = RenameAliasIfNeeded(alias);
             DocumentQuery.AddFromAliasToWhereTokens(FromAlias);
+            DocumentQuery.AddFromAliasToFilterTokens(FromAlias);
             DocumentQuery.AddFromAliasToOrderByTokens(FromAlias);
         }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1963,6 +1963,21 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             }
         }
 
+        public void AddFromAliasToFilterTokens(string fromAlias)
+        {
+            if (string.IsNullOrEmpty(fromAlias))
+                throw new InvalidOperationException("Alias cannot be null or empty");
+
+            var tokens = GetCurrentFilterTokens();
+            var current = tokens.First;
+            while (current != null)
+            {
+                if (current.Value is WhereToken w)
+                    current.Value = w.AddAlias(fromAlias);
+                current = current.Next;
+            }
+        }
+        
         public string AddAliasToIncludesTokens(string fromAlias)
         {
             if (_includesAlias == null)

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1948,7 +1948,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             }
         }
 
-        public void AddAliasToOrderByTokens(string fromAlias)
+        public void AddFromAliasToOrderByTokens(string fromAlias)
         {
             if (string.IsNullOrEmpty(fromAlias))
                 throw new InvalidOperationException("Alias cannot be null or empty");

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1935,45 +1935,39 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         /// <param name = "fromAlias">The alias</param>
         public void AddFromAliasToWhereTokens(string fromAlias)
         {
-            if (string.IsNullOrEmpty(fromAlias))
-                throw new InvalidOperationException("Alias cannot be null or empty");
-
             var tokens = GetCurrentWhereTokens();
-            var current = tokens.First;
-            while (current != null)
-            {
-                if (current.Value is WhereToken w)
-                    current.Value = w.AddAlias(fromAlias);
-                current = current.Next;
-            }
+            AddFromAliasToTokens(fromAlias, tokens);
         }
 
         public void AddFromAliasToOrderByTokens(string fromAlias)
         {
-            if (string.IsNullOrEmpty(fromAlias))
-                throw new InvalidOperationException("Alias cannot be null or empty");
-
             var tokens = GetCurrentOrderByTokens();
-            var current = tokens.First;
-            while (current != null)
-            {
-                if (current.Value is OrderByToken w)
-                    current.Value = w.AddAlias(fromAlias);
-                current = current.Next;
-            }
+            AddFromAliasToTokens(fromAlias, tokens);
         }
 
         public void AddFromAliasToFilterTokens(string fromAlias)
         {
+            var tokens = GetCurrentFilterTokens();
+            AddFromAliasToTokens(fromAlias, tokens);
+        }
+
+        private void AddFromAliasToTokens(string fromAlias, LinkedList<QueryToken> tokens)
+        {
             if (string.IsNullOrEmpty(fromAlias))
                 throw new InvalidOperationException("Alias cannot be null or empty");
 
-            var tokens = GetCurrentFilterTokens();
             var current = tokens.First;
             while (current != null)
             {
-                if (current.Value is WhereToken w)
-                    current.Value = w.AddAlias(fromAlias);
+                switch (current.Value)
+                {
+                    case WhereToken w:
+                        current.Value = w.AddAlias(fromAlias);
+                        break;
+                    case OrderByToken o:
+                        current.Value = o.AddAlias(fromAlias);
+                        break;
+                }
                 current = current.Next;
             }
         }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1892,6 +1892,12 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         {
             return FilterTokens;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private LinkedList<QueryToken> GetCurrentOrderByTokens()
+        {
+            return OrderByTokens;
+        }
 
         protected void UpdateFieldsToFetchToken(FieldsToFetchToken fieldsToFetch)
         {
@@ -1937,6 +1943,21 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             while (current != null)
             {
                 if (current.Value is WhereToken w)
+                    current.Value = w.AddAlias(fromAlias);
+                current = current.Next;
+            }
+        }
+
+        public void AddAliasToOrderByTokens(string fromAlias)
+        {
+            if (string.IsNullOrEmpty(fromAlias))
+                throw new InvalidOperationException("Alias cannot be null or empty");
+
+            var tokens = GetCurrentOrderByTokens();
+            var current = tokens.First;
+            while (current != null)
+            {
+                if (current.Value is OrderByToken w)
                     current.Value = w.AddAlias(fromAlias);
                 current = current.Next;
             }

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -333,6 +333,8 @@ namespace Raven.Client.Documents.Session
         void AggregateUsing(string facetSetupDocumentId);
 
         void AddFromAliasToWhereTokens(string fromAlias);
+        
+        void AddAliasToOrderByTokens(string fromAlias);
 
         string AddAliasToIncludesTokens(string fromAlias);
 

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -334,7 +334,7 @@ namespace Raven.Client.Documents.Session
 
         void AddFromAliasToWhereTokens(string fromAlias);
         
-        void AddAliasToOrderByTokens(string fromAlias);
+        void AddFromAliasToOrderByTokens(string fromAlias);
 
         string AddAliasToIncludesTokens(string fromAlias);
 

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -333,6 +333,8 @@ namespace Raven.Client.Documents.Session
         void AggregateUsing(string facetSetupDocumentId);
 
         void AddFromAliasToWhereTokens(string fromAlias);
+
+        void AddFromAliasToFilterTokens(string fromAlias);
         
         void AddFromAliasToOrderByTokens(string fromAlias);
 

--- a/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
@@ -124,7 +124,10 @@ namespace Raven.Client.Documents.Session.Tokens
         
         public OrderByToken AddAlias(string alias)
         {
-            if (_fieldName == "id()")
+            if (_fieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
+                return this;
+
+            if (_fieldName.Contains("(")) // we must not alias RQL methods
                 return this;
             
             var aliasedName = $"{alias}.{_fieldName}";

--- a/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
@@ -9,51 +9,54 @@ namespace Raven.Client.Documents.Session.Tokens
         private readonly bool _descending;
         private readonly string _sorterName;
         private readonly OrderingType _ordering;
+        private readonly bool _isMethodField;
 
-        private OrderByToken(string fieldName, bool descending, string sorterName)
+        private OrderByToken(string fieldName, bool descending, string sorterName, bool isMethodField = false)
         {
             _fieldName = fieldName;
             _descending = descending;
             _sorterName = sorterName;
+            _isMethodField = isMethodField;
         }
 
-        private OrderByToken(string fieldName, bool descending, OrderingType ordering)
+        private OrderByToken(string fieldName, bool descending, OrderingType ordering, bool isMethodField = false)
         {
             _fieldName = fieldName;
             _descending = descending;
             _ordering = ordering;
+            _isMethodField = isMethodField;
         }
 
-        public static OrderByToken Random = new OrderByToken("random()", descending: false, ordering: OrderingType.String);
+        public static OrderByToken Random = new OrderByToken("random()", descending: false, ordering: OrderingType.String, isMethodField: true);
 
-        public static OrderByToken ScoreAscending = new OrderByToken("score()", descending: false, ordering: OrderingType.String);
+        public static OrderByToken ScoreAscending = new OrderByToken("score()", descending: false, ordering: OrderingType.String, isMethodField: true);
 
-        public static OrderByToken ScoreDescending = new OrderByToken("score()", descending: true, ordering: OrderingType.String);
+        public static OrderByToken ScoreDescending = new OrderByToken("score()", descending: true, ordering: OrderingType.String, isMethodField: true);
 
         public static OrderByToken CreateDistanceAscending(string fieldName, string latitudeParameterName, string longitudeParameterName, string roundFactorParameterName)
         {
             return new OrderByToken($"spatial.distance({fieldName}, spatial.point(${latitudeParameterName}, " +
                 $"${longitudeParameterName}" +
-                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", false, OrderingType.String);
+                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", false, OrderingType.String, isMethodField: true);
         }
 
         public static OrderByToken CreateDistanceAscending(string fieldName, string shapeWktParameterName, string roundFactorParameterName)
         {
             return new OrderByToken($"spatial.distance({fieldName}, spatial.wkt(${shapeWktParameterName}" +
-                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", false, OrderingType.String);
+                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", false, OrderingType.String, isMethodField: true);
         }
 
         public static OrderByToken CreateDistanceDescending(string fieldName, string latitudeParameterName, string longitudeParameterName, string roundFactorParameterName)
         {
             return new OrderByToken($"spatial.distance({fieldName}, " +
                 $"spatial.point(${latitudeParameterName}, ${longitudeParameterName}" +
-                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", true, OrderingType.String);
+                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", true, OrderingType.String, isMethodField: true);
         }
 
         public static OrderByToken CreateDistanceDescending(string fieldName, string shapeWktParameterName, string roundFactorParameterName)
         {
             return new OrderByToken($"spatial.distance({fieldName}, spatial.wkt(${shapeWktParameterName}" +
-                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", true, OrderingType.String);
+                $"){(roundFactorParameterName == null ? "" : ", $" + roundFactorParameterName)})", true, OrderingType.String, isMethodField: true);
         }
 
         public static OrderByToken CreateRandom(string seed)
@@ -61,7 +64,7 @@ namespace Raven.Client.Documents.Session.Tokens
             if (seed == null)
                 throw new ArgumentNullException(nameof(seed));
 
-            return new OrderByToken("random('" + seed.Replace("'", "''") + "')", false, OrderingType.String);
+            return new OrderByToken("random('" + seed.Replace("'", "''") + "')", false, OrderingType.String, isMethodField: true);
         }
 
         public static OrderByToken CreateAscending(string fieldName, string sorterName)
@@ -127,7 +130,7 @@ namespace Raven.Client.Documents.Session.Tokens
             if (_fieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                 return this;
 
-            if (_fieldName.Contains("(")) // we must not alias RQL methods
+            if (_isMethodField) // we must not alias RQL methods
                 return this;
             
             var aliasedName = $"{alias}.{_fieldName}";

--- a/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
@@ -121,5 +121,15 @@ namespace Raven.Client.Documents.Session.Tokens
             if (_descending) // we only add this if we have to, ASC is the default and reads nicer
                 writer.Append(" desc");
         }
+        
+        public OrderByToken AddAlias(string alias)
+        {
+            var aliasedName = $"{alias}.{_fieldName}";
+
+            if (_sorterName != null)
+                return new OrderByToken(aliasedName, _descending, _sorterName);
+            else
+                return new OrderByToken(aliasedName, _descending, _ordering);
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/OrderByToken.cs
@@ -124,6 +124,9 @@ namespace Raven.Client.Documents.Session.Tokens
         
         public OrderByToken AddAlias(string alias)
         {
+            if (_fieldName == "id()")
+                return this;
+            
             var aliasedName = $"{alias}.{_fieldName}";
 
             if (_sorterName != null)

--- a/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
@@ -102,7 +102,7 @@ namespace Raven.Client.Documents.Session.Tokens
 
         public WhereToken AddAlias(string alias)
         {
-            if (FieldName == "id()")
+            if (FieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                 return this;
 
             return new WhereToken

--- a/test/SlowTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/SlowTests/Client/QueriesWithCustomFunctions.cs
@@ -1088,7 +1088,7 @@ from 'Users' as u select output(u)", query.ToString());
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
-from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by LastName desc select output(u)", query.ToString());
+from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by u.LastName desc select output(u)", query.ToString());
 
                     var queryResult = query.ToList();
 

--- a/test/SlowTests/Client/QueriesWithCustomFunctions.cs
+++ b/test/SlowTests/Client/QueriesWithCustomFunctions.cs
@@ -1133,7 +1133,7 @@ from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by u.LastNam
 	var detail = load(u.DetailId);
 	return { FullName : format(u), DetailNumber : detail.Number };
 }
-from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by LastName desc select output(u)", query.ToString());
+from 'Users' as u where (u.Name = $p0) and (u.IsActive = $p1) order by u.LastName desc select output(u)", query.ToString());
 
                     var queryResult = await query.ToListAsync();
 

--- a/test/SlowTests/Issues/RavenDB-20248.cs
+++ b/test/SlowTests/Issues/RavenDB-20248.cs
@@ -55,43 +55,21 @@ public class RavenDB_20248 : RavenTestBase
             session.SaveChanges();
             
             var source = session.Advanced.DocumentQuery<First>()
+                .WhereEquals(i => i.Inner.SortOrder, "order1")
                 .Filter(i => i.Equals(a => a.Inner.SortOrder, "order1"))
                 .ToQueryable();
             
             var query =
                 from e in source
                 select new First {Name = e.Name + "Test", Inner = e.Inner};
+
+            Assert.Equal( "from 'Firsts' as e where e.Inner.SortOrder = $p0 filter e.Inner.SortOrder = $p1 select { Name : e.Name+\"Test\", Inner : e.Inner }", query.ToString());
             
             var queryResult = query.ToList();
             
             Assert.Equal(2, queryResult.Count);
             Assert.Equal(queryResult[0].Name, "Name1" + "Test");
             Assert.Equal(queryResult[1].Name, "Name3" + "Test");
-        }
-    }
-    
-    [Fact]
-    public void TestGroupByAliasing()
-    {
-        using var store = GetDocumentStore();
-        using (var session = store.OpenSession())
-        {
-            session.Store(new First() {Name = "Name1", Inner = new Inner() {SortOrder = "order1"}});
-            session.Store(new First() {Name = "Name2", Inner = new Inner() {SortOrder = "order2"}});
-            session.Store(new First() {Name = "Name3", Inner = new Inner() {SortOrder = "order1"}});
-            session.SaveChanges();
-            
-            var query = session.Query<First>()
-                .GroupBy(x => new { Inner = x.Inner })
-                .Select(x => new { Inner = x.Key.Inner, Count = x.Count() });
-            
-            var queryResult = query.ToList();
-            
-            Assert.Equal(2, queryResult.Count);
-            Assert.Equal(2, queryResult[0].Count);
-            Assert.Equal(1, queryResult[1].Count);
-            Assert.Equal("order1", queryResult[0].Inner.SortOrder);
-            Assert.Equal("order2", queryResult[1].Inner.SortOrder);
         }
     }
     

--- a/test/SlowTests/Issues/RavenDB-20248.cs
+++ b/test/SlowTests/Issues/RavenDB-20248.cs
@@ -42,6 +42,58 @@ public class RavenDB_20248 : RavenTestBase
             Assert.Equal(queryResult[1].Name, "Maciej" + "Test");
         }
     }
+
+    [Fact]
+    public void TestFilterAliasing()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new First() {Name = "Name1", Inner = new Inner() {SortOrder = "order1"}});
+            session.Store(new First() {Name = "Name2", Inner = new Inner() {SortOrder = "order2"}});
+            session.Store(new First() {Name = "Name3", Inner = new Inner() {SortOrder = "order1"}});
+            session.SaveChanges();
+            
+            var source = session.Advanced.DocumentQuery<First>()
+                .Filter(i => i.Equals(a => a.Inner.SortOrder, "order1"))
+                .ToQueryable();
+            
+            var query =
+                from e in source
+                select new First {Name = e.Name + "Test", Inner = e.Inner};
+            
+            var queryResult = query.ToList();
+            
+            Assert.Equal(2, queryResult.Count);
+            Assert.Equal(queryResult[0].Name, "Name1" + "Test");
+            Assert.Equal(queryResult[1].Name, "Name3" + "Test");
+        }
+    }
+    
+    [Fact]
+    public void TestGroupByAliasing()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new First() {Name = "Name1", Inner = new Inner() {SortOrder = "order1"}});
+            session.Store(new First() {Name = "Name2", Inner = new Inner() {SortOrder = "order2"}});
+            session.Store(new First() {Name = "Name3", Inner = new Inner() {SortOrder = "order1"}});
+            session.SaveChanges();
+            
+            var query = session.Query<First>()
+                .GroupBy(x => new { Inner = x.Inner })
+                .Select(x => new { Inner = x.Key.Inner, Count = x.Count() });
+            
+            var queryResult = query.ToList();
+            
+            Assert.Equal(2, queryResult.Count);
+            Assert.Equal(2, queryResult[0].Count);
+            Assert.Equal(1, queryResult[1].Count);
+            Assert.Equal("order1", queryResult[0].Inner.SortOrder);
+            Assert.Equal("order2", queryResult[1].Inner.SortOrder);
+        }
+    }
     
     private class First
     {

--- a/test/SlowTests/Issues/RavenDB-20248.cs
+++ b/test/SlowTests/Issues/RavenDB-20248.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20248 : RavenTestBase
+{
+    public RavenDB_20248(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public void CanSortByNestedPropertyViaDocumentQuery()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new First() {Name = "Maciej", Inner = new Inner() {SortOrder = "aaaa"}});
+            session.Store(new First() {Name = "macieJ", Inner = new Inner() {SortOrder = "bbbb"}});
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var source = session.Advanced.DocumentQuery<First>()
+                .WaitForNonStaleResults()
+                .WhereEquals(i => i.Name, "maciej")
+                .AddOrder(i => i.Inner.SortOrder, descending: true)
+                .ToQueryable();
+
+            var query =
+                from e in source
+                select new First {Name = e.Name + "Test", Inner = e.Inner};
+
+            var queryResult = query.ToList();
+
+            Assert.Equal(2, queryResult.Count);
+            Assert.Equal(queryResult[0].Name, "macieJ" + "Test");
+            Assert.Equal(queryResult[1].Name, "Maciej" + "Test");
+        }
+    }
+    
+    private class First
+    {
+        public string Name { get; set; }
+        public Inner Inner { get; set; }
+    }
+
+    private class Inner
+    {
+        public string SortOrder { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20248/Alias-is-not-appended-to-OrderBy-clause-via-DocumentQuery

### Additional description

We want to apply alias (if given in query) to OrderBy fields that are nested paths when using JavaScript projection

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
