### PR TITLE
RavenDB-20119 Support for `OrderByTicksAutomaticallyWhenDatesAreInvolved` in Corax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1016,10 +1016,14 @@ internal static class CoraxQueryBuilder
                 continue;
             }
 
+            var orderingType = field.OrderingType;
+            if (index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(field.Name.Value))
+                orderingType = OrderByFieldType.Long;
+
             var metadataField = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name.Value, index, builderParameters.HasDynamics, builderParameters.DynamicFields,
                 indexMapping, queryMapping, false);
             OrderMetadata? temporaryOrder = null;
-            switch (field.OrderingType)
+            switch (orderingType)
             {
                 case OrderByFieldType.Custom:
                     throw new NotSupportedException($"{nameof(Corax)} doesn't support Custom OrderBy.");

--- a/test/SlowTests/Issues/RavenDB-19843.cs
+++ b/test/SlowTests/Issues/RavenDB-19843.cs
@@ -15,14 +15,15 @@ public class RavenDB_19843 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void CheckIfNullDatesAreReturnedLastWithConfigOptionEnabled(bool configEnabled)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {true})]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = new object[] {false})]
+    public void CheckIfNullDatesAreReturnedLastWithConfigOptionEnabled(Options options, bool configEnabled)
     {
         using (var store = GetDocumentStore(new Options
                {
                    ModifyDatabaseRecord = r =>
                    {
+                       options.ModifyDatabaseRecord(r);
                        r.Settings[RavenConfiguration.GetKey(x => x.Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved)] = configEnabled.ToString();
                    }
                }))
@@ -44,7 +45,7 @@ public class RavenDB_19843 : RavenTestBase
                 var results = session.Query<DtoWithDate>()
                     .OrderByDescending(x => x.CreationTime).ToList();
                 
-                if(configEnabled)
+                if (options.SearchEngineMode is RavenSearchEngineMode.Lucene && configEnabled)
                     Assert.Equal(null, results[2].CreationTime);
                 else
                     Assert.Equal(null, results[0].CreationTime);

--- a/test/Tests.Infrastructure/RavenDataAttribute.cs
+++ b/test/Tests.Infrastructure/RavenDataAttribute.cs
@@ -76,7 +76,6 @@ public class RavenDataAttribute : DataAttribute
         {
             var coraxOptions = options.Clone();
             coraxOptions.SearchEngineMode = RavenSearchEngineMode.Corax;
-
             coraxOptions.ModifyDatabaseRecord += record =>
             {
                 record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20119

### Additional description
When an entry has null on the sorted property let set it as "cannot" read. 

### Type of change

- New feature

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
