### PR TITLE
RavenDB-20321: Avoid fixed statements on high traffic code.

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -29,7 +29,6 @@ using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
-using Sparrow.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Data.Fixed;
@@ -2568,6 +2567,11 @@ namespace Raven.Server.Documents
             return value;
         }
 
+        private static void ThrowInvalidTagLength()
+        {
+            throw new InvalidOperationException($"The tag length is invalid.");
+        }
+
         private static void ThrowInvalidShortSize(string name, int size)
         {
             throw new InvalidOperationException($"{name} size is invalid, expected short but got {size}.");
@@ -2604,7 +2608,10 @@ namespace Raven.Server.Documents
         public static LazyStringValue TableValueToId(JsonOperationContext context, int index, ref TableValueReader tvr)
         {
             var ptr = tvr.Read(index, out _);
-            return context.GetLazyStringValue(ptr);
+            var lzs = context.GetLazyStringValue(ptr, out bool success);
+            if (success == false)
+                ThrowInvalidTagLength();
+            return lzs;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorExtensions.cs
@@ -15,11 +15,8 @@ namespace Raven.Server.Documents.Replication
         public static unsafe string AsChangeVectorDbId(this Guid DbId)
         {
             var dbIdAsString = new string(' ', 22);
-            fixed (char* dbIdPtr = dbIdAsString)
-            {
-                var res = Base64.ConvertToBase64ArrayUnpadded(dbIdPtr, (byte*)&DbId, 0, 16);
-                Debug.Assert(res == 22);
-            }
+            var res = Base64.ConvertToBase64ArrayUnpadded(dbIdAsString, (byte*)&DbId, 0, 16);
+            Debug.Assert(res == 22);
 
             return dbIdAsString;
         }

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -93,20 +93,6 @@ namespace Raven.Server.Documents.Replication
             return etag;
         }
 
-        private static unsafe Guid ParseDbId(string changeVector, int start)
-        {
-            Guid id = Guid.Empty;
-            char* buffer = stackalloc char[24];
-            fixed (char* str = changeVector)
-            {
-                Buffer.MemoryCopy(str + start, buffer, 24 * sizeof(char), 22 * sizeof(char));
-                buffer[22] = '=';
-                buffer[23] = '=';
-                Base64.FromBase64_Decode(buffer, 24, (byte*)&id, 16);
-            }
-            return id;
-        }
-
         public static List<ChangeVectorEntry> ToChangeVectorList(this string changeVector)
         {
             if (string.IsNullOrEmpty(changeVector))

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -613,7 +613,10 @@ namespace Raven.Server.Documents.TimeSeries
             if (tagPointer.Pointer == null)
                 return null;
 
-            return context.GetLazyStringValue(tagPointer.Pointer);
+            var lzs = context.GetLazyStringValue(tagPointer.Pointer, out bool success);
+            if (success == false)
+                ThrowInvalidTagLength();
+            return lzs;
         }
 
         public IEnumerable<SingleResult> YieldAllValues(DocumentsOperationContext context, DateTime baseline, bool includeDead = true)

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -2342,11 +2342,8 @@ namespace Raven.Server.Rachis
                 return;
 
             var guid = new Guid(str);
-            fixed (char* pChars = _clusterIdBase64Id)
-            {
-                var result = Base64.ConvertToBase64ArrayUnpadded(pChars, (byte*)&guid, 0, 16);
-                Debug.Assert(result == 22);
-            }
+            var result = Base64.ConvertToBase64ArrayUnpadded(_clusterIdBase64Id, (byte*)&guid, 0, 16);
+            Debug.Assert(result == 22);
         }
 
         public void ReportLeaderTime(long leaderTime)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -511,11 +511,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             var databaseGuidId = new Guid(buffer);
             var dbIdStr = new string(' ', 22);
 
-            fixed (char* pChars = dbIdStr)
-            {
-                var result = Base64.ConvertToBase64ArrayUnpadded(pChars, (byte*)&databaseGuidId, 0, 16);
-                Debug.Assert(result == 22);
-            }
+            var result = Base64.ConvertToBase64ArrayUnpadded(dbIdStr, (byte*)&databaseGuidId, 0, 16);
+            Debug.Assert(result == 22);
 
             return dbIdStr;
         }

