### PR TITLE
RavenDB-20149 User can escape characters in `Search` | Proper ranking calculation for Search.

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -7,7 +7,12 @@ namespace Corax
     public static class Constants
     {
         public const string NullValue = "NULL_VALUE";
+        public static readonly ReadOnlyMemory<char> NullValueCharSpan = new(Constants.NullValue.ToCharArray());
+        
+        
         public const string EmptyString = "EMPTY_STRING";
+        public static readonly ReadOnlyMemory<char> EmptyStringCharSpan = new(Constants.EmptyString.ToCharArray());
+        
         public const string IndexMetadata = "@index_metadata";
         public const string IndexTimeFields = "@index_time_fields";
         public const string DocumentBoost = "@document_boost";
@@ -87,12 +92,12 @@ namespace Corax
             public const byte Wildcard = (byte)'*';
 
             [Flags]
-            internal enum SearchMatchOptions
+            public enum SearchMatchOptions
             {
                 TermMatch = 0,
                 StartsWith = 1,
                 EndsWith = 2,
-                Contains = 4
+                Contains = StartsWith | EndsWith
             }
 
             public enum Operator

--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -1,172 +1,81 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
+using System.Linq;
 using Corax.Mappings;
-using Corax.Pipeline;
 using Corax.Queries;
-using Sparrow.Server;
-using Voron;
 
 namespace Corax;
 
 public partial class IndexSearcher
 {
-
-    public IQueryMatch SearchQuery(FieldMetadata field, string searchTerm,  Constants.Search.Operator @operator, bool isNegated = false, bool manuallyCutWildcards = false)
+    public IQueryMatch SearchQuery(FieldMetadata field, List<string> termMatches, List<(string Term, Constants.Search.SearchMatchOptions Match)> prefixSuffixMatches, Constants.Search.Operator @operator)
     {
-        bool isDynamic = field.FieldId == Constants.IndexWriter.DynamicField;
-        ReadOnlySpan<byte> term = Encoding.UTF8.GetBytes(searchTerm).AsSpan();
-        if (isNegated)
+        AssertFieldIsSearched();
+        var searchAnalyzer = field.IsDynamic
+            ? _fieldMapping.SearchAnalyzer(field.FieldName.ToString()) 
+            : field.Analyzer;
+
+        field = field.ChangeAnalyzer(field.Mode, searchAnalyzer);
+        
+        IQueryMatch searchQuery = null;
+        
+        if (termMatches?.Count > 0)
         {
-            @operator = @operator switch
+            searchQuery = @operator switch
             {
-                Constants.Search.Operator.Or => Constants.Search.Operator.And,
-                Constants.Search.Operator.And => Constants.Search.Operator.Or,
+                Constants.Search.Operator.And => AllInQuery(field, termMatches.ToHashSet(), skipEmptyItems: true),
+                Constants.Search.Operator.Or => InQuery(field, termMatches),
                 _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
             };
         }
 
-        if (field.Analyzer == null && isDynamic == false)
+        for (int termIdx = 0; termIdx < prefixSuffixMatches?.Count; ++termIdx)
         {
-            throw new InvalidOperationException($"{nameof(SearchQuery)} requires analyzer.");
-        }
+            var currentItem = prefixSuffixMatches[termIdx];
 
-        var searchAnalyzer = isDynamic 
-            ? _fieldMapping.SearchAnalyzer(field.FieldName.ToString()) 
-            : field.Analyzer;
-        
-        var wildcardAnalyzer = Analyzer.Create<WhitespaceTokenizer, ExactTransformer>(this.Allocator);
-
-        searchAnalyzer.GetOutputBuffersSize(term.Length, out var outputSize, out var tokenSize);
-        wildcardAnalyzer.GetOutputBuffersSize(term.Length, out var wildcardSize, out var wildcardTokenSize);
-
-        var tokenStructSize = Unsafe.SizeOf<Token>();
-        using var __ = Allocator.Allocate(outputSize + wildcardSize + tokenStructSize * (tokenSize + wildcardTokenSize),  out var buffer);
-        Span<byte> encodeBufferOriginal = buffer.ToSpan().Slice(0, outputSize);
-        Span<Token> tokensBufferOriginal = MemoryMarshal.Cast<byte, Token>(buffer.ToSpan().Slice(outputSize, tokenSize * tokenStructSize));
-
-        var wildcardAnalyzerBuffer = buffer.ToSpan().Slice(outputSize + tokenSize * tokenStructSize, wildcardSize);
-        var wildcardTokenizerBuffer = MemoryMarshal.Cast<byte, Token>(buffer.ToSpan().Slice(outputSize + tokenSize * tokenStructSize + wildcardSize));
-
-        var encodedWildcard = wildcardAnalyzerBuffer;
-        var tokensWildcard = wildcardTokenizerBuffer;
-
-
-        wildcardAnalyzer.Execute(term, ref encodedWildcard, ref tokensWildcard);
-        IQueryMatch match = null;
-        foreach (var tokenWildcard in tokensWildcard)
-        {
-            var encoded = encodeBufferOriginal;
-            var tokens = tokensBufferOriginal;
-            var originalWord = term.Slice(tokenWildcard.Offset, (int)tokenWildcard.Length);
-            searchAnalyzer.Execute(term.Slice(tokenWildcard.Offset, (int)tokenWildcard.Length), ref encoded, ref tokens);
-            if (tokens.Length == 0)
-                continue;
-
-
-            Constants.Search.SearchMatchOptions mode = Constants.Search.SearchMatchOptions.TermMatch;
-            if (originalWord[0] is Constants.Search.Wildcard)
-                mode |= Constants.Search.SearchMatchOptions.EndsWith;
-            if (originalWord[^1] is Constants.Search.Wildcard)
-                mode |= Constants.Search.SearchMatchOptions.StartsWith;
-            if (mode.HasFlag(Constants.Search.SearchMatchOptions.StartsWith | Constants.Search.SearchMatchOptions.EndsWith))
-                mode = Constants.Search.SearchMatchOptions.Contains;
-
-            int termStart = tokens[0].Offset;
-            int termLength = (int)tokens[0].Length;
-            if (manuallyCutWildcards)
-            {
-                if (mode != Constants.Search.SearchMatchOptions.TermMatch)
+            (int startIncrement, int lengthIncrement) = currentItem.Match switch
                 {
-                    if (mode is Constants.Search.SearchMatchOptions.Contains && termLength <= 2)
-                        throw new InvalidDataException(
-                            "You are looking for an empty term. Search doesn't support it. If you want to find empty strings, you have to write an equal inside WHERE clause.");
-                    if (termLength == 1)
-                        throw new InvalidDataException("You are looking for all matches. To retrieve all matches you have to write `true` in WHERE clause.");
-                }
-
-                (int startIncrement, int lengthIncrement) = mode switch
-                {
-                    Constants.Search.SearchMatchOptions.StartsWith => (0,-1),
-                    Constants.Search.SearchMatchOptions.EndsWith => (1,0),
-                    Constants.Search.SearchMatchOptions.Contains => (1,-3),
-                    Constants.Search.SearchMatchOptions.TermMatch => (0,0),
+                    Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
+                    Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
+                    Constants.Search.SearchMatchOptions.Contains => (1, -1),
+                    Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
                     _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
                 };
+            
+            var termReadyToAnalyze = prefixSuffixMatches[termIdx].Term.AsSpan(startIncrement, currentItem.Term.Length - startIncrement + lengthIncrement);
+            var term = EncodeAndApplyAnalyzer(field, termReadyToAnalyze);
 
-                termStart += startIncrement;
-                termLength += lengthIncrement;
-            }
-
-            _transaction.Allocator.Allocate(termLength, out ByteString encodedString);
-            unsafe
+            var query = prefixSuffixMatches[termIdx].Match switch
             {
-                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(encodedString.Ptr), ref encoded[termStart], (uint)termLength);
-            }
+                Constants.Search.SearchMatchOptions.TermMatch => throw new InvalidDataException($"{nameof(TermMatch)} is handled in different part of evaluator. This is a bug."),
+                Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, term),
+                Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, term),
+                Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, term),
+                _ => throw new ArgumentOutOfRangeException()
+            };
 
