### PR TITLE
RavenDB-19743: Made Disabled configuration respected

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -20,6 +20,11 @@ namespace Raven.Client
             }
         }
 
+        public class Identities
+        {
+            public const char DefaultSeparator = '/';
+        }
+
         public class Headers
         {
             private Headers()

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -20,11 +20,6 @@ namespace Raven.Client
             }
         }
 
-        public class Identities
-        {
-            public const char DefaultSeparator = '/';
-        }
-
         public class Headers
         {
             private Headers()
@@ -447,6 +442,11 @@ namespace Raven.Client
 
                 public const string DestinationDocumentChangeVector = null;
             }
+        }
+
+        internal static class Identities
+        {
+            public const char DefaultSeparator = '/';
         }
     }
 }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1338,9 +1338,9 @@ namespace Raven.Server.Documents
                     _lastTopologyIndex = record.Topology.Stamp.Index;
 
                 ClientConfiguration = record.Client;
-                IdentityPartsSeparator = record.Client?.IdentityPartsSeparator ?? '/';
-                if (record.Client?.Disabled ?? false)
-                    IdentityPartsSeparator = '/';
+                IdentityPartsSeparator = record.Client is { Disabled: false }
+                    ? record.Client.IdentityPartsSeparator ?? Constants.Identities.DefaultSeparator
+                    : Constants.Identities.DefaultSeparator;
                 StudioConfiguration = record.Studio;
 
                 NotifyFeaturesAboutStateChange(record, index);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1339,7 +1339,8 @@ namespace Raven.Server.Documents
 
                 ClientConfiguration = record.Client;
                 IdentityPartsSeparator = record.Client?.IdentityPartsSeparator ?? '/';
-
+                if (record.Client?.Disabled ?? false)
+                    IdentityPartsSeparator = '/';
                 StudioConfiguration = record.Studio;
 
                 NotifyFeaturesAboutStateChange(record, index);

--- a/test/SlowTests/Issues/RavenDB_19743.cs
+++ b/test/SlowTests/Issues/RavenDB_19743.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19743 : RavenTestBase
+    {
+        public RavenDB_19743(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void DisabledConfigurationBaseCase()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    IdentityPartsSeparator = '!',
+                    Disabled = true
+                }));
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        session.Store(new Company
+                        {
+                            Id = "company|"
+                        });
+                        session.SaveChanges();
+                    }
+                    var company = session.Advanced.LoadStartingWith<Company>("company");
+
+                    for (int i = 0; i < 10; i++)
+                        Assert.StartsWith("company/", company[i].Id);
+                }
+            }
+        }
+
+        [Fact]
+        public void DisabledConfigurationGoodCase()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    IdentityPartsSeparator = '!',
+                    Disabled = false
+                }));
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        session.Store(new Company
+                        {
+                            Id = "company|"
+                        });
+
+                        session.SaveChanges();
+                    }
+                    var company = session.Advanced.LoadStartingWith<Company>("company");
+
+                    for (int i = 0; i < 10; i++)
+                        Assert.StartsWith("company!", company[i].Id);
+                }
+            }
+        }
+
+        [Fact]
+        public void DisabledConfigurationDefaultChange_tryToCrateDataWithDisabledSigh_shouldThrow()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    IdentityPartsSeparator = '!',
+                    Disabled = true
+                }));
+
+                Assert.Throws<NonUniqueObjectException>(() =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            session.Store(new Company { Id = "companies!" });
+
+                            session.SaveChanges();
+                        }
+                    }
+                });
+            }
+        }
+
+        [Fact]
+        public void CrateValidConfigurationThenDisable_ShouldCrateDataWithDefaultPartSeparator()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    IdentityPartsSeparator = '!',
+                    Disabled = false
+                }));
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    Disabled = true
+                }));
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        session.Store(new Company
+                        {
+                            Id = "company|"
+                        });
+                        session.SaveChanges();
+                    }
+                    var company = session.Advanced.LoadStartingWith<Company>("company");
+
+                    for (int i = 0; i < company.Length; i++)
+                        Assert.StartsWith("company/", company[i].Id);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19743/Disabled-configuration-not-respected

### Additional description

Found where the Disabled configuration is not respected,  
and added a check that will make sure that if disable is true, then we use the default identity separator
and not the one that the user provided

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform-specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