--- a/src/Sparrow.Server/Format.cs
+++ b/src/Sparrow.Server/Format.cs
@@ -76,12 +76,8 @@ namespace Sparrow.Server
             if (bytes.Length != 16)
                 throw new ArgumentException("Expected buffer to be exactly 16 bytes long");
             string result = new string(' ', 22);
-            fixed (char* pChars = result)
-            fixed(byte* pBytes = bytes)
-            {
-                int size = Base64.ConvertToBase64ArrayUnpadded(pChars, pBytes, 0, 16);
-                Debug.Assert(size == 22);
-            }
+            int size = Base64.ConvertToBase64ArrayUnpadded(result, bytes, 0, 16);
+            Debug.Assert(size == 22);
 
             return result;
         }

--- a/src/Sparrow/Compression/VariableSizeEncoding.cs
+++ b/src/Sparrow/Compression/VariableSizeEncoding.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Sparrow.Compression
 {
@@ -11,18 +12,22 @@ namespace Sparrow.Compression
             if (output.Length < count)
                 goto FailCount;
 
+
+            ref var bufferRef = ref MemoryMarshal.GetReference(buffer);
+
             int pos = 0;
-            
             for (int i = 0; i < count; i++)
             {
+                ref var outputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(output), i);
                 if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
                 {
+                    
                     if (typeof(T) == typeof(bool))
-                        output[i] = (T)(object)(buffer[pos + 0] == 1);
+                        outputRef = (T)(object)(Unsafe.Add(ref bufferRef, pos) == 1);
                     else if (typeof(T) == typeof(sbyte))
-                        output[i] = (T)(object)(sbyte)buffer[pos + 0];
+                        outputRef = (T)(object)(sbyte)Unsafe.Add(ref bufferRef, pos);
                     else
-                        output[i] = (T)(object)buffer[pos + 0];
+                        outputRef = (T)(object)Unsafe.Add(ref bufferRef, pos);
 
                     pos += 1;
                     continue;
@@ -36,19 +41,19 @@ namespace Sparrow.Compression
                 {
                     long ul = 0;
 
-                    byte b = buffer[pos + 0];
+                    byte b = Unsafe.Add(ref bufferRef, pos);
                     ul |= (long)(b & 0x7F);
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 1];
+                    b = Unsafe.Add(ref bufferRef, pos + 1);
                     ul |= (long)(b & 0x7F) << 7;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 2];
+                    b = Unsafe.Add(ref bufferRef, pos + 2);
                     ul |= (long)(b & 0x7F) << 14;
                     offset++;
 
@@ -65,13 +70,13 @@ namespace Sparrow.Compression
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 3];
+                    b = Unsafe.Add(ref bufferRef, pos + 3);
                     ul |= (long)(b & 0x7F) << 21;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 4];
+                    b = Unsafe.Add(ref bufferRef, pos + 4);
                     ul |= (long)(b & 0x7F) << 28;
                     offset++;
 
@@ -88,31 +93,31 @@ namespace Sparrow.Compression
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 5];
+                    b = Unsafe.Add(ref bufferRef, pos + 5);
                     ul |= (long)(b & 0x7F) << 35;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 6];
+                    b = Unsafe.Add(ref bufferRef, pos + 6);
                     ul |= (long)(b & 0x7F) << 42;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 7];
+                    b = Unsafe.Add(ref bufferRef, pos + 7);
                     ul |= (long)(b & 0x7F) << 49;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 8];
+                    b = Unsafe.Add(ref bufferRef, pos + 8);
                     ul |= (long)(b & 0x7F) << 56;
                     offset++;
                     if ((b & 0x80) == 0)
                         goto End;
 
-                    b = buffer[pos + 9];
+                    b = Unsafe.Add(ref bufferRef, pos + 9);
                     ul |= (long)(b & 0x7F) << 63;
                     offset++;
                     if ((b & 0x80) != 0)
@@ -122,17 +127,17 @@ namespace Sparrow.Compression
                     pos += offset;
 
                     if (typeof(T) == typeof(short))
-                        output[i] = (T)(object)(short)ul;
+                        outputRef = (T)(object)(short)ul;
                     else if (typeof(T) == typeof(ushort))
-                        output[i] = (T)(object)(ushort)ul;
+                        outputRef = (T)(object)(ushort)ul;
                     else if (typeof(T) == typeof(int))
-                        output[i] = (T)(object)(int)ul;
+                        outputRef = (T)(object)(int)ul;
                     else if (typeof(T) == typeof(uint))
-                        output[i] = (T)(object)(uint)ul;
+                        outputRef = (T)(object)(uint)ul;
                     else if (typeof(T) == typeof(ulong))
-                        output[i] = (T)(object)(ulong)ul;
+                        outputRef = (T)(object)(ulong)ul;
                     else
-                        output[i] = (T)(object)ul;
+                        outputRef = (T)(object)ul;
 
                     continue;
                 }
@@ -236,6 +241,101 @@ namespace Sparrow.Compression
 
         Fail:
             success = false;
+
+            if (typeof(T) == typeof(short))
+                return (T)(object)(short)0;
+            if (typeof(T) == typeof(ushort))
+                return (T)(object)(ushort)0;
+            if (typeof(T) == typeof(int))
+                return (T)(object)(int)0;
+            if (typeof(T) == typeof(uint))
+                return (T)(object)(uint)0;
+            if (typeof(T) == typeof(long))
+                return (T)(object)(long)0;
+            return (T)(object)(ulong)0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<T>(ReadOnlySpan<byte> input, int pos, out int offset, out bool success) where T : unmanaged
+        {
+            success = true;
+
+            ref var inputStart = ref Unsafe.Add(ref MemoryMarshal.GetReference(input), pos);
+            if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
+            {
+                offset = 1;
+
+                if (typeof(T) == typeof(bool))
+                    return (T)(object)(inputStart == 1);
+                return (typeof(T) == typeof(sbyte)) ? (T)(object)(sbyte)inputStart : (T)(object)inputStart;
+            }
+
+            if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(int) || typeof(T) == typeof(uint) ||
+                typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
+            {
+                const int bitsToShift = 7;
+
+                ulong ul;
+                byte b = inputStart;
+                if (b < 0x80)
+                {
+                    ul = (ulong)(b & 0x7F);
+                    offset = 1;
+                    goto End;
+                }
+
+                byte b1 = Unsafe.Add(ref inputStart, 1);
+                ul = (b1 & 0x7Ful) << bitsToShift | (b & 0x7Ful);
+                if (b1 < 0x80)
+                {
+                    offset = 2;
+                    goto End;
+                }
+
+                int bytesReadWhenOverflow;
+                if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+                    bytesReadWhenOverflow = 10;
+                else if (typeof(T) == typeof(int) || typeof(T) == typeof(uint))
+                    bytesReadWhenOverflow = 5;
+                else
+                    bytesReadWhenOverflow = 3;
+
+                // PERF: We need this for the JIT to understand that this can be profitable. 
+                ref var inputRef = ref Unsafe.Add(ref inputStart, 2);
+                int shift = 2 * bitsToShift;
+                do
+                {
+                    if (shift == bytesReadWhenOverflow * bitsToShift)
+                        goto Fail; // PERF: Using goto to diminish the size of the loop.
+
+                    b = inputRef;
+                    ul |= (b & 0x7Ful) << shift;
+                    shift += bitsToShift;
+
+                    inputRef = Unsafe.Add(ref inputRef, 1);
+                }
+                while (b >= 0x80);
+                offset = Unsafe.ByteOffset(ref inputRef, ref inputStart).ToInt32();
+
+            End:
+                
+                if (typeof(T) == typeof(short))
+                    return (T)(object)(short)ul;
+                if (typeof(T) == typeof(ushort))
+                    return (T)(object)(ushort)ul;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)(int)ul;
+                if (typeof(T) == typeof(uint))
+                    return (T)(object)(uint)ul;
+                if (typeof(T) == typeof(long))
+                    return (T)(object)(long)ul;
+                return (T)(object)ul;
+            }
+
+            Fail:
+            success = false;
+            offset = 0;
 
             if (typeof(T) == typeof(short))
                 return (T)(object)(short)0;
@@ -369,7 +469,7 @@ namespace Sparrow.Compression
                     return (T)(object)(long)count;
                 return (T)(object)count;
 
-                Error:
+            Error:
                 success = false;
                 return (T)(object)-1;
             }
@@ -377,24 +477,161 @@ namespace Sparrow.Compression
             throw new NotSupportedException("Unsupported type.");
         }
 
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe T Read<T>(ReadOnlySpan<byte> input, out int offset, int pos = 0) where T : unmanaged
+        public static T ReadCompact<T>(ReadOnlySpan<byte> input, int pos, out int offset, out bool success) where T : unmanaged
         {
+            ref var inputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(input), pos);
             if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
             {
                 offset = 1;
-                byte b = input[pos + 0];
+                success = true;
 
                 if (typeof(T) == typeof(bool))
-                    return (T)(object)(b == 1);
-                return (T)(object)b;
+                    return (T)(object)(inputRef == 1);
+                return (T)(object)inputRef;
             }
 
-            fixed (byte* buffer = input)
+            offset = 0;
+
+            if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(int) || typeof(T) == typeof(uint) ||
+                typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                return Read<T>(buffer + pos, out offset);
+                const int bitsToShift = 7;
+                int maxBytesWithoutOverflow;
+                if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+                    maxBytesWithoutOverflow = 10;
+                else if (typeof(T) == typeof(int) || typeof(T) == typeof(uint))
+                    maxBytesWithoutOverflow = 5;
+                else
+                    maxBytesWithoutOverflow = 3;
+
+                ulong count = 0;
+                byte b;
+                byte shift = 0;
+                do
+                {
+                    if (shift == maxBytesWithoutOverflow * bitsToShift)
+                        goto Error; // PERF: Using goto to diminish the size of the loop.
+
+                    b = inputRef;
+                    inputRef = ref Unsafe.Add(ref inputRef, 1);
+                    offset++;
+
+                    count |= (b & 0x7Ful) << shift;
+                    shift += bitsToShift;
+                }
+                while (b >= 0x80);
+
+                success = true;
+
+                if (typeof(T) == typeof(short))
+                    return (T)(object)(short)count;
+                if (typeof(T) == typeof(ushort))
+                    return (T)(object)(ushort)count;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)(int)count;
+                if (typeof(T) == typeof(uint))
+                    return (T)(object)(uint)count;
+                if (typeof(T) == typeof(long))
+                    return (T)(object)(long)count;
+                return (T)(object)count;
             }
+
+            Error:
+            success = false;
+            return (T)(object)-1;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<T>(ReadOnlySpan<byte> input, out int offset, int pos = 0) where T : unmanaged
+        {
+            ref var destRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(input), pos);
+            if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
+            {
+                offset = 1;
+
+                if (typeof(T) == typeof(bool))
+                    return (T)(object)(destRef == 1);
+                return (T)(object)destRef;
+            }
+
+            if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
+            {
+                offset = 1;
+                if (typeof(T) == typeof(bool))
+                    return (T)(object)(destRef == 1);
+                return (typeof(T) == typeof(sbyte)) ? (T)(object)(sbyte)destRef : (T)(object)destRef;
+            }
+
+            offset = 0;
+
+            if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(int) || typeof(T) == typeof(uint) ||
+                typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
+            {
+                const int bitsToShift = 7;
+
+                ulong ul = 0;
+                byte b = destRef;
+                offset++;
+                if (b < 0x80)
+                {
+                    ul = (ulong)(b & 0x7F);
+                    goto End;
+                }
+
+                byte b1 = Unsafe.Add(ref destRef, 1);
+                ul = (b1 & 0x7Ful) << bitsToShift | (b & 0x7Ful);
+                offset++;
+                if (b1 < 0x80)
+                    goto End;
+
+                int bytesReadWhenOverflow;
+                if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+                    bytesReadWhenOverflow = 10;
+                else if (typeof(T) == typeof(int) || typeof(T) == typeof(uint))
+                    bytesReadWhenOverflow = 5;
+                else
+                    bytesReadWhenOverflow = 3;
+
+                // PERF: We need this for the JIT to understand that this can be profitable. 
+                destRef = ref Unsafe.Add(ref destRef, 2);
+                int shift = 2 * bitsToShift;
+                do
+                {
+                    if (shift == bytesReadWhenOverflow * bitsToShift)
+                        goto Fail; // PERF: Using goto to diminish the size of the loop.
+
+                    b = destRef;
+                    ul |= (b & 0x7Ful) << shift;
+                    shift += bitsToShift;
+
+                    offset++;
+                    destRef = ref Unsafe.Add(ref destRef, 1);
+                }
+                while (b >= 0x80);
+
+            End:
+                if (typeof(T) == typeof(short))
+                    return (T)(object)(short)ul;
+                if (typeof(T) == typeof(ushort))
+                    return (T)(object)(ushort)ul;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)(int)ul;
+                if (typeof(T) == typeof(uint))
+                    return (T)(object)(uint)ul;
+                if (typeof(T) == typeof(long))
+                    return (T)(object)(long)ul;
+                return (T)(object)ul;
+            }
+
+            ThrowNotSupportedException<T>();
+
+        Fail:
+            ThrowInvalidShift();
+            return (T)(object)-1;
         }
 
         private static void ThrowNotSupportedException<T>()
@@ -422,7 +659,10 @@ namespace Sparrow.Compression
 
             int startPos = pos;
             for (int i = 0; i < values.Length; i++)
-                pos += Write(dest, values[i], pos);
+            {
+                ref var valueToWrite = ref Unsafe.Add(ref MemoryMarshal.GetReference(values), i);
+                pos += Write(dest, valueToWrite, pos);
+            }
 
             return pos - startPos;
         }
@@ -563,8 +803,10 @@ namespace Sparrow.Compression
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int Write<T>(Span<byte> dest, T value, int pos = 0) where T : unmanaged
+        public static int Write<T>(Span<byte> dest, T value, int pos = 0) where T : unmanaged
         {
+            ref var destRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(dest), pos);
+
             if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
             {
                 byte b;
@@ -578,19 +820,125 @@ namespace Sparrow.Compression
                 int i = 0;
                 if (b < 0x80)
                     goto End;
-                dest[pos] = (byte)(b | 0x80);
+
+                destRef = (byte)(b | 0x80);
                 b >>= 7;
                 i++;
 
             End:
-                dest[pos + i] = b;
+                Unsafe.Add(ref destRef, i) = b;
                 return i + 1;
             }
-            
-            fixed (byte* buffer = dest)
+
+            if (typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                return Write(buffer + pos, value);
+                ushort ui;
+                if (typeof(T) == typeof(short))
+                    ui = (ushort)(short)(object)value;
+                else
+                    ui = (ushort)(object)value;
+
+                if (ui < 0x80)
+                {
+                    destRef = (byte)ui;
+                    return 1;
+                }
+
+                destRef = (byte)(ui | 0x80);
+                ui >>= 7;
+
+                destRef = ref Unsafe.Add(ref destRef, 1);
+
+                int i = 1;
+                while (ui >= 0x80)
+                {
+                    destRef = (byte)(ui | 0x80);
+                    destRef = ref Unsafe.Add(ref destRef, 1);
+                    ui >>= 7;
+                    i++;
+                }
+
+                destRef = (byte)ui;
+                destRef = ref Unsafe.Add(ref destRef, 1);
+                i++;
+
+                return i;
             }
