### PR TITLE
RavenDB-20205: Raven will not calculate the number of entries in Corax's indexes but will take it directly from Corax.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -52,7 +52,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private readonly IndexSearcher _indexSearcher;
         private readonly ByteStringContext _allocator;
 
-        private long _entriesCount = 0;
 
         public CoraxIndexReadOperation(Index index, Logger logger, Transaction readTransaction, QueryBuilderFactories queryBuilderFactories, IndexFieldsMapping fieldsMapping, IndexQueryServerSide query) : base(index, logger, queryBuilderFactories, query)
         {
@@ -61,8 +60,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings);
         }
 
-        // TODO: This will always return 0, most likely a reporting bug atm. 
-        public override long EntriesCount() => _entriesCount;
+        public override long EntriesCount() => _indexSearcher.NumberOfEntries;
 
 
         private interface ISupportsHighlighting

--- a/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
+++ b/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
@@ -35,8 +35,7 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
 
             using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
             var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
-            long numberOfEntries =0;
-            oldId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan(), ref numberOfEntries);
+            oldId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
             
             indexWriter.Commit();
         }
@@ -61,8 +60,7 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
 
             using var _ = Allocator.From("cars/1", ByteStringType.Immutable, out var str);
             var lowerId = new LazyStringValue(null, str.Ptr, str.Size, JsonOperationContext.ShortTermSingleUse());
-            long numberOfEntries =0;
-            newId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan(), ref numberOfEntries);
+            newId = indexWriter.Update("id()", str.ToSpan(), lowerId, entrySpan.ToSpan());
             
             indexWriter.Commit();
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20205
### Additional description

In `SlowTests.Client.Indexing.TimeSeries.BasicTimeSeriesIndexes_JavaScript.BasicMapIndexWithLoad` there was some kind of race where we take the number of entries. This PR eliminates it since we're only relying on `NumberOfEntries` from Corax.

### Type of change

- Bug fix


### How risky is the change?


- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
