### PR TITLE
RavenDB-20230 Corax: `DynamicNullObject` objects where `IsExplicitNull == false` will be skipped in map-reduce output.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -65,7 +65,9 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
                 if (_fields.TryGetValue(property.Key, out var field) == false)
                     throw new InvalidOperationException($"Field '{property.Key}' is not defined. Available fields: {string.Join(", ", _fields.Keys)}.");
 
-                if (storedValue is not null)
+                
+                InsertRegularField(field, value, indexContext, ref entryWriter, scope, out var shouldSkip);
+                if (storedValue is not null && shouldSkip == false)
                 {
                     //Notice: we are always saving values inside Corax index. This method is explicitly for MapReduce because we have to have JSON as the last item.
                     var blittableValue = TypeConverter.ToBlittableSupportedType(value, out TypeConverter.BlittableSupportedReturnType returnType, flattenArrays: true);
@@ -75,8 +77,6 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
 
                     storedValue[property.Key] = blittableValue;
                 }
-
-                InsertRegularField(field, value, indexContext, ref entryWriter, scope);
             }
 
             if (storedValue is not null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -68,11 +68,11 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
                             throw new ArgumentOutOfRangeException($"{spatialOptions.MethodType} is not implemented.");
                     }
 
-                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope, out var _);
                 }
                 else if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, indexField.OriginalName ?? indexField.Name, out value))
                 {
-                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope);
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope, out var _);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -274,7 +274,6 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 var iterator = (IEnumerable)value;
 
                 var canFinishEnumerableWriting = false;
-                shouldSkip = true;
                 
                 if (scope is not EnumerableWriterScope enumerableWriterScope)
                 {
@@ -284,11 +283,9 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                
                 foreach (var item in iterator)
                 {
-                    InsertRegularField(field, item, indexContext, ref entryWriter, enumerableWriterScope, out var innerShouldSkip, nestedArray);
-                    //Should override shouldSkip to false when something is not skipped.
-                    shouldSkip &= innerShouldSkip;
+                    InsertRegularField(field, item, indexContext, ref entryWriter, enumerableWriterScope, out var _, nestedArray);
                 }
-
+                
                 if (canFinishEnumerableWriting)
                 {
                     enumerableWriterScope.Finish(path, fieldId, ref entryWriter);

--- a/test/SlowTests/Issues/RavenDB_12334.cs
+++ b/test/SlowTests/Issues/RavenDB_12334.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Map_reduce_results_should_not_contains_implicit_nulls_wich_were_not_indexed(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -29,7 +29,6 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
 
                     Indexes.WaitForIndexing(store);
-                    WaitForUserToContinueTheTest(store);
 
                     var result = await session.Query<BlittableJsonReaderObject, DocsIndex>().FirstAsync();
 
@@ -55,6 +54,7 @@ namespace SlowTests.Issues
             public double? NumVal { get; set; }
         }
 
+        
         public class DocsIndex : AbstractMultiMapIndexCreationTask<DocView>
         {
             public DocsIndex()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20230
### Additional description

 `DynamicNullObject` objects where `IsExplicitNull == false` will be skipped in map-reduce output.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
