### PR TITLE
HRINT-3161 Pull latest docker image before build

### DIFF
--- a/scripts/linux/pkg/deb/build-deb.sh
+++ b/scripts/linux/pkg/deb/build-deb.sh
@@ -37,6 +37,7 @@ fi
 
 DEB_BUILD_ENV_IMAGE="ravendb-deb_ubuntu_$DEB_ARCHITECTURE"
 
+docker pull --platform $DOCKER_BUILDPLATFORM ubuntu:$DISTRO_VERSION
 docker build \
     --platform $DOCKER_BUILDPLATFORM \
     --build-arg "DISTRO_VERSION_NAME=$DISTRO_VERSION_NAME" \

--- a/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
+++ b/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
@@ -15,6 +15,9 @@ RUN apt update \
     && apt-get -y dist-upgrade \
     && apt install -y curl wget apt-transport-https 
 
+# https://stackoverflow.com/a/70771488
+RUN for i in /etc/ssl/certs/*.pem; do HASH=$(openssl x509 -hash -noout -in $i); if [ ! -f /etc/ssl/certs/$HASH.0 ]; then ln -s $(basename $i) /etc/ssl/certs/$HASH.0; fi; done
+
 ENV DEBEMAIL=support@ravendb.net DEBFULLNAME="Hibernating Rhinos LTD" 
 ENV DEB_ARCHITECTURE="" DOTNET_RUNTIME_VERSION="" DOTNET_DEPS_VERSION=""
 ENV RAVEN_PLATFORM="" RAVEN_ARCH=""


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-3161

### Additional description

Needs to be merged to v5.4 and v6.0 too.