### PR TITLE
RavenDB-20249 Corax projections - take value from index by default.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3210,7 +3210,7 @@ namespace Raven.Server.Documents.Indexes
                                 IncludeTimeSeriesCommand includeTimeSeriesCommand = null;
                                 IncludeRevisionsCommand includeRevisionsCommand = new(DocumentDatabase, queryContext.Documents, query.Metadata.RevisionIncludes);
 
-                                var fieldsToFetch = new FieldsToFetch(query, Definition);
+                                var fieldsToFetch = new FieldsToFetch(query, Definition, SearchEngineType);
 
                                 var includeDocumentsCommand = new IncludeDocumentsCommand(
                                     DocumentDatabase.DocumentsStorage, queryContext.Documents,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
@@ -324,7 +324,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
 
             if (_count.Spatials > 0)
             {
-                type |= DataType.Spatials;
+                type |= _count.Spatials == 1 
+                    ? DataType.SingleSpatial 
+                    : DataType.Spatials;
             }
 
             if (_count.Raws > 0)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/WriterScopes/EnumerableWriterScope.cs
@@ -324,16 +324,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax.WriterScopes
 
             if (_count.Spatials > 0)
             {
-                type |= _count.Spatials == 1 
-                    ? DataType.SingleSpatial 
-                    : DataType.Spatials;
+                type |= DataType.Spatials;
             }
 
             if (_count.Raws > 0)
             {
-                type |= _count.Raws == 1 
-                    ? DataType.SingleRaw 
-                    : DataType.Raws;
+                type |= DataType.Raws;
             }
 
             if (type == DataType.Tuples)

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -555,7 +555,8 @@ namespace Raven.Server.Documents.Queries.Results
 
         private bool CoraxTryExtractValueFromIndex(FieldsToFetch.FieldToFetch fieldToFetch, ref RetrieverInput retrieverInput, DynamicJsonValue toFill)
         {
-            if (fieldToFetch.CanExtractFromIndex == false && fieldToFetch.IsDocumentId == false) //in case of ID we can always give it for user.
+            // We can always perform projection of ID from Index.
+            if (fieldToFetch.CanExtractFromIndex == false && fieldToFetch.IsDocumentId == false)
                 return false;
 
 

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -560,18 +560,15 @@ namespace Raven.Server.Documents.Queries.Results
 
             var name = fieldToFetch.ProjectedName ?? fieldToFetch.Name.Value;
 
-            if (FieldsToFetch.IndexFields.ContainsKey(fieldToFetch.Name.Value) == false && retrieverInput.KnownFields.ContainsField(fieldToFetch.Name.Value) == false)
+            object value = null;
+            if (retrieverInput.KnownFields.TryGetByFieldName(name, out var binding) == false)
+            {
+                if (TryGetValueFromCoraxIndex(_context, name, Corax.Constants.IndexWriter.DynamicField, ref retrieverInput, out value) == false)
+                    return false;
+            }
+            else if (TryGetValueFromCoraxIndex(_context, name, binding.FieldId, ref retrieverInput, out value) == false)
                 return false;
-
-            int fieldId = -1;
-            if (FieldsToFetch.IndexFields.TryGetValue(fieldToFetch.Name.Value, out var indexField))
-                fieldId = indexField.Id;
-            else if (fieldToFetch.Name.Value.Equals(Constants.Documents.Indexing.Fields.DocumentIdFieldName))
-                fieldId = 0;
             
-            if (fieldId < 0 || TryGetValueFromCoraxIndex(_context, name, fieldId, ref retrieverInput, out var value) == false)
-                return false;
-
             toFill[name] = value;
             return true;
         }

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -558,18 +558,19 @@ namespace Raven.Server.Documents.Queries.Results
             if (fieldToFetch.CanExtractFromIndex == false && fieldToFetch.IsDocumentId == false) //in case of ID we can always give it for user.
                 return false;
 
-            var name = fieldToFetch.ProjectedName ?? fieldToFetch.Name.Value;
 
             object value = null;
-            if (retrieverInput.KnownFields.TryGetByFieldName(name, out var binding) == false)
+            if (retrieverInput.KnownFields.TryGetByFieldName(fieldToFetch.Name.Value, out var binding) == false)
             {
-                if (TryGetValueFromCoraxIndex(_context, name, Corax.Constants.IndexWriter.DynamicField, ref retrieverInput, out value) == false)
+                if (TryGetValueFromCoraxIndex(_context, fieldToFetch.Name.Value, Corax.Constants.IndexWriter.DynamicField, ref retrieverInput, out value) == false)
                     return false;
             }
-            else if (TryGetValueFromCoraxIndex(_context, name, binding.FieldId, ref retrieverInput, out value) == false)
+            else if (TryGetValueFromCoraxIndex(_context, fieldToFetch.Name.Value, binding.FieldId, ref retrieverInput, out value) == false)
                 return false;
             
+            var name = fieldToFetch.ProjectedName ?? fieldToFetch.Name.Value;
             toFill[name] = value;
+            
             return true;
         }
 

--- a/test/FastTests/Corax/CoraxProjections.cs
+++ b/test/FastTests/Corax/CoraxProjections.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Counters;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class CoraxProjections : RavenTestBase
+{
+    public CoraxProjections(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task MapReduceIndex(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        CreateSampleDb<MyMapReduceIndex>(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session
+            .Query<MyMapReduceIndex.Result, MyMapReduceIndex>()
+            .OrderByDescending(i => i.Count)
+            .Select(i => i.Count)
+            .ToArrayAsync();
+
+        var expected = new int[] {-1, -2, -3};
+        Assert.Equal(expected, results);
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromIndex})]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromDocument})]
+    public async Task MapIndex(Options options, ProjectionBehavior projectionBehavior)
+    {
+        using var store = GetDocumentStore(options);
+        CreateSampleDb<MyMapIndex>(store);
+
+        using var session = store.OpenAsyncSession();
+        var results = await session
+            .Query<Dto, MyMapIndex>()
+            .Customize(x => x.Projection(projectionBehavior))
+            .OrderByDescending(i => i.Count)
+            .Select(i => (int?)i.Count)
+            .ToArrayAsync();
+
+        var expected = (options.SearchEngineMode, projectionBehavior) switch
+        {
+            (RavenSearchEngineMode.Lucene, ProjectionBehavior.FromIndex) => new int?[] {null, null, null},
+            (_, ProjectionBehavior.FromDocument) => new int?[] {1, 2, 3},
+            (RavenSearchEngineMode.Corax, ProjectionBehavior.FromIndex) => new int?[] {-1, -2, -3},
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        Assert.Equal(expected, results);
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromIndex})]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromDocument})]
+    public async Task CanProjectFromIndexInAutoIndexes(Options options, ProjectionBehavior projectionBehavior)
+    {
+        using var store = GetDocumentStore(options);
+        DeployData(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session
+                .Query<Dto>()
+                .Customize(i => i.WaitForNonStaleResults())
+                .Where(i => i.Name == "maciej")
+                .Select(i => new {i.Id, i.Name})
+                .ToListAsync();
+
+            Assert.Equal("Maciej", results[0].Name);
+
+            await store.Maintenance.SendAsync(new StopIndexingOperation());
+
+            var doc = await session.LoadAsync<Dto>(results[0].Id);
+            doc.Name = "Second";
+            await session.StoreAsync(doc);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session
+                .Query<Dto>()
+                .Customize(x => x.Projection(projectionBehavior))
+                .Where(i => i.Name == "maciej")
+                .Select(i => i.Name)
+                .ToListAsync();
+
+            var expected = (options.SearchEngineMode, projectionBehavior) switch
+            {
+                (RavenSearchEngineMode.Lucene, ProjectionBehavior.FromIndex) => null,
+                (RavenSearchEngineMode.Lucene, ProjectionBehavior.FromDocument) => "Second",
+                (RavenSearchEngineMode.Corax, ProjectionBehavior.FromIndex) => "Maciej",
+                (RavenSearchEngineMode.Corax, ProjectionBehavior.FromDocument) => "Second",
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            Assert.Equal(expected, results[0]);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromIndex})]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {ProjectionBehavior.FromDocument})]
+    public async Task CanProjectFromDynamicField(Options options, ProjectionBehavior projectionBehavior)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new DtoWithDict() {Values = new Dictionary<string, string>() {{nameof(Dto.Name), "Maciej"}}, Name = "Jan"});
+            await session.SaveChangesAsync();
+        }
+
+        await new DynamicIndexProjection().ExecuteAsync(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var result = await session
+                .Query<DtoWithDict, DynamicIndexProjection>()
+                .Customize(x => x.Projection(projectionBehavior))
+                .Select(i => i.Name)
+                .SingleAsync();
+
+
+            var expected = (options.SearchEngineMode, projectionBehavior) switch
+            {
+                (_, ProjectionBehavior.FromDocument) => "Jan",
+                (RavenSearchEngineMode.Corax, ProjectionBehavior.FromIndex) => "Maciej",
+                (RavenSearchEngineMode.Lucene, ProjectionBehavior.FromIndex) => null,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            Assert.Equal(expected, result);
+        }
+    }
+
+    private void CreateSampleDb<TIndex>(IDocumentStore store) where TIndex : AbstractIndexCreationTask, new()
+    {
+        DeployData(store);
+        var index = new TIndex();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    private void DeployData(IDocumentStore store)
+    {
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto() {Name = "Maciej", Count = 1});
+            session.Store(new Dto() {Name = "Gracjan", Count = 2});
+            session.Store(new Dto() {Name = "Marcin", Count = 3});
+            session.SaveChanges();
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int Count { get; set; }
+    }
+
+    private class DtoWithDict : Dto
+    {
+        public Dictionary<string, string> Values;
+    }
+
+
+    private class MyMapIndex : AbstractIndexCreationTask<Dto>
+    {
+        public MyMapIndex()
+        {
+            Map = dtos => dtos.Select(i => new {i.Id, i.Name, Count = i.Count * (-1)});
+        }
+    }
+
+    private class DynamicIndexProjection : AbstractIndexCreationTask<DtoWithDict>
+    {
+        public DynamicIndexProjection()
+        {
+            Map = dicts => dicts.Select(i => new {_ = i.Values.Select(z => CreateField(z.Key, z.Value))});
+        }
+    }
+
+    private class MyMapReduceIndex : AbstractIndexCreationTask<Dto, MyMapReduceIndex.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        public MyMapReduceIndex()
+        {
+            Map = dtos => dtos.Select(i => new Result() {Name = i.Name, Count = i.Count});
+            Reduce = results => results.GroupBy(i => i.Name).Select(g => new Result() {Name = g.Key, Count = -1 * g.Sum(i => i.Count)});
+        }
+    }
+
+    public class MyCounterIndex : AbstractCountersIndexCreationTask<Company>
+    {
+        public MyCounterIndex()
+        {
+            AddMap("HeartRate", counters => from counter in counters
+                select new {HeartBeat = counter.Value, Name = counter.Name, User = counter.DocumentId});
+        }
+    }
+}

--- a/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_StrongSyntax.cs
@@ -25,19 +25,7 @@ namespace SlowTests.Client.Indexing.Counters
         {
         }
 
-        private class MyCounterIndex : AbstractCountersIndexCreationTask<Company>
-        {
-            public MyCounterIndex()
-            {
-                AddMap("HeartRate", counters => from counter in counters
-                                                select new
-                                                {
-                                                    HeartBeat = counter.Value,
-                                                    Name = counter.Name,
-                                                    User = counter.DocumentId
-                                                });
-            }
-        }
+
 
         private class MyCounterIndex_Load : AbstractCountersIndexCreationTask<Company>
         {
@@ -263,7 +251,7 @@ namespace SlowTests.Client.Indexing.Counters
 
                 store.Maintenance.Send(new StopIndexingOperation());
 
-                var countersIndex = new MyCounterIndex();
+                var countersIndex = new FastTests.Corax.CoraxProjections.MyCounterIndex();
                 var indexDefinition = countersIndex.CreateIndexDefinition();
                 RavenTestHelper.AssertEqualRespectingNewLines("counters.Companies.HeartRate.Select(counter => new {\r\n    HeartBeat = counter.Value,\r\n    Name = counter.Name,\r\n    User = counter.DocumentId\r\n})", indexDefinition.Maps.First());
 

--- a/test/SlowTests/Issues/RavenDB-11480.cs
+++ b/test/SlowTests/Issues/RavenDB-11480.cs
@@ -134,8 +134,9 @@ namespace SlowTests.Issues
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "Corax do projection from index by default")]
         public void IndexWithDynamicFieldsShouldNotTryToExtractBySourceAliasIfFieldIsNotStored(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-17061.cs
+++ b/test/SlowTests/Issues/RavenDB-17061.cs
@@ -175,7 +175,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Can_project_when_mixed_stored_options_in_index(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -228,7 +228,7 @@ namespace SlowTests.Issues
                     session.Delete(userId);
                     await session.SaveChangesAsync();
                 }
-WaitForUserToContinueTheTest(store);
+
                 using (var session = store.OpenAsyncSession())
                 {
                     var users = await session.Query<User, UserIndexPartialStore>()
@@ -237,7 +237,8 @@ WaitForUserToContinueTheTest(store);
                         .Select(user => new
                         {
                             user.Name, // stored field
-                            user.LastName // not stored field
+                            user.LastName, // not stored field
+                            user.AddressId //made-up field for corax, has no impact on lucene projection
                         })
                         .ToListAsync();
 

--- a/test/SlowTests/Issues/RavenDB_10504.cs
+++ b/test/SlowTests/Issues/RavenDB_10504.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Indexes;
@@ -57,6 +58,10 @@ namespace SlowTests.Issues
                     session.Advanced.WaitForIndexesAfterSaveChanges(indexes: new[] { nameof(DocumentIndex) });
                     session.SaveChanges();
                 }
+                
+                var idComparer = options.SearchEngineMode is RavenSearchEngineMode.Corax 
+                    ? StringComparer.OrdinalIgnoreCase 
+                    : StringComparer.Ordinal;
 
                 using (var session = store.OpenSession())
                 {
@@ -69,7 +74,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(1, docs.Count);
                     Assert.NotNull(docs[0]);
-                    Assert.Equal(doc.Id, docs[0].Id);
+                    Assert.Equal(doc.Id, docs[0].Id, comparer: idComparer);
                     Assert.Null(docs[0].Name);
                 }
 
@@ -84,7 +89,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(1, docs.Count);
                     Assert.NotNull(docs[0]);
-                    Assert.Equal(doc.Id, docs[0].Id);
+                    Assert.Equal(doc.Id, docs[0].Id, comparer: idComparer);
                     Assert.Null(docs[0].Name);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_2994.cs
+++ b/test/SlowTests/Issues/RavenDB_2994.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Globalization;
 using System.Linq;
 using FastTests;
@@ -118,7 +119,9 @@ namespace SlowTests.Issues
                 }
 
                 Indexes.WaitForIndexing(store);
