### PR TITLE
RavenDB-20085 Changed CanTranslateDateTimeMinValueMaxValue to be consistent

### DIFF
--- a/test/SlowTests/Issues/RavenDB-10493.cs
+++ b/test/SlowTests/Issues/RavenDB-10493.cs
@@ -33,9 +33,6 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession())
                 {
-                    var dateTimeUtcNow = DateTime.UtcNow;
-                    var dateTimeToday = DateTime.Today;
-                    
                     var query = from x in session.Query<Article>()
                                 let test = 1
                                 select new
@@ -43,22 +40,25 @@ namespace SlowTests.Issues
                                     x.DateTime,
                                     DateTimeMinValue = DateTime.MinValue,
                                     DateTimeMaxValue = DateTime.MaxValue,
-                                    DateTimeUtcNow = dateTimeUtcNow,
-                                    DateTimeToday = dateTimeToday
+                                    DateTimeUtcNow = DateTime.UtcNow,
+                                    DateTimeToday = DateTime.Today
                                 };
 
-                    RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(x, $p0, $p1) {
+                    RavenTestHelper.AssertEqualRespectingNewLines(@"declare function output(x) {
 	var test = 1;
-	return { DateTime : x.DateTime, DateTimeMinValue : new Date(-62135596800000), DateTimeMaxValue : new Date(253402297199999), DateTimeUtcNow : $p0, DateTimeToday : $p1 };
+	return { DateTime : x.DateTime, DateTimeMinValue : new Date(-62135596800000), DateTimeMaxValue : new Date(253402297199999), DateTimeUtcNow : ((date) => new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds()))(new Date()), DateTimeToday : new Date(new Date().setHours(0,0,0,0)) };
 }
-from 'Articles' as x select output(x, $p0, $p1)", query.ToString());
+from 'Articles' as x select output(x)", query.ToString());
 
                     var result = query.ToList();
 
                     Assert.Equal(DateTime.MinValue, result[0].DateTimeMinValue);
 
-                    Assert.Equal(dateTimeUtcNow, result[0].DateTimeUtcNow);
-                    Assert.Equal(dateTimeToday, result[0].DateTimeToday);
+                    Assert.Equal(DateTime.UtcNow, result[0].DateTimeUtcNow, TimeSpan.FromSeconds(20));
+                    
+                    // We want to have one day margin, so if we assign DateTimeToday before midnight, and check the assertion
+                    // after, the test will not fail
+                    Assert.Equal(DateTime.Today, result[0].DateTimeToday, TimeSpan.FromDays(1));
 
                     // Only missing 0.9999 ms, but with additional timezone
                     var epsilon = 1 + Math.Abs((DateTime.UtcNow - DateTime.Now).TotalSeconds); // Lower than 1 ms


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20085/SlowTests.Issues.RavenDB10493.CanTranslateDateTimeMinValueMaxValue

### Additional description

Changed UtcNow assertion, to have bigger margin (5 seconds may not be enough for test to finish), and Today assertion to have one day margin in case the test starts before midnight, and finishes after midnight.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
