### PR TITLE
RavenDB-20315 Fix docker tags for ubuntu images having ubuntu version…

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -40,7 +40,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
                 "$($repo):latest-lts",
                 "$($repo):ubuntu-latest-lts",
                 "$($repo):5.4-ubuntu-latest",
-                "$($repo):$($version)-ubuntu.20.04-x64"
+                "$($repo):$($version)-ubuntu.22.04-x64"
             )
             break;
         }
@@ -49,7 +49,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
                 "$($repo):ubuntu-arm32v7-latest",
                 "$($repo):ubuntu-arm32v7-latest-lts",
                 "$($repo):5.4-ubuntu-arm32v7-latest",
-                "$($repo):$($version)-ubuntu.20.04-arm32v7"
+                "$($repo):$($version)-ubuntu.22.04-arm32v7"
             )
             break;
         }
@@ -58,7 +58,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
                 "$($repo):ubuntu-arm64v8-latest",
                 "$($repo):ubuntu-arm64v8-latest-lts",
                 "$($repo):5.4-ubuntu-arm64v8-latest",
-                "$($repo):$($version)-ubuntu.20.04-arm64v8"
+                "$($repo):$($version)-ubuntu.22.04-arm64v8"
                 )
                 break;
         }


### PR DESCRIPTION
… embedded

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20315/Fix-docker-tags-for-ubuntu-images

### Description

We use jammy now so it should be reflected in the tags.