### PR TITLE
RavenDB-20337: `HardResetToNewCluster` leads to null `ClusterTransactionId` and `DatabaseTopologyId`

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2598,7 +2598,11 @@ namespace Raven.Server.ServerWide
                             continue;
 
                         var record = rawRecord.MaterializedRecord;
-                        record.Topology = new DatabaseTopology();
+                        record.Topology = new DatabaseTopology
+                        {
+                            ClusterTransactionIdBase64 = rawRecord.Topology.ClusterTransactionIdBase64,
+                            DatabaseTopologyIdBase64 = rawRecord.Topology.DatabaseTopologyIdBase64
+                        };
                         record.Topology.Members.Add(newTag);
                         toShrink.Add(record);
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20337/HardResetToNewCluster-leads-to-null-ClusterTransactionId-and-DatabaseTopologyId.

### Additional description

When using the `HardResetToNewCluster` method for cluster recreation, both the `ClusterTransactionId` and `DatabaseTopologyId` are set to `null`. However, they should retain their original IDs.
### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed