### PR TITLE
RavenDB-20269 Ensure no Microsoft logs are written if they are disabled

### DIFF
--- a/src/Raven.Server/Utils/MicrosoftLogging/SparrowLoggerWrapper.cs
+++ b/src/Raven.Server/Utils/MicrosoftLogging/SparrowLoggerWrapper.cs
@@ -25,6 +25,9 @@ public class SparrowLoggerWrapper : ILogger<RavenServer>
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
+        if (IsEnabled(logLevel) == false)
+            return;
+        
         if (formatter == null)
             throw new ArgumentNullException(nameof(formatter));
         


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20269/Debug-kestrel-logs-logged-by-default

### Additional description
It seems that some logging in AspDotNet missing the `IsEnabled` check.
If you don't define a custom ILogger like we do the default implementation will do the check inside the `Log` function since it should check all the output providers.
I opened an issue in AspNetCore GitHub - https://github.com/dotnet/aspnetcore/issues/47620
For an immediate fix, I added a check inside the `Log` function.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- No tests

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
