### PR TITLE
RavenDB-20315 fix docker tags for 6.0

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -38,7 +38,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
                 # "$($repo):latest",
                 # "$($repo):ubuntu-latest",
                 "$($repo):6.0-ubuntu-latest",
-                "$($repo):$($version)-ubuntu.20.04-x64"
+                "$($repo):$($version)-ubuntu.22.04-x64"
             )
             break;
         }
@@ -46,7 +46,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
             return @(
                 # "$($repo):ubuntu-arm32v7-latest",
                 "$($repo):6.0-ubuntu-arm32v7-latest",
-                "$($repo):$($version)-ubuntu.20.04-arm32v7"
+                "$($repo):$($version)-ubuntu.22.04-arm32v7"
             )
             break;
         }
@@ -54,7 +54,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
             return @(
                 # "$($repo):ubuntu-arm64v8-latest",
                 "$($repo):6.0-ubuntu-arm64v8-latest",
-                "$($repo):$($version)-ubuntu.20.04-arm64v8"
+                "$($repo):$($version)-ubuntu.22.04-arm64v8"
                 )
                 break;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20315/Fix-docker-tags-for-ubuntu-6.0-images

### Additional description

It said 20.04 instead of 22.04

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. Docker

### Documentation update

- No documentation update is needed 


