### PR TITLE
RavenDB-20207: add ability to set CV in subscription, fix possible stale

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -629,7 +629,7 @@ namespace Raven.Client.Documents.Subscriptions
             return incomingBatch;
         }
 
-        internal virtual async Task<BatchFromServer> ReadSingleSubscriptionBatchFromServerAsync(JsonContextPool contextPool, Stream tcpStream,
+        internal async Task<BatchFromServer> ReadSingleSubscriptionBatchFromServerAsync(JsonContextPool contextPool, Stream tcpStream,
             JsonOperationContext.MemoryBuffer buffer, TBatch batch)
         {
             var incomingBatch = new List<SubscriptionConnectionServerMessage>();

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -747,7 +747,7 @@ namespace Raven.Client.Documents.Subscriptions
             }
         }
 
-        internal virtual async Task SendAckAsync(TBatch batch, Stream stream, JsonOperationContext context, CancellationToken token)
+        protected virtual async Task SendAckAsync(TBatch batch, Stream stream, JsonOperationContext context, CancellationToken token)
         {
             try
             {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Documents.Replication;
@@ -94,7 +95,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 ChangeVectorsCollection = null,
                 InitialChangeVector = null
             };
-            if (Enum.TryParse(options.ChangeVector, out Client.Constants.Documents.SubscriptionChangeVectorSpecialStates changeVectorSpecialValue))
+            if (Enum.TryParse(options.ChangeVector, out Constants.Documents.SubscriptionChangeVectorSpecialStates changeVectorSpecialValue))
             {
                 switch (changeVectorSpecialValue)
                 {
@@ -119,13 +120,15 @@ namespace Raven.Server.Documents.Sharding.Handlers
                         result.InitialChangeVector = options.ChangeVector;
                         break;
                     default:
-                        result.InitialChangeVector = options.ChangeVector;
-                        if (string.IsNullOrEmpty(result.InitialChangeVector) == false)
-                        {
-                            throw new InvalidOperationException("Setting initial change vector for sharded subscription is not allowed.");
-                        }
-
-                        break;
+                        throw new ArgumentOutOfRangeException($"Expected to get '{nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates)}' but got '{changeVectorSpecialValue}'");
+                }
+            }
+            else
+            {
+                result.InitialChangeVector = options.ChangeVector;
+                if (string.IsNullOrEmpty(result.InitialChangeVector) == false)
+                {
+                    throw new InvalidOperationException("Setting initial change vector for sharded subscription is not allowed.");
                 }
             }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -101,7 +101,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                     case Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.BeginningOfTime:
                         break;
                     case Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument:
-                        result.ChangeVectorsCollection = (await ShardExecutor.ExecuteParallelForAllAsync(new ShardedLastChangeVectorForCollectionOperation(this, sub.Collection, DatabaseContext.DatabaseName))).LastChangeVectors;
+                        result.ChangeVectorsCollection = (await ShardExecutor.ExecuteParallelForAllAsync(new ShardedLastChangeVectorForCollectionOperation(HttpContext.Request, sub.Collection, DatabaseContext.DatabaseName))).LastChangeVectors;
                         foreach ((string key, string value) in result.ChangeVectorsCollection)
                         {
                             try

--- a/src/Raven.Server/Documents/Sharding/Operations/ShardedLastChangeVectorForCollectionOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/ShardedLastChangeVectorForCollectionOperation.cs
@@ -13,18 +13,17 @@ namespace Raven.Server.Documents.Sharding.Operations;
 
 public readonly struct ShardedLastChangeVectorForCollectionOperation : IShardedOperation<LastChangeVectorForCollectionResult, LastChangeVectorForCollectionCombinedResult>
 {
-    private readonly ShardedSubscriptionsHandler _shardedSubscriptionsHandler;
     private readonly string _collection;
     private readonly string _database;
 
-    public ShardedLastChangeVectorForCollectionOperation(ShardedSubscriptionsHandler shardedSubscriptionsHandler, string collection, string database)
+    public ShardedLastChangeVectorForCollectionOperation(HttpRequest request, string collection, string database)
     {
-        _shardedSubscriptionsHandler = shardedSubscriptionsHandler;
+        HttpRequest = request;
         _collection = collection ?? throw new ArgumentNullException(nameof(collection));
         _database = database ?? throw new ArgumentNullException(nameof(database));
     }
 
-    public HttpRequest HttpRequest => _shardedSubscriptionsHandler.HttpContext.Request;
+    public HttpRequest HttpRequest { get; }
 
     public LastChangeVectorForCollectionCombinedResult Combine(Dictionary<int, ShardExecutionResult<LastChangeVectorForCollectionResult>> results)
     {

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
@@ -47,24 +47,17 @@ public class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJsonReade
     {
         SendBatchToClientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         ConfirmFromShardSubscriptionConnectionTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        
+
         ReturnContext = batch.ReturnContext;
         Context = batch.Context;
         batch.ReturnContext = null; // move the release responsibility to the OrchestratedSubscriptionProcessor
         batch.Context = null;
 
-        try
-        {
-            await InitializeDocumentIncludesAsync(batch);
-            await base.InitializeAsync(batch);
 
-            LastSentChangeVectorInBatch = null;
-        }
-        catch (Exception e)
-        {
-            SetException(e);
-            throw;
-        }
+        await InitializeDocumentIncludesAsync(batch);
+        await base.InitializeAsync(batch);
+
+        LastSentChangeVectorInBatch = null;
     }
 
     internal async ValueTask InitializeDocumentIncludesAsync(BatchFromServer batchFromServer)

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
             }
         }
 
-        internal override async Task SendAckAsync(ShardedSubscriptionBatch batch, Stream stream, JsonOperationContext context, CancellationToken token)
+        protected override async Task SendAckAsync(ShardedSubscriptionBatch batch, Stream stream, JsonOperationContext context, CancellationToken token)
         {
             try
             {

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -33,19 +33,6 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
             };
         }
 
-        internal override async Task<BatchFromServer> ReadSingleSubscriptionBatchFromServerAsync(JsonContextPool contextPool, Stream tcpStream, JsonOperationContext.MemoryBuffer buffer, ShardedSubscriptionBatch batch)
-        {
-            try
-            {
-                return await base.ReadSingleSubscriptionBatchFromServerAsync(contextPool, tcpStream, buffer, batch);
-            }
-            catch (Exception e)
-            {
-                batch.SetException(e);
-                throw;
-            }
-        }
-
         internal override async Task<BatchFromServer> PrepareBatchAsync(JsonContextPool contextPool, Stream tcpStreamCopy, JsonOperationContext.MemoryBuffer buffer,
             ShardedSubscriptionBatch batch, Task notifiedSubscriber)
         {

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -121,9 +121,9 @@ public class SubscriptionConnectionsStateOrchestrator : AbstractSubscriptionConn
         _databaseContext.SubscriptionsStorage.DropSubscriptionConnections(SubscriptionId, e);
     }
 
-    public override async Task HandleConnectionException(OrchestratedSubscriptionConnection connection, Exception e)
+    public override async Task HandleConnectionExceptionAsync(OrchestratedSubscriptionConnection connection, Exception e)
     {
-        await base.HandleConnectionException(connection, e);
+        await base.HandleConnectionExceptionAsync(connection, e);
         if (e is SubscriptionException se and not SubscriptionChangeVectorUpdateConcurrencyException and not SubscriptionInUseException)
         {
             DropSubscription(se);

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -70,6 +70,7 @@ public class SubscriptionConnectionsStateOrchestrator : AbstractSubscriptionConn
 
     private void StartShardSubscriptionWorkers()
     {
+        ClosedDueToNoDocs = 0;
         foreach (var shardNumber in _databaseContext.ShardsTopology.Keys)
         {
             var re = _databaseContext.ShardExecutor.GetRequestExecutorAt(shardNumber);

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
@@ -575,7 +575,7 @@ public abstract class AbstractSubscriptionConnectionsState<TSubscriptionConnecti
         }
     }
 
-    public virtual async Task HandleConnectionException(TSubscriptionConnection connection, Exception e)
+    public virtual async Task HandleConnectionExceptionAsync(TSubscriptionConnection connection, Exception e)
     {
         switch (e)
         {

--- a/src/Raven.Server/Documents/Subscriptions/DummySubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/DummySubscriptionConnectionsState.cs
@@ -12,7 +12,6 @@ public class DummySubscriptionConnectionsState : SubscriptionConnectionsState
         _subscriptionName = "dummy";
 
         LastChangeVectorSent = state.ChangeVectorForNextBatchStartingPoint;
-        PreviouslyRecordedChangeVector = LastChangeVectorSent;
         Query = state.Query;
     }
 

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/SubscriptionConnectionsStateForShard.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/SubscriptionConnectionsStateForShard.cs
@@ -41,6 +41,7 @@ public class SubscriptionConnectionsStateForShard : SubscriptionConnectionsState
         var cmd = base.GetAcknowledgeSubscriptionBatchCommand(changeVector, batchId, docsToResend);
         cmd.ShardName = ShardedDocumentDatabase.Name;
         cmd.DatabaseName = ShardedDocumentDatabase.ShardedDatabaseName;
+        cmd.LastKnownSubscriptionChangeVector = LastChangeVectorSent;
         return cmd;
     }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
@@ -111,7 +111,7 @@ public class SubscriptionBinder<TState, TConnection, TIncludeCommand> : ISubscri
             }
             catch (Exception e)
             {
-                await _subscriptionConnectionsState.HandleConnectionException(_connection, e);
+                await _subscriptionConnectionsState.HandleConnectionExceptionAsync(_connection, e);
             }
             finally
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
@@ -109,18 +109,9 @@ public class SubscriptionBinder<TState, TConnection, TIncludeCommand> : ISubscri
                     _storage.ReleaseSubscriptionsSemaphore();
                 }
             }
-            catch (SubscriptionChangeVectorUpdateConcurrencyException e)
-            {
-                _subscriptionConnectionsState.DropSubscription(e);
-                await _connection.ReportExceptionAsync(SubscriptionError.Error, e);
-            }
-            catch (SubscriptionInUseException e)
-            {
-                await _connection.ReportExceptionAsync(SubscriptionError.ConnectionRejected, e);
-            }
             catch (Exception e)
             {
-                await _connection.ReportExceptionAsync(SubscriptionError.Error, e);
+                await _subscriptionConnectionsState.HandleConnectionException(_connection, e);
             }
             finally
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -914,6 +914,8 @@ namespace Raven.Server.Documents.Subscriptions
 
         private async Task<Task<SubscriptionConnectionClientMessage>> WaitForClientAck(Task<SubscriptionConnectionClientMessage> replyFromClientTask)
         {
+            AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info, "Waiting for acknowledge from client."));
+
             SubscriptionConnectionClientMessage clientReply;
             while (true)
             {
@@ -942,6 +944,7 @@ namespace Raven.Server.Documents.Subscriptions
             {
                 case SubscriptionConnectionClientMessage.MessageType.Acknowledge:
                 {
+                    AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info, "Got acknowledge from client."));
                     await OnClientAckAsync(clientReply.ChangeVector);
                     break;
                 }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +16,6 @@ using Raven.Server.ServerWide.Commands.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
