### PR TITLE
RavenDB-20250 Client configuration - allow to select both options: 'U…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
@@ -86,22 +86,7 @@ class clientConfigurationModel {
            }
         });
         
-        this.isDefined.subscribe((changesList) => {
-            const change = changesList[0];
-            
-            if (_.includes(this.isDefined(), "readBalanceBehavior")) {
-                if (change.status === "added" && change.value === "useSessionContextForLoadBehavior") {
-                    _.remove(this.isDefined(), x => x === "readBalanceBehavior");
-                }
-            }
-
-            if (_.includes(this.isDefined(), "useSessionContextForLoadBehavior")) {
-                if (change.status === "added" && change.value === "readBalanceBehavior") {
-                    _.remove(this.isDefined(), x => x === "useSessionContextForLoadBehavior");
-                    this.setLoadBalanceSeed(false);
-                }
-            }
-
+        this.isDefined.subscribe(() => {
             if (!_.includes(this.isDefined(), "useSessionContextForLoadBehavior")) {
                 this.setLoadBalanceSeed(false);
             }


### PR DESCRIPTION
…se Session Context for Load Balancing' and 'Read balance behavior'

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20250 

### Additional description

 allow to select both options: 'Use Session Context for Load Balancing' and 'Read balance behavior'

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