-
+                var idComparer = options.SearchEngineMode is RavenSearchEngineMode.Corax 
+                    ? StringComparer.OrdinalIgnoreCase 
+                    : StringComparer.Ordinal;
                 using (var session = store.OpenSession())
                 {
                     var items = session
@@ -128,7 +131,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(2, items.Count);
 
-                    var item1 = items.Single(x => x.Id == "items/1-A");
+                    var item1 = items.Single(x => idComparer.Compare(x.Id, "items/1-A") == 0);
 
                     Assert.Equal(dec, item1.Decimal1);
                     Assert.Equal(dec, item1.Decimal2);
@@ -142,7 +145,7 @@ namespace SlowTests.Issues
                     Assert.Equal(l, item1.Long1);
                     Assert.Equal(l, item1.Long2);
 
-                    var item2 = items.Single(x => x.Id == "items/2-A");
+                    var item2 = items.Single(x => idComparer.Compare(x.Id, "items/2-A") == 0);
 
                     Assert.Equal(default(decimal), item2.Decimal1);
                     Assert.Equal(-1, item2.Decimal2);

--- a/test/SlowTests/Tests/Linq/OfTypeSuppor3.cs
+++ b/test/SlowTests/Tests/Linq/OfTypeSuppor3.cs
@@ -34,6 +34,7 @@ namespace SlowTests.Tests.Linq
 
                 store.ExecuteIndex(new Index());
 
+                Indexes.WaitForIndexing(store);
                 using (var session = store.OpenSession())
                 {
                     var item = session.Query<Index.Result, Index>()

--- a/test/Tests.Infrastructure/RavenDataAttribute.cs
+++ b/test/Tests.Infrastructure/RavenDataAttribute.cs
@@ -75,6 +75,7 @@ public class RavenDataAttribute : DataAttribute
         if (mode.HasFlag(RavenSearchEngineMode.Corax))
         {
             var coraxOptions = options.Clone();
+            coraxOptions.SearchEngineMode = RavenSearchEngineMode.Corax;
 
             coraxOptions.ModifyDatabaseRecord += record =>
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20249

### Additional description

The first idea was to set `FieldStorage` as `Yes` in `IndexDefinition` when opening the index (this was happening at runtime since writing to DatabaseRecord goes through Cluster), but it turned out that this solution had some disadvantages. The biggest one was the complexity of the code, as each type of index had its own implementation of `CreateNew/Open/Update`, which led to duplicating the same code in many places and some tricks depending on the type of index to set it right. For example, in MapIndex, we could do this through the GetFields function, but in the case of AutoIndexes, we had to iterate over `IndexFields` and replace the storage option. The second problem, in this case, was the lack of support for dynamic field projections, as we do not have them on any list (at least for Corax).

During the conversation with @arekpalinski , we decided to simply ignore FieldStorage if the index is built on Corax, for this purpose I modified GetFieldsToFetch.

However, I was not able to throw an exception when someone explicitly set `FieldStorage` to `No`, because the definition is filtered higher up and does not receive information if someone set it (whether it comes as a default value). However, I think that Studio, which does not allow changing Store, shows the user quite strongly that this config field is not used by the engine.


### Type of change

- New feature

### How risky is the change?

- High

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