-using Sparrow.Server.Utils;
 using Voron;
 
 namespace Raven.Server.Documents.Subscriptions
@@ -82,8 +80,6 @@ namespace Raven.Server.Documents.Subscriptions
                 // update the subscription data only on new concurrent connection or regular connection
                 SetLastChangeVectorSent(connection);
 
-                PreviouslyRecordedChangeVector = LastChangeVectorSent;
-                
                 using (var old = _disposableNotificationsRegistration)
                 {
                     _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
@@ -208,7 +204,7 @@ namespace Raven.Server.Documents.Subscriptions
                 SubscriptionId, 
                 SubscriptionName, 
                 list, 
-                PreviouslyRecordedChangeVector, 
+                LastChangeVectorSent, 
                 lastRecordedChangeVector, 
                 _server.NodeTag, 
                 _server.LicenseManager.HasHighlyAvailableTasks(), 
@@ -230,7 +226,7 @@ namespace Raven.Server.Documents.Subscriptions
                 SubscriptionId, 
                 SubscriptionName, 
                 list, 
-                PreviouslyRecordedChangeVector, 
+                LastChangeVectorSent, 
                 lastRecordedChangeVector, 
                 _server.NodeTag, 
                 _server.LicenseManager.HasHighlyAvailableTasks(), 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -426,9 +426,6 @@ namespace Raven.Server.Documents.TcpHandlers
             _subscriptionConnectionsState.LastChangeVectorSent = ChangeVectorUtils.MergeVectors(
                 _subscriptionConnectionsState.LastChangeVectorSent,
                 lastChangeVectorSentInThisBatch);
-
-            _subscriptionConnectionsState.PreviouslyRecordedChangeVector =
-                ChangeVectorUtils.MergeVectors(_subscriptionConnectionsState.PreviouslyRecordedChangeVector, lastChangeVectorSentInThisBatch);
         }
 
         protected virtual void FillIncludedDocuments(DatabaseIncludesCommandImpl includeDocumentsCommand, List<Document> includes)

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -137,6 +137,10 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                     shouldUpdateChangeVector = false;
                 }
 
