### PR TITLE
RavenDB-20290 Use ValueTuple in GetValueTokenTupleByIndex

### DIFF
--- a/src/Raven.Server/Utils/ConflictResolverAdvisor.cs
+++ b/src/Raven.Server/Utils/ConflictResolverAdvisor.cs
@@ -102,7 +102,7 @@ namespace Raven.Server.Utils
                 arrays.Add(token);
             }
 
-            var set = new HashSet<Tuple<object, BlittableJsonToken>>();
+            var set = new HashSet<(object, BlittableJsonToken)>();
             var lastLength = arrays[0].Length;
             var sameSize = true;
             foreach (var arr in arrays)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20290

### Additional description

Changing to value type from reference type reduces unnecessary allocations. Data contained in tuple is also small (pointer + byte).

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests cover

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
