### PR TITLE
RavenDB-18687 use ordinal comparer to sort fields to avoid issues with handling auto-indexes in mixed clusters, which could cause them to be reset on every database record change

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
+++ b/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Indexes
             if (groupBy == null)
                 throw new ArgumentNullException(nameof(groupBy));
 
-            var reducedByFields = string.Join("And", groupBy.Select(GetName).OrderBy(x => x));
+            var reducedByFields = string.Join("And", groupBy.Select(GetName).OrderBy(x => x, StringComparer.Ordinal));
 
             return $"{FindName(collection, fields, isMapReduce: true)}ReducedBy{reducedByFields}";
         }
@@ -50,7 +50,7 @@ namespace Raven.Server.Documents.Indexes
                 return collectionOnly;
             }
             
-            var combinedFields = string.Join("And", fields.Select(GetName).OrderBy(x => x));
+            var combinedFields = string.Join("And", fields.Select(GetName).OrderBy(x => x, StringComparer.Ordinal));
 
             string formattableString = $"Auto/{collection}/By{combinedFields}";
             if (formattableString.Length > 256)

--- a/test/SlowTests/Issues/RavenDB_8328.cs
+++ b/test/SlowTests/Issues/RavenDB_8328.cs
@@ -119,7 +119,7 @@ namespace SlowTests.Issues
                         .ToList();
 
                     Assert.Equal(1, results.Count);
-                    Assert.Equal("Auto/Items/BySpatial.point(Latitude|Longitude)AndSpatial.point(Latitude2|Longitude2)", stats.IndexName);
+                    Assert.Equal("Auto/Items/BySpatial.point(Latitude2|Longitude2)AndSpatial.point(Latitude|Longitude)", stats.IndexName);
 
                     results = session.Query<Item>()
                         .Statistics(out stats)
@@ -127,7 +127,7 @@ namespace SlowTests.Issues
                         .ToList();
 
                     Assert.Equal(1, results.Count);
-                    Assert.Equal("Auto/Items/BySpatial.point(Latitude|Longitude)AndSpatial.point(Latitude2|Longitude2)AndSpatial.wkt(ShapeWkt)", stats.IndexName);
+                    Assert.Equal("Auto/Items/BySpatial.point(Latitude2|Longitude2)AndSpatial.point(Latitude|Longitude)AndSpatial.wkt(ShapeWkt)", stats.IndexName);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
                     var count = session.Query<Item>().Statistics(out var stats).Count(x => x.Name == "joe" || x.name == "da");
 
                     Assert.Equal(2, count);
-                    Assert.Equal("Auto/Items/BynameAndName", stats.IndexName);
+                    Assert.Equal("Auto/Items/ByNameAndname", stats.IndexName);
                 }
             }
         }
@@ -79,7 +79,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
                     var results = session.Query<Item>().Statistics(out stats).Count(x => x.Name == "joe" || x.name == "da");
 
                     Assert.Equal(2, results);
-                    Assert.Equal("Auto/Items/BynameAndName", stats.IndexName);
+                    Assert.Equal("Auto/Items/ByNameAndname", stats.IndexName);
                 }
 
                 IndexInformation[] indexes = null;
@@ -87,7 +87,7 @@ namespace SlowTests.Server.Documents.Indexing.Auto
                 Assert.True(SpinWait.SpinUntil(() => (indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes).Length == 1, 1000));
 
                 Assert.Equal(1, indexes.Length);
-                Assert.Equal("Auto/Items/BynameAndName", indexes[0].Name);
+                Assert.Equal("Auto/Items/ByNameAndname", indexes[0].Name);
             }
         }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18687

### Additional description

The problem was that on Windows and Linux some characters are sorted differently e.g. `'` character which we have when a field name is quoted (e.g. `Group` since it's a keyword). Note that this change can make that we'll generate new index name so also a different directory name on the disk. It means that affected auto indexes will be rebuilt. This is why we apply it to 6.0 version instead of fixing it in 5.4.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- I will be tested internally after merge
 
### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
