### PR TITLE
RavenDB-20327 Can't click anywhere (outside modal) when shard selecto…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/common/sharding/shardSelector.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/sharding/shardSelector.html
@@ -1,4 +1,4 @@
-<div class="modal bs3" style="display:block">
+<div class="scoped-modal" style="display:block">
     <div class="modal-dialog" role="document">
     <div class="modal-content neo-modal">
         <div class="modal-body text-center overflow-y-inherit">

--- a/src/Raven.Studio/wwwroot/Content/css/modals.less
+++ b/src/Raven.Studio/wwwroot/Content/css/modals.less
@@ -321,6 +321,11 @@
     }
 }
 
+.scoped-modal {    
+    position: absolute;    
+    width: 100%;
+    z-index: @zindex-modal;    
+}
 
 .neo-modal {
     border-radius: @gutter-xxs;


### PR DESCRIPTION
…r pops out

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20327

### Additional description

Added a class to display modals bound to view not to the whole UI

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
