### PR TITLE
RavenDB-20185: Fix bug causing `number of currently running backups` endpoint to return -1 after delaying/snoozing backup

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1149,7 +1149,6 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 periodicBackup.BackupStatus ??= new PeriodicBackupStatus();
                 periodicBackup.BackupStatus.DelayUntil = state.DelayUntil;
-                ScheduleNextBackup(periodicBackup, state.DelayUntil.Subtract(DateTime.UtcNow), lockTaken: false);
             }
         }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3045,6 +3045,52 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         }
 
         [Fact, Trait("Category", "Smuggler")]
+        public async Task NumberOfCurrentlyRunningBackupsShouldBeCorrectAfterBackupTaskDelay()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                    await Backup.FillDatabaseWithRandomDataAsync(databaseSizeInMb: 1, session);
+
+                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(database);
+                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
+
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, opStatus: OperationStatus.InProgress);
+
+                // The backup task is running, and the next backup should be scheduled for the next minute (based on the backup configuration)
+                var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                Assert.NotNull(taskBackupInfo);
+                Assert.NotNull(taskBackupInfo.OnGoingBackup);
+
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    AssertNumberOfConcurrentBackups(expectedNumber: 1);
+                    
+                    // Let's delay the backup task to 1 hour
+                    var delayDuration = TimeSpan.FromHours(1);
+                    await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+
+                    AssertNumberOfConcurrentBackups(expectedNumber: 0);
+
+                    void AssertNumberOfConcurrentBackups(int expectedNumber)
+                    {
+                        int concurrentBackups = WaitForValue( () => Server.ServerStore.ConcurrentBackupsCounter.CurrentNumberOfRunningBackups,
+                            expectedVal: expectedNumber,
+                            timeout: Convert.ToInt32(TimeSpan.FromMinutes(1).TotalMilliseconds),
+                            interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+
+                        Assert.Equal(expectedNumber, concurrentBackups);
+                    }
+                }
+            }
+        }
+        
+        [Fact, Trait("Category", "Smuggler")]
         public async Task ShouldRearrangeTheBackupTimer_IfItGot_ActiveByOtherNode_Then_ActiveByCurrentNode_WhileRunning()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20185/SNMP-Number-of-currently-running-backups-endpoint-returns-1-after-delaying-snoozing-the-backup

### Additional description

This pull request addresses a bug that causes the "number of currently running backups" endpoint to return `-1` after delaying a backup. The issue was due to the `ScheduleNextBackup` method being executed twice in different locations, resulting in the `ConcurrentBackupsCounter.FinishBackup` method being called twice, leading to the error.

**Changes:**
- Identified and removed the duplicate invocation of `ScheduleNextBackup` method;
- Ensured that `ConcurrentBackupsCounter.FinishBackup` is called only once per backup completion;
- Added unit tests to validate the correct behavior of the SNMP "Number of backups currently running" endpoint after delaying a backup.

With these changes, the endpoint should now return the correct number of running backups after a backup has been delayed.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Yes. Please list the affected platforms.
- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed