### PR TITLE
RavenDB-20222 when querying counters or timeseries index we need to use ConstantComparer by default, because there is no @last-modified field available

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -207,7 +207,7 @@ public class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQueryResul
         if (Query.Metadata.Query.Filter == null)
             return;
 
-        if (IsMapReduceIndex == false && IsAutoMapReduceQuery == false)
+        if (IndexType.IsMapReduce() == false && IsAutoMapReduceQuery == false)
             return;
 
         using (scope?.For(nameof(QueryTimingsScope.Names.Filter)))

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using NetTopologySuite.Algorithm;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Timings;
@@ -75,7 +76,7 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
 
     protected void ReduceResults(ref TCombinedResult result, QueryTimingsScope scope)
     {
-        if (IsMapReduceIndex == false && IsAutoMapReduceQuery == false)
+        if (IndexType.IsMapReduce() == false && IsAutoMapReduceQuery == false)
             return;
 
         using (scope?.For(nameof(QueryTimingsScope.Names.Reduce)))

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Commands.Streaming;
 using Raven.Server.Documents.Queries;
@@ -36,7 +37,7 @@ namespace Raven.Server.Documents.Sharding.Queries
         {
             base.AssertQueryExecution();
 
-            if (IsAutoMapReduceQuery || IsMapReduceIndex)
+            if (IsAutoMapReduceQuery || IndexType.IsMapReduce())
                 throw new NotSupportedInShardingException("MapReduce is not supported in sharded streaming queries");
 
             if (Query.Metadata.HasIncludeOrLoad)

--- a/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
@@ -1154,8 +1154,8 @@ return ({
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes | RavenTestCategory.Counters | RavenTestCategory.JavaScript)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public async Task BasicMultiMapIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1178,7 +1178,7 @@ return ({
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -1210,6 +1210,18 @@ return ({
                         .ToListAsync();
 
                     Assert.Equal(3, results.Count);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var results = await session.Advanced.AsyncDocumentQuery<MyMultiMapCounterIndex.Result, MyMultiMapCounterIndex>()
+                        .OrderByDescending(x => x.HeartBeat)
+                        .ToListAsync();
+
+                    var orderedResults = results.OrderByDescending(x => x.HeartBeat);
+
+                    Assert.Equal(3, results.Count);
+                    Assert.Equal(orderedResults, results);
                 }
             }
         }

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
@@ -1207,8 +1207,8 @@ return ({
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.JavaScript)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public async Task BasicMultiMapIndex(Options options)
         {
             var now = DateTime.UtcNow.Date;
@@ -1233,7 +1233,7 @@ return ({
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -1265,6 +1265,18 @@ return ({
                         .ToListAsync();
 
                     Assert.Equal(3, results.Count);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var results = await session.Advanced.AsyncDocumentQuery<MyMultiMapTsIndex.Result, MyMultiMapTsIndex>()
+                        .OrderByDescending(x => x.HeartBeat)
+                        .ToListAsync();
+
+                    var orderedResults = results.OrderByDescending(x => x.HeartBeat);
+
+                    Assert.Equal(3, results.Count);
+                    Assert.Equal(orderedResults, results);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20222