### PR TITLE
RavenDB-18073 Comparing incorrect dates as strings, instead of translating them to ticks

### DIFF
--- a/test/SlowTests/Issues/RavenDB-18073.cs
+++ b/test/SlowTests/Issues/RavenDB-18073.cs
@@ -1,0 +1,49 @@
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18073 : RavenTestBase
+{
+    public RavenDB_18073(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData("from Dtos where SomeDate < \"2024-02-31T00:00:00.0000000\"")]
+    [InlineData("from Dtos where SomeDate between \"2023-01-01T00:00:00.0000000\" and \"2024-15-31T00:00:00.0000000\"")]
+    private void CheckIfIncorrectDateIsComparedAsString(string query)
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() { Name = "Name1", SomeDate = "2023-05-14T00:00:00.0000000" };
+                var d2 = new Dto() { Name = "Name2", SomeDate = "2023-17-14T00:00:00.0000000" };
+                var d3 = new Dto() { Name = "Name3", SomeDate = "2033-04-14T00:00:00.0000000" };
+                var d4 = new Dto() { Name = "Name4", SomeDate = "2023-02-35T00:00:00.0000000" };
+                
+                session.Store(d1);
+                session.Store(d2);
+                session.Store(d3);
+                session.Store(d4);
+                
+                session.SaveChanges();
+                
+                WaitForUserToContinueTheTest(store);
+                
+                var res = session.Advanced.RawQuery<Dto>(query).ToList();
+                
+                Assert.Equal(3, res.Count);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public string SomeDate { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-18073.cs
+++ b/test/SlowTests/Issues/RavenDB-18073.cs
@@ -32,8 +32,6 @@ public class RavenDB_18073 : RavenTestBase
                 
                 session.SaveChanges();
                 
-                WaitForUserToContinueTheTest(store);
-                
                 var res = session.Advanced.RawQuery<Dto>(query).ToList();
                 
                 Assert.Equal(3, res.Count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18073/Sparrow.Json.LazyStringParser.DateToTicks-returns-wrong-result-for-incorrect-dates.

### Additional description

We want to compare incorrect dates (e.g. 2022 Feb 31) using string comparison instead of trying to convert it into ticks.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No.

### UI work

- No UI work is needed
