### PR TITLE
RavenDB-20286 Support for MySqlConnector in SQL ETL and Import from SQL

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionStringParser.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionStringParser.cs
@@ -29,6 +29,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
                         server += $":{postgrePort}";
                     break;
                 case SqlProvider.MySqlClient:
+                case SqlProvider.MySqlConnectorFactory:
                     database = GetConnectionStringValue(connectionString, new[] { "Database", "Initial Catalog" });
 
                     if (database == null)

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -82,6 +82,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
                     return false;
 
                 case SqlProvider.MySqlClient:
+                case SqlProvider.MySqlConnectorFactory:
                     encrypt = SqlConnectionStringParser.GetConnectionStringValue(Connection.ConnectionString, new[] { "Encrypt", "UseSSL" });
 
                     if (string.IsNullOrEmpty(encrypt) == false)

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProvider.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProvider.cs
@@ -8,6 +8,7 @@
         OracleClient,
         MySqlClient,
         SqlServerCe_4_0,
-        SqlServerCe_3_5
+        SqlServerCe_3_5,
+        MySqlConnectorFactory,
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
@@ -22,6 +22,8 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
                     return SqlProvider.OracleClient;
                 case "MySql.Data.MySqlClient":
                     return SqlProvider.MySqlClient;
+                case "MySqlConnector.MySqlConnectorFactory":
+                    return SqlProvider.MySqlConnectorFactory;
                 case "System.Data.SqlServerCe.3.5":
                     throw new NotImplementedException($"Factory '{factoryName}' is not implemented yet");
                     //return SqlProvider.SqlServerCe_3_5;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Data.Common;
 using System.Data.SqlClient;
-using MySql.Data.MySqlClient;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ETL.SQL;
@@ -19,7 +18,9 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                 case SqlProvider.Npgsql:
                     return NpgsqlFactory.Instance;
                 case SqlProvider.MySqlClient:
-                    return MySqlClientFactory.Instance;
+                    return MySql.Data.MySqlClient.MySqlClientFactory.Instance;
+                case SqlProvider.MySqlConnectorFactory:
+                    return MySqlConnector.MySqlConnectorFactory.Instance;
                 case SqlProvider.OracleClient:
                     return OracleClientFactory.Instance;
                 default:

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using MySql.Data.MySqlClient;
-using NpgsqlTypes;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Server.Documents.ETL.Providers.SQL.Test;
@@ -89,7 +86,10 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             param = new Npgsql.NpgsqlParameter();
                             break;
                         case SqlProvider.MySqlClient:
-                            param = new MySqlParameter();
+                            param = new MySql.Data.MySqlClient.MySqlParameter();
+                            break;
+                        case SqlProvider.MySqlConnectorFactory:
+                            param = new MySqlConnector.MySqlParameter();
                             break;
                         case SqlProvider.OracleClient:
                             param = new OracleParameter();

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using MySqlX.XDevAPI;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
 using Raven.Server.Web;

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -181,6 +181,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MySql.Data" Version="8.0.32.1" />
+    <PackageReference Include="MySqlConnector" Version="2.2.5" />
     <PackageReference Include="NCrontab.Advanced" Version="1.3.28" />
     <PackageReference Include="NEST" Version="7.17.5" />
     <PackageReference Include="Npgsql" Version="5.0.16" />

