### PR TITLE
RavenDB-17824 - DistributedDatabaseWithRevision_WhenReAadNodeToGroup_…

### DIFF
--- a/src/Raven.Client/Documents/Commands/WaitForDatabaseIndexNotificationCommand.cs
+++ b/src/Raven.Client/Documents/Commands/WaitForDatabaseIndexNotificationCommand.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Commands
+{
+    public class WaitForDatabaseIndexNotificationCommand : RavenCommand
+    {
+        private readonly long _index;
+        private readonly string _database;
+
+        public WaitForDatabaseIndexNotificationCommand(long index, string database)
+        {
+            _index = index;
+            _database = database;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{_database}/admin/rachis/wait-for-index-notification?index={_index}";
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post
+            };
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1429,6 +1429,7 @@ namespace Raven.Server.Documents
                         DatabaseGroupId = record.Topology.DatabaseTopologyIdBase64;
                         ClusterTransactionId = record.Topology.ClusterTransactionIdBase64;
 
+                        ForTestingPurposes?.BeforeUpdateUnused?.Invoke();
                         SetUnusedDatabaseIds(record);
                         InitializeFromDatabaseRecord(record);
                         IndexStore.HandleDatabaseRecordChange(record, index);
@@ -1931,6 +1932,8 @@ namespace Raven.Server.Documents
             internal Action BeforeSnapshotOfDocuments;
 
             internal Action AfterSnapshotOfDocuments;
+
+            internal Action BeforeUpdateUnused;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands;
@@ -32,6 +33,7 @@ using Raven.Server.Documents.Queries.Revisions;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -52,6 +54,7 @@ namespace Raven.Server.Documents.Handlers
 {
     public class DocumentHandler : DatabaseRequestHandler
     {
+
         [RavenAction("/databases/*/docs", "HEAD", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public Task Head()
         {

--- a/src/Raven.Server/Documents/Handlers/RachisDatabaseHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RachisDatabaseHandler.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Rachis;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Handlers
+{
+    public class RachisDatabaseHandler : DatabaseRequestHandler
+    {
+        [RavenAction("/databases/*/admin/rachis/wait-for-index-notification", "Post", AuthorizationStatus.DatabaseAdmin)]
+        public async Task WaitForDatabaseNotification()
+        {
+            var index = GetLongQueryString("index");
+            using (var cts = new CancellationTokenSource(Server.Configuration.Cluster.OperationTimeout.AsTimeSpan))
+            {
+                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, cts.Token);
+                await Database.RachisLogIndexNotifications.WaitForIndexNotification(index, cts.Token);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -36,9 +36,7 @@ namespace Raven.Server.ServerWide.Commands
 
             if (deletionStatus == DeletionInProgressStatus.HardDelete)
             {
-                if (record.UnusedDatabaseIds == null)
-                    record.UnusedDatabaseIds = new HashSet<string>();
-
+                record.UnusedDatabaseIds ??= new HashSet<string>();
                 record.UnusedDatabaseIds.Add(DatabaseId);
             }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -940,7 +940,8 @@ namespace Raven.Server.ServerWide.Maintenance
                     databaseTopology.Promotables.Add(node);
                     databaseTopology.DemotionReasons[node] = $"Just replaced the promotable node {promotable}";
                     databaseTopology.PromotablesStatus[node] = DatabasePromotionStatus.WaitingForFirstPromotion;
-                    var deletionCmd = new DeleteDatabaseCommand(dbName, RaftIdGenerator.NewId())
+                    var cmdId = DeleteDatabaseCommand.GenerateUniqueRequestId(dbName, new List<string>() { promotable }, RaftIdGenerator.NewId());
+                    var deletionCmd = new DeleteDatabaseCommand(dbName, cmdId)
                     {
                         ErrorOnDatabaseDoesNotExists = false,
                         FromNodes = new[] { promotable },
@@ -1458,7 +1459,8 @@ namespace Raven.Server.ServerWide.Maintenance
 
             LogMessage($"We reached the replication factor on database '{dbName}', so we try to remove redundant nodes from {string.Join(", ", nodesToDelete)}.", database: dbName);
 
-            var deletionCmd = new DeleteDatabaseCommand(dbName, RaftIdGenerator.NewId())
+            var cmdId = DeleteDatabaseCommand.GenerateUniqueRequestId(dbName, nodesToDelete, RaftIdGenerator.NewId());
+            var deletionCmd = new DeleteDatabaseCommand(dbName, cmdId)
             {
                 ErrorOnDatabaseDoesNotExists = false,
                 FromNodes = nodesToDelete.ToArray(),

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1808,7 +1808,10 @@ namespace Raven.Server.ServerWide
         
         public Task<(long Index, object Result)> DeleteDatabaseAsync(string db, bool hardDelete, string[] fromNodes, string raftRequestId)
         {
-            var deleteCommand = new DeleteDatabaseCommand(db, raftRequestId)
+            if (raftRequestId == RaftIdGenerator.DontCareId)
+                raftRequestId = Guid.NewGuid().ToString();
+            var deleteDatabaseCmdId = DeleteDatabaseCommand.GenerateUniqueRequestId(db, fromNodes, raftRequestId);
+            var deleteCommand = new DeleteDatabaseCommand(db, deleteDatabaseCmdId)
             {
                 HardDelete = hardDelete,
                 FromNodes = fromNodes

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -64,7 +64,8 @@ namespace FastTests.Client
                 "GetDatabaseSettingsCommand", "PutDatabaseConfigurationSettingsCommand", "ConfigurePostgreSqlCommand", "ValidateTwoFactorAuthenticationTokenCommand",
                 "GetTrafficWatchConfigurationCommand", "SetTrafficWatchConfigurationCommand",
                 "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand", "DelayBackupCommand",
-                "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand", "GetTcpInfoForReplicationCommand"
+                "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand", "GetTcpInfoForReplicationCommand",
+                "WaitForDatabaseIndexNotificationCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/SlowTests/Issues/RavenDB-17824.cs
+++ b/test/SlowTests/Issues/RavenDB-17824.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
+using Xunit;
+using Constants = Raven.Client.Constants;
+using Xunit.Abstractions;
+using Raven.Server.Rachis;
+using Tests.Infrastructure;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17824 : ReplicationTestBase
+    {
+        public RavenDB_17824(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.None)]
+        public async Task DeleteDatabasesOperationShouldWaitForBeingAppliedInAllNodes()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var follower = nodes.Single(n => n != leader);
+
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 2 });
+            var config = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration() };
+            await RevisionsHelper.SetupRevisions(store, leader.ServerStore, config);
+
+            using var storeL = GetDocumentStoreForSpecificServer(leader, store.Database);
+            using var storeF = GetDocumentStoreForSpecificServer(follower, store.Database);
+
+            var entity = new User { Name = "Old" };
+            using (var session = storeL.OpenAsyncSession())
+            {
+                await session.StoreAsync(entity);
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+                await session.SaveChangesAsync();
+            }
+
+            // prevent from follower to get updated record
+            var followerDb = await follower.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var mre = new ManualResetEvent(false);
+            followerDb.ForTestingPurposes = new DocumentDatabase.TestingStuff();
+            followerDb.ForTestingPurposes.BeforeUpdateUnused = () =>
+            {
+                mre.WaitOne(5_000);
+            };
+
+            // delete database from leader node
+            await storeL.Maintenance.Server.SendAsync(
+                new DeleteDatabasesOperation(store.Database, true, leader.ServerStore.NodeTag, TimeSpan.FromSeconds(30)));
+
+            Assert.True(await WaitForValueAsync(async () =>
+            {
+                var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return res != null && res.Topology.Count == 1;
+            }, true));
+
+            Assert.Equal(0, await WaitForValueAsync(async () =>
+            {
+                var records = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return records.DeletionInProgress.Count;
+            }, 0));
+
+            followerDb.ForTestingPurposes.BeforeUpdateUnused = null;
+
+            // add leader node to the database again(now leaser has the same db with different dbId)
+            await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database, leader.ServerStore.NodeTag));
+
+            Assert.True(await WaitForValueAsync(async () =>
+            {
+                var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return res != null && res.Topology.Members.Count == 2;
+            }, true));
+
+            await EnsureReplicatingAsync((DocumentStore)storeF, (DocumentStore)storeL);
+
+            // update 'entity' in leader node - conflict (because follower didnt get the updated record,
+            // so it doesnt has the upsated databases 'unused list',
+            // and because of it - the follower doesnt remove the tag with leader old db id from the change-vector).
+            // A:3-newDbId B:8 A:5-oldDbId
+            // var newLeaderDbId = (await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database)).DbBase64Id;
+            using (var session = storeL.OpenAsyncSession())
+            {
+                entity.Name = $"Change after adding again node {leader.ServerStore.NodeTag} ";
+                await session.StoreAsync(entity);
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);//, timeout: TimeSpan.FromDays(1));
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = storeL.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>(entity.Id);
+                var metadata = session.Advanced.GetMetadataFor(loaded);
+                var flags = metadata.GetString(Constants.Documents.Metadata.Flags);
+                var info = "";
+                var lastRevisionIsResolved = flags.Contains(DocumentFlags.Resolved.ToString());
+                if (lastRevisionIsResolved)
+                {
+                    info += $"Flags: {flags}\n";
+                    var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    info += $"Topology: \n";
+                    foreach (var member in res.Topology.Members)
+                    {
+                        info += $"{member} \n";
+                    }
+
+                    var revisions = await session.Advanced.Revisions.GetForAsync<User>(entity.Id);
+                    info += $"Revisions: \n";
+                    foreach (var rev in revisions)
+                    {
+                        var ch = session.Advanced.GetChangeVectorFor(rev);
+                        var fl = session.Advanced.GetMetadataFor(rev).GetString(Constants.Documents.Metadata.Flags);
+                        info += $"{rev.Name} : {fl} - {ch} \n";
+                    }
+                    info += $"Flags: {flags}\n";
+                    Assert.False(true, info);
+                }
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.None)]
+        public async Task TwoDeleteRequestShouldThrow()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 2 });
+            var nodeToRemove = "B";
+
+            // delete database from leader node
+            var delete1 = store.Maintenance.Server.SendAsync(
+                new DeleteDatabasesOperation(store.Database, true, nodeToRemove, TimeSpan.FromSeconds(30)));
+
+            // delete database from leader node
+            var delete2 = store.Maintenance.Server.SendAsync(
+                new DeleteDatabasesOperation(store.Database, true, nodeToRemove, TimeSpan.FromSeconds(30)));
+
+            // can't use Assert.Throws<T>(..) because it can be here Exception or RavenException,
+            // and if you passes type 'Exception' and you get 'RavenException' it throws.
+            Exception ex = null;
+            try
+            {
+                await delete1;
+                await delete2;
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+            Assert.NotNull(ex);
+
+            var inner = ex.InnerException;
+            var m1 = GetSecondDeleteExceptionMessege(store.Database, "A");
+            var m2 = GetSecondDeleteExceptionMessege(store.Database, "B");
+
+
+            if (ex is RavenException)
+            {
+                if (inner != null)
+                {
+                    Assert.True(inner is InvalidOperationException or RachisApplyException, $"inner exception should be of type 'InvalidOperationException' or 'RachisApplyException', but it is '{inner.GetType()}'");
+                    Assert.True(ex.Message.Contains(m1) || ex.Message.Contains(m2));
+                }
+                else
+                    Assert.True(ex.Message.Contains(m1) || ex.Message.Contains(m2));
+            }
+            else
+            {
+                if (inner != null)
+                {
+                    Assert.True(inner is RavenTimeoutException, $"inner exception should be of type 'RavenTimeoutException', but it is '{inner.GetType()}'");
+                    Assert.True(ex.Message.Contains(m1) || ex.Message.Contains(m2), $"The message is: \"{ex.Message}\"");
+                }
+                else
+                {
+                    Assert.True(ex.Message.Contains(m1) || ex.Message.Contains(m2));
+                }
+            }
+        }
+
+        private string GetSecondDeleteExceptionMessege(string database, string nodeTag)
+        {
+            return $"Database '{database}' doesn't reside on node '{nodeTag}' so it can't be deleted from it";
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -293,7 +293,7 @@ namespace FastTests
             }
             catch (Exception e)
             {
-                if (e is RavenException && (e.InnerException is TimeoutException || e.InnerException is OperationCanceledException))
+                if (e is RavenException && (e.InnerException is TimeoutException or OperationCanceledException or TaskCanceledException))
                     return null;
 
                 if (Servers.Contains(serverToUse))

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
@@ -286,6 +287,9 @@ namespace FastTests
             catch (AllTopologyNodesDownException)
             {
 
+            }
+            catch (RavenTimeoutException)
+            {
             }
             catch (Exception e)
             {
@@ -900,6 +904,16 @@ namespace FastTests
             }
 
             return sb.ToString();
+        }
+
+        public static IDocumentStore GetDocumentStoreForSpecificServer(RavenServer server, string database)
+        {
+            return new DocumentStore()
+            {
+                Database = database,
+                Urls = new[] { server.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+            }.Initialize();
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17824/SlowTests.Server.Replication.ReplicationConflictsTests.DistributedDatabaseWithRevisionWhenReAadNodeToGroupShouldNotHaveConflicts

### Additional description

Fixing DistributedDatabaseWithRevision_WhenReAadNodeToGroup_ShouldNotHaveConflictsfailure.
The leader is being deleted and added again to the db, and before the first change of the db record in the follower is handled, we store in the leader the same doc that was in it before with different content and it causes a conflict after it replicated from leader to follower (because the doc in the follower has change vector that contains the old leader db id).


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