+                if (string.IsNullOrEmpty(ShardName) == false)
+                {
+                }
+
                 CheckConcurrencyForBatchCv(subscriptionState, subscriptionName);
 
                 foreach (var deletedId in Deleted)

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -137,10 +137,6 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                     shouldUpdateChangeVector = false;
                 }
 
-                if (string.IsNullOrEmpty(ShardName) == false)
-                {
-                }
-
                 CheckConcurrencyForBatchCv(subscriptionState, subscriptionName);
 
                 foreach (var deletedId in Deleted)

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -1145,7 +1145,6 @@ namespace SlowTests.Sharding.Subscriptions
 
 
         [RavenFact(RavenTestCategory.Subscriptions | RavenTestCategory.Sharding)]
-
         public async Task AbortWhenNoDocsLeft2()
         {
             using (var store = Sharding.GetDocumentStore())

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -560,6 +560,14 @@ namespace FastTests
                 try
                 {
                     var currentVal = act();
+                    if (expectedVal == null)
+                    {
+                        if (currentVal == null)
+                            return default;
+
+                        continue;
+                    }
+
                     if (expectedVal.Equals(currentVal))
                     {
                         return currentVal;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20207

### Additional description

Add ability to set the CV to LastDocument (and ability to set CV by admin (only serverside))
Fix possible stale of subscription, wasn't setting result to the tcs of subscription batch

### Type of change


- Regression bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