-            BuildExpression(Allocator, mode, new Slice(encodedString));
+            if (searchQuery is null)
+            {
+                searchQuery = query;
+                continue;
+            }
+            
+            searchQuery = @operator switch
+            {
+                Constants.Search.Operator.Or => Or(searchQuery, query),
+                Constants.Search.Operator.And => And(searchQuery, query),
+                _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
+            };
         }
 
-        return match;
-
-        void BuildExpression(ByteStringContext ctx, Constants.Search.SearchMatchOptions mode, Slice encodedString)
+        void AssertFieldIsSearched()
         {
-            switch (mode)
-            {
-                case Constants.Search.SearchMatchOptions.TermMatch:
-                    IQueryMatch exactMatch = isNegated
-                        ? UnaryQuery(AllEntries(), field, encodedString, UnaryMatchOperation.NotEquals)
-                        : TermQuery(field, encodedString);
-
-                    if (match is null)
-                    {
-                        match = exactMatch;
-                        return;
-                    }
-
-                    match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, exactMatch)
-                        : And(match, exactMatch);
-                    break;
-                case Constants.Search.SearchMatchOptions.StartsWith:
-                    if (match is null)
-                    {
-                        match = StartWithQuery(field, encodedString, isNegated);
-                        return;
-                    }
-
-                    match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, StartWithQuery(field, encodedString, isNegated))
-                        : And(match, StartWithQuery(field, encodedString, isNegated));
-                    break;
-                case Constants.Search.SearchMatchOptions.EndsWith:
-                    if (match is null)
-                    {
-                        match = EndsWithQuery(field, encodedString, isNegated);
-                        return;
-                    }
-
-                    match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, EndsWithQuery(field, encodedString, isNegated))
-                        : And(match, EndsWithQuery(field, encodedString, isNegated));
-                    break;
-                case Constants.Search.SearchMatchOptions.Contains:
-                    if (match is null)
-                    {
-                        match = ContainsQuery(field, encodedString, isNegated);
-                        return;
-                    }
-
-                    match = @operator is Constants.Search.Operator.Or
-                        ? Or(match, ContainsQuery(field, encodedString, isNegated))
-                        : And(match, ContainsQuery(field, encodedString, isNegated));
-                    break;
-                default:
-                    throw new InvalidExpressionException("Unknown flag inside Search match.");
-            }
+            if (field.Analyzer == null && field.IsDynamic == false)
+                throw new InvalidOperationException($"{nameof(SearchQuery)} requires analyzer.");
         }
+
+        return searchQuery ?? TermMatch.CreateEmpty(this, Allocator);
     }
 }

--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -104,7 +104,9 @@ public partial class IndexSearcher
             termKey = null;
         }
 
-        return TermQuery(field, termKey, terms);
+        return termKey is null 
+            ? TermMatch.CreateEmpty(this, Allocator) 
+            : TermQuery(field, termKey, terms);
     }
     
     //Should be already analyzed...

--- a/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
+++ b/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
@@ -60,8 +60,9 @@ public partial class IndexSearcher
     //Unlike the In operation, this one requires us to check all entries in a given entry.
     //However, building a query with And can quickly lead to a Stackoverflow Exception.
     //In this case, when we get more conditions, we have to quit building the tree and manually check the entries with UnaryMatch.
-    public IQueryMatch AllInQuery(FieldMetadata field, HashSet<string> allInTerms)
+    public IQueryMatch AllInQuery(in FieldMetadata field, HashSet<string> allInTerms, bool skipEmptyItems = false)
     {
+        var canUseUnaryMatch = field.HasBoost == false;
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
 
         if (terms == null)
@@ -76,11 +77,14 @@ public partial class IndexSearcher
         //In the future, this can be optimized by adding some values at which it makes sense to skip And and go directly into checking.
         TermQueryItem[] list = new TermQueryItem[allInTerms.Count];
 
-        var it = 0;
+        var termCount = 0;
         var llt = _transaction.LowLevelTransaction;
         foreach (var item in allInTerms)
         {
             var itemSlice = EncodeAndApplyAnalyzer(field, item);
+            if (itemSlice.Size == 0 && skipEmptyItems)
+                continue;
+
             var amount = NumberOfDocumentsUnderSpecificTerm(terms, itemSlice);
             if (amount == 0)
             {
@@ -89,48 +93,54 @@ public partial class IndexSearcher
 
             var itemKey = llt.AcquireCompactKey();
             itemKey.Set(itemSlice.AsReadOnlySpan());
-            list[it++] = new TermQueryItem(itemKey, amount);
+            list[termCount++] = new TermQueryItem(itemKey, amount);
         }
 
 
         //Sort by density.
-        Array.Sort(list, (tuple, valueTuple) => tuple.Density.CompareTo(valueTuple.Density));
+        Array.Sort(list[..termCount], (tuple, valueTuple) => tuple.Density.CompareTo(valueTuple.Density));
 
-        var allInTermsCount = (allInTerms.Count % 16);
-        var stack = new BinaryMatch[allInTermsCount / 2];
-        for (int i = 0; i < allInTermsCount / 2; i++)
+        //UnaryMatch doesn't support boosting, when we wants to calculate ranking we've to build query like And(Term, And(...)).
+        var termCountToProceed = canUseUnaryMatch
+            ? (termCount % 16)
+            : termCount;
+        
+        var BinaryMatchOfTermMatches = new BinaryMatch[termCountToProceed / 2];
+        for (int i = 0; i < termCountToProceed / 2; i++)
         {
             var term1 = TermQuery(field, list[i * 2].Item, terms);
             var term2 = TermQuery(field, list[i * 2 + 1].Item, terms);
-            stack[i] = And(term1, term2);
+            BinaryMatchOfTermMatches[i] = And(term1, term2);
         }
 
-        if (allInTermsCount % 2 == 1)
+        if (termCountToProceed % 2 == 1)
         {
             // We need even values to make the last work. 
             var term = TermQuery(field, list[^1].Item, terms);
-            stack[^1] = And(stack[^1], term);
+            BinaryMatchOfTermMatches[^1] = And(BinaryMatchOfTermMatches[^1], term);
         }
 
-        int currentTerms = stack.Length;
+        
+        
+        int currentTerms = BinaryMatchOfTermMatches.Length;
         while (currentTerms > 1)
         {
             int termsToProcess = currentTerms / 2;
             int excessTerms = currentTerms % 2;
 
             for (int i = 0; i < termsToProcess; i++)
-                stack[i] = And(stack[i * 2], stack[i * 2 + 1]);
+                BinaryMatchOfTermMatches[i] = And(BinaryMatchOfTermMatches[i * 2], BinaryMatchOfTermMatches[i * 2 + 1]);
 
             if (excessTerms != 0)
-                stack[termsToProcess - 1] = And(stack[termsToProcess - 1], stack[currentTerms - 1]);
+                BinaryMatchOfTermMatches[termsToProcess - 1] = And(BinaryMatchOfTermMatches[termsToProcess - 1], BinaryMatchOfTermMatches[currentTerms - 1]);
 
             currentTerms = termsToProcess;
         }
 
 
         //Just perform normal And.
-        if (allInTerms.Count is > 1 and <= 16)
-            return MultiTermMatch.Create(stack[0]);
+        if (allInTerms.Count is > 1 and <= 16 || canUseUnaryMatch == false)
+            return MultiTermMatch.Create(BinaryMatchOfTermMatches[0]);
 
 
         //We don't have to check previous items. We have to check if those entries contain the rest of them.
@@ -138,12 +148,11 @@ public partial class IndexSearcher
 
         // BinarySearch requires sorted array.
         Array.Sort(list, ((item, inItem) => item.Item.Compare(inItem.Item)));
-        return UnaryQuery(stack[0], field, list, UnaryMatchOperation.AllIn, -1);
+        return UnaryQuery(BinaryMatchOfTermMatches[0], field, list, UnaryMatchOperation.AllIn, -1);
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public AndNotMatch NotInQuery<TInner>(FieldMetadata field, TInner inner, List<string> notInTerms)
-        where TInner : IQueryMatch
+    public AndNotMatch NotInQuery<TInner>(FieldMetadata field, TInner inner, List<string> notInTerms) where TInner : IQueryMatch
     {
         return AndNot(inner, MultiTermMatch.Create(new MultiTermMatch<InTermProvider>(field, _transaction.Allocator, new InTermProvider(this, field, notInTerms))));
     }

--- a/src/Corax/Mappings/FieldMetadata.cs
+++ b/src/Corax/Mappings/FieldMetadata.cs
@@ -70,6 +70,8 @@ public readonly struct FieldMetadata
         return new FieldMetadata(FieldName, TermLengthSumName, FieldId, Mode, Analyzer, hasBoost);
 
     }
+
+    public bool IsDynamic => FieldId == Constants.IndexWriter.DynamicField;
     
     public override string ToString()
     {

--- a/src/Corax/Queries/TermProviders/TermProvider.In.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.In.cs
@@ -34,6 +34,7 @@ namespace Corax.Queries
             term = _searcher.TermQuery(_field, _terms[_termIndex]);
             return true;
         }
+        
         public QueryInspectionNode Inspect()
         {
             return new QueryInspectionNode($"{nameof(InTermProvider)}",

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Corax;
 using Corax.Mappings;
 using Corax.Queries;
@@ -828,13 +829,139 @@ internal static class CoraxQueryBuilder
         }
 
 
-        if (fieldMetadata.Analyzer is not LuceneAnalyzerAdapter)
+        List<string> termMatches = null;
+        List<(string Term, Constants.Search.SearchMatchOptions Match)> othersMatches = null;
+        
+        foreach (var v in GetValues())
         {
-            return indexSearcher.SearchQuery(fieldMetadata, valueAsString, @operator, false, true);
+            var type = GetTermType(v);
+            if (type is Constants.Search.SearchMatchOptions.TermMatch)
+            {
+                termMatches ??= new();
+                termMatches.Add(v);
+                continue;
+            }
+
+            othersMatches ??= new();
+            othersMatches.Add((v, type));
         }
 
-        return indexSearcher.SearchQuery(fieldMetadata, valueAsString, @operator);
+        return indexSearcher.SearchQuery(fieldMetadata, termMatches, othersMatches, @operator);
+
+        Constants.Search.SearchMatchOptions GetTermType(string termValue)
+        {
+            if (string.IsNullOrEmpty(termValue))
+                return Constants.Search.SearchMatchOptions.TermMatch;
+            Constants.Search.SearchMatchOptions mode = default;
+            if (termValue[0] == LuceneQueryHelper.AsteriskChar)
+                mode |= Constants.Search.SearchMatchOptions.EndsWith;
+
+            if (termValue[^1] == LuceneQueryHelper.AsteriskChar)
+            {
+                if (termValue[^2] != '\\')
+                    mode |= Constants.Search.SearchMatchOptions.StartsWith;
+            }
+
+            return mode;
+        }
+
+        /*
+         * Here we need to deal with value that comes from the user, which means that we
+         * have to be careful.
+         *
+         * The rules are that we'll split the terms on whitespace, except if they are quoted
+         * using ", however, you may escape the " using \, and \ using \\.
+         */
+        IEnumerable<string> GetValues()
+        {
+            List<int> escapePositions = null;
+
+            var quoted = false;
+            var lastWordStart = 0;
+            for (var i = 0; i < valueAsString.Length; i++)
+            {
+                switch (valueAsString[i])
+                {
+                    case '\\' when IsEscaped(valueAsString, i):
+                        AddEscapePosition(i);
+                        break;
+                    case '"':
+                        if (IsEscaped(valueAsString, i))
+                        {
+                            AddEscapePosition(i);
+                            continue;
+                        }
+
+                        if (lastWordStart != i)
+                        {
+                            yield return YieldValue(valueAsString, lastWordStart, i - lastWordStart, escapePositions);
+                        }
+
+                        quoted = !quoted;
+                        lastWordStart = i + 1;
+                        break;
+                    case '\t':
+                    case ' ':
+                        if (quoted)
+                            continue;
+
+                        if (lastWordStart != i)
+                        {
+                            yield return YieldValue(valueAsString, lastWordStart, i - lastWordStart, escapePositions);
+                        }
+
+                        lastWordStart = i + 1; // skipping
+                        break;
+                }
+            }
+
+            if (valueAsString.Length - lastWordStart > 0)
+                yield return YieldValue(valueAsString, lastWordStart, valueAsString.Length - lastWordStart, escapePositions);
+
+
+            void AddEscapePosition(int i)
+            {
+                escapePositions ??= new List<int>(16);
+                escapePositions.Add(i - 1);
+            }
+        }
+
+        string YieldValue(string input, int startIndex, int length, List<int> escapePositions)
+        {
+            if (escapePositions == null || escapePositions.Count == 0)
+                return input.Substring(startIndex, length);
+
+            var sb = new StringBuilder(input, startIndex, length, length);
+
+            for (int i = escapePositions.Count - 1; i >= 0; i--)
+            {
+                sb.Remove(escapePositions[i] - startIndex, 1);
+            }
+
+            escapePositions.Clear();
+
+            return sb.ToString();
+        }
+
+        bool IsEscaped(string input, int index)
+        {
+            var count = 0;
+            for (int i = index - 1; i >= 0; i--)
+            {
+                if (input[i] == '\\')
+                {
+                    count++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return (count & 1) == 1;
+        }
     }
+
 
     private static IQueryMatch HandleSpatial(Parameters builderParameters, MethodExpression expression, MethodType spatialMethod)
     {

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Corax;
 using Corax.Mappings;
 using FastTests.Voron;
@@ -64,7 +65,7 @@ public class RawCoraxFlag : StorageTest
         {
             using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
             ;
-            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, "1", Constants.Search.Operator.Or, false);
+            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, null, Constants.Search.Operator.Or);
             Assert.Equal(1, match.Fill(mem));
             var result = searcher.GetEntryReaderFor(mem[0]);
             result.GetFieldReaderFor(fieldName).Read(out Span<byte> blittableBinary);
@@ -125,7 +126,7 @@ public class RawCoraxFlag : StorageTest
         Span<long> mem = stackalloc long[1024];
         {
             using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
-            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, "1", Constants.Search.Operator.Or, false);
+            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, null, Constants.Search.Operator.Or);
             Assert.Equal(1, match.Fill(mem));
             var result = searcher.GetEntryReaderFor(mem[0]);
             result.GetFieldReaderFor(1).Read(out Span<byte> blittableBinary);

--- a/test/SlowTests/Issues/RavenDB-15924.cs
+++ b/test/SlowTests/Issues/RavenDB-15924.cs
@@ -15,8 +15,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-20149")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldWork(Options options)
         {
             using var store = GetDocumentStore(options);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20149 

### Additional description

I introduced the same behavior as in Lucene, removed old "tricks" of how we build queries, and simplified the whole code of `Search`. 

### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
