### PR TITLE
RavenDB-20144 Neon `Lzcnt` is using 64 bit number (Intel LZCNT is using 32bit)

### DIFF
--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -171,7 +171,7 @@ public static class EntryIdEncodings
         if (ArmBase.Arm64.IsSupported)
             ArmLzcntFrequencyQuantization(frequency);
         
-        return ClassicFrequencyQuantization(frequency);
+        return FrequencyQuantizationWithoutAcceleration(frequency);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
@@ -180,8 +180,8 @@ public static class EntryIdEncodings
         if (frequency < 16)
             return frequency;
 
-        var leadingZeros = ArmBase.Arm64.LeadingZeroCount((uint)frequency);
-        var level = (28 - leadingZeros + (leadingZeros & 0b1)) >> 1;
+        var leadingZeros = ArmBase.Arm64.LeadingZeroCount((long)frequency);
+        var level = (60 - leadingZeros + (leadingZeros & 0b1)) >> 1;
         var mod = (frequency - Step[level - 1]) / LevelSizeInStep[level];
         Debug.Assert((long)mod < 16);
         return ((long)(level << 4)) | (long)mod;
@@ -200,7 +200,7 @@ public static class EntryIdEncodings
         return ((long)(level << 4)) | (long)mod;
     }
 
-    private static long ClassicFrequencyQuantization(short frequency)
+    public static long FrequencyQuantizationWithoutAcceleration(short frequency)
     {
         if (frequency < 16) //shortcut
             return frequency;

--- a/test/FastTests/Corax/Ranking/QuantizationTest.cs
+++ b/test/FastTests/Corax/Ranking/QuantizationTest.cs
@@ -24,7 +24,8 @@ public class QuantizationTest : RavenTestBase
         for (short value = 1; value < short.MaxValue; ++value)
         {
             var quantized = EntryIdEncodings.FrequencyQuantization(value);
-
+            var quantizedByClassic = EntryIdEncodings.FrequencyQuantizationWithoutAcceleration(value);
+            Assert.Equal(quantizedByClassic, quantized);
             Assert.True(quantized <= byte.MaxValue); //In range
 
             var decoded = EntryIdEncodings.FrequencyReconstructionFromQuantization(quantized);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20144/Neon-code-fails-in-EntryIdEncodings
### Additional description

The Neon `Lzcnt` is using 64 bits, which is different from the Intel LZCNT (32 bits).

### Type of change

- Regression bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