--- a/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
+++ b/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
@@ -14,10 +14,10 @@ namespace Raven.Server.SqlMigration
             {
                 case MigrationProvider.MsSQL:
                     return new MsSqlDatabaseMigrator(connectionString);
-                
-                case MigrationProvider.MySQL:
-                    return new MySqlDatabaseMigrator(connectionString);
-
+                case MigrationProvider.MySQL_MySql_Data:
+                    return new MySqlDatabaseMigrator(connectionString, "MySql.Data.MySqlClient");
+                case MigrationProvider.MySQL_MySqlConnector:
+                    return new MySqlDatabaseMigrator(connectionString, "MySqlConnector.MySqlConnectorFactory");
                 case MigrationProvider.NpgSQL:
                     return new NpgSqlDatabaseMigrator(connectionString);
 

--- a/src/Raven.Server/SqlMigration/MigrationProvider.cs
+++ b/src/Raven.Server/SqlMigration/MigrationProvider.cs
@@ -3,7 +3,8 @@
     public enum MigrationProvider
     {
         MsSQL,
-        MySQL,
+        MySQL_MySql_Data,
+        MySQL_MySqlConnector,
         NpgSQL,
         Oracle
     }

--- a/src/Raven.Server/SqlMigration/MySQL/MySqlDatabaseMigrator.Migration.cs
+++ b/src/Raven.Server/SqlMigration/MySQL/MySqlDatabaseMigrator.Migration.cs
@@ -4,10 +4,12 @@ namespace Raven.Server.SqlMigration.MySQL
 {
     internal partial class MySqlDatabaseMigrator : GenericDatabaseMigrator
     {
-        protected override string FactoryName => "MySql.Data.MySqlClient";
+        private readonly string _factoryName;
+        protected override string FactoryName => _factoryName;
 
-        public MySqlDatabaseMigrator(string connectionString) : base(connectionString)
+        public MySqlDatabaseMigrator(string connectionString, string factoryName) : base(connectionString)
         {
+            _factoryName = factoryName;
         }
 
         protected override string QuoteColumn(string columnName)

--- a/src/Raven.Server/Web/System/AdminDebugQueryClauseCacheHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDebugQueryClauseCacheHandler.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Google.Protobuf.WellKnownTypes;
 using Raven.Server.Documents.Queries.LuceneIntegration;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
@@ -11,6 +11,7 @@ class connectionStringSqlEtlModel extends connectionStringModel {
     static sqlProviders: Array<valueAndLabelItem<string, string> & { tooltip: string }> = [
         { value: "System.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
         { value: "MySql.Data.MySqlClient", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
+        { value: "MySqlConnector.MySqlConnectorFactory", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "Npgsql", label: "PostgreSQL", tooltip: sqlConnectionStringSyntax.npgsqlSyntax },
         { value: "Oracle.ManagedDataAccess.Client", label: "Oracle Database", tooltip: sqlConnectionStringSyntax.oracleSyntax },
     ];

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -6,8 +6,8 @@ import sqlColumn = require("models/database/tasks/sql/sqlColumn");
 import sqlReference = require("models/database/tasks/sql/sqlReference");
 
 class sqlMigration {
-    
-    static possibleProviders: Raven.Server.SqlMigration.MigrationProvider[] = ["MsSQL", "MySQL", "NpgSQL", "Oracle"];
+
+    static possibleProviders: Raven.Server.SqlMigration.MigrationProvider[] = ["MsSQL", "MySQL_MySql_Data", "MySQL_MySqlConnector", "NpgSQL", "Oracle"];
     
     databaseType = ko.observable<Raven.Server.SqlMigration.MigrationProvider>("MsSQL");
     binaryToAttachment = ko.observable<boolean>(true);
@@ -152,8 +152,10 @@ class sqlMigration {
         switch (type) {
             case "MsSQL":
                 return "Microsoft SQL Server (System.Data.SqlClient)";
-            case "MySQL":
+            case "MySQL_MySql_Data":
                 return "MySQL Server (MySql.Data.MySqlClient)";
+            case "MySQL_MySqlConnector":
+                return "MySQL Server (MySqlConnector.MySqlConnectorFactory)";
             case "NpgSQL":
                 return "PostgreSQL (Npgsql)";
             case "Oracle":
@@ -288,8 +290,10 @@ class sqlMigration {
 
     getFactoryName() {
         switch (this.databaseType()) {
-            case "MySQL":
+            case "MySQL_MySql_Data":
                 return "MySql.Data.MySqlClient";
+            case "MySQL_MySqlConnector":
+                return "MySqlConnector.MySqlConnectorFactory";
             case "MsSQL":
                 return "System.Data.SqlClient";
             case "NpgSQL":
@@ -308,7 +312,8 @@ class sqlMigration {
         }
         
         switch (this.databaseType()) {
-            case "MySQL":
+            case "MySQL_MySql_Data":
+            case "MySQL_MySqlConnector":
                 return this.mySql.connectionString();
                 
             case "MsSQL":
@@ -377,7 +382,8 @@ class sqlMigration {
 
     getValidationGroup(): KnockoutValidationGroup {
         switch (this.databaseType()) {
-            case "MySQL":
+            case "MySQL_MySql_Data":
+            case "MySQL_MySqlConnector":
                 return this.mySqlValidationGroup;
 
             case "MsSQL":

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromSql.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromSql.ts
@@ -413,7 +413,8 @@ class importDatabaseFromSql extends viewModelBase {
         switch (this.model.databaseType()) {
             case "MsSQL":
                 return "ace/mode/sqlserver";
-            case "MySQL":
+            case "MySQL_MySql_Data":
+            case "MySQL_MySqlConnector":
                 return "ace/mode/mysql";
             case "NpgSQL":
                 return "ace/mode/sql";

--- a/test/SlowTests/Issues/RavenDB_20286.cs
+++ b/test/SlowTests/Issues/RavenDB_20286.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using System.Reflection;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20286 : NoDisposalNeeded
+{
+    public RavenDB_20286(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void MustNotHaveMySqlConnectorUsing()
+    {
+        string currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string server = Path.Combine(currentDir, "../../../../../src/Raven.Server");
+
+        var csharpFiles = Directory.GetFiles(server, "*.cs", SearchOption.AllDirectories);
+
+        Assert.True(csharpFiles.Length > 0);
+
+        foreach (string filePath in csharpFiles)
+        {
+            using (var file = File.OpenText(filePath))
+            {
+                string line = file.ReadToEnd();
+
+                Assert.DoesNotContain("using MySql.Data.MySqlClient", line);
+                Assert.DoesNotContain("using MySqlConnector", line);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Migration/MySQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/MySQLSchemaTest.cs
@@ -14,11 +14,13 @@ namespace SlowTests.Server.Documents.Migration
         }
 
         [RequiresMySqlFact]
-        public void CanFetchSchema()
+        [InlineData(MigrationProvider.MySQL_MySql_Data)]
+        [InlineData(MigrationProvider.MySQL_MySqlConnector)]
+        public void CanFetchSchema(MigrationProvider provider)
         {
-            using (WithSqlDatabase(MigrationProvider.MySQL, out var connectionString, out string schemaName, includeData: false))
+            using (WithSqlDatabase(provider, out var connectionString, out string schemaName, includeData: false))
             {
-                var driver = DatabaseDriverDispatcher.CreateDriver(MigrationProvider.MySQL, connectionString);
+                var driver = DatabaseDriverDispatcher.CreateDriver(provider, connectionString);
                 var schema = driver.FindSchema();
                 Assert.NotNull(schema.CatalogName);
 

--- a/test/SlowTests/Server/Documents/Migration/MySQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/MySQLSchemaTest.cs
@@ -13,9 +13,8 @@ namespace SlowTests.Server.Documents.Migration
         {
         }
 
-        [RequiresMySqlFact]
-        [InlineData(MigrationProvider.MySQL_MySql_Data)]
-        [InlineData(MigrationProvider.MySQL_MySqlConnector)]
+        [Theory]
+        [RequiresMySqlInlineData]
         public void CanFetchSchema(MigrationProvider provider)
         {
             using (WithSqlDatabase(provider, out var connectionString, out string schemaName, includeData: false))

--- a/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
+++ b/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using FastTests;
-using MySql.Data.MySqlClient;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Server.SqlMigration;
@@ -74,12 +75,25 @@ namespace SlowTests.Server.Documents.Migration
         {
             switch (provider)
             {
-                case MigrationProvider.MySQL:
+                case MigrationProvider.MySQL_MySql_Data:
                 {
-                    using (var connection = new MySqlConnection(connectionString))
+                    using (var connection = new MySql.Data.MySqlClient.MySqlConnection(connectionString))
                     {
                         connection.Open();
-                        using (var cmd = new MySqlCommand(query, connection))
+                        using (var cmd = new MySql.Data.MySqlClient.MySqlCommand(query, connection))
+                        {
+                            cmd.ExecuteNonQuery();
+                        }
+                    }
+
+                    break;
+                }
+                case MigrationProvider.MySQL_MySqlConnector:
+                {
+                    using (var connection = new MySqlConnector.MySqlConnection(connectionString))
+                    {
+                        connection.Open();
+                        using (var cmd = new MySqlConnector.MySqlCommand(query, connection))
                         {
                             cmd.ExecuteNonQuery();
                         }
@@ -129,8 +143,9 @@ namespace SlowTests.Server.Documents.Migration
         {
             switch (provider)
             {
-                case MigrationProvider.MySQL:
-                    return WithMySqlDatabase(out connectionString, out schemaName, dataSet, includeData);
+                case MigrationProvider.MySQL_MySql_Data:
+                case MigrationProvider.MySQL_MySqlConnector:
+                    return WithMySqlDatabase(out connectionString, out schemaName, dataSet, provider, includeData);
                 case MigrationProvider.MsSQL:
                     schemaName = "dbo";
                     return WithMsSqlDatabase(out connectionString, out string databaseName, dataSet, includeData);
@@ -239,7 +254,16 @@ namespace SlowTests.Server.Documents.Migration
             });
         }
 
-        private static DisposableAction WithMySqlDatabase(out string connectionString, out string databaseName, string dataSet, bool includeData = true)
+        private static DbConnection GetMySqlConnection(MigrationProvider provider, string connectionString)
+        {
+            Debug.Assert(provider is MigrationProvider.MySQL_MySql_Data or MigrationProvider.MySQL_MySqlConnector);
+
+            return provider == MigrationProvider.MySQL_MySql_Data
+                ? new MySql.Data.MySqlClient.MySqlConnection(connectionString)
+                : new MySqlConnector.MySqlConnection(connectionString);
+        }
+
+        private static DisposableAction WithMySqlDatabase(out string connectionString, out string databaseName, string dataSet, MigrationProvider provider, bool includeData = true)
         {
             databaseName = "sql_test_" + Guid.NewGuid();
             var rawConnectionString = MySqlConnectionString.Instance.VerifiedConnectionString.Value;
@@ -249,7 +273,7 @@ namespace SlowTests.Server.Documents.Migration
             
             connectionString = $"{rawConnectionString};database='{databaseName}'";
 
-            using (var connection = new MySqlConnection(rawConnectionString))
+            using (var connection = GetMySqlConnection(provider, rawConnectionString))
             {
                 connection.Open();
 
@@ -263,7 +287,7 @@ namespace SlowTests.Server.Documents.Migration
             
             if (string.IsNullOrEmpty(dataSet) == false)
             {
-                using (var dbConnection = new MySqlConnection(connectionString))
+                using (var dbConnection = GetMySqlConnection(provider, connectionString))
                 {
                     dbConnection.Open();
 
@@ -293,7 +317,7 @@ namespace SlowTests.Server.Documents.Migration
             string dbName = databaseName;
             return new DisposableAction(() =>
             {
-                using (var con = new MySqlConnection(rawConnectionString))
+                using (var con = GetMySqlConnection(provider, rawConnectionString))
                 {
                     con.Open();
 

--- a/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
+++ b/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
@@ -1,25 +1,15 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using MySqlX.XDevAPI;
-using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Documents.Indexes;
-using Raven.Server.Documents.Indexes.Auto;
-using Raven.Server.Documents.Indexes.MapReduce.Auto;
-using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries;
-using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
-using Sparrow.Json;
-using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Tests.Infrastructure/RequiresMySqlInlineData.cs
+++ b/test/Tests.Infrastructure/RequiresMySqlInlineData.cs
@@ -20,7 +20,7 @@ namespace Tests.Infrastructure
 
         public override IEnumerable<object[]> GetData(MethodInfo testMethod)
         {
-            return new[] { new object[] { MigrationProvider.MySQL } };
+            return new[] { new object[] { MigrationProvider.MySQL_MySql_Data }, new object[] { MigrationProvider.MySQL_MySqlConnector } };
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20286/SQL-ETL-SQL-Migration-Support-for-MySqlConnector

### Additional description

Support for connecting to MySQL db with the usage of MySqlConnector

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured - we're providing it as additional connector instead of replacing `MySql.Data`

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Handled
