### PR TITLE
RavenDB-20125 & RavenDB-19968 Ensure that `Indexes`  methods are waiting for exceptions in test.

### DIFF
--- a/test/SlowTests/Issues/RavenDB_18357.cs
+++ b/test/SlowTests/Issues/RavenDB_18357.cs
@@ -70,7 +70,16 @@ public class RavenDB_18357 : RavenTestBase
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void StaticIndexShouldThrowWhenTryingToIndexComplexObjectAndIndexFieldOptionsWereExplicitlySetInDefinition(Options options)
     {
-        using var store = GetDocumentStore(options);
+        var modifiedOptions = new Options()
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                options.ModifyDatabaseRecord(record);
+                record.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+            }
+        };
+
+        using var store = GetDocumentStore(modifiedOptions);
         {
             using var s = store.OpenSession();
             s.Store(new Input {Nested = new NestedItem {Name = "Matt"}});
@@ -79,8 +88,8 @@ public class RavenDB_18357 : RavenTestBase
         var index = new InputIndex(setSearchOption: true);
 
         index.Execute(store);
-        Indexes.WaitForIndexing(store);
-        var errors = Indexes.WaitForIndexingErrors(store);
+        Indexes.WaitForIndexing(store, allowErrors: true);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: true);
         Assert.NotEmpty(errors);
         Assert.NotEmpty(errors[0].Errors);
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20125 
https://issues.hibernatingrhinos.com/issue/RavenDB-19968

### Additional description

Test fix.

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
