### PR TITLE
RavenDB-20249: Don't override `canExtractFromIndex` in the case of Corax's map-reduce indexes.

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -170,7 +170,7 @@ namespace Raven.Server.Documents
 
                 isStartsWithOrIdQuery = true;
 
-                return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, new FieldsToFetch(_operationQuery, null),
+                return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, new FieldsToFetch(_operationQuery, null, IndexType.None),
                     collectionName, _operationQuery, null, context, null, null, null, new Reference<int>(), new Reference<int>(), new Reference<long>(), token)
                 {
                     Fields = fields, StartAfterId = startAfterId, AlreadySeenIdsCount = alreadySeenIdsCount

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -423,7 +423,7 @@ namespace Raven.Server.Documents.Indexes.Debugging
                 }, "query/parameters");
                 var query = new IndexQueryServerSide($"FROM INDEX '{index.Name}' WHERE '{Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName}' = $p0", queryParameters);
 
-                var fieldsToFetch = new FieldsToFetch(query, index.Definition);
+                var fieldsToFetch = new FieldsToFetch(query, index.Definition, index.Type);
 
                 var retriever = new MapReduceQueryResultRetriever(null, null, null, null, context, SearchEngineType.Lucene, fieldsToFetch, null, null, null);
                 var result = reader

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3210,7 +3210,7 @@ namespace Raven.Server.Documents.Indexes
                                 IncludeTimeSeriesCommand includeTimeSeriesCommand = null;
                                 IncludeRevisionsCommand includeRevisionsCommand = new(DocumentDatabase, queryContext.Documents, query.Metadata.RevisionIncludes);
 
-                                var fieldsToFetch = new FieldsToFetch(query, Definition, SearchEngineType);
+                                var fieldsToFetch = new FieldsToFetch(query, Definition, Type, SearchEngineType);
 
                                 var includeDocumentsCommand = new IncludeDocumentsCommand(
                                     DocumentDatabase.DocumentsStorage, queryContext.Documents,

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -134,7 +134,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 resultToFill.IndexTimestamp = DateTime.MinValue;
                 resultToFill.IncludedPaths = query.Metadata.Includes;
 
-                var fieldsToFetch = new FieldsToFetch(query, null);
+                var fieldsToFetch = new FieldsToFetch(query, null, IndexType.None);
                 var includeDocumentsCommand  = new IncludeDocumentsCommand(Database.DocumentsStorage, context.Documents, query.Metadata.Includes, fieldsToFetch.IsProjection);
                 var includeRevisionsCommand  = new IncludeRevisionsCommand(Database, context.Documents, query.Metadata.RevisionIncludes);
                 

--- a/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
+++ b/src/Raven.Server/Documents/Queries/FieldsToFetch.cs
@@ -35,10 +35,10 @@ namespace Raven.Server.Documents.Queries
 
         public readonly ProjectionOptions Projection;
 
-        public FieldsToFetch(IndexQueryServerSide query, IndexDefinitionBaseServerSide indexDefinition, SearchEngineType searchEngineType = SearchEngineType.None)
+        public FieldsToFetch(IndexQueryServerSide query, IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, SearchEngineType searchEngineType = SearchEngineType.None)
         {
             Projection = new ProjectionOptions(query);
-            Fields = GetFieldsToFetch(query.Metadata, query.ProjectionBehavior, indexDefinition, searchEngineType, out AnyExtractableFromIndex, out bool extractAllStoredFields, out SingleBodyOrMethodWithNoAlias, out AnyTimeSeries);
+            Fields = GetFieldsToFetch(query.Metadata, query.ProjectionBehavior, indexDefinition, searchEngineType, indexType, out AnyExtractableFromIndex, out bool extractAllStoredFields, out SingleBodyOrMethodWithNoAlias, out AnyTimeSeries);
             IsProjection = Fields != null && Fields.Count > 0;
             IndexFields = indexDefinition?.IndexFields;
             AnyDynamicIndexFields = indexDefinition != null && indexDefinition.HasDynamicFields;
@@ -60,6 +60,7 @@ namespace Raven.Server.Documents.Queries
             SelectField selectField,
             Dictionary<string, FieldToFetch> results,
             SearchEngineType searchEngineType,
+            IndexType indexType,
             out string selectFieldKey,
             ref bool anyExtractableFromIndex,
             ref bool extractAllStoredFields,
@@ -68,8 +69,10 @@ namespace Raven.Server.Documents.Queries
             var mustExtractFromIndex = projectionBehavior.FromIndexOnly();
             var maybeExtractFromIndex = projectionBehavior.FromIndexOrDefault();
             
-            //Since we always store field in Corax we can try to get it from index entry when performing projection. This is an alternative value for `canExtractFromIndex`.  
-            var isCorax = searchEngineType is SearchEngineType.Corax;
+            // Since we always store fields in Corax, we can try to retrieve them from the index entry when performing projection. This is an alternative value for `canExtractFromIndex`.
+            // Additionally, when the index is a map-reduce, we have to skip the fields' stored values and look them up in the stored JSON of the reduce-map.
+            // The reason behind this is related to the type of value we return to the client. In the field, we can have a LazyStringValue, but the client may want a numeric value.
+            var forceExtractFromIndex = searchEngineType is SearchEngineType.Corax && indexType.IsMapReduce() is false;
 
             selectFieldKey = selectField.Alias ?? selectField.Name;
             var selectFieldName = selectField.Name;
@@ -107,6 +110,7 @@ namespace Raven.Server.Documents.Queries
                         selectField.FunctionArgs[j],
                         null,
                         searchEngineType,
+                        indexType,
                         out _,
                         ref ignored,
                         ref ignored,
@@ -119,7 +123,7 @@ namespace Raven.Server.Documents.Queries
             if (selectField.IsCounter)
             {
                 var fieldToFetch = new FieldToFetch(selectField.Name, selectField, selectField.Alias ?? selectField.Name,
-                    canExtractFromIndex: isCorax, isDocumentId: false, isTimeSeries: false);
+                    canExtractFromIndex: forceExtractFromIndex, isDocumentId: false, isTimeSeries: false);
                 if (selectField.FunctionArgs != null)
                 {
                     fieldToFetch.FunctionArgs = new FieldToFetch[0];
@@ -159,7 +163,7 @@ namespace Raven.Server.Documents.Queries
                     anyExtractableFromIndex = maybeExtractFromIndex;
                     
                     return new FieldToFetch(selectFieldName, selectField, selectField.Alias, 
-                        canExtractFromIndex: (indexDefinition is MapReduceIndexDefinition or AutoMapReduceIndexDefinition) || isCorax, 
+                        canExtractFromIndex: (indexDefinition is MapReduceIndexDefinition or AutoMapReduceIndexDefinition) || forceExtractFromIndex, 
                         isDocumentId: true, isTimeSeries: false);
                 }
 
@@ -176,7 +180,7 @@ namespace Raven.Server.Documents.Queries
 
                         foreach (var kvp in indexDefinition.MapFields)
                         {
-                            var stored = isCorax || kvp.Value.Storage == FieldStorage.Yes;
+                            var stored = forceExtractFromIndex || kvp.Value.Storage == FieldStorage.Yes;
                             if (stored == false)
                                 continue;
 
@@ -194,7 +198,7 @@ namespace Raven.Server.Documents.Queries
                     ? selectField.SourceAlias
                     : selectFieldName;
 
-            var extract = mustExtractFromIndex || (maybeExtractFromIndex && indexDefinition.MapFields.TryGetValue(key, out var value) && (isCorax || value.Storage == FieldStorage.Yes));
+            var extract = mustExtractFromIndex || (maybeExtractFromIndex && indexDefinition.MapFields.TryGetValue(key, out var value) && (forceExtractFromIndex || value.Storage == FieldStorage.Yes));
 
             if (extract)
                 anyExtractableFromIndex = true;
@@ -223,6 +227,7 @@ namespace Raven.Server.Documents.Queries
             ProjectionBehavior? projectionBehavior,
             IndexDefinitionBaseServerSide indexDefinition,
             SearchEngineType searchEngineType,
+            IndexType indexType,
             out bool anyExtractableFromIndex,
             out bool extractAllStoredFields,
             out bool singleFieldNoAlias,
@@ -249,7 +254,7 @@ namespace Raven.Server.Documents.Queries
             for (var i = 0; i < metadata.SelectFields.Length; i++)
             {
                 var selectField = metadata.SelectFields[i];
-                var val = GetFieldToFetch(indexDefinition, metadata, projectionBehavior, selectField, result, searchEngineType,
+                var val = GetFieldToFetch(indexDefinition, metadata, projectionBehavior, selectField, result, searchEngineType, indexType,
                     out var key, ref anyExtractableFromIndex, ref extractAllStoredFields, ref anyTimeSeries);
                 if (extractAllStoredFields)
                     return result;

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Config.Categories;
@@ -140,7 +141,7 @@ namespace Raven.Server.Documents.Queries
                     else if (q.Select != null)
                     {
                         //TODO : investigate fields to fetch
-                        var fieldsToFetch = new FieldsToFetch(query, null);
+                        var fieldsToFetch = new FieldsToFetch(query, null, IndexType.None);
                         idc = new IncludeDocumentsCommand(Database.DocumentsStorage, queryContext.Documents, query.Metadata.Includes, fieldsToFetch.IsProjection);
                         icevc = IncludeCompareExchangeValuesCommand.ExternalScope(queryContext, query.Metadata.CompareExchangeValueIncludes);
                         irc = new IncludeRevisionsCommand(database: Database, context: queryContext.Documents, query.Metadata.RevisionIncludes);

--- a/test/FastTests/Corax/MapReduceProjection.cs
+++ b/test/FastTests/Corax/MapReduceProjection.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Server.Documents.Indexes.Static;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class MapReduceProjection : RavenTestBase
+{
+    public MapReduceProjection(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task ProjectionWillReturnCorrectTypeFromOriginalReduceMap(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var index = new MapReduceDtoIndex();
+        await index.ExecuteAsync(store);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto(){Name = "Maciej"});
+            session.SaveChanges();
+        }
+        
+        Indexes.WaitForIndexing(store);
+        
+        using (var commands = store.Commands())
+        {
+            var command = new QueryCommand(commands.Session, new IndexQuery
+            {
+                Query = $"from index '{index.IndexName}' select Count"
+            });
+
+            await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
+
+            var results = new DynamicArray(command.Result.Results)[0]["Count"];
+            
+            Assert.False(results is LazyStringValue or string);
+            Assert.True(results is long);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class MapReduceDtoIndex : AbstractIndexCreationTask<Dto, MapReduceDtoIndex.ReduceResult>
+    {
+        public class ReduceResult
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        public MapReduceDtoIndex()
+        {
+            Map = dtos => dtos.Select(i => new {Name = i.Name, Count = 1});
+            Reduce = results => from reduce in results
+                group reduce by reduce.Name
+                into g
+                select new ReduceResult() {Name = g.Key, Count = g.Sum(i => i.Count)};
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20249

### Additional description

We have to skip the fields' stored values and look them up in the stored JSON of the reduce-map. The reason behind this is related to the type of value we return to the client. In the field, we can have a LazyStringValue, but the client may want a numeric value.

### Type of change


- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
