### PR TITLE
RavenDB-20127 Schema upgrader for Corax indexes

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -45,10 +45,6 @@ namespace Corax
 
         public static class IndexWriter
         {
-            // This is the schema version for the indexes. 
-            public const long SchemaVersion = 54_006;
-            
-            
             public static ReadOnlySpan<byte> DoubleTreeSuffix => DoubleTreeSuffixBytes.AsSpan();
             private static readonly byte[] DoubleTreeSuffixBytes = new byte[]  { (byte)'-', (byte)'D' };
 
@@ -56,7 +52,7 @@ namespace Corax
             private static readonly byte[] LongTreeSuffixBytes = new byte[]  { (byte)'-', (byte)'L' };
 
             
-            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, IndexVersionSlice, DynamicFieldsAnalyzersSlice, NumberOfTermsInIndex;
+            public static readonly Slice PostingListsSlice, EntriesContainerSlice, FieldsSlice, NumberOfEntriesSlice, SuggestionsFieldsSlice, DynamicFieldsAnalyzersSlice, NumberOfTermsInIndex;
             public const int IntKnownFieldMask = unchecked((int)0x80000000);
             public const short ShortKnownFieldMask = unchecked((short)0x8000);
             public const byte ByteKnownFieldMask = unchecked((byte)0x80);
@@ -70,7 +66,6 @@ namespace Corax
                     Slice.From(ctx, "Entries", ByteStringType.Immutable, out EntriesContainerSlice);
                     Slice.From(ctx, "NumberOfEntries", ByteStringType.Immutable, out NumberOfEntriesSlice);
                     Slice.From(ctx, "SuggestionFields", ByteStringType.Immutable, out SuggestionsFieldsSlice);
-                    Slice.From(ctx, "IndexVersion", ByteStringType.Immutable, out IndexVersionSlice);
                     Slice.From(ctx, "DynamicFieldsAnalyzers", ByteStringType.Immutable, out DynamicFieldsAnalyzersSlice);
                     Slice.From(ctx, "NumberOfTermsInIndex", ByteStringType.Immutable, out NumberOfTermsInIndex);
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -113,26 +113,6 @@ public class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Initialize(StorageEnvironment environment)
     {
-        using (var tx = environment.WriteTransaction())
-        {
-            var metadataTree = tx.ReadTree(global::Corax.Constants.IndexMetadataSlice);
-            var version = metadataTree?.ReadInt64(global::Corax.Constants.IndexWriter.IndexVersionSlice);
-            if (version.HasValue)
-            {
-                var currentCoraxVersion = global::Corax.Constants.IndexWriter.SchemaVersion;
-                if (version.Value != currentCoraxVersion)
-                {
-                    
-                    throw new CoraxInvalidIndexVersionException(
-                        $"Index was built on Corax version {version.ToString()}. The current version {currentCoraxVersion} uses different structures than its predecessors. To use Corax, please restart the entire index.");
-                }
-            }
-            else
-            {
-                tx.CreateTree(global::Corax.Constants.IndexMetadataSlice).Add(global::Corax.Constants.IndexWriter.IndexVersionSlice, global::Corax.Constants.IndexWriter.SchemaVersion);
-                tx.Commit();
-            }
-        }
     }
 
     public override void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache)
@@ -163,7 +143,6 @@ public class CoraxIndexPersistence : IndexPersistenceBase
     }
     #endregion
     
-
     public override IndexWriteOperationBase OpenIndexWriter(Transaction writeTransaction, JsonOperationContext indexContext)
     {
         if (_index.Type == IndexType.MapReduce || _index.Type == IndexType.JavaScriptMapReduce)

--- a/src/Raven.Server/Storage/Schema/Updates/CoraxIndex/60000/From54000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/CoraxIndex/60000/From54000.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Raven.Server.Storage.Schema.Updates.CoraxIndex;
+
+public unsafe class From54000 : ISchemaUpdate
+{
+    public int From => 54_000;
+
+    public int To => 60_000;
+
+    public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.CoraxIndex;
+
+    public bool Update(UpdateStep step)
+    {
+        throw new NotSupportedException("Backward compatibility is not supported for Corax indexes built on versions before RavenDB 6.0. Please reset the index.");
+    }
+}

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
@@ -3,13 +3,13 @@ using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Tables;
 
-namespace Raven.Server.Storage.Schema.Updates.Index
+namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
 {
     public unsafe class From40010 : ISchemaUpdate
     {
         public int From => 40_010;
         public int To => 40_011;
-        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Index;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.LuceneIndex;
 
         public bool Update(UpdateStep step)
         {

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40012/From40011.cs
@@ -2,13 +2,13 @@
 using Voron.Data;
 using Voron.Data.Tables;
 
-namespace Raven.Server.Storage.Schema.Updates.Index
+namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
 {
     public class From40011 : ISchemaUpdate
     {
         public int From => 40_011;
         public int To => 40_012;
-        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Index;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.LuceneIndex;
 
         public bool Update(UpdateStep step)
         {

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/50000/From40012.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/50000/From40012.cs
@@ -1,4 +1,4 @@
-﻿namespace Raven.Server.Storage.Schema.Updates.Index
+﻿namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
 {
     public unsafe class From40012 : ISchemaUpdate
     {
@@ -6,7 +6,7 @@
 
         public int To => 50_000;
 
-        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Index;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.LuceneIndex;
 
         public bool Update(UpdateStep step)
         {

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/54000/From50000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/54000/From50000.cs
@@ -1,4 +1,4 @@
-﻿namespace Raven.Server.Storage.Schema.Updates.Index
+﻿namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
 {
     public unsafe class From5000 : ISchemaUpdate
     {
@@ -6,7 +6,7 @@
 
         public int To => 54_000;
 
-        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Index;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.LuceneIndex;
 
         public bool Update(UpdateStep step)
         {

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -365,6 +365,7 @@ namespace Voron
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
                     schemaVersionVal = schemaVersion.Reader.ReadLittleEndianInt32();
+                    Options.OnVersionReadingTransaction?.Invoke(readTx);
                 }
 
                 if (Options.SchemaVersion != 0 &&

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -177,6 +177,8 @@ namespace Voron
         public int SchemaVersion { get; set; }
 
         public UpgraderDelegate SchemaUpgrader { get; set; }
+        
+        public Action<Transaction> OnVersionReadingTransaction { get; set; }
 
         public Action<StorageEnvironment> BeforeSchemaUpgrade { get; set; }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20127

### Additional description

- removing `IndexVersion` from Corax
- introducing two separate SchemaUpgrader (for Corax/Lucene)

![image](https://user-images.githubusercontent.com/86351904/231738730-d7f13fb9-9110-4a02-985c-ae10634386a2.png)

### Type of change


- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
