### PR TITLE
RavenDB-20077 : certificate with permissions for sharded database should allow access to individual shards

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1498,7 +1498,7 @@ namespace Raven.Server
                 if (_caseSensitiveAuthorizedDatabases.TryGetValue(database, out var mode))
                     return CheckAccess(mode, requireAdmin, requireWrite);
 
-                if (AuthorizedDatabases.TryGetValue(database, out mode) == false)
+                if (AuthorizedDatabases.TryGetValue(ShardHelper.ToDatabaseName(database), out mode) == false)
                     return false;
 
                 // Technically speaking, since this is per connection, this is single threaded. But I'm


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20077

### Additional description

use database name instead of shard name when checking if access is allowed

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
