### PR TITLE
RavenDB-20314 support importing dump when change-vector is null

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -479,6 +479,10 @@ namespace Raven.Server.Documents
                                 aboutToReadPropertyName = false;
                                 return true;
                             }
+
+                            if (state.CurrentTokenType == JsonParserToken.Null)
+                                break;
+
                             if (state.CurrentTokenType != JsonParserToken.String)
                                 ThrowExpectedFieldTypeOfString(Constants.Documents.Metadata.ChangeVector, state, reader);
                             ChangeVector = CreateLazyStringValueFromParserState(state);
@@ -824,6 +828,9 @@ namespace Raven.Server.Documents
                 case State.ReadingChangeVector:
                     if (reader.Read() == false)
                         return false;
+
+                    if (state.CurrentTokenType == JsonParserToken.Null)
+                        break;
 
                     if (state.CurrentTokenType != JsonParserToken.String)
                         ThrowExpectedFieldTypeOfString(Constants.Documents.Metadata.ChangeVector, state, reader);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20314

### Additional description

Allow to import dumps into sharded database that do not have change vector property.

In such case the orchestrator will write `null` and the shard need accept it and ignore

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
