### PR TITLE
RavenDB-20292 Only inject parameters required by ScriptRunner

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries.AST
         public Dictionary<string, DeclaredFunction> DeclaredFunctions;
 
         public string QueryText;
-        public (string FunctionText, Esprima.Ast.Program Program) SelectFunctionBody;
+        public (string FunctionText, Esprima.Ast.Program Program, HashSet<string> ReferencedParameters) SelectFunctionBody;
         public string UpdateBody;
         public ValueExpression Offset;
         public ValueExpression Limit;

--- a/test/FastTests/Issues/RavenDB-20292.cs
+++ b/test/FastTests/Issues/RavenDB-20292.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_20292 : RavenTestBase
+    {
+        public RavenDB_20292(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task WhereIdInLargeCollectionPerformance()
+        {
+            // before fixing id injection to script, this could take more than two minutes
+            var documents = Enumerable.Range(1, 20_000)
+                .Select(x => new Document
+                {
+                    Id = "documents/" + x,
+                    Number = x
+                })
+                .ToList();
+
+            var ids = documents.Select(x => x.Id).ToList();
+
+            using (var store = GetDocumentStore())
+            {
+                await using (var insert = store.BulkInsert())
+                {
+                    foreach (var document in documents)
+                    {
+                        await insert.StoreAsync(document);
+                    }
+                }
+
+                var sw = Stopwatch.StartNew();
+                using (var session = store.OpenAsyncSession())
+                {
+                    var results = await session.Query<Document>()
+                        .Where(x => x.Id.In(ids))
+                        .Select(x => new
+                        {
+                            Number = x.Number + 1
+                        })
+                        .ToListAsync();
+
+                    Assert.Equal(ids.Count, results.Count);
+                }
+                sw.Stop();
+
+                Output.WriteLine("Took: " + sw.Elapsed);
+            }
+        }
+
+        private class Document
+        {
+            public string Id { get; set; }
+            public int Number { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20292

### Additional description

Now injecting only parameters to script runner which are actually referenced by identifiers in script. Improves performance when parameter is never needed and thus needs no possibly costly JS materialization.

Behavioral change that can be observed by user is that there might be gaps in parameter list, like `p0`, `p2`, `p3` when unnecessary parameters are no longer injected, felt easier than trying to compute the parameters elsewhere.

I've replaced `ValidateScript` with `ScriptValidator` which traverses AST and relies on Esprima knowing how to traverse scripts now and in the future (new constructs) As visitor checks `Identifier`, we should be able to gather are references and thus have solid knowledge what is actually needed (based on how RavenDB emits JS). Shouldn't be a performance issue as scripts are small and the vising is fast.

Test case (stopwatch for the actual projection) went from `Took: 00:02:28.7342251` to `Took: 00:00:01.0919910` on my laptop.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

Not sure where this somewhat slow test should be placed or if its written correctly to demonstrate.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
