### PR TITLE
RavenDB-20249 Fixing a test which started to fail on sharded database when using Corax.

### DIFF
--- a/test/SlowTests/Core/Querying/Paging.cs
+++ b/test/SlowTests/Core/Querying/Paging.cs
@@ -4,12 +4,14 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;
 
 using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
-using SlowTests.Issues;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -24,7 +26,8 @@ namespace SlowTests.Core.Querying
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void BasicPaging(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -80,6 +83,111 @@ namespace SlowTests.Core.Querying
                     Assert.Equal(1, companies.Length);
                     Assert.Equal("Company6", companies[0]);
                 }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void BasicPaging_Sharded_Corax(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    RunTestWhenProjectedFieldsAreExtractedFromIndex(store, session.Query<Company>());
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void BasicPaging_Sharded_Lucene_StaticIndexWithStoredField(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Companies_ByName().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    RunTestWhenProjectedFieldsAreExtractedFromIndex(store, session.Query<Company, Companies_ByName>());
+                }
+            }
+        }
+
+        public void RunTestWhenProjectedFieldsAreExtractedFromIndex(IDocumentStore store, Raven.Client.Documents.Linq.IRavenQueryable<Company> baseQuery)
+        {
+            // if all projection fields are extracted from an index then we don't read documents at all
+            // in result we don't return @last-modified metadata which is used by orchestrator for default ordering
+            // this mean that we cannot have assertions which rely on the insertion order of documents (as it was in the original BasicPaging test)
+
+            // here we're collecting the results from two pages and verify at the end that all results were returned and there are no duplicates
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Company { Name = "Company1" });
+                session.SaveChanges();
+
+                for (var i = 1; i < 7; i++)
+                {
+                    session.Store(new Company { Name = $"Company{i}" });
+                    session.SaveChanges();
+                }
+
+                session.Store(new Company { Name = "ompany7" });
+                session.SaveChanges();
+
+                QueryStatistics stats;
+
+                var allCompanies = new List<string>();
+
+                var companies = baseQuery
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Statistics(out stats)
+                    .Where(c => c.Name.StartsWith("Company"))
+                    .Select(c => c.Name)
+                    .Distinct()
+                    .Take(5)
+                    .ToArray();
+                Assert.Equal(7, stats.TotalResults);
+
+                Assert.Equal(5, companies.Length);
+
+                allCompanies.AddRange(companies);
+
+                var skipped = stats.SkippedResults;
+                companies = baseQuery
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Statistics(out stats)
+                    .Where(c => c.Name.StartsWith("Company"))
+                    .Select(c => c.Name)
+                    .Distinct()
+                    .Skip(5 + (int)skipped)
+                    .Take(5)
+                    .ToArray();
+                Assert.Equal(7, stats.TotalResults);
+                Assert.Equal(0, stats.SkippedResults);
+                Assert.Equal(1, companies.Length);
+
+                allCompanies.AddRange(companies);
+
+                Assert.Equal(6, allCompanies.Count);
+
+                Assert.Contains("Company1", allCompanies);
+                Assert.Contains("Company2", allCompanies);
+                Assert.Contains("Company3", allCompanies);
+                Assert.Contains("Company4", allCompanies);
+                Assert.Contains("Company5", allCompanies);
+                Assert.Contains("Company6", allCompanies);
+            }
+        }
+
+        private class Companies_ByName : AbstractIndexCreationTask<Company>
+        {
+            public Companies_ByName()
+            {
+                Map = companies => from c in companies select new {c.Name};
+
+                Store(x => x.Name, FieldStorage.Yes);
             }
         }
     }


### PR DESCRIPTION
The reason was the introduction of reading projection fields from Corax index by default. The same case would be for Lucene index if all projected field are stored (test added).

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20249/Corax-projection-should-try-get-value-from-index-in-the-first-place.

### Additional description

The test `SlowTests.Core.Querying.Paging.BasicPaging` started to fail after merging https://github.com/ravendb/ravendb/pull/16186 to 6.0. The underlying reason was that after that change the projection fields were taken directly from index so we no longer return `@last-modified` which is used by orchestrator for default query results sorting.


### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- No UI work is needed