+
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(uint))
+            {
+                uint ui;
+                if (typeof(T) == typeof(short))
+                    ui = (uint)(short)(object)value;
+                else if (typeof(T) == typeof(ushort))
+                    ui = (ushort)(object)value;
+                else if (typeof(T) == typeof(int))
+                    ui = (uint)(int)(object)value;
+                else
+                    ui = (uint)(object)value;
+
+                if (ui < 0x80)
+                {
+                    destRef = (byte)ui;
+                    return 1;
+                }
+
+                destRef = (byte)(ui | 0x80);
+                ui >>= 7;
+                destRef = ref Unsafe.Add(ref destRef, 1);
+
+                int i = 1;
+                while (ui >= 0x80)
+                {
+                    destRef = (byte)(ui | 0x80);
+                    destRef = ref Unsafe.Add(ref destRef, 1);
+                    ui >>= 7;
+                    i++;
+                }
+
+                destRef = (byte)ui;
+                destRef = ref Unsafe.Add(ref destRef, 1);
+                i++;
+
+                return i;
+            }
+
+            if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+            {
+                ulong ul;
+                if (typeof(T) == typeof(long))
+                    ul = (ulong)(long)(object)value;
+                else
+                    ul = (ulong)(object)value;
+
+                if (ul < 0x80)
+                {
+                    destRef = (byte)ul;
+                    return 1;
+                }
+
+                destRef = (byte)(ul | 0x80);
+                destRef = ref Unsafe.Add(ref destRef, 1);
+                
+                ul >>= 7;
+                int i = 1;
+                while (ul >= 0x80)
+                {
+                    destRef = (byte)(ul | 0x80);
+                    destRef = ref Unsafe.Add(ref destRef, 1);
+                    ul >>= 7;
+                    i++;
+                }
+
+                destRef = (byte)ul;
+                destRef = ref Unsafe.Add(ref destRef, 1);
+                i++;
+
+                return i;
+            }
+
+            ThrowNotSupportedException<T>();
+            return -1;
         }
     }
 }

--- a/src/Sparrow/Compression/ZigZagEncoding.cs
+++ b/src/Sparrow/Compression/ZigZagEncoding.cs
@@ -139,6 +139,13 @@ namespace Sparrow.Compression
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T DecodeCompact<T>(ReadOnlySpan<byte> buffer, out int len, out bool success, int pos = 0) where T : unmanaged
+        {
+            T value = VariableSizeEncoding.ReadCompact<T>(buffer, pos, out len, out success);
+            return UnZag(value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Decode<T>(ReadOnlySpan<byte> buffer, out int len, int pos = 0) where T : unmanaged
         {
             T value = VariableSizeEncoding.Read<T>(buffer, out len, pos);

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -188,9 +188,15 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadVariableSizeInt(byte* buffer, int pos, out int offset)
+        public static int ReadVariableSizeInt(byte* buffer, int pos, out int offset, out bool success)
         {
-            return VariableSizeEncoding.Read<int>(buffer + pos, out offset);
+            return VariableSizeEncoding.Read<int>(buffer + pos, out offset, out success);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadVariableSizeInt(ReadOnlySpan<byte> buffer, int pos, out int offset, out bool success)
+        {
+            return VariableSizeEncoding.ReadCompact<int>(buffer, pos, out offset, out success);
         }
 
         private static void ThrowInvalidShift()

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -536,10 +536,10 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe LazyStringValue GetLazyStringValue(byte* ptr)
+        public unsafe LazyStringValue GetLazyStringValue(byte* ptr, out bool success)
         {
             // See format of the lazy string ID in the GetLowerIdSliceAndStorageKey method
-            var size = BlittableJsonReaderBase.ReadVariableSizeInt(ptr, 0, out var offset);
+            var size = BlittableJsonReaderBase.ReadVariableSizeInt(ptr, 0, out var offset, out success);
             return AllocateStringValue(null, ptr + offset, size);
         }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -424,12 +424,8 @@ namespace Voron
         public unsafe void FillBase64Id(Guid databaseGuidId)
         {
             DbId = databaseGuidId;
-            fixed (char* pChars = Base64Id)
-            {
-                var result = Base64.ConvertToBase64ArrayUnpadded(pChars, (byte*)&databaseGuidId, 0, 16);
-                Debug.Assert(result == 22);
-            }
-
+            var result = Base64.ConvertToBase64ArrayUnpadded(Base64Id, (byte*)&databaseGuidId, 0, 16);
+            Debug.Assert(result == 22);
             _options.SetEnvironmentId(databaseGuidId);
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20321

### Additional description
This PR will reimplement in native form the Span versions of methods that use pointers in order to avoid `fixed` statements on high traffic code.

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change