### PR TITLE
RavenDB-20112 - Validate database topology - check nodes uniqness

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -213,7 +213,7 @@ namespace Raven.Client.ServerWide
             return true;
         }
 
-        public void ValidateTopology(string databaseName)
+        internal void ValidateTopology(string databaseName)
         {
             var nodes = new HashSet<string>();
             if (Count > 0)

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -213,6 +213,22 @@ namespace Raven.Client.ServerWide
             return true;
         }
 
+        public void ValidateTopology(string databaseName)
+        {
+            var nodes = new HashSet<string>();
+            if (Count > 0)
+            {
+                nodes.Clear();
+                foreach (var node in AllNodes)
+                {
+                    if (nodes.Contains(node))
+                        throw new InvalidOperationException(
+                            $"Database {databaseName} cannot have multiple replicas reside on the same node {node}.");
+                    nodes.Add(node);
+                }
+            }
+        }
+
         private bool IsReorderNeeded()
         {
             if (PriorityOrder == null || PriorityOrder.Count == 0)

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -109,13 +109,11 @@ namespace SlowTests.Sharding
                 Assert.Contains("already exists on all the nodes of the cluster", error.Message);
             }
         }
-
-        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
-        public async Task EnsureAddingNewShardNodesListCantContainDuplicates()
+        
+        [RavenTheory(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void EnsureTopologyCantContainDuplicates(Options options)
         {
-            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
-            var options = Sharding.GetOptionsForCluster(leader, shards: 1, shardReplicationFactor: 1, orchestratorReplicationFactor: 2);
-
             using (var store = GetDocumentStore(options))
             {
                 //try to add a new shard with a list of the same node twice

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -111,7 +111,7 @@ namespace SlowTests.Sharding
         }
         
         [RavenTheory(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
         public void EnsureTopologyCantContainDuplicates(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -180,7 +180,7 @@ namespace SlowTests.Sharding
                     
                 }
             });
-            Assert.Contains("Can't have multiple replicas of the same shard on the same node", error.Message);
+            Assert.Contains("cannot have multiple replicas reside on the same node", error.Message);
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20112

### Additional description

Validating the topology in the database record so we can't have 2 replicas of the same shard on one node

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
