### PR TITLE
RavenDB-11310 v6.0 - ServerStore Tx Merger

### DIFF
--- a/RavenDB.sln
+++ b/RavenDB.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{02838C57-DE0E-465D-9FBB-248DA87BEAAE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AbstractTransactionOperationsMerger", "AbstractTransactionOperationsMerger", "{02838C57-DE0E-465D-9FBB-248DA87BEAAE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7C0225BB-6184-4859-8ED1-2251A492A449}"
 	ProjectSection(SolutionItems) = preProject
@@ -86,6 +86,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Voron.Dictionary.Generator", "tools\Voron.Dictionary.Generator\Voron.Dictionary.Generator.csproj", "{4A27BC98-D655-4335-B761-A7084799CB77}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VxSort.Benchmark", "bench\VxSort.Benchmark\VxSort.Benchmark.csproj", "{BF70E6D6-9BF4-4580-85E9-E908CD7D823E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerStoreTxMerger.Benchmark", "bench\ServerStoreTxMerger.Benchmark\ServerStoreTxMerger.Benchmark.csproj", "{F3A0869F-CC53-4E09-9688-7A98A0AF2996}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -727,6 +729,24 @@ Global
 		{BF70E6D6-9BF4-4580-85E9-E908CD7D823E}.Validate|x64.Build.0 = Debug|Any CPU
 		{BF70E6D6-9BF4-4580-85E9-E908CD7D823E}.Validate|x86.ActiveCfg = Debug|Any CPU
 		{BF70E6D6-9BF4-4580-85E9-E908CD7D823E}.Validate|x86.Build.0 = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|x64.Build.0 = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Debug|x86.Build.0 = Debug|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|x64.Build.0 = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|x86.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Release|x86.Build.0 = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|Any CPU.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|Any CPU.Build.0 = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|x64.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|x64.Build.0 = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|x86.ActiveCfg = Release|Any CPU
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996}.Validate|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -767,6 +787,7 @@ Global
 		{9AE9D686-5E30-4F52-BC8B-DE08130F6843} = {02838C57-DE0E-465D-9FBB-248DA87BEAAE}
 		{4A27BC98-D655-4335-B761-A7084799CB77} = {FAAED88A-1C25-4853-9A1B-C41BCF9BED1F}
 		{BF70E6D6-9BF4-4580-85E9-E908CD7D823E} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
+		{F3A0869F-CC53-4E09-9688-7A98A0AF2996} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {032D6274-16A5-43ED-920F-D37BBD4B9628}

--- a/RavenDB.sln
+++ b/RavenDB.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AbstractTransactionOperationsMerger", "AbstractTransactionOperationsMerger", "{02838C57-DE0E-465D-9FBB-248DA87BEAAE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{02838C57-DE0E-465D-9FBB-248DA87BEAAE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7C0225BB-6184-4859-8ED1-2251A492A449}"
 	ProjectSection(SolutionItems) = preProject

--- a/bench/ServerStoreTxMerger.Benchmark/Program.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/Program.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Columns;
+﻿using System.Diagnostics;
+using System.Linq;
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -19,7 +23,43 @@ public class Program
                 .WithIterationCount(10)
                 .WithWarmupCount(5)
                 .AsDefault());
-
+        
         var summary = BenchmarkRunner.Run(typeof(Program).Assembly, config);
+
+        // RunTestManually().Wait();
+    }
+
+    public static async Task RunTestManually()
+    {
+        var count = 5;
+
+        var time = TimeSpan.Zero;
+        for (int i = 0; i < count; i++)
+        {
+            var test = new ServerStoreTxMergerBenchRealClusterTests();
+            test.DocsGroup = ServerStoreTxMergerBenchRealClusterTests.DocsArraysKeys.First();
+            test.NumOfNodes = 1;
+            Console.WriteLine($"Start {i}");
+            test.BeforeTest();
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                await test.ClusterTest();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            time += sw.Elapsed;
+            Console.WriteLine($"time: {sw.Elapsed.Hours}:{sw.Elapsed.Minutes}:{sw.Elapsed.Seconds}");
+
+            test.AfterTest();
+        }
+
+        Console.WriteLine($"total time: {time.Hours}:{time.Minutes}:{time.Seconds}");
+        time = time / count;
+        Console.WriteLine($"avg time: {time.Hours}:{time.Minutes}:{time.Seconds}");
     }
 }

--- a/bench/ServerStoreTxMerger.Benchmark/Program.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/Program.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+
+namespace ServerStoreTxMerger.Benchmark;
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var config = new ManualConfig()
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddValidator(JitOptimizationsValidator.DontFailOnError)
+            .AddLogger(ConsoleLogger.Default)
+            .AddColumnProvider(DefaultColumnProviders.Instance)
+            .AddJob(Job.Default
+                .WithIterationCount(10)
+                .WithWarmupCount(5)
+                .AsDefault());
+
+        var summary = BenchmarkRunner.Run(typeof(Program).Assembly, config);
+    }
+}

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMerger.Benchmark.csproj
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMerger.Benchmark.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <RuntimeFrameworkVersion>7.0.3</RuntimeFrameworkVersion>
+    <AssemblyName>ServerStoreTxMerger.Benchmark</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>ServerStoreTxMerger.Benchmark</PackageId>
+    <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\..\test\Tests.Infrastructure\Tests.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchRealClusterTests.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchRealClusterTests.cs
@@ -6,13 +6,35 @@ using Tests.Infrastructure;
 using Xunit.Abstractions;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
+using Microsoft.AspNetCore.Http;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Commands;
+using static Raven.Server.Utils.MetricCacher.Keys;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
+using Raven.Server;
+using Raven.Server.Documents.Handlers;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using System.Diagnostics;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Handlers.Batches.Commands;
+using Raven.Server.Documents.Handlers.Batches;
 
 namespace ServerStoreTxMerger.Benchmark;
 
 public class ServerStoreTxMergerBenchRealClusterTests
 {
-    private static readonly List<(int Count, int Size)> _numAndSizeOfDocs = new List<(int, int)> { (30000, 1_024) };
-    public static Dictionary<string, Doc[]> DocsArrays = new Dictionary<string, Doc[]>();
+    private static readonly List<(int Count, int Size)> _numAndSizeOfDocs = new List<(int, int)> { (30_00, 1_024) };
+    public static Dictionary<string, DynamicJsonValue[]> DocsArrays = new Dictionary<string, DynamicJsonValue[]>();
     public static List<string> DocsArraysKeys { get; set; } = new List<string>();
 
     [ParamsSource(nameof(DocsArraysKeys))]
@@ -23,7 +45,7 @@ public class ServerStoreTxMergerBenchRealClusterTests
 
     static ServerStoreTxMergerBenchRealClusterTests()
     {
-        CreateDocs();
+        CreateCmpxg();
     }
 
     private static void CreateDocs()
@@ -35,15 +57,15 @@ public class ServerStoreTxMergerBenchRealClusterTests
             var numOfDocs = pair.Count;
             var docSizeInBytes = pair.Size;
 
-            var docs = new Doc[numOfDocs];
+            var docs = new DynamicJsonValue[numOfDocs];
 
             for (int i = 0; i < numOfDocs; i++)
             {
                 var randomData = strRan.GetRandomData(docSizeInBytes);
-                docs[i] = new Doc
+                docs[i] = new DynamicJsonValue()
                 {
-                    Id = $"Docs/{i}",
-                    Data = randomData
+                    ["Id"] = $"Docs/{i}",
+                    ["Data"] = randomData
                 };
             }
 
@@ -63,8 +85,44 @@ public class ServerStoreTxMergerBenchRealClusterTests
     }
 
 
-    private readonly MyOutputHelper? _testOutputHelper = new MyOutputHelper();
-    private ActualClusterTests? _tests;
+    private static void CreateCmpxg()
+    {
+        var strRan = new StringRandom();
+
+        foreach (var pair in _numAndSizeOfDocs)
+        {
+            var numOfDocs = pair.Count;
+            var docSizeInBytes = pair.Size;
+
+            var docs = new DynamicJsonValue[numOfDocs];
+
+            for (int i = 0; i < numOfDocs; i++)
+            {
+                var randomData = strRan.GetRandomData(docSizeInBytes);
+                docs[i] = new DynamicJsonValue()
+                {
+                    ["Object"] = randomData
+                };
+            }
+
+            string sizeStr = docSizeInBytes + " Bytes";
+            if (docSizeInBytes / (1024 * 1024) > 0)
+            {
+                sizeStr = docSizeInBytes / (1024 * 1024) + " MB";
+            }
+            else if (docSizeInBytes / 1024 > 0)
+            {
+                sizeStr = docSizeInBytes / 1024 + " KB";
+            }
+            var key = $"{numOfDocs} of {sizeStr}";
+            DocsArraysKeys.Add(key);
+            DocsArrays[key] = docs;
+        }
+    }
+
+
+    private static MyOutputHelper _testOutputHelper = new MyOutputHelper();
+    private ActualClusterTests _tests;
 
 
     [IterationSetup(Targets = new[] { nameof(ClusterTest) })]
@@ -95,7 +153,9 @@ public class ServerStoreTxMergerBenchRealClusterTests
 
 public class ActualClusterTests : ClusterTestBase
 {
-    private DocumentStore? _store;
+    private DocumentStore _store;
+    private RavenServer _leader;
+    private long _index = 0;
 
     public ActualClusterTests(ITestOutputHelper output) : base(output)
     {
@@ -105,20 +165,34 @@ public class ActualClusterTests : ClusterTestBase
     {
         var (nodes, leader) = await CreateRaftCluster(numberOfNodes: nodesCount, watcherCluster: true, shouldRunInMemory: false);
         _store = GetDocumentStore(new Options() { Server = leader, ReplicationFactor = nodesCount });
+        _leader = leader;
+
+        DatabaseRecordWithEtag record = null;
+        while (record == null || record.Topology.Count != 1)
+        {
+            record = _store.Maintenance.Server.Send(new GetDatabaseRecordOperation(_store.Database));
+            Thread.Sleep(100);
+        }
     }
 
-    public async Task Test(Doc[] docs)
+    public async Task Test(DynamicJsonValue[] docs)
     {
         if (_store == null)
         {
             throw new InvalidOperationException("store cannot be null");
         }
 
+        if (_leader == null)
+        {
+            throw new InvalidOperationException("leader cannot be null");
+        }
+
+        var sw = Stopwatch.StartNew();
         var tasks = new HashSet<Task>();
 
         for (int index = 0; index < docs.Length; index++)
         {
-            var t = StoreClusterWide(_store, docs[index], index);
+            var t = StoreCompareExchange(_store, docs[index], index);
 
             tasks.Add(t);
 
@@ -129,21 +203,174 @@ public class ActualClusterTests : ClusterTestBase
             tasks.Remove(finished);
         }
 
+
         await Task.WhenAll(tasks);
+
+        // var lastDoc = docs[docs.Length - 1];
+        // var id = (string)lastDoc["Id"];
+        // Doc d = null;
+        // while (d == null)
+        // {
+        //     using (var session = _store.OpenSession())
+        //     {
+        //         d = session.Load<Doc>(id);
+        //     }
+        //
+        //     await Task.Delay(200);
+        // }
     }
 
-    private static async Task StoreClusterWide(DocumentStore store, Doc doc, int index1)
+    private async Task StoreClusterWide(DocumentStore store, DynamicJsonValue doc, int index1)
     {
-        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+
+        var db = await _leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(_store.Database);
+        var id = (string)doc["Id"];
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        var blittable = context.ReadObject(doc, id);
+
+        var options = new ClusterTransactionCommand.ClusterTransactionOptions(Guid.NewGuid().ToString(), disableAtomicDocumentWrites: false, clusterMinVersion: 60_000)
         {
-            await session.StoreAsync(doc);
-            await session.SaveChangesAsync();
+            WaitForIndexesTimeout = null,
+            WaitForIndexThrow = true,
+            SpecifiedIndexesQueryString = null
+        };
+
+        var commands = new[]
+        {
+            new BatchRequestParser.CommandData
+            {
+                Id = id,
+                Document = blittable,
+                AttachmentStream = new MergedBatchCommand.AttachmentStream { Hash = null, Stream = null },
+                Type = CommandType.PUT,
+                ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+            // new BatchRequestParser.CommandData
+            // {
+            //     Type = CommandType.None,
+            //     ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            // },
+        };
+        ArraySegment<BatchRequestParser.CommandData> parsedCommands = commands;
+
+        var raftRequestId = Interlocked.Increment(ref _index).ToString();
+        var topology = _leader.ServerStore.LoadDatabaseTopology(db.Name);
+
+        if (topology.Promotables.Contains(_leader.ServerStore.NodeTag))
+            throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
+
+        var clusterTransactionCommand = new ClusterTransactionCommand(db.Name, db.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
+        var result = await _leader.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+
+        if (result.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
+        {
+            throw new InvalidOperationException("Command ended with errors");
         }
+
+        await _leader.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
+    }
+
+    private async Task StoreCompareExchange(DocumentStore store, DynamicJsonValue doc, int index1)
+    {
+
+        var db = await _leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(_store.Database);
+        var id = $"Cmp{index1}";
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        var blittable = context.ReadObject(doc, id);
+
+        var options = new ClusterTransactionCommand.ClusterTransactionOptions(Guid.NewGuid().ToString(), disableAtomicDocumentWrites: false, clusterMinVersion: 60_000)
+        {
+            WaitForIndexesTimeout = null,
+            WaitForIndexThrow = true,
+            SpecifiedIndexesQueryString = null
+        };
+
+        var commands = new[]
+        {
+            new BatchRequestParser.CommandData
+            {
+                Id = id,
+                Document = blittable,
+                AttachmentStream = new MergedBatchCommand.AttachmentStream { Hash = null, Stream = null },
+                Type = CommandType.CompareExchangePUT,
+                ForceRevisionCreationStrategy = ForceRevisionStrategy.None
+            },
+        };
+        ArraySegment<BatchRequestParser.CommandData> parsedCommands = commands;
+
+        var raftRequestId = Interlocked.Increment(ref _index).ToString();
+        var topology = _leader.ServerStore.LoadDatabaseTopology(db.Name);
+
+        if (topology.Promotables.Contains(_leader.ServerStore.NodeTag))
+            throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
+
+        var clusterTransactionCommand = new ClusterTransactionCommand(db.Name, db.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
+        var result = await _leader.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+
+        if (result.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
+        {
+            throw new InvalidOperationException("Command ended with errors");
+        }
+
+        await _leader.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
     }
 
     public override void Dispose()
     {
+        var dbName = _store.Database;
+        var results = _store
+            .Maintenance
+            .Server
+            .Send(new DeleteDatabasesOperation(new DeleteDatabasesOperation.Parameters()
+            {
+                DatabaseNames = new[] { dbName },
+                HardDelete = true
+            }));
+
+        DatabaseRecordWithEtag record = null;
+        do
+        {
+            Thread.Sleep(100);
+            record = _store.Maintenance.Server.Send(new GetDatabaseRecordOperation(dbName));
+        } while (record != null && record.Topology.Count > 0);
+
+        _store.Dispose();
         _store = null;
+        _leader = null;
         base.Dispose();
     }
 }

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchRealClusterTests.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchRealClusterTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace ServerStoreTxMerger.Benchmark;
+
+public class ServerStoreTxMergerBenchRealClusterTests
+{
+    private static readonly List<(int Count, int Size)> _numAndSizeOfDocs = new List<(int, int)> { (30000, 1_024) };
+    public static Dictionary<string, Doc[]> DocsArrays = new Dictionary<string, Doc[]>();
+    public static List<string> DocsArraysKeys { get; set; } = new List<string>();
+
+    [ParamsSource(nameof(DocsArraysKeys))]
+    public string DocsGroup { get; set; }
+
+    [Params(1, 3)]
+    public int NumOfNodes { get; set; }
+
+    static ServerStoreTxMergerBenchRealClusterTests()
+    {
+        CreateDocs();
+    }
+
+    private static void CreateDocs()
+    {
+        var strRan = new StringRandom();
+
+        foreach (var pair in _numAndSizeOfDocs)
+        {
+            var numOfDocs = pair.Count;
+            var docSizeInBytes = pair.Size;
+
+            var docs = new Doc[numOfDocs];
+
+            for (int i = 0; i < numOfDocs; i++)
+            {
+                var randomData = strRan.GetRandomData(docSizeInBytes);
+                docs[i] = new Doc
+                {
+                    Id = $"Docs/{i}",
+                    Data = randomData
+                };
+            }
+
+            string sizeStr = docSizeInBytes + " Bytes";
+            if (docSizeInBytes / (1024 * 1024) > 0)
+            {
+                sizeStr = docSizeInBytes / (1024 * 1024) + " MB";
+            }
+            else if (docSizeInBytes / 1024 > 0)
+            {
+                sizeStr = docSizeInBytes / 1024 + " KB";
+            }
+            var key = $"{numOfDocs} of {sizeStr}";
+            DocsArraysKeys.Add(key);
+            DocsArrays[key] = docs;
+        }
+    }
+
+
+    private readonly MyOutputHelper? _testOutputHelper = new MyOutputHelper();
+    private ActualClusterTests? _tests;
+
+
+    [IterationSetup(Targets = new[] { nameof(ClusterTest) })]
+    public void BeforeTest()
+    {
+        _tests = new ActualClusterTests(_testOutputHelper);
+        _tests.Initialize(NumOfNodes).GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task ClusterTest()
+    {
+        if (_tests == null)
+        {
+            throw new InvalidOperationException("\'_tests\' cannot be null");
+        }
+        await _tests.Test(DocsArrays[DocsGroup]);
+    }
+
+    [IterationCleanup(Targets = new[] { nameof(ClusterTest) })]
+    public void AfterTest()
+    {
+        _tests?.Dispose();
+    }
+
+}
+
+
+public class ActualClusterTests : ClusterTestBase
+{
+    private DocumentStore? _store;
+
+    public ActualClusterTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public async Task Initialize(int nodesCount)
+    {
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes: nodesCount, watcherCluster: true, shouldRunInMemory: false);
+        _store = GetDocumentStore(new Options() { Server = leader, ReplicationFactor = nodesCount });
+    }
+
+    public async Task Test(Doc[] docs)
+    {
+        if (_store == null)
+        {
+            throw new InvalidOperationException("store cannot be null");
+        }
+
+        var tasks = new HashSet<Task>();
+
+        for (int index = 0; index < docs.Length; index++)
+        {
+            var t = StoreClusterWide(_store, docs[index], index);
+
+            tasks.Add(t);
+
+            if (tasks.Count < 1500)
+                continue;
+
+            var finished = await Task.WhenAny(tasks);
+            tasks.Remove(finished);
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    private static async Task StoreClusterWide(DocumentStore store, Doc doc, int index1)
+    {
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            await session.StoreAsync(doc);
+            await session.SaveChangesAsync();
+        }
+    }
+
+    public override void Dispose()
+    {
+        _store = null;
+        base.Dispose();
+    }
+}

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchTests.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchTests.cs
@@ -63,8 +63,8 @@ public class ServerStoreTxMergerBenchTests
     }
 
 
-    private readonly MyOutputHelper? _testOutputHelper = new MyOutputHelper();
-    private ActualTests? _tests;
+    private static MyOutputHelper _testOutputHelper = new MyOutputHelper();
+    private ActualTests _tests;
 
 
     [IterationSetup(Targets = new[] { nameof(Test) })]
@@ -94,7 +94,7 @@ public class ServerStoreTxMergerBenchTests
 
 public class ActualTests : RachisConsensusTestBase
 {
-    private RachisConsensus<CountingStateMachine>? _leader;
+    private RachisConsensus<CountingStateMachine> _leader;
 
     public ActualTests(ITestOutputHelper output) : base(output)
     {

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchTests.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMergerBenchTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Raven.Server.Rachis;
+
+namespace ServerStoreTxMerger.Benchmark;
+
+public class ServerStoreTxMergerBenchTests
+{
+    private static readonly List<(int Count, int Size)> _numAndSizeOfCmds = new List<(int, int)> { (30000, 1_024) };
+    public static Dictionary<string, RachisConsensusTestBase.TestCommandWithLargeData[]> CmdsArrays = new Dictionary<string, RachisConsensusTestBase.TestCommandWithLargeData[]>();
+    public static List<string> CmdsArraysKeys { get; set; } = new List<string>();
+
+    [ParamsSource(nameof(CmdsArraysKeys))]
+    public string CommandsGroup { get; set; }
+
+    [Params(1, 3)]
+    public int NumOfNodes { get; set; }
+
+    static ServerStoreTxMergerBenchTests()
+    {
+        CreateCmds();
+    }
+
+    private static void CreateCmds()
+    {
+        var strRan = new StringRandom();
+
+        foreach (var pair in _numAndSizeOfCmds)
+        {
+            var numOfCmds = pair.Count;
+            var cmdSizeInBytes = pair.Size;
+
+            var cmds = new RachisConsensusTestBase.TestCommandWithLargeData[numOfCmds];
+
+            for (int i = 0; i < numOfCmds; i++)
+            {
+                var randomData = strRan.GetRandomData(cmdSizeInBytes);
+                cmds[i] = new RachisConsensusTestBase.TestCommandWithLargeData
+                {
+                    Name = $"test{i}",
+                    RandomData = randomData,
+                    Timeout = TimeSpan.MaxValue
+                };
+            }
+
+            string sizeStr = cmdSizeInBytes + " Bytes";
+            if (cmdSizeInBytes / (1024 * 1024) > 0)
+            {
+                sizeStr = cmdSizeInBytes / (1024 * 1024) + " MB";
+            }
+            else if (cmdSizeInBytes / 1024 > 0)
+            {
+                sizeStr = cmdSizeInBytes / 1024 + " KB";
+            }
+            var key = $"{numOfCmds} of {sizeStr}";
+            CmdsArraysKeys.Add(key);
+            CmdsArrays[key] = cmds;
+        }
+    }
+
+
+    private readonly MyOutputHelper? _testOutputHelper = new MyOutputHelper();
+    private ActualTests? _tests;
+
+
+    [IterationSetup(Targets = new[] { nameof(Test) })]
+    public void BeforeTest()
+    {
+        _tests = new ActualTests(_testOutputHelper);
+        _tests.Initialize(NumOfNodes).GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task Test()
+    {
+        if (_tests == null)
+        {
+            throw new InvalidOperationException("\'_tests\' cannot be null");
+        }
+        await _tests.Test(CmdsArrays[CommandsGroup]);
+    }
+
+    [IterationCleanup(Targets = new[] { nameof(Test) })]
+    public void AfterTest()
+    {
+        _tests?.Dispose();
+    }
+
+}
+
+public class ActualTests : RachisConsensusTestBase
+{
+    private RachisConsensus<CountingStateMachine>? _leader;
+
+    public ActualTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public async Task Initialize(int nodesCount)
+    {
+        _leader = await CreateNetworkAndGetLeader(nodeCount: nodesCount, watcherCluster: true, shouldRunInMemory: false);
+    }
+
+    public async Task Test(TestCommandWithLargeData[] cmds)
+    {
+        if (_leader == null)
+        {
+            throw new InvalidOperationException("leader cannot be null");
+        }
+        var tasks = new HashSet<Task>();
+        foreach (var cmd in cmds)
+        {
+            var t = _leader.PutAsync(cmd);
+            tasks.Add(t);
+
+            if (tasks.Count < 1500)
+                continue;
+
+            var finished = await Task.WhenAny(tasks);
+            tasks.Remove(finished);
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    public override void Dispose()
+    {
+        _leader = null;
+        base.Dispose();
+    }
+}

--- a/bench/ServerStoreTxMerger.Benchmark/Utils.cs
+++ b/bench/ServerStoreTxMerger.Benchmark/Utils.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace ServerStoreTxMerger.Benchmark;
+
+public class Doc
+{
+    public string Id { get; set; }
+    public string Data { get; set; }
+}
+
+public class MyOutputHelper : ITestOutputHelper
+{
+    public void WriteLine(string message) => Console.WriteLine(message);
+
+    public void WriteLine(string format, params object[] args) => Console.WriteLine(format, args);
+
+    public void Dispose()
+    {
+    }
+}
+
+public class StringRandom
+{
+    private readonly Random _random = new Random();
+    public string GetRandomData(int size)
+    {
+        var sb = new StringBuilder();
+        int a = 'a' - 0;
+        int z = 'z' - 0;
+        for (int i = 0; i < size; i++)
+        {
+            var c = (char)(_random.Next(a, z + 1));
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+}

--- a/bench/TimeSeries.Benchmark/Program.cs
+++ b/bench/TimeSeries.Benchmark/Program.cs
@@ -38,7 +38,7 @@ namespace TimeSeries.Benchmark
                     Console.WriteLine();
                 }
             }
-
+            
             private static BenchParameters ParseArguments(string[] args, out string url, out int workers)
             {
                 url = null;

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -771,7 +771,7 @@ namespace Raven.Server.Commercial
         {
             try
             {
-                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                await serverStore.Engine.SetNewStateAsync(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
             }
             catch (Exception e)
             {
@@ -948,7 +948,7 @@ namespace Raven.Server.Commercial
         {
             try
             {
-                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                await serverStore.Engine.SetNewStateAsync(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
             }
             catch (Exception e)
             {
@@ -1069,7 +1069,7 @@ namespace Raven.Server.Commercial
                 {
                     try
                     {
-                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                        await serverStore.Engine.SetNewStateAsync(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
                     }
                     catch (Exception e)
                     {
@@ -1130,7 +1130,7 @@ namespace Raven.Server.Commercial
                         {
                             try
                             {
-                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                                await serverStore.Engine.SetNewStateAsync(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
                             }
                             catch (Exception e)
                             {

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Commercial
         }
 
         public static async Task<IOperationResult> SetupUnsecuredTask(Action<IOperationProgress> onProgress, UnsecuredSetupInfo unsecuredSetupInfo,
-            ServerStore serverStore, ClusterOperationContext context, CancellationToken token)
+            ServerStore serverStore, CancellationToken token)
         {
             var zipOnly = unsecuredSetupInfo.ZipOnly;
             var progress = new SetupProgressAndResult(tuple =>

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Config.Categories
         public TimeSetting CompareExchangeTombstonesCleanupInterval { get; set; }
 
         [Description("Maximum number of log entires to keep in the history log table.")]
-        [DefaultValue(2048)]
+        [DefaultValue(4096)]
         [ConfigurationEntry("Cluster.LogHistoryMaxEntries", ConfigurationEntryScope.ServerWideOnly)]
         public int LogHistoryMaxEntries { get; set; }
 

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Config.Categories
         public TimeSetting CompareExchangeTombstonesCleanupInterval { get; set; }
 
         [Description("Maximum number of log entires to keep in the history log table.")]
-        [DefaultValue(4096)]
+        [DefaultValue(2048)]
         [ConfigurationEntry("Cluster.LogHistoryMaxEntries", ConfigurationEntryScope.ServerWideOnly)]
         public int LogHistoryMaxEntries { get; set; }
 

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -10,7 +10,7 @@ using Raven.Client.Util.RateLimiting;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents
         }
 
         protected async Task<IOperationResult> ExecuteOperation(string collectionName, long start, long take, CollectionOperationOptions options, DocumentsOperationContext context,
-             Action<DeterminateProgress> onProgress, Func<string, TransactionOperationsMerger.MergedTransactionCommand> action, OperationCancelToken token)
+             Action<DeterminateProgress> onProgress, Func<string, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> action, OperationCancelToken token)
         {
             var progress = new DeterminateProgress();
             var cancellationToken = token.Token;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -36,6 +36,7 @@ using Raven.Server.Documents.Smuggler;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.Documents.TransactionMerger;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
@@ -157,7 +158,7 @@ namespace Raven.Server.Documents
                 OngoingTasks = new OngoingTasks.OngoingTasks(this);
                 Metrics = new MetricCounters();
                 MetricCacher = new DatabaseMetricCacher(this);
-                TxMerger = new TransactionOperationsMerger(this, DatabaseShutdown);
+                TxMerger = new DocumentsTransactionOperationsMerger(this);
                 ConfigurationStorage = new ConfigurationStorage(this);
                 NotificationCenter = new DatabaseNotificationCenter(this);
                 HugeDocuments = new HugeDocuments(NotificationCenter, configuration.PerformanceHints.HugeDocumentsCollectionSize,
@@ -240,7 +241,8 @@ namespace Raven.Server.Documents
         public readonly SystemTime Time = new SystemTime();
 
         public ScriptRunnerCache Scripts;
-        public readonly TransactionOperationsMerger TxMerger;
+
+        public readonly DocumentsTransactionOperationsMerger TxMerger;
 
         public SubscriptionStorage SubscriptionStorage { get; }
 
@@ -359,6 +361,7 @@ namespace Raven.Server.Documents
                 _addToInitLog("Initializing DocumentStorage");
                 DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
                 _addToInitLog("Starting Transaction Merger");
+                TxMerger.Initialize(DocumentsStorage.ContextPool, NotificationCenter);
                 TxMerger.Start();
                 _addToInitLog("Initializing ConfigurationStorage");
                 ConfigurationStorage.Initialize();

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -105,11 +105,6 @@ namespace Raven.Server.Documents
             base.Dispose();
         }
 
-        private static void ThrowInvalidTransactionUsage()
-        {
-            throw new InvalidOperationException("There is a different transaction in context.");
-        }
-
         protected override void RaiseNotifications()
         {
             base.RaiseNotifications();

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/QueueEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/QueueEtl.cs
@@ -14,7 +14,7 @@ using Raven.Server.Documents.ETL.Providers.Queue.Test;
 using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Exceptions.ETL.QueueEtl;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;

--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Threading;
 using Raven.Client.Util.RateLimiting;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -10,10 +12,10 @@ using Constants = Voron.Global.Constants;
 
 namespace Raven.Server.Documents
 {
-    public class ExecuteRateLimitedOperations<T> : TransactionOperationsMerger.MergedTransactionCommand
+    public class ExecuteRateLimitedOperations<T> : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         private readonly Queue<T> _documentIds;
-        private readonly Func<T, TransactionOperationsMerger.MergedTransactionCommand> _commandToExecute;
+        private readonly Func<T, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> _commandToExecute;
         private readonly RateGate _rateGate;
         private readonly OperationCancelToken _token;
         private readonly int? _maxTransactionSizeInPages;
@@ -21,11 +23,11 @@ namespace Raven.Server.Documents
         private readonly CancellationToken _cancellationToken;
 
         internal ExecuteRateLimitedOperations(
-            Queue<T> documentIds, 
-            Func<T, TransactionOperationsMerger.MergedTransactionCommand> commandToExecute, 
+            Queue<T> documentIds,
+            Func<T, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> commandToExecute,
             RateGate rateGate,
-            OperationCancelToken token, 
-            int? maxTransactionSize ,
+            OperationCancelToken token,
+            int? maxTransactionSize,
             int? batchSize)
         {
             _documentIds = documentIds;
@@ -42,7 +44,7 @@ namespace Raven.Server.Documents
 
         public long Processed { get; private set; }
 
-        public override long Execute(DocumentsOperationContext context, TransactionOperationsMerger.RecordingState recording)
+        public override long Execute(DocumentsOperationContext context, AbstractTransactionOperationsMerger<DocumentsOperationContext, DocumentsTransaction>.RecordingState recording)
         {
             var count = 0;
             foreach (T id in _documentIds)
@@ -94,11 +96,11 @@ namespace Raven.Server.Documents
                     _documentIds.Dequeue();
                 }
             };
-            
+
             return Processed;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             throw new NotSupportedException($"ToDto() of {nameof(ExecuteRateLimitedOperations<T>)} Should not be called");
         }

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.ServerWide;
 using Raven.Server.Background;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -182,7 +183,7 @@ namespace Raven.Server.Documents.Expiration
             }
         }
 
-        internal class DeleteExpiredDocumentsCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class DeleteExpiredDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly Dictionary<Slice, List<(Slice LowerId, string Id)>> _expired;
             private readonly DocumentDatabase _database;
@@ -209,7 +210,7 @@ namespace Raven.Server.Documents.Expiration
                 return DeletionCount;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
 
                 var keyValuePairs = new KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[_expired.Count];
@@ -230,7 +231,7 @@ namespace Raven.Server.Documents.Expiration
         }
     }
 
-    internal class DeleteExpiredDocumentsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand>
+    internal class DeleteExpiredDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand>
     {
         public ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForDeleteRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForDeleteRevisions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -17,7 +18,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
             await RequestHandler.Database.TxMerger.Enqueue(cmd);
         }
 
-        internal class DeleteRevisionsCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class DeleteRevisionsCommand : DocumentMergedTransactionCommand
         {
             private readonly Microsoft.Extensions.Primitives.StringValues _ids;
             private readonly DocumentDatabase _database;
@@ -38,13 +39,14 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
             {
                 return new DeleteRevisionsCommandDto {Ids = _ids};
             }
         }
 
-        internal class DeleteRevisionsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<DeleteRevisionsCommand>
+        internal class DeleteRevisionsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DeleteRevisionsCommand>
         {
             public string[] Ids;
 

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -684,11 +684,15 @@ namespace Raven.Server.Documents.Handlers.Admin
             if (removed)
                 nodeList.Add(ServerStore.NodeTag);
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
             {
                 if (first)
                 {
-                    foreach (var node in ServerStore.GetClusterTopology(context).AllNodes)
+                    Dictionary<string, string> allNodes = null;
+                    using (context.OpenReadTransaction())
+                    {
+                        allNodes = ServerStore.GetClusterTopology(context).AllNodes;
+                    }
+                    foreach (var node in allNodes)
                     {
                         if (node.Value == Server.WebUrl)
                         {

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -680,13 +680,12 @@ namespace Raven.Server.Documents.Handlers.Admin
             var index = GetLongQueryString("index");
             var first = GetBoolValueQueryString("first", false) ?? true;
             var nodeList = new List<string>();
+            var removed = await ServerStore.Engine.RemoveEntryFromRaftLogAsync(index);
+            if (removed)
+                nodeList.Add(ServerStore.NodeTag);
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var removed = ServerStore.Engine.RemoveEntryFromRaftLog(index);
-                if (removed)
-                    nodeList.Add(ServerStore.NodeTag);
-
                 if (first)
                 {
                     foreach (var node in ServerStore.GetClusterTopology(context).AllNodes)

--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -7,10 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Server.Documents.Handlers.Processors.Attachments;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -158,7 +160,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        public class MergedPutAttachmentCommand : TransactionOperationsMerger.MergedTransactionCommand
+        public class MergedPutAttachmentCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             public string DocumentId;
             public string Name;
@@ -175,7 +177,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new MergedPutAttachmentCommandDto
                 {
@@ -189,7 +191,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        internal class MergedDeleteAttachmentCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class MergedDeleteAttachmentCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             public string DocumentId;
             public string Name;
@@ -202,7 +204,7 @@ namespace Raven.Server.Documents.Handlers
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new MergedDeleteAttachmentCommandDto
                 {
@@ -214,7 +216,7 @@ namespace Raven.Server.Documents.Handlers
         }
     }
 
-    public class MergedPutAttachmentCommandDto : TransactionOperationsMerger.IReplayableCommandDto<AttachmentHandler.MergedPutAttachmentCommand>
+    public class MergedPutAttachmentCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, AttachmentHandler.MergedPutAttachmentCommand>
     {
         public string DocumentId;
         public string Name;
@@ -238,7 +240,7 @@ namespace Raven.Server.Documents.Handlers
         }
     }
 
-    internal class MergedDeleteAttachmentCommandDto : TransactionOperationsMerger.IReplayableCommandDto<AttachmentHandler.MergedDeleteAttachmentCommand>
+    internal class MergedDeleteAttachmentCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, AttachmentHandler.MergedDeleteAttachmentCommand>
     {
         public string DocumentId;
         public string Name;

--- a/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
@@ -11,7 +11,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Batches.Commands;
 using Raven.Server.Documents.Patch;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.Smuggler;
 using Raven.Server.Web;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -16,7 +16,6 @@ using Raven.Client.Documents.Session;
 using Raven.Server.Documents.Handlers.Batches.Commands;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Sharding.Handlers.Batches;
-using Raven.Server.Documents.TransactionCommands;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Exceptions;
 using Sparrow;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -17,6 +17,7 @@ using Raven.Server.Documents.Handlers.Batches.Commands;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Sharding.Handlers.Batches;
 using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Exceptions;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -30,7 +30,6 @@ namespace Raven.Server.Documents.Handlers.Batches
     {
         internal static BatchRequestParser Instance = new BatchRequestParser();
 
-#pragma warning disable CS0659
         public class CommandData : IBatchCommandData
         {
             public CommandType Type { get; set; }
@@ -93,34 +92,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
             #endregion ravendata
 
-            public override bool Equals(object obj)
-            {
-                if ((obj == null) || this.GetType().Equals(obj.GetType()) == false )
-                {
-                    return false;
-                }
-
-                if (this != null && obj != null)
-                {
-                    Type type = this.GetType();
-                    foreach (System.Reflection.PropertyInfo pi in type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
-                    {
-                        object selfValue = type.GetProperty(pi.Name).GetValue(this, null);
-                        object toValue = type.GetProperty(pi.Name).GetValue(obj, null);
-
-                        if (selfValue != toValue && (selfValue == null || !selfValue.Equals(toValue)))
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
-                return this == obj;
-            }
-
         }
-#pragma warning restore CS0659
 
 
         private static readonly int MaxSizeOfCommandsInBatchToCache = 128;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -91,6 +91,33 @@ namespace Raven.Server.Documents.Handlers.Batches
             public long ContentLength { get; set; }
 
             #endregion ravendata
+
+            public override bool Equals(object obj)
+            {
+                if ((obj == null) || this.GetType().Equals(obj.GetType()) == false )
+                {
+                    return false;
+                }
+
+                if (this != null && obj != null)
+                {
+                    Type type = this.GetType();
+                    foreach (System.Reflection.PropertyInfo pi in type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+                    {
+                        object selfValue = type.GetProperty(pi.Name).GetValue(this, null);
+                        object toValue = type.GetProperty(pi.Name).GetValue(obj, null);
+
+                        if (selfValue != toValue && (selfValue == null || !selfValue.Equals(toValue)))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+                return this == obj;
+            }
+
         }
 
         private static readonly int MaxSizeOfCommandsInBatchToCache = 128;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -30,6 +30,7 @@ namespace Raven.Server.Documents.Handlers.Batches
     {
         internal static BatchRequestParser Instance = new BatchRequestParser();
 
+#pragma warning disable CS0659
         public class CommandData : IBatchCommandData
         {
             public CommandType Type { get; set; }
@@ -119,6 +120,8 @@ namespace Raven.Server.Documents.Handlers.Batches
             }
 
         }
+#pragma warning restore CS0659
+
 
         private static readonly int MaxSizeOfCommandsInBatchToCache = 128;
 

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions.Documents;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -178,7 +179,7 @@ public class ClusterTransactionMergedCommand : TransactionMergedCommand
         return Reply.Count;
     }
 
-    public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
     {
         return new ClusterTransactionMergedCommandDto
         {

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommandDto.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommandDto.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Batches.Commands;
 
-public class ClusterTransactionMergedCommandDto : TransactionOperationsMerger.IReplayableCommandDto<ClusterTransactionMergedCommand>
+public class ClusterTransactionMergedCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, ClusterTransactionMergedCommand>
 {
     public List<ClusterTransactionCommand.SingleClusterDatabaseCommand> Batch { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Session;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -452,7 +453,7 @@ public class MergedBatchCommand : TransactionMergedCommand
         return Reply.Count;
     }
 
-    public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
     {
         return new MergedBatchCommandDto
         {

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Batches.Commands;
 
-public class MergedBatchCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedBatchCommand>
+public class MergedBatchCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedBatchCommand>
 {
     public BatchRequestParser.CommandData[] ParsedCommands { get; set; }
     public List<MergedBatchCommand.AttachmentStream> AttachmentStreams;

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/TransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/TransactionMergedCommand.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using Raven.Client;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Batches.Commands;
 
-public abstract class TransactionMergedCommand : TransactionOperationsMerger.MergedTransactionCommand, IBatchCommand
+public abstract class TransactionMergedCommand : DocumentMergedTransactionCommand, IBatchCommand
 {
     protected readonly DocumentDatabase Database;
 

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Handlers.Processors.Counters;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
@@ -28,7 +29,7 @@ namespace Raven.Server.Documents.Handlers
 {
     public class CountersHandler : DatabaseRequestHandler
     {
-        public class ExecuteCounterBatchCommand : TransactionOperationsMerger.MergedTransactionCommand
+        public class ExecuteCounterBatchCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             public bool HasWrites;
             public string LastChangeVector;
@@ -245,7 +246,7 @@ namespace Raven.Server.Documents.Handlers
                 countersToRemove.Clear();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new ExecuteCounterBatchCommandDto
                 {
@@ -267,7 +268,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        public class SmugglerCounterBatchCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
+        public class SmugglerCounterBatchCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>, IDisposable
         {
             private readonly DocumentDatabase _database;
             private readonly List<CounterGroupDetail> _counterGroups;
@@ -587,7 +588,7 @@ namespace Raven.Server.Documents.Handlers
                 _result.Counters.ErroredCount += ErrorCount;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new SmugglerCounterBatchCommandDto
                 {
@@ -621,7 +622,7 @@ namespace Raven.Server.Documents.Handlers
         }
     }
 
-    public class ExecuteCounterBatchCommandDto : TransactionOperationsMerger.IReplayableCommandDto<CountersHandler.ExecuteCounterBatchCommand>
+    public class ExecuteCounterBatchCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, CountersHandler.ExecuteCounterBatchCommand>
     {
         public bool ReplyWithAllNodesValues;
         public bool FromEtl;
@@ -635,7 +636,7 @@ namespace Raven.Server.Documents.Handlers
         }
     }
 
-    public class SmugglerCounterBatchCommandDto : TransactionOperationsMerger.IReplayableCommandDto<CountersHandler.SmugglerCounterBatchCommand>
+    public class SmugglerCounterBatchCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, CountersHandler.SmugglerCounterBatchCommand>
     {
         public List<CounterGroupDetail> CounterGroups;
         public Dictionary<string, Dictionary<string, List<(string ChangeVector, long Value)>>> LegacyDictionary;

--- a/src/Raven.Server/Documents/Handlers/JsonPatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/JsonPatchHandler.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Extensions;

--- a/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommand.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Numerics;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Server.Documents.Handlers.Batches;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
@@ -13,7 +14,7 @@ using Voron.Exceptions;
 
 namespace Raven.Server.Documents.Handlers.Processors.BulkInsert;
 
-public class MergedInsertBulkCommand : TransactionOperationsMerger.MergedTransactionCommand
+public class MergedInsertBulkCommand : DocumentMergedTransactionCommand
 {
     public Logger Logger;
     public DocumentDatabase Database;
@@ -157,7 +158,7 @@ public class MergedInsertBulkCommand : TransactionOperationsMerger.MergedTransac
         return NumberOfCommands;
     }
 
-    public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
     {
         return new MergedInsertBulkCommandDto
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommandDto.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommandDto.cs
@@ -1,11 +1,12 @@
 ﻿using System.Linq;
 using Raven.Server.Documents.Handlers.Batches;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.BulkInsert;
 
-public class MergedInsertBulkCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedInsertBulkCommand>
+public class MergedInsertBulkCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedInsertBulkCommand>
 {
     public BatchRequestParser.CommandData[] Commands { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForDelete.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.Documents;

--- a/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForGetNextHiLo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForGetNextHiLo.cs
@@ -7,6 +7,7 @@ using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Identity;
 using Raven.Client.Exceptions.Documents;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
@@ -86,7 +87,7 @@ internal class HiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerProcessor
         return Math.Max(32, lastSize);
     }
 
-    internal class MergedNextHiLoCommand : TransactionOperationsMerger.MergedTransactionCommand
+    internal class MergedNextHiLoCommand : DocumentMergedTransactionCommand
     {
         public string Key;
         public DocumentDatabase Database;
@@ -152,7 +153,7 @@ internal class HiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerProcessor
             return 1;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
         {
             return new MergedNextHiLoCommandDto
             {
@@ -166,7 +167,7 @@ internal class HiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerProcessor
         }
     }
 
-    internal class MergedNextHiLoCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedNextHiLoCommand>
+    internal class MergedNextHiLoCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedNextHiLoCommand>
     {
         public string Key;
         public long Capacity;

--- a/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForReturnHiLo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForReturnHiLo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Identity;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -30,7 +31,7 @@ internal class HiLoHandlerProcessorForReturnHiLo : AbstractHiLoHandlerProcessorF
         await RequestHandler.Database.TxMerger.Enqueue(cmd);
     }
 
-    internal class MergedHiLoReturnCommand : TransactionOperationsMerger.MergedTransactionCommand
+    internal class MergedHiLoReturnCommand : DocumentMergedTransactionCommand
     {
         public string Key;
         public DocumentDatabase Database;
@@ -63,7 +64,7 @@ internal class HiLoHandlerProcessorForReturnHiLo : AbstractHiLoHandlerProcessorF
             return 1;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
         {
             return new MergedHiLoReturnCommandDto
             {
@@ -74,7 +75,7 @@ internal class HiLoHandlerProcessorForReturnHiLo : AbstractHiLoHandlerProcessorF
         }
     }
 
-    internal class MergedHiLoReturnCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedHiLoReturnCommand>
+    internal class MergedHiLoReturnCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedHiLoReturnCommand>
     {
         public string Key;
         public long End;

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -11,8 +11,11 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.TransactionsRecording;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Operations;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Json;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler;
 using Sparrow.Json;
@@ -169,7 +172,7 @@ namespace Raven.Server.Documents.Handlers
                 var tcs = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var operationId = ServerStore.Operations.GetNextOperationId();
 
-                var command = new StartTransactionsRecordingCommand(
+                var command = new StartTransactionsRecordingCommand<DocumentsOperationContext, DocumentsTransaction>(
                         Database.TxMerger,
                         parameters.File,
                         () => tcs.SetResult(null) // we don't provide any completion details
@@ -204,7 +207,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/transactions/stop-recording", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task StopRecording()
         {
-            var command = new StopTransactionsRecordingCommand(Database.TxMerger);
+            var command = new StopTransactionsRecordingCommand<DocumentsOperationContext, DocumentsTransaction>(Database.TxMerger);
 
             await Database.TxMerger.Enqueue(command);
             NoContentStatus();
@@ -227,58 +230,62 @@ namespace Raven.Server.Documents.Handlers
         }
     }
 
-    public class StartTransactionsRecordingCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class StartTransactionsRecordingCommand<TOperationContext, TTransaction> : MergedTransactionCommand<TOperationContext, TTransaction>
+        where TOperationContext : TransactionOperationContext<TTransaction>
+        where TTransaction : RavenTransaction
     {
-        private readonly TransactionOperationsMerger _databaseTxMerger;
+        private readonly AbstractTransactionOperationsMerger<TOperationContext, TTransaction> _txMerger;
         private readonly string _filePath;
         private readonly Action _onStop;
 
-        public StartTransactionsRecordingCommand(TransactionOperationsMerger databaseTxMerger, string filePath, Action onStop)
+        public StartTransactionsRecordingCommand(AbstractTransactionOperationsMerger<TOperationContext, TTransaction> txMerger, string filePath, Action onStop)
         {
-            _databaseTxMerger = databaseTxMerger;
+            _txMerger = txMerger;
             _filePath = filePath;
             _onStop = onStop;
         }
 
-        public override long Execute(DocumentsOperationContext context, TransactionOperationsMerger.RecordingState recordingState)
+        public override long Execute(TOperationContext context, AbstractTransactionOperationsMerger<TOperationContext, TTransaction>.RecordingState recordingState)
         {
             return ExecuteDirectly(context);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<TOperationContext, TTransaction, MergedTransactionCommand<TOperationContext, TTransaction>> ToDto(TOperationContext context)
         {
             return null;
         }
 
-        protected override long ExecuteCmd(DocumentsOperationContext context)
+        protected override long ExecuteCmd(TOperationContext context)
         {
-            _databaseTxMerger.StartRecording(_filePath, _onStop);
+            _txMerger.StartRecording(_filePath, _onStop);
             return 0;
         }
     }
 
-    public class StopTransactionsRecordingCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class StopTransactionsRecordingCommand<TOperationContext, TTransaction> : MergedTransactionCommand<TOperationContext, TTransaction>
+        where TOperationContext : TransactionOperationContext<TTransaction>
+        where TTransaction : RavenTransaction
     {
-        private readonly TransactionOperationsMerger _databaseTxMerger;
+        private readonly AbstractTransactionOperationsMerger<TOperationContext, TTransaction> _txMerger;
 
-        public StopTransactionsRecordingCommand(TransactionOperationsMerger databaseTxMerger)
+        public StopTransactionsRecordingCommand(AbstractTransactionOperationsMerger<TOperationContext, TTransaction> _txMerger)
         {
-            _databaseTxMerger = databaseTxMerger;
+            this._txMerger = _txMerger;
         }
 
-        public override long Execute(DocumentsOperationContext context, TransactionOperationsMerger.RecordingState recordingState)
+        public override long Execute(TOperationContext context, AbstractTransactionOperationsMerger<TOperationContext, TTransaction>.RecordingState recordingState)
         {
             return ExecuteDirectly(context);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<TOperationContext, TTransaction, MergedTransactionCommand<TOperationContext, TTransaction>> ToDto(TOperationContext context)
         {
             return null;
         }
 
-        protected override long ExecuteCmd(DocumentsOperationContext context)
+        protected override long ExecuteCmd(TOperationContext context)
         {
-            _databaseTxMerger.StopRecording();
+            _txMerger.StopRecording();
             return 0;
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2393,7 +2393,7 @@ namespace Raven.Server.Documents.Indexes
                             tx.InnerTransaction.LowLevelTransaction.OnDispose += _ => IndexPersistence.CleanWritersIfNeeded();
 
                             tx.Commit();
-                            SlowWriteNotification.Notify(commitStats, DocumentDatabase);
+                            SlowWriteNotification.Notify(commitStats, DocumentDatabase.NotificationCenter);
                             stats.RecordCommitStats(commitStats.NumberOfModifiedPages, commitStats.NumberOf4KbsWrittenToDisk);
                         }
                     }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes.MapReduce;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
@@ -133,7 +135,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             }
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             return new DeleteReduceOutputDocumentsCommandDto
             {
@@ -149,7 +151,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
         }
     }
 
-    public class DeleteReduceOutputDocumentsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<DeleteReduceOutputDocumentsCommand>
+    public class DeleteReduceOutputDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DeleteReduceOutputDocumentsCommand>
     {
         public string DocumentsPrefix;
         public string OriginalPattern;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -199,7 +200,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
         }
     }
 
-    public abstract class OutputReduceAbstractCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public abstract class OutputReduceAbstractCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         protected readonly DocumentDatabase _database;
 
@@ -322,7 +323,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             {
                 if (skipAdd.Contains(output.Key))
                     continue;
-                
+
                 for (var i = 0; i < output.Value.Count; i++) // we have hash collision so there might be multiple outputs for the same reduce key hash
                 {
                     var id = output.Value.Count == 1 ? GetOutputDocumentKey(output.Key) : GetOutputDocumentKeyForSameReduceKeyHash(output.Key, i);
@@ -373,7 +374,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             }
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             var dto = new OutputReduceToCollectionCommandDto
             {
@@ -604,7 +605,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
         }
     }
 
-    public class OutputReduceToCollectionCommandDto : TransactionOperationsMerger.IReplayableCommandDto<OutputReduceToCollectionCommand>
+    public class OutputReduceToCollectionCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, OutputReduceToCollectionCommand>
     {
         public string OutputReduceToCollection;
         public long? ReduceOutputIndex;

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -18,7 +18,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Patch
 {
-    public abstract class PatchDocumentCommandBase : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+    public abstract class PatchDocumentCommandBase : DocumentMergedTransactionCommand
     {
         private readonly bool _skipPatchIfChangeVectorMismatch;
 
@@ -426,7 +426,7 @@ namespace Raven.Server.Documents.Patch
             return null;
         }
 
-        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, BatchPatchDocumentCommand> ToDto(DocumentsOperationContext context)
         {
             var dto = new BatchPatchDocumentCommandDto();
             FillDto(dto);
@@ -483,7 +483,7 @@ namespace Raven.Server.Documents.Patch
             return HandleReply(_id, PatchResult, reply, modifiedCollections);
         }
 
-        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
         {
             var dto = new PatchDocumentCommandDto();
             FillDto(dto);

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -10,6 +10,7 @@ using Raven.Client.Exceptions;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -17,7 +18,7 @@ using Voron;
 
 namespace Raven.Server.Documents.Patch
 {
-    public abstract class PatchDocumentCommandBase : TransactionOperationsMerger.MergedTransactionCommand
+    public abstract class PatchDocumentCommandBase : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         private readonly bool _skipPatchIfChangeVectorMismatch;
 
@@ -425,7 +426,7 @@ namespace Raven.Server.Documents.Patch
             return null;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             var dto = new BatchPatchDocumentCommandDto();
             FillDto(dto);
@@ -482,7 +483,7 @@ namespace Raven.Server.Documents.Patch
             return HandleReply(_id, PatchResult, reply, modifiedCollections);
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             var dto = new PatchDocumentCommandDto();
             FillDto(dto);
@@ -538,8 +539,8 @@ namespace Raven.Server.Documents.Patch
         }
     }
 
-    public abstract class PatchDocumentCommandDtoBase<TCommand> : PatchDocumentCommandDtoBase, TransactionOperationsMerger.IReplayableCommandDto<TCommand>
-        where TCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public abstract class PatchDocumentCommandDtoBase<TCommand> : PatchDocumentCommandDtoBase, IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, TCommand>
+        where TCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         public abstract TCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database);
     }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
@@ -2,6 +2,7 @@
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TcpHandlers;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -24,7 +25,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             _shardedDatabase = ShardedDocumentDatabase.CastToShardedDocumentDatabase(parent.Database);
         }
 
-        protected override TransactionOperationsMerger.MergedTransactionCommand GetMergeDocumentsCommand(DocumentsOperationContext context,
+        protected override DocumentMergedTransactionCommand GetMergeDocumentsCommand(DocumentsOperationContext context,
             DataForReplicationCommand data, long lastDocumentEtag)
         {
             return new MergedIncomingMigrationCommand(_shardedDatabase, data, lastDocumentEtag, _currentMigrationIndex);

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingInternalReplicationHandler.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -55,7 +56,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             _lastDestinationEtag = replicationBatchReply.CurrentEtag;
         }
 
-        internal class UpdateSiblingCurrentEtag : TransactionOperationsMerger.MergedTransactionCommand
+        internal class UpdateSiblingCurrentEtag : DocumentMergedTransactionCommand
         {
             private readonly ReplicationMessageReply _replicationBatchReply;
             private readonly AsyncManualResetEvent _trigger;
@@ -143,13 +144,13 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 return result.IsValid ? 1 : 0;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
             {
                 return new UpdateSiblingCurrentEtagDto { ReplicationBatchReply = _replicationBatchReply };
             }
         }
 
-        internal class UpdateSiblingCurrentEtagDto : TransactionOperationsMerger.IReplayableCommandDto<UpdateSiblingCurrentEtag>
+        internal class UpdateSiblingCurrentEtagDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, UpdateSiblingCurrentEtag>
         {
             public ReplicationMessageReply ReplicationBatchReply;
 

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -11,6 +11,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
@@ -70,7 +71,7 @@ namespace Raven.Server.Documents.Replication
             // update to larger index;
             if (ThreadingHelper.InterlockedExchangeMax(ref _processedRaftIndex, index) == false)
                 return;
-            
+
             try
             {
                 using (await RunOnceAsync())
@@ -174,7 +175,7 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        internal class PutResolvedConflictsCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class PutResolvedConflictsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly ConflictsStorage _conflictsStorage;
             private readonly List<(DocumentConflict ResolvedConflict, long MaxConflictEtag, bool resovedToLatest)> _resolvedConflicts;
@@ -212,10 +213,10 @@ namespace Raven.Server.Documents.Replication
                 return count;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 // The LowerId created as in memory LazyStringValue that doesn't have escape characters
-                // so EscapePositions set to empty to avoid reference to escape bytes (after string bytes) while serializing
+                // so EscapePositions set to empty to avoid reference to escape bytes (after string bytes) while serializing    
                 foreach (var conflict in _resolvedConflicts)
                 {
                     conflict.ResolvedConflict.LowerId.EscapePositions = Array.Empty<int>();
@@ -441,7 +442,7 @@ namespace Raven.Server.Documents.Replication
                 var msg = $"Script failed to resolve the conflict in doc: {updatedConflict?.Id} because exception was raised in it.";
                 if (_log.IsInfoEnabled)
                     _log.Info(msg, e);
-                
+
                 var alert = AlertRaised.Create(
                     _database.Name,
                     "User-provided conflict script raised an error during conflict resolution, manual intervention required!",
@@ -449,7 +450,7 @@ namespace Raven.Server.Documents.Replication
                     AlertType.Replication,
                     NotificationSeverity.Error,
                     details: new ExceptionDetails(e));
-                
+
                 _database.NotificationCenter.Add(alert);
             }
             return false;
@@ -540,7 +541,7 @@ namespace Raven.Server.Documents.Replication
         }
     }
 
-    internal class PutResolvedConflictsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand>
+    internal class PutResolvedConflictsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand>
     {
         public List<(DocumentConflict ResolvedConflict, long MaxConflictEtag, bool ResolvedToLatests)> ResolvedConflicts;
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsOperations.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsOperations.cs
@@ -1,5 +1,6 @@
 using System;
 using Raven.Client.Exceptions.Documents.Revisions;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -22,7 +23,7 @@ namespace Raven.Server.Documents.Revisions
             _database.TxMerger.Enqueue(new DeleteRevisionsBeforeCommand(collection, time, _database)).GetAwaiter().GetResult();
         }
 
-        internal class DeleteRevisionsBeforeCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class DeleteRevisionsBeforeCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly string _collection;
             private readonly DateTime _time;
@@ -41,7 +42,7 @@ namespace Raven.Server.Documents.Revisions
                 return 1;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new DeleteRevisionsBeforeCommandDto
                 {
@@ -53,7 +54,7 @@ namespace Raven.Server.Documents.Revisions
         }
     }
 
-    internal class DeleteRevisionsBeforeCommandDto : TransactionOperationsMerger.IReplayableCommandDto<RevisionsOperations.DeleteRevisionsBeforeCommand>
+    internal class DeleteRevisionsBeforeCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RevisionsOperations.DeleteRevisionsBeforeCommand>
     {
         public string Collection;
         public DateTime Time;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
@@ -1325,7 +1326,7 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        private class EnforceRevisionConfigurationCommand : TransactionOperationsMerger.MergedTransactionCommand
+        private class EnforceRevisionConfigurationCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly RevisionsStorage _revisionsStorage;
             private readonly List<string> _ids;
@@ -1358,12 +1359,12 @@ namespace Raven.Server.Documents.Revisions
                 return _ids.Count;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new EnforceRevisionConfigurationCommandDto(_revisionsStorage, _ids);
             }
 
-            private class EnforceRevisionConfigurationCommandDto : TransactionOperationsMerger.IReplayableCommandDto<EnforceRevisionConfigurationCommand>
+            private class EnforceRevisionConfigurationCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, EnforceRevisionConfigurationCommand>
             {
                 private readonly RevisionsStorage _revisionsStorage;
                 private readonly List<string> _ids;
@@ -1592,7 +1593,7 @@ namespace Raven.Server.Documents.Revisions
             list.Add(revision);
         }
 
-        internal class RevertDocumentsCommand : TransactionOperationsMerger.MergedTransactionCommand
+        internal class RevertDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly List<Document> _list;
             private readonly CancellationToken _token;
@@ -1664,13 +1665,13 @@ namespace Raven.Server.Documents.Revisions
                 return collectionName;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new RevertDocumentsCommandDto(_list);
             }
         }
 
-        internal class RevertDocumentsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<RevertDocumentsCommand>
+        internal class RevertDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RevertDocumentsCommand>
         {
             public readonly List<Document> List;
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -10,6 +10,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Sharding.Background;
 using Raven.Server.Documents.Sharding.Smuggler;
 using Raven.Server.Documents.Subscriptions.Sharding;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -227,7 +228,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
 
     public static ShardedDocumentDatabase CastToShardedDocumentDatabase(DocumentDatabase database) => database as ShardedDocumentDatabase ?? throw new ArgumentException($"Database {database.Name} must be sharded!");
 
-    public class DeleteBucketCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class DeleteBucketCommand : DocumentMergedTransactionCommand
     {
         private readonly ShardedDocumentDatabase _database;
         private readonly int _bucket;
@@ -250,7 +251,7 @@ public class ShardedDocumentDatabase : DocumentDatabase
             return 1;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/Documents/SlowWriteNotification.cs
+++ b/src/Raven.Server/Documents/SlowWriteNotification.cs
@@ -4,7 +4,7 @@ namespace Raven.Server.Documents
 {
     public class SlowWriteNotification
     {
-        public static void Notify(CommitStats stats, DocumentDatabase database)
+        public static void Notify(CommitStats stats, NotificationCenter.NotificationCenter notificationCenter)
         {
             if (stats.NumberOf4KbsWrittenToDisk == 0 ||
                 // we don't want to raise the error too often
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents
 
             if (rateOfWritesInMbPerSec < 1)
             {
-                database.NotificationCenter.SlowWrites.Add(stats.JournalFilePath, writtenDataInMb, seconds);
+                notificationCenter.SlowWrites.Add(stats.JournalFilePath, writtenDataInMb, seconds);
             }
         }
     }

--- a/src/Raven.Server/Documents/SlowWriteNotification.cs
+++ b/src/Raven.Server/Documents/SlowWriteNotification.cs
@@ -4,7 +4,7 @@ namespace Raven.Server.Documents
 {
     public class SlowWriteNotification
     {
-        public static void Notify(CommitStats stats, NotificationCenter.NotificationCenter notificationCenter)
+        public static void Notify(CommitStats stats, NotificationCenter.AbstractDatabaseNotificationCenter notificationCenter)
         {
             if (stats.NumberOf4KbsWrittenToDisk == 0 ||
                 // we don't want to raise the error too often

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Util;
 using Raven.Server.Background;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -292,7 +294,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        internal class DeleteTombstonesCommand : TransactionOperationsMerger.MergedTransactionCommand
+		internal class DeleteTombstonesCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly Dictionary<string, StateHolder> _tombstones;
             private readonly long _minAllDocsEtag;
@@ -362,7 +364,7 @@ namespace Raven.Server.Documents
                 return NumberOfTombstonesDeleted;
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new DeleteTombstonesCommandDto
                 {
@@ -410,7 +412,7 @@ namespace Raven.Server.Documents
         }
     }
 
-    internal class DeleteTombstonesCommandDto : TransactionOperationsMerger.IReplayableCommandDto<TombstoneCleaner.DeleteTombstonesCommand>
+    internal class DeleteTombstonesCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, TombstoneCleaner.DeleteTombstonesCommand>
     {
         public Dictionary<string, TombstoneCleaner.StateHolder> Tombstones;
         public long MinAllDocsEtag;

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.Recording.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.Recording.cs
@@ -1,0 +1,209 @@
+﻿using Raven.Server.ServerWide.Context;
+using System.Threading;
+using Sparrow.Json;
+using Sparrow.Json.Sync;
+using System;
+using System.IO;
+using System.IO.Compression;
+using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Documents.TransactionMerger;
+
+public abstract partial class AbstractTransactionOperationsMerger<TOperationContext, TTransaction>
+    where TOperationContext : TransactionOperationContext<TTransaction>
+    where TTransaction : RavenTransaction
+{
+    private RecordingTx _recording;
+
+    private struct RecordingTx
+    {
+        public RecordingState State;
+        public Stream Stream;
+        public Action StopAction;
+    }
+
+    public void StartRecording(string filePath, Action stopAction)
+    {
+        var recordingFileStream = new FileStream(filePath, FileMode.Create);
+        if (null != Interlocked.CompareExchange(ref _recording.State, new RecordingState.BeforeEnabledRecordingState(this), null))
+        {
+            recordingFileStream.Dispose();
+            File.Delete(filePath);
+        }
+        _recording.Stream = new GZipStream(recordingFileStream, CompressionMode.Compress);
+        _recording.StopAction = stopAction;
+    }
+
+    public bool RecordingEnabled => _recording.State != null;
+
+    public void StopRecording()
+    {
+        var recordingState = _recording.State;
+        if (recordingState != null)
+        {
+            recordingState.Shutdown();
+            _waitHandle.Set();
+            _recording.StopAction?.Invoke();
+            _recording.StopAction = null;
+        }
+    }
+
+    public class EnabledRecordingState : RecordingState
+    {
+        private readonly AbstractTransactionOperationsMerger<TOperationContext, TTransaction> _txMerger;
+        private int _isDisposed = 0;
+
+        public EnabledRecordingState(AbstractTransactionOperationsMerger<TOperationContext, TTransaction> txMerger)
+        {
+            _txMerger = txMerger;
+        }
+
+        public override void TryRecord(TOperationContext context, MergedTransactionCommand<TOperationContext, TTransaction> operation)
+        {
+            var obj = new RecordingCommandDetails<TOperationContext, TTransaction>(operation.GetType().Name)
+            {
+                Command = operation.ToDto(context)
+            };
+
+            TryRecord(obj, context);
+        }
+
+        internal override void TryRecord(TOperationContext ctx, TxInstruction tx, bool doRecord = true)
+        {
+            if (doRecord == false)
+            {
+                return;
+            }
+
+            var commandDetails = new RecordingDetails(tx.ToString());
+
+            TryRecord(commandDetails, ctx);
+        }
+
+        private void TryRecord(RecordingDetails commandDetails, JsonOperationContext context)
+        {
+            try
+            {
+                using (var commandDetailsReader = RecordingState.SerializeRecordingCommandDetails(context, commandDetails))
+                using (var writer = new BlittableJsonTextWriter(context, _txMerger._recording.Stream))
+                {
+                    writer.WriteComma();
+                    context.Write(writer, commandDetailsReader);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        public override void Prepare(ref RecordingState state)
+        {
+            if (IsShutdown == false)
+                return;
+
+            state = null;
+            Dispose();
+
+            _txMerger._recording.Stream?.Dispose();
+            _txMerger._recording.Stream = null;
+        }
+
+        public override void Dispose()
+        {
+            if (1 == Interlocked.CompareExchange(ref _isDisposed, 1, 0))
+            {
+                return;
+            }
+
+            using (_txMerger._contextPool.AllocateOperationContext(out TOperationContext ctx))
+            {
+                using (var writer = new BlittableJsonTextWriter(ctx, _txMerger._recording.Stream))
+                {
+                    writer.WriteEndArray();
+                }
+            }
+        }
+    }
+
+    public abstract class RecordingState : IDisposable
+    {
+        public abstract void TryRecord(TOperationContext context, MergedTransactionCommand<TOperationContext, TTransaction> cmd);
+
+        internal abstract void TryRecord(TOperationContext context, TxInstruction tx, bool doRecord = true);
+
+        public abstract void Prepare(ref RecordingState state);
+
+        internal static BlittableJsonReaderObject SerializeRecordingCommandDetails(
+            JsonOperationContext context,
+            RecordingDetails commandDetails)
+        {
+            using (var writer = new BlittableJsonWriter(context))
+            {
+                var jsonSerializer = ReplayTxCommandHelper.GetJsonSerializer();
+
+                jsonSerializer.Serialize(writer, commandDetails);
+                writer.FinalizeDocument();
+
+                return writer.CreateReader();
+            }
+        }
+
+
+        public class BeforeEnabledRecordingState : RecordingState
+        {
+            private readonly AbstractTransactionOperationsMerger<TOperationContext, TTransaction> _txMerger;
+
+            public BeforeEnabledRecordingState(AbstractTransactionOperationsMerger<TOperationContext, TTransaction> txMerger)
+            {
+                _txMerger = txMerger;
+            }
+
+            public override void TryRecord(TOperationContext context, MergedTransactionCommand<TOperationContext, TTransaction> cmd)
+            {
+            }
+
+            internal override void TryRecord(TOperationContext context, TxInstruction tx, bool doRecord = true)
+            {
+            }
+
+            public override void Prepare(ref RecordingState state)
+            {
+                if (IsShutdown)
+                {
+                    state = null;
+                    return;
+                }
+
+                using (_txMerger._contextPool.AllocateOperationContext(out TOperationContext context))
+                using (var writer = new BlittableJsonTextWriter(context, _txMerger._recording.Stream))
+                {
+                    writer.WriteStartArray();
+
+                    var commandDetails = new StartRecordingDetails();
+                    var commandDetailsReader = SerializeRecordingCommandDetails(context, commandDetails);
+
+                    context.Write(writer, commandDetailsReader);
+                }
+
+                state = new EnabledRecordingState(_txMerger);
+            }
+
+            public override void Dispose()
+            {
+            }
+        }
+
+        protected bool IsShutdown { private set; get; }
+
+        public void Shutdown()
+        {
+            IsShutdown = true;
+        }
+
+        public abstract void Dispose();
+    }
+}
+

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -398,7 +398,6 @@ namespace Raven.Server.Documents.TransactionMerger
                                 _recording.State?.TryRecord(context, TxInstruction.Commit);
                                 tx.Commit();
 
-                                // SlowWriteNotification.Notify(stats, _notificationCenter);
                                 NotifyAboutSlowWrite(stats);
                                 _recording.State?.TryRecord(context, TxInstruction.DisposeTx, tx.Disposed == false);
                                 tx.Dispose();
@@ -603,7 +602,6 @@ namespace Raven.Server.Documents.TransactionMerger
                                 _recording.State?.TryRecord(current, TxInstruction.Commit);
                                 previous.Transaction.Commit();
 
-                                // SlowWriteNotification.Notify(stats, NotificationCenter);
                                 NotifyAboutSlowWrite(stats);
                             }
                             catch (Exception e)

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -2,20 +2,19 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
+using JetBrains.Annotations;
+using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Config.Settings;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
-using Sparrow.Json.Sync;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server.Meters;
@@ -25,23 +24,30 @@ using Voron;
 using Voron.Debugging;
 using Voron.Global;
 using Voron.Impl;
+using Size = Sparrow.Size;
 
-namespace Raven.Server.Documents
+namespace Raven.Server.Documents.TransactionMerger
 {
     /// <summary>
     /// Merges multiple commands into a single transaction. Any commands that implement IDisposable
     /// will be disposed after the command is executed and transaction is committed
     /// </summary>
-    public class TransactionOperationsMerger : IDisposable
+    public abstract partial class AbstractTransactionOperationsMerger<TOperationContext, TTransaction> : IDisposable
+        where TOperationContext : TransactionOperationContext<TTransaction>
+        where TTransaction : RavenTransaction
     {
-        private readonly DocumentDatabase _parent;
+        private readonly string _resourceName;
+        private JsonContextPoolBase<TOperationContext> _contextPool;
+        private NotificationCenter.NotificationCenter _notificationCenter;
+        private readonly RavenConfiguration _configuration;
+        private readonly SystemTime _time;
         private readonly CancellationToken _shutdown;
         private bool _runTransactions = true;
-        private readonly ConcurrentQueue<MergedTransactionCommand> _operations = new ConcurrentQueue<MergedTransactionCommand>();
-        private readonly CountdownEvent _concurrentOperations = new CountdownEvent(1);
+        private readonly ConcurrentQueue<MergedTransactionCommand<TOperationContext, TTransaction>> _operations = new();
+        private readonly CountdownEvent _concurrentOperations = new(1);
 
-        private readonly ConcurrentQueue<List<MergedTransactionCommand>> _opsBuffers = new ConcurrentQueue<List<MergedTransactionCommand>>();
-        private readonly ManualResetEventSlim _waitHandle = new ManualResetEventSlim(false);
+        private readonly ConcurrentQueue<List<MergedTransactionCommand<TOperationContext, TTransaction>>> _opsBuffers = new();
+        private readonly ManualResetEventSlim _waitHandle = new(false);
         private ExceptionDispatchInfo _edi;
         private readonly Logger _log;
         private PoolOfThreads.LongRunningWork _txLongRunningOperation;
@@ -50,75 +56,62 @@ namespace Raven.Server.Documents
         private readonly long _maxTxSizeInBytes;
         private readonly double _maxTimeToWaitForPreviousTxBeforeRejectingInMs;
 
-        public TransactionOperationsMerger(DocumentDatabase parent, CancellationToken shutdown)
+        private bool _initialized;
+
+        protected AbstractTransactionOperationsMerger(
+            [NotNull] string resourceName,
+            [NotNull] RavenConfiguration configuration,
+            [NotNull] SystemTime time,
+            CancellationToken shutdown)
         {
-            _parent = parent;
-            _log = LoggingSource.Instance.GetLogger<TransactionOperationsMerger>(_parent.Name);
+            _resourceName = resourceName ?? throw new ArgumentNullException(nameof(resourceName));
+            _log = LoggingSource.Instance.GetLogger<AbstractTransactionOperationsMerger<TOperationContext, TTransaction>>(_resourceName);
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _time = time ?? throw new ArgumentNullException(nameof(time));
             _shutdown = shutdown;
 
-            _maxTimeToWaitForPreviousTxInMs = _parent.Configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTx.AsTimeSpan.TotalMilliseconds;
-            _maxTxSizeInBytes = _parent.Configuration.TransactionMergerConfiguration.MaxTxSize.GetValue(SizeUnit.Bytes);
-            _maxTimeToWaitForPreviousTxBeforeRejectingInMs = _parent.Configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTxBeforeRejecting.AsTimeSpan.TotalMilliseconds;
-            _timeToCheckHighDirtyMemory = _parent.Configuration.Memory.TemporaryDirtyMemoryChecksPeriod;
-            _lastHighDirtyMemCheck = _parent.Time.GetUtcNow();
+            _maxTimeToWaitForPreviousTxInMs = configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTx.AsTimeSpan.TotalMilliseconds;
+            _maxTxSizeInBytes = configuration.TransactionMergerConfiguration.MaxTxSize.GetValue(SizeUnit.Bytes);
+            _maxTimeToWaitForPreviousTxBeforeRejectingInMs = configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTxBeforeRejecting.AsTimeSpan.TotalMilliseconds;
+            _timeToCheckHighDirtyMemory = configuration.Memory.TemporaryDirtyMemoryChecksPeriod;
+            _lastHighDirtyMemCheck = time.GetUtcNow();
         }
 
-        public DatabasePerformanceMetrics GeneralWaitPerformanceMetrics = new DatabasePerformanceMetrics(DatabasePerformanceMetrics.MetricType.GeneralWait, 256, 1);
-        public DatabasePerformanceMetrics TransactionPerformanceMetrics = new DatabasePerformanceMetrics(DatabasePerformanceMetrics.MetricType.Transaction, 256, 8);
+        public void Initialize([NotNull] JsonContextPoolBase<TOperationContext> contextPool, [NotNull] NotificationCenter.NotificationCenter notificationCenter)
+        {
+            _contextPool = contextPool ?? throw new ArgumentNullException(nameof(contextPool));
+            _notificationCenter = notificationCenter ?? throw new ArgumentNullException(nameof(notificationCenter));
+
+            _initialized = true;
+        }
+
+        protected abstract bool IsEncrypted { get; }
+
+        protected abstract bool Is32Bits { get; }
+
+        internal abstract TTransaction BeginAsyncCommitAndStartNewTransaction(TTransaction previousTransaction, TOperationContext currentContext);
+
+        public DatabasePerformanceMetrics GeneralWaitPerformanceMetrics = new(DatabasePerformanceMetrics.MetricType.GeneralWait, 256, 1);
+        public DatabasePerformanceMetrics TransactionPerformanceMetrics = new(DatabasePerformanceMetrics.MetricType.Transaction, 256, 8);
 
         public int NumberOfQueuedOperations => _operations.Count;
 
-        private string TransactionMergerThreadName => $"'{_parent.Name}' Transaction Merging Thread";
+        private string TransactionMergerThreadName => $"'{_resourceName}' TxMT";
 
         public void Start()
         {
-            _txLongRunningOperation = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => MergeOperationThreadProc(), null, ThreadNames.ForTransactionMerging(TransactionMergerThreadName, _parent.Name));
-        }
-
-        public interface IRecordableCommand
-        {
-            IReplayableCommandDto<MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) where TTransaction : RavenTransaction;
-        }
-
-        public interface IReplayableCommandDto<out T> where T : MergedTransactionCommand
-        {
-            T ToCommand(DocumentsOperationContext context, DocumentDatabase database);
-        }
-
-        public abstract class MergedTransactionCommand : IRecordableCommand
-        {
-            public bool UpdateAccessTime = true;
-
-            protected abstract long ExecuteCmd(DocumentsOperationContext context);
-
-            internal long ExecuteDirectly(DocumentsOperationContext context)
-            {
-                return ExecuteCmd(context);
-            }
-
-            public virtual long Execute(DocumentsOperationContext context, RecordingState recordingState)
-            {
-                recordingState?.TryRecord(context, this);
-
-                return ExecuteCmd(context);
-            }
-
-            public abstract IReplayableCommandDto<MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) where TTransaction : RavenTransaction;
-
-            [JsonIgnore]
-            public readonly TaskCompletionSource<object> TaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            public Exception Exception;
-
-            public bool RetryOnError = false;
+            _txLongRunningOperation = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => MergeOperationThreadProc(), null, ThreadNames.ForTransactionMerging(TransactionMergerThreadName, _resourceName));
         }
 
         /// <summary>
         /// Enqueue the command to be eventually executed.
         /// </summary>
-        public async Task Enqueue(MergedTransactionCommand cmd)
+        public async Task Enqueue(MergedTransactionCommand<TOperationContext, TTransaction> cmd)
         {
             Debug.Assert(cmd.TaskCompletionSource.Task.IsCompleted == false, $"{cmd.GetType()} is already completed");
+
+            if (_initialized == false)
+                throw new InvalidOperationException($"Tx Merger for '{_resourceName}' is not initialized.");
 
             _edi?.Throw();
             _operations.Enqueue(cmd);
@@ -129,7 +122,7 @@ namespace Raven.Server.Documents
 
             try
             {
-                await cmd.TaskCompletionSource.Task.ConfigureAwait(false);
+                await cmd.TaskCompletionSource.Task;
             }
             finally
             {
@@ -149,161 +142,6 @@ namespace Raven.Server.Documents
             throw new ObjectDisposedException("Transaction Merger");
         }
 
-        public abstract class RecordingState : IDisposable
-        {
-            public abstract void TryRecord(DocumentsOperationContext context, MergedTransactionCommand cmd);
-
-            internal abstract void TryRecord(DocumentsOperationContext context, TxInstruction tx, bool doRecord = true);
-
-            public abstract void Prepare(ref RecordingState state);
-
-            private static BlittableJsonReaderObject SerializeRecordingCommandDetails(
-                JsonOperationContext context,
-                RecordingDetails commandDetails)
-            {
-                using (var writer = new BlittableJsonWriter(context))
-                {
-                    var jsonSerializer = ReplayTxCommandHelper.GetJsonSerializer();
-
-                    jsonSerializer.Serialize(writer, commandDetails);
-                    writer.FinalizeDocument();
-
-                    return writer.CreateReader();
-                }
-            }
-
-            protected class EnabledRecordingState : RecordingState
-            {
-                private readonly TransactionOperationsMerger _txOpMerger;
-                private int _isDisposed = 0;
-
-                public EnabledRecordingState(TransactionOperationsMerger txOpMerger)
-                {
-                    _txOpMerger = txOpMerger;
-                }
-
-                public override void TryRecord(DocumentsOperationContext context, MergedTransactionCommand operation)
-                {
-                    var obj = new RecordingCommandDetails(operation.GetType().Name)
-                    {
-                        Command = operation.ToDto(context)
-                    };
-
-                    TryRecord(obj, context);
-                }
-
-                internal override void TryRecord(DocumentsOperationContext ctx, TxInstruction tx, bool doRecord = true)
-                {
-                    if (doRecord == false)
-                    {
-                        return;
-                    }
-
-                    var commandDetails = new RecordingDetails(tx.ToString());
-
-                    TryRecord(commandDetails, ctx);
-                }
-
-                private void TryRecord(RecordingDetails commandDetails, JsonOperationContext context)
-                {
-                    try
-                    {
-                        using (var commandDetailsReader = SerializeRecordingCommandDetails(context, commandDetails))
-                        using (var writer = new BlittableJsonTextWriter(context, _txOpMerger._recording.Stream))
-                        {
-                            writer.WriteComma();
-                            context.Write(writer, commandDetailsReader);
-                        }
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-                }
-
-                public override void Prepare(ref RecordingState state)
-                {
-                    if (IsShutdown == false)
-                        return;
-
-                    state = null;
-                    Dispose();
-
-                    _txOpMerger._recording.Stream?.Dispose();
-                    _txOpMerger._recording.Stream = null;
-                }
-
-                public override void Dispose()
-                {
-                    if (1 == Interlocked.CompareExchange(ref _isDisposed, 1, 0))
-                    {
-                        return;
-                    }
-
-                    using (_txOpMerger._parent.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                    {
-                        using (var writer = new BlittableJsonTextWriter(ctx, _txOpMerger._recording.Stream))
-                        {
-                            writer.WriteEndArray();
-                        }
-                    }
-                }
-            }
-
-            public class BeforeEnabledRecordingState : RecordingState
-            {
-                private readonly TransactionOperationsMerger _txOpMerger;
-
-                public BeforeEnabledRecordingState(TransactionOperationsMerger txOpMerger)
-                {
-                    _txOpMerger = txOpMerger;
-                }
-
-                public override void TryRecord(DocumentsOperationContext context, MergedTransactionCommand cmd)
-                {
-                }
-
-                internal override void TryRecord(DocumentsOperationContext context, TxInstruction tx, bool doRecord = true)
-                {
-                }
-
-                public override void Prepare(ref RecordingState state)
-                {
-                    if (IsShutdown)
-                    {
-                        state = null;
-                        return;
-                    }
-
-                    using (_txOpMerger._parent.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (var writer = new BlittableJsonTextWriter(context, _txOpMerger._recording.Stream))
-                    {
-                        writer.WriteStartArray();
-
-                        var commandDetails = new StartRecordingDetails();
-                        var commandDetailsReader = SerializeRecordingCommandDetails(context, commandDetails);
-
-                        context.Write(writer, commandDetailsReader);
-                    }
-
-                    state = new EnabledRecordingState(_txOpMerger);
-                }
-
-                public override void Dispose()
-                {
-                }
-            }
-
-            protected bool IsShutdown { private set; get; }
-
-            public void Shutdown()
-            {
-                IsShutdown = true;
-            }
-
-            public abstract void Dispose();
-        }
-
         private void MergeOperationThreadProc()
         {
             ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, TransactionMergerThreadName, _log);
@@ -321,9 +159,9 @@ namespace Raven.Server.Documents
 
                         if (_operations.IsEmpty)
                         {
-                            if (_parent.IsEncrypted)
+                            if (IsEncrypted)
                             {
-                                using (_parent.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                                using (_contextPool.AllocateOperationContext(out TOperationContext ctx))
                                 {
                                     using (ctx.OpenWriteTransaction())
                                     {
@@ -425,7 +263,7 @@ namespace Raven.Server.Documents
 
             void ClearQueueWithException(Exception e)
             {
-                while (_operations.TryDequeue(out MergedTransactionCommand result))
+                while (_operations.TryDequeue(out MergedTransactionCommand<TOperationContext, TTransaction> result))
                 {
                     result.Exception = e;
                     NotifyOnThreadPool(result);
@@ -433,18 +271,18 @@ namespace Raven.Server.Documents
             }
         }
 
-        private List<MergedTransactionCommand> GetBufferForPendingOps()
+        private List<MergedTransactionCommand<TOperationContext, TTransaction>> GetBufferForPendingOps()
         {
             if (_opsBuffers.TryDequeue(out var pendingOps) == false)
             {
-                return new List<MergedTransactionCommand>();
+                return new List<MergedTransactionCommand<TOperationContext, TTransaction>>();
             }
             return pendingOps;
         }
 
         private void DoCommandsNotification(object cmds)
         {
-            var pendingOperations = (List<MergedTransactionCommand>)cmds;
+            var pendingOperations = (List<MergedTransactionCommand<TOperationContext, TTransaction>>)cmds;
             foreach (var op in pendingOperations)
             {
                 DoCommandNotification(op);
@@ -456,10 +294,10 @@ namespace Raven.Server.Documents
 
         private void DoCommandNotification(object op)
         {
-            DoCommandNotification((MergedTransactionCommand)op);
+            DoCommandNotification((MergedTransactionCommand<TOperationContext, TTransaction>)op);
         }
 
-        private static void DoCommandNotification(MergedTransactionCommand cmd)
+        private static void DoCommandNotification(MergedTransactionCommand<TOperationContext, TTransaction> cmd)
         {
             if (cmd.Exception != null)
             {
@@ -473,13 +311,13 @@ namespace Raven.Server.Documents
 
         private void MergeTransactionsOnce()
         {
-            DocumentsOperationContext context = null;
+            TOperationContext context = null;
             IDisposable returnContext = null;
-            DocumentsTransaction tx = null;
+            TTransaction tx = null;
             try
             {
                 var pendingOps = GetBufferForPendingOps();
-                returnContext = _parent.DocumentsStorage.ContextPool.AllocateOperationContext(out context);
+                returnContext = _contextPool.AllocateOperationContext(out context);
                 {
                     try
                     {
@@ -490,7 +328,7 @@ namespace Raven.Server.Documents
                     {
                         try
                         {
-                            if (_operations.TryDequeue(out MergedTransactionCommand command))
+                            if (_operations.TryDequeue(out MergedTransactionCommand<TOperationContext, TTransaction> command))
                             {
                                 command.Exception = e;
                                 DoCommandNotification(command);
@@ -562,7 +400,7 @@ namespace Raven.Server.Documents
                                 _recording.State?.TryRecord(context, TxInstruction.Commit);
                                 tx.Commit();
 
-                                SlowWriteNotification.Notify(stats, _parent);
+                                SlowWriteNotification.Notify(stats, _notificationCenter);
                                 _recording.State?.TryRecord(context, TxInstruction.DisposeTx, tx.Disposed == false);
                                 tx.Dispose();
                             }
@@ -599,7 +437,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void NotifyHighDirtyMemoryFailure(List<MergedTransactionCommand> pendingOps, HighDirtyMemoryException exception)
+        private void NotifyHighDirtyMemoryFailure(List<MergedTransactionCommand<TOperationContext, TTransaction>> pendingOps, HighDirtyMemoryException exception)
         {
             // set all pending ops exception
             foreach (var pendingOp in pendingOps)
@@ -618,23 +456,9 @@ namespace Raven.Server.Documents
             NotifyOnThreadPool(rejectedBuffer);
         }
 
-        internal void UpdateGlobalReplicationInfoBeforeCommit(DocumentsOperationContext context)
-        {
-            if (context.LastDatabaseChangeVector?.IsNullOrEmpty == false)
-            {
-                _parent.DocumentsStorage.SetDatabaseChangeVector(context, context.LastDatabaseChangeVector);
-            }
+        internal abstract void UpdateGlobalReplicationInfoBeforeCommit(TOperationContext context);
 
-            if (context.LastReplicationEtagFrom != null)
-            {
-                foreach (var repEtag in context.LastReplicationEtagFrom)
-                {
-                    DocumentsStorage.SetLastReplicatedEtagFrom(context, repEtag.Key, repEtag.Value);
-                }
-            }
-        }
-
-        private void NotifyTransactionFailureAndRerunIndependently(List<MergedTransactionCommand> pendingOps, Exception e)
+        private void NotifyTransactionFailureAndRerunIndependently(List<MergedTransactionCommand<TOperationContext, TTransaction>> pendingOps, Exception e)
         {
             if (pendingOps.Count == 1 && pendingOps[0].RetryOnError == false)
             {
@@ -652,11 +476,11 @@ namespace Raven.Server.Documents
         }
 
         private void MergeTransactionsWithAsyncCommit(
-            ref DocumentsOperationContext previous,
+            ref TOperationContext previous,
             ref IDisposable returnPreviousContext,
-            List<MergedTransactionCommand> previousPendingOps)
+            List<MergedTransactionCommand<TOperationContext, TTransaction>> previousPendingOps)
         {
-            DocumentsOperationContext current = null;
+            TOperationContext current = null;
             IDisposable currentReturnContext = null;
             try
             {
@@ -665,13 +489,13 @@ namespace Raven.Server.Documents
                     if (_log.IsInfoEnabled)
                         _log.Info($"BeginAsyncCommit on {previous.Transaction.InnerTransaction.LowLevelTransaction.Id} with {_operations.Count} additional operations pending");
 
-                    currentReturnContext = _parent.DocumentsStorage.ContextPool.AllocateOperationContext(out current);
+                    currentReturnContext = _contextPool.AllocateOperationContext(out current);
                     CommitStats commitStats = null;
                     try
                     {
                         previous.Transaction.InnerTransaction.LowLevelTransaction.RetrieveCommitStats(out commitStats);
                         _recording.State?.TryRecord(current, TxInstruction.BeginAsyncCommitAndStartNewTransaction);
-                        current.Transaction = previous.Transaction.BeginAsyncCommitAndStartNewTransaction(current);
+                        current.Transaction = BeginAsyncCommitAndStartNewTransaction(previous.Transaction, current);
                     }
                     catch (Exception e)
                     {
@@ -779,7 +603,7 @@ namespace Raven.Server.Documents
                                 _recording.State?.TryRecord(current, TxInstruction.Commit);
                                 previous.Transaction.Commit();
 
-                                SlowWriteNotification.Notify(stats, _parent);
+                                SlowWriteNotification.Notify(stats, _notificationCenter);
                             }
                             catch (Exception e)
                             {
@@ -814,10 +638,10 @@ namespace Raven.Server.Documents
         }
 
         private void CompletePreviousTransaction(
-            DocumentsOperationContext context,
+            TOperationContext context,
             RavenTransaction previous,
             CommitStats commitStats,
-            ref List<MergedTransactionCommand> previousPendingOps,
+            ref List<MergedTransactionCommand<TOperationContext, TTransaction>> previousPendingOps,
             bool throwOnError)
         {
             try
@@ -828,7 +652,7 @@ namespace Raven.Server.Documents
                 //not sure about this 'if'
                 if (commitStats != null)
                 {
-                    SlowWriteNotification.Notify(commitStats, _parent);
+                    SlowWriteNotification.Notify(commitStats, _notificationCenter);
                 }
 
                 if (_log.IsInfoEnabled)
@@ -857,8 +681,8 @@ namespace Raven.Server.Documents
         private bool _alreadyListeningToPreviousOperationEnd;
 
         private PendingOperations ExecutePendingOperationsInTransaction(
-            List<MergedTransactionCommand> executedOps,
-            DocumentsOperationContext context,
+            List<MergedTransactionCommand<TOperationContext, TTransaction>> executedOps,
+            TOperationContext context,
             Task previousOperation, ref PerformanceMetrics.DurationMeasurement meter)
         {
             _alreadyListeningToPreviousOperationEnd = false;
@@ -873,7 +697,7 @@ namespace Raven.Server.Documents
                 // overly large replication batches.
                 context.TransactionMarkerOffset++;
 
-                if (TryGetNextOperation(previousOperation, out MergedTransactionCommand op, ref meter) == false)
+                if (TryGetNextOperation(previousOperation, out MergedTransactionCommand<TOperationContext, TTransaction> op, ref meter) == false)
                     break;
 
                 executedOps.Add(op);
@@ -883,7 +707,7 @@ namespace Raven.Server.Documents
                 var dirtyMemoryState = LowMemoryNotification.Instance.DirtyMemoryState;
                 if (dirtyMemoryState.IsHighDirty)
                 {
-                    var now = _parent.Time.GetUtcNow();
+                    var now = _time.GetUtcNow();
                     if (now - _lastHighDirtyMemCheck > _timeToCheckHighDirtyMemory.AsTimeSpan)
                     {
                         // we need to ask for a flush here
@@ -896,20 +720,20 @@ namespace Raven.Server.Documents
                         $" This might be caused by a slow IO storage. Current memory usage: " +
                         $"Total Physical Memory: {MemoryInformation.TotalPhysicalMemory}, " +
                         $"Total Scratch Allocated Memory: {new Size(dirtyMemoryState.TotalDirtyInBytes, SizeUnit.Bytes)} " +
-                        $"(which is above {_parent.Configuration.Memory.TemporaryDirtyMemoryAllowedPercentage * 100}%)");
+                        $"(which is above {_configuration.Memory.TemporaryDirtyMemoryAllowedPercentage * 100}%)");
                 }
 
                 meter.IncrementCounter(1);
                 meter.IncrementCommands(op.Execute(context, _recording.State));
                 if (op.UpdateAccessTime)
-                    _parent.LastAccessTime = _parent.Time.GetUtcNow();
+                    UpdateLastAccessTime(_time.GetUtcNow());
 
                 var modifiedSize = llt.NumberOfModifiedPages * Constants.Storage.PageSize;
 
                 modifiedSize += llt.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
 
                 var canCloseCurrentTx = previousOperation == null || previousOperation.IsCompleted;
-                if (canCloseCurrentTx || _parent.Is32Bits)
+                if (canCloseCurrentTx || Is32Bits)
                 {
                     if (_operations.IsEmpty)
                         break; // nothing remaining to do, let's us close this work
@@ -944,6 +768,8 @@ namespace Raven.Server.Documents
             }
             return status;
         }
+
+        protected abstract void UpdateLastAccessTime(DateTime time);
 
         private void UnlikelyRejectOperations(IAsyncResult previousOperation, Stopwatch sp, LowLevelTransaction llt, long modifiedSize)
         {
@@ -998,7 +824,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private bool TryGetNextOperation(Task previousOperation, out MergedTransactionCommand op, ref PerformanceMetrics.DurationMeasurement meter)
+        private bool TryGetNextOperation(Task previousOperation, out MergedTransactionCommand<TOperationContext, TTransaction> op, ref PerformanceMetrics.DurationMeasurement meter)
         {
             if (_operations.TryDequeue(out op))
                 return true;
@@ -1010,7 +836,7 @@ namespace Raven.Server.Documents
         }
 
         private bool UnlikelyWaitForNextOperationOrPreviousTransactionComplete(Task previousOperation,
-            out MergedTransactionCommand op, ref PerformanceMetrics.DurationMeasurement meter)
+            out MergedTransactionCommand<TOperationContext, TTransaction> op, ref PerformanceMetrics.DurationMeasurement meter)
         {
             if (_alreadyListeningToPreviousOperationEnd == false)
             {
@@ -1042,14 +868,14 @@ namespace Raven.Server.Documents
             }
         }
 
-        private PendingOperations GetPendingOperationsStatus(DocumentsOperationContext context, bool forceCompletion = false)
+        private PendingOperations GetPendingOperationsStatus(TOperationContext context, bool forceCompletion = false)
         {
             // this optimization is disabled for 32 bits
-            if (_parent.Is32Bits)
+            if (Is32Bits)
                 return PendingOperations.CompletedAll;
 
             // This optimization is disabled when encryption is on
-            if (context.Environment.Options.Encryption.IsEnabled)
+            if (IsEncrypted)
                 return PendingOperations.CompletedAll;
 
             if (forceCompletion)
@@ -1058,20 +884,20 @@ namespace Raven.Server.Documents
             return PendingOperations.HasMore;
         }
 
-        private void NotifyOnThreadPool(MergedTransactionCommand cmd)
+        private void NotifyOnThreadPool(MergedTransactionCommand<TOperationContext, TTransaction> command)
         {
-            TaskExecutor.Execute(DoCommandNotification, cmd);
+            TaskExecutor.Execute(DoCommandNotification, command);
         }
 
-        private void NotifyOnThreadPool(List<MergedTransactionCommand> cmds)
+        private void NotifyOnThreadPool(List<MergedTransactionCommand<TOperationContext, TTransaction>> commands)
         {
-            if (cmds == null)
+            if (commands == null)
                 return;
 
-            TaskExecutor.Execute(DoCommandsNotification, cmds);
+            TaskExecutor.Execute(DoCommandsNotification, commands);
         }
 
-        private void RunEachOperationIndependently(List<MergedTransactionCommand> pendingOps)
+        private void RunEachOperationIndependently(List<MergedTransactionCommand<TOperationContext, TTransaction>> pendingOps)
         {
             try
             {
@@ -1082,7 +908,7 @@ namespace Raven.Server.Documents
                     {
                         try
                         {
-                            using (_parent.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                            using (_contextPool.AllocateOperationContext(out TOperationContext context))
                             {
                                 _recording.State?.TryRecord(context, TxInstruction.BeginTx);
                                 using (var tx = context.OpenWriteTransaction())
@@ -1095,7 +921,7 @@ namespace Raven.Server.Documents
 
                                     _recording.State?.TryRecord(context, TxInstruction.Commit);
                                     tx.Commit();
-                                    SlowWriteNotification.Notify(stats, _parent);
+                                    SlowWriteNotification.Notify(stats, _notificationCenter);
                                 }
                             }
 
@@ -1123,7 +949,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             StopRecording();
 
@@ -1157,47 +983,13 @@ namespace Raven.Server.Documents
                 }
             }
 
-            while (_operations.TryDequeue(out MergedTransactionCommand result))
+            while (_operations.TryDequeue(out MergedTransactionCommand<TOperationContext, TTransaction> result))
             {
                 result.TaskCompletionSource.TrySetCanceled();
             }
         }
 
-        private RecordingTx _recording = default;
         private DateTime _lastHighDirtyMemCheck;
         private readonly TimeSetting _timeToCheckHighDirtyMemory;
-
-        private struct RecordingTx
-        {
-            public RecordingState State;
-            public Stream Stream;
-            public Action StopAction;
-        }
-
-        public void StartRecording(string filePath, Action stopAction)
-        {
-            var recordingFileStream = new FileStream(filePath, FileMode.Create);
-            if (null != Interlocked.CompareExchange(ref _recording.State, new RecordingState.BeforeEnabledRecordingState(this), null))
-            {
-                recordingFileStream.Dispose();
-                File.Delete(filePath);
-            }
-            _recording.Stream = new GZipStream(recordingFileStream, CompressionMode.Compress);
-            _recording.StopAction = stopAction;
-        }
-
-        public bool RecordingEnabled => _recording.State != null;
-
-        public void StopRecording()
-        {
-            var recordingState = _recording.State;
-            if (recordingState != null)
-            {
-                recordingState.Shutdown();
-                _waitHandle.Set();
-                _recording.StopAction?.Invoke();
-                _recording.StopAction = null;
-            }
-        }
     }
 }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentCommand.cs
@@ -1,11 +1,9 @@
-﻿using System.Runtime.ExceptionServices;
-using Raven.Client.Exceptions;
-using Raven.Server.ServerWide.Context;
+﻿using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
-namespace Raven.Server.Documents.TransactionCommands
+namespace Raven.Server.Documents.TransactionMerger.Commands
 {
-    public class DeleteDocumentCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class DeleteDocumentCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         private readonly string _id;
         private readonly string _expectedChangeVector;
@@ -26,9 +24,9 @@ namespace Raven.Server.Documents.TransactionCommands
             return 1;
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
-            return new DeleteDocumentCommandDto()
+            return new DeleteDocumentCommandDto
             {
                 Id = _id,
                 ChangeVector = _expectedChangeVector,
@@ -36,7 +34,7 @@ namespace Raven.Server.Documents.TransactionCommands
         }
     }
 
-    public class DeleteDocumentCommandDto : TransactionOperationsMerger.IReplayableCommandDto<DeleteDocumentCommand>
+    public class DeleteDocumentCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DeleteDocumentCommand>
     {
         public string Id { get; set; }
         public string ChangeVector { get; set; }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentCommand.cs
@@ -3,7 +3,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.TransactionMerger.Commands
 {
-    public class DeleteDocumentCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+    public class DeleteDocumentCommand : DocumentMergedTransactionCommand
     {
         private readonly string _id;
         private readonly string _expectedChangeVector;
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             return 1;
         }
 
-        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
         {
             return new DeleteDocumentCommandDto
             {

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteDocumentsCommand.cs
@@ -2,9 +2,9 @@
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
-namespace Raven.Server.Documents.TransactionCommands;
+namespace Raven.Server.Documents.TransactionMerger.Commands;
 
-public class DeleteDocumentsCommand : TransactionOperationsMerger.MergedTransactionCommand
+public class DeleteDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
 {
     private readonly List<string> _ids;
     private readonly DocumentDatabase _database;
@@ -25,15 +25,15 @@ public class DeleteDocumentsCommand : TransactionOperationsMerger.MergedTransact
         return _ids.Count;
     }
 
-    public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
     {
-        return new DeleteDocumentsCommandDto()
+        return new DeleteDocumentsCommandDto
         {
             Ids = _ids
         };
     }
 
-    public class DeleteDocumentsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<DeleteDocumentsCommand>
+    public class DeleteDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DeleteDocumentsCommand>
     {
         public List<string> Ids { get; set; }
 

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/IRecordableCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/IRecordableCommand.cs
@@ -1,0 +1,12 @@
+﻿using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands;
+
+public interface IRecordableCommand<TOperationContext, TTransaction>
+    where TOperationContext : TransactionOperationContext<TTransaction>
+    where TTransaction : RavenTransaction
+{
+    IReplayableCommandDto<TOperationContext, TTransaction, MergedTransactionCommand<TOperationContext, TTransaction>> ToDto(TOperationContext context);
+}

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/IReplayableCommandDto.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/IReplayableCommandDto.cs
@@ -1,0 +1,12 @@
+﻿using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands;
+
+public interface IReplayableCommandDto<TOperationContext, TTransaction, out TCommand> 
+    where TCommand : MergedTransactionCommand<TOperationContext, TTransaction>
+    where TOperationContext : TransactionOperationContext<TTransaction>
+    where TTransaction : RavenTransaction
+{
+    TCommand ToCommand(TOperationContext context, DocumentDatabase database);
+}

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
@@ -12,9 +12,9 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Operation = Microsoft.AspNetCore.JsonPatch.Operations.Operation;
 
-namespace Raven.Server.Documents.TransactionCommands
+namespace Raven.Server.Documents.TransactionMerger.Commands
 {
-    public class JsonPatchCommand : TransactionOperationsMerger.MergedTransactionCommand
+    public class JsonPatchCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         private readonly string _id;
         private readonly List<Command> _commands;
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.TransactionCommands
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
             var document = context.DocumentDatabase.DocumentsStorage.Get(context, _id);
-            
+
             if (document == null)
             {
                 throw new InvalidOperationException($"Cannot apply json patch because the document {_id} does not exist");
@@ -90,7 +90,7 @@ namespace Raven.Server.Documents.TransactionCommands
 
                 if (putResult == null)
                 {
-                    _patchResult = new JsonPatchResult {Status = PatchStatus.NotModified,};
+                    _patchResult = new JsonPatchResult { Status = PatchStatus.NotModified, };
                 }
                 else
                 {
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.TransactionCommands
         {
             if (_patchResult.ModifiedDocument != null)
                 database.HugeDocuments.AddIfDocIsHuge(_id, _patchResult.ModifiedDocument.Size);
-            
+
             if (_patchResult.Collection != null)
                 modifiedCollections?.Add(_patchResult.Collection);
 
@@ -133,30 +133,30 @@ namespace Raven.Server.Documents.TransactionCommands
                 patchReply[nameof(PatchResult.ModifiedDocument)] = _patchResult.ModifiedDocument;
 
             reply.Add(patchReply);
-            
+
             return _patchResult.ChangeVector;
         }
-        
+
         public record Command(CommandTypes Type, string[] Paths, string[] FromPaths, string OriginalPath, string OriginalFrom, object Value)
         {
             public BlittableJsonReaderBase GetActionableObject(Document document, string[] paths, string fullPath)
             {
                 BlittableJsonReaderBase root = document.Data;
-                
+
                 for (int i = 1; i < paths.Length - 1; i++)
                 {
                     TryGetMember(root, paths[i], out var member, fullPath);
-                    
+
                     if (member is BlittableJsonReaderObject nested)
                         root = nested;
                     else if (member is BlittableJsonReaderArray arr)
                     {
-                        if(i == paths.Length - 2)
+                        if (i == paths.Length - 2)
                             return arr;
                         root = arr;
                     }
                     else
-                        throw new ArgumentException($"Cannot reach target location. Failed to fetch '{paths[i+1]}' in path '{fullPath}' for operation '{Type}' because element at {paths[i]} is not an object or a collection");
+                        throw new ArgumentException($"Cannot reach target location. Failed to fetch '{paths[i + 1]}' in path '{fullPath}' for operation '{Type}' because element at {paths[i]} is not an object or a collection");
                 }
 
                 return root;
@@ -251,7 +251,7 @@ namespace Raven.Server.Documents.TransactionCommands
                             throw new ArgumentException($"Expected an index but got a '{prop}' at path {OriginalPath}");
                         if (index >= arr.Length || index < 0)
                             throw new ArgumentOutOfRangeException($"Position {index} is out of array bounds at array {OriginalPath}");
-                        
+
                         arr.Modifications.Items.Insert(index, value);
                         break;
 
@@ -271,11 +271,11 @@ namespace Raven.Server.Documents.TransactionCommands
                 switch (blittable)
                 {
                     case BlittableJsonReaderArray arr:
-                    {
-                        arr.EnsureArrayModifiable();
-                        arr.Modifications.Items[int.Parse(prop)] = value; // Parse is sure to work because of TryGetMember
-                        break;
-                    }
+                        {
+                            arr.EnsureArrayModifiable();
+                            arr.Modifications.Items[int.Parse(prop)] = value; // Parse is sure to work because of TryGetMember
+                            break;
+                        }
                     case BlittableJsonReaderObject obj:
                         obj.Modifications ??= new DynamicJsonValue(obj);
                         obj.Modifications[prop] = value;
@@ -330,10 +330,10 @@ namespace Raven.Server.Documents.TransactionCommands
 
                 var paths = path.Split('/');
                 var fromPaths = from?.Split('/');
-                
+
                 for (int i = 1; i < paths.Length; i++)
                 {
-                    if(paths[i].IsNullOrWhiteSpace())
+                    if (paths[i].IsNullOrWhiteSpace())
                         throw new ArgumentException($"Invalid path {path}. Paths must be of format /*/*/*... ");
                     paths[i] = EscapePathMember(paths[i]);
                 }
@@ -356,7 +356,7 @@ namespace Raven.Server.Documents.TransactionCommands
             return member.Replace("~0", "~").Replace("~1", "/");
         }
 
-        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
             return new JsonPatchCommandDto
             {
@@ -367,17 +367,16 @@ namespace Raven.Server.Documents.TransactionCommands
             };
         }
 
-        public class JsonPatchCommandDto : TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand>
+        public class JsonPatchCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>>
         {
             public string Id;
             public List<Command> Commands;
             public bool ReturnDocument;
             public JsonOperationContext ExternalContext;
 
-            TransactionOperationsMerger.MergedTransactionCommand TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand>.ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            public MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction> ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                var jsonPatchCommand = new JsonPatchCommand(Id, Commands, ReturnDocument, ExternalContext);
-                return jsonPatchCommand;
+                return new JsonPatchCommand(Id, Commands, ReturnDocument, ExternalContext);
             }
         }
     }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/MergedTransactionCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/MergedTransactionCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands;
+
+public abstract class MergedTransactionCommand<TOperationContext, TTransaction> : IRecordableCommand<TOperationContext, TTransaction>
+    where TOperationContext : TransactionOperationContext<TTransaction>
+    where TTransaction : RavenTransaction
+{
+    public bool UpdateAccessTime = true;
+
+    protected abstract long ExecuteCmd(TOperationContext context);
+
+    internal long ExecuteDirectly(TOperationContext context)
+    {
+        return ExecuteCmd(context);
+    }
+
+    public virtual long Execute(TOperationContext context, AbstractTransactionOperationsMerger<TOperationContext, TTransaction>.RecordingState recordingState)
+    {
+        recordingState?.TryRecord(context, this);
+
+        return ExecuteCmd(context);
+    }
+
+    public abstract IReplayableCommandDto<TOperationContext, TTransaction, MergedTransactionCommand<TOperationContext, TTransaction>> ToDto(TOperationContext context);
+
+    [JsonIgnore]
+    public readonly TaskCompletionSource<object> TaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Exception Exception;
+
+    public bool RetryOnError = false;
+}
+

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/MergedTransactionCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/MergedTransactionCommand.cs
@@ -7,6 +7,11 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.TransactionMerger.Commands;
 
+public abstract class DocumentMergedTransactionCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+{
+
+}
+
 public abstract class MergedTransactionCommand<TOperationContext, TTransaction> : IRecordableCommand<TOperationContext, TTransaction>
     where TOperationContext : TransactionOperationContext<TTransaction>
     where TTransaction : RavenTransaction

--- a/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.TransactionMerger;
+
+public class DocumentsTransactionOperationsMerger : AbstractTransactionOperationsMerger<DocumentsOperationContext, DocumentsTransaction>
+{
+    private readonly DocumentDatabase _database;
+
+    public DocumentsTransactionOperationsMerger([NotNull] DocumentDatabase database)
+        : base(database.Name, database.Configuration, database.Time, database.DatabaseShutdown)
+    {
+        _database = database ?? throw new ArgumentNullException(nameof(database));
+        IsEncrypted = database.IsEncrypted;
+        Is32Bits = database.Is32Bits;
+    }
+
+    protected override bool IsEncrypted { get; }
+
+    protected override bool Is32Bits { get; }
+
+    internal override DocumentsTransaction BeginAsyncCommitAndStartNewTransaction(DocumentsTransaction previousTransaction, DocumentsOperationContext currentContext)
+    {
+        return previousTransaction.BeginAsyncCommitAndStartNewTransaction(currentContext);
+    }
+
+    internal override void UpdateGlobalReplicationInfoBeforeCommit(DocumentsOperationContext context)
+    {
+        if (string.IsNullOrEmpty(context.LastDatabaseChangeVector) == false)
+        {
+            _database.DocumentsStorage.SetDatabaseChangeVector(context, context.LastDatabaseChangeVector);
+        }
+
+        if (context.LastReplicationEtagFrom != null)
+        {
+            foreach (var repEtag in context.LastReplicationEtagFrom)
+            {
+                DocumentsStorage.SetLastReplicatedEtagFrom(context, repEtag.Key, repEtag.Value);
+            }
+        }
+    }
+
+    protected override void UpdateLastAccessTime(DateTime time)
+    {
+        _database.LastAccessTime = time;
+    }
+}

--- a/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using JetBrains.Annotations;
+using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide.Context;
+using Voron.Debugging;
+using Voron.Util;
 
 namespace Raven.Server.Documents.TransactionMerger;
 
@@ -44,5 +47,14 @@ public class DocumentsTransactionOperationsMerger : AbstractTransactionOperation
     protected override void UpdateLastAccessTime(DateTime time)
     {
         _database.LastAccessTime = time;
+    }
+
+    internal override void NotifyAboutSlowWrite(CommitStats stats)
+    {
+        if (NotificationCenter is not AbstractDatabaseNotificationCenter)
+        {
+            throw new InvalidOperationException("DocumentsTransactionOperationsMerger NotificationCenter should be 'AbstractDatabaseNotificationCenter'");
+        }
+        SlowWriteNotification.Notify(stats, (AbstractDatabaseNotificationCenter)NotificationCenter);
     }
 }

--- a/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
@@ -17,7 +17,12 @@ public abstract class AbstractDatabaseNotificationCenter : AbstractNotificationC
     public readonly SlowWriteNotifications SlowWrites;
 
     protected AbstractDatabaseNotificationCenter(ServerStore serverStore, string database, RavenConfiguration configuration, CancellationToken shutdown)
-        : base(serverStore.NotificationCenter.Storage.GetStorageFor(database), configuration, LoggingSource.Instance.GetLogger<DatabaseNotificationCenter>(database))
+        : this(serverStore.NotificationCenter.Storage.GetStorageFor(database), database, configuration, shutdown)
+    {
+    }
+
+    protected AbstractDatabaseNotificationCenter(NotificationsStorage notificationsStorage, string database, RavenConfiguration configuration, CancellationToken shutdown)
+        : base(notificationsStorage, configuration, LoggingSource.Instance.GetLogger<DatabaseNotificationCenter>(database))
     {
         Database = database;
         Paging = new Paging(this);

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -13,7 +13,7 @@ public class DatabaseStatsSender : AbstractDatabaseStatsSender
 {
     private readonly DocumentDatabase _database;
 
-    public DatabaseStatsSender([NotNull] DocumentDatabase database, DatabaseNotificationCenter notificationCenter)
+    public DatabaseStatsSender([NotNull] DocumentDatabase database, AbstractDatabaseNotificationCenter notificationCenter)
         : base(database.Name, notificationCenter, database.DatabaseShutdown)
     {
         _database = database ?? throw new ArgumentNullException(nameof(database));

--- a/src/Raven.Server/NotificationCenter/DatabaseNotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/DatabaseNotificationCenter.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading;
 using JetBrains.Annotations;
+using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.NotificationCenter.BackgroundWork;
 

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -71,7 +71,7 @@ namespace Raven.Server.Rachis
         public void Start()
         {
             _candidateAmbassadorLongRunningWork =
-                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => Run(), null, ThreadNames.ForCandidateAmbassador($"Candidate Ambassador for {_engine.Tag} > {_tag}", _engine.Tag, _tag));
+                PoolOfThreads.GlobalRavenThreadPool.LongRunning(Run, null, ThreadNames.ForCandidateAmbassador($"Candidate Ambassador for {_engine.Tag} > {_tag}", _engine.Tag, _tag));
         }
 
         public void Dispose()
@@ -113,7 +113,7 @@ namespace Raven.Server.Rachis
         /// This method may run for a long while, as we are trying to get agreement 
         /// from a majority of the cluster
         /// </summary>
-        private void Run()
+        private void Run(object o)
         {
             try
             {

--- a/src/Raven.Server/Rachis/Commands/CandidateCastVoteInTermCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/CandidateCastVoteInTermCommand.cs
@@ -26,7 +26,10 @@ public class CandidateCastVoteInTermCommand : MergedTransactionCommand<ClusterOp
     protected override long ExecuteCmd(ClusterOperationContext context)
     {
         _engine.CastVoteInTerm(context, _electionTerm, _engine.Tag, _reason);
-        _candidate.ElectionTerm = _candidate.RunRealElectionAtTerm = _electionTerm;
+        context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += (tx) =>
+        {
+            _candidate.ElectionTerm = _candidate.RunRealElectionAtTerm = _electionTerm;
+        };
         return 1;
     }
 

--- a/src/Raven.Server/Rachis/Commands/CandidateCastVoteInTermCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/CandidateCastVoteInTermCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Jint;
+using System.Drawing;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class CandidateCastVoteInTermCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly Candidate _candidate;
+    private readonly RachisConsensus _engine;
+    private readonly long _electionTerm;
+    private readonly string _reason;
+
+    public CandidateCastVoteInTermCommand([NotNull] Candidate candidate, [NotNull] RachisConsensus engine, long electionTerm, string reason)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _electionTerm = electionTerm;
+        _reason = reason;
+        _candidate = candidate;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        _engine.CastVoteInTerm(context, _electionTerm, _engine.Tag, _reason);
+        _candidate.ElectionTerm = _candidate.RunRealElectionAtTerm = _electionTerm;
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/CastVoteInTermCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/CastVoteInTermCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class CastVoteInTermCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly long _term;
+    private readonly string _reason;
+
+    public CastVoteInTermCommand([NotNull] RachisConsensus engine, long term, string reason)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _term = term;
+        _reason = reason;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        // we check it here again because now we are under the tx lock, so we can't get into concurrency issues
+        if (_term <= _engine.CurrentTerm)
+            return 1;
+
+        _engine.CastVoteInTerm(context, _term, votedFor: null, reason: _reason);
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/DeleteTopologyCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/DeleteTopologyCommand.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class DeleteTopologyCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+
+    public DeleteTopologyCommand(RachisConsensus engine)
+    {
+        _engine = engine;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        var topology = _engine.GetTopology(context);
+        var newTopology = new ClusterTopology(
+            topology.TopologyId,
+            new Dictionary<string, string>(),
+            new Dictionary<string, string>(),
+            new Dictionary<string, string>(),
+            topology.LastNodeId,
+            -1
+        );
+        _engine.SetTopology(context, newTopology);
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/ElectorCastVoteInTermCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/ElectorCastVoteInTermCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class ElectorCastVoteInTermCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly RequestVote _requestVote;
+
+    public ElectorCastVoteInTermCommand([NotNull] RachisConsensus engine, [NotNull] RequestVote requestVote)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _requestVote = requestVote ?? throw new ArgumentNullException(nameof(requestVote));
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        // double checking things under the transaction lock
+        if (_requestVote.Term > _engine.CurrentTerm + 1)
+        {
+            _engine.CastVoteInTerm(context, _requestVote.Term - 1, null, "Noticed that the term in the cluster grew beyond what I was familiar with, increasing it");
+        }
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/ElectorCastVoteInTermWithShouldGrantVoteCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/ElectorCastVoteInTermWithShouldGrantVoteCommand.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+internal class ElectorCastVoteInTermWithShouldGrantVoteCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly RequestVote _requestVote;
+    private readonly long _lastLogIndex;
+
+    public Elector.HandleVoteResult VoteResult { get; private set; }
+
+    public ElectorCastVoteInTermWithShouldGrantVoteCommand([NotNull] RachisConsensus engine, [NotNull] RequestVote requestVote, long lastLogIndex)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _requestVote = requestVote ?? throw new ArgumentNullException(nameof(requestVote));
+        _lastLogIndex = lastLogIndex;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        VoteResult = ShouldGrantVote(context, _lastLogIndex, _requestVote);
+        if (VoteResult.DeclineVote == false)
+            _engine.CastVoteInTerm(context, _requestVote.Term, _requestVote.Source, "Casting vote as elector");
+
+        return 1;
+    }
+
+    private Elector.HandleVoteResult ShouldGrantVote(ClusterOperationContext context, long lastIndex, RequestVote rv)
+    {
+        var result = new Elector.HandleVoteResult();
+        var lastLogIndexUnderWriteLock = _engine.GetLastEntryIndex(context);
+        var lastLogTermUnderWriteLock = _engine.GetTermFor(context, lastLogIndexUnderWriteLock);
+    
+        if (lastLogIndexUnderWriteLock != lastIndex)
+        {
+            result.DeclineVote = true;
+            result.DeclineReason = "Log was changed";
+            return result;
+        }
+    
+        if (lastLogTermUnderWriteLock > rv.LastLogTerm)
+        {
+            result.DeclineVote = true;
+            result.DeclineReason = $"My last log term {lastLogTermUnderWriteLock}, is higher than yours {rv.LastLogTerm}.";
+            return result;
+        }
+    
+        if (lastLogIndexUnderWriteLock > rv.LastLogIndex)
+        {
+            result.DeclineVote = true;
+            result.DeclineReason = $"Vote declined because my last log index {lastLogIndexUnderWriteLock} is more up to date than yours {rv.LastLogIndex}";
+            return result;
+        }
+    
+        var (whoGotMyVoteIn, votedTerm) = _engine.GetWhoGotMyVoteIn(context, rv.Term);
+        result.VotedTerm = votedTerm;
+    
+        if (whoGotMyVoteIn != null && whoGotMyVoteIn != rv.Source)
+        {
+            result.DeclineVote = true;
+            result.DeclineReason = $"Already voted in {rv.LastLogTerm}, for {whoGotMyVoteIn}";
+            return result;
+        }
+    
+        if (votedTerm >= rv.Term)
+        {
+            result.DeclineVote = true;
+            result.DeclineReason = $"Already voted in {rv.LastLogTerm}, for another node in higher term: {votedTerm}";
+            return result;
+        }
+    
+        return result;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/Follower.FollowerReadAndCommitSnapshotCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Follower.FollowerReadAndCommitSnapshotCommand.cs
@@ -1,0 +1,368 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.Rachis.Remote;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.Server;
+using Voron.Data.BTrees;
+using Voron.Data.Tables;
+using Voron.Data;
+using Voron;
+using Voron.Impl;
+
+namespace Raven.Server.Rachis;
+
+public partial class Follower
+{
+    public class FollowerReadAndCommitSnapshotCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+        private readonly Follower _follower;
+        private readonly InstallSnapshot _snapshot;
+        private readonly CancellationToken _token;
+
+        public Task OnFullSnapshotInstalledTask { get; private set; }
+
+        public FollowerReadAndCommitSnapshotCommand([NotNull] RachisConsensus engine, Follower follower, [NotNull] InstallSnapshot snapshot, CancellationToken token)
+        {
+            _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            _follower = follower;
+            _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+            _token = token;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            var lastTerm = _engine.GetTermFor(context, _snapshot.LastIncludedIndex);
+            var lastCommitIndex = _engine.GetLastEntryIndex(context);
+
+            if (_engine.GetSnapshotRequest(context) == false &&
+                _snapshot.LastIncludedTerm == lastTerm && _snapshot.LastIncludedIndex < lastCommitIndex)
+            {
+                if (_engine.Log.IsInfoEnabled)
+                {
+                    _engine.Log.Info(
+                        $"{ToString()}: Got installed snapshot with last index={_snapshot.LastIncludedIndex} while our lastCommitIndex={lastCommitIndex}, will just ignore it");
+                }
+
+                //This is okay to ignore because we will just get the committed entries again and skip them
+                ReadInstallSnapshotAndIgnoreContent(_token);
+            }
+            else if (InstallSnapshot(context, _token))
+            {
+                if (_engine.Log.IsInfoEnabled)
+                {
+                    _engine.Log.Info(
+                        $"{ToString()}: Installed snapshot with last index={_snapshot.LastIncludedIndex} with LastIncludedTerm={_snapshot.LastIncludedTerm} ");
+                }
+
+                _engine.SetLastCommitIndex(context, _snapshot.LastIncludedIndex, _snapshot.LastIncludedTerm);
+                _engine.ClearLogEntriesAndSetLastTruncate(context, _snapshot.LastIncludedIndex, _snapshot.LastIncludedTerm);
+
+                OnFullSnapshotInstalledTask = _engine.OnSnapshotInstalled(context, _snapshot.LastIncludedIndex, _token);
+            }
+            else
+            {
+                var lastEntryIndex = _engine.GetLastEntryIndex(context);
+                if (lastEntryIndex < _snapshot.LastIncludedIndex)
+                {
+                    var message =
+                        $"The snapshot installation had failed because the last included index {_snapshot.LastIncludedIndex} in term {_snapshot.LastIncludedTerm} doesn't match the last entry {lastEntryIndex}";
+                    if (_engine.Log.IsInfoEnabled)
+                    {
+                        _engine.Log.Info($"{ToString()}: {message}");
+                    }
+
+                    throw new InvalidOperationException(message);
+                }
+            }
+
+            // snapshot always has the latest topology
+            if (_snapshot.Topology == null)
+            {
+                const string message = "Expected to get topology on snapshot";
+                if (_engine.Log.IsInfoEnabled)
+                {
+                    _engine.Log.Info($"{ToString()}: {message}");
+                }
+
+                throw new InvalidOperationException(message);
+            }
+
+            using (var topologyJson = context.ReadObject(_snapshot.Topology, "topology"))
+            {
+                if (_engine.Log.IsInfoEnabled)
+                {
+                    _engine.Log.Info($"{ToString()}: topology on install snapshot: {topologyJson}");
+                }
+
+                var topology = JsonDeserializationRachis<ClusterTopology>.Deserialize(topologyJson);
+
+                RachisConsensus.SetTopology(_engine, context, topology);
+            }
+
+            _engine.SetSnapshotRequest(context, false);
+
+            context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += t =>
+            {
+                if (t is LowLevelTransaction llt && llt.Committed)
+                {
+                    // we might have moved from passive node, so we need to start the timeout clock
+                    _engine.Timeout.Start(_engine.SwitchToCandidateStateOnTimeout);
+                }
+            };
+
+            return 1;
+        }
+
+        private bool InstallSnapshot(ClusterOperationContext context, CancellationToken token)
+        {
+            var txw = context.Transaction.InnerTransaction;
+
+            var fileName = $"snapshot.{Guid.NewGuid():N}";
+            var filePath = context.Environment.Options.DataPager.Options.TempPath.Combine(fileName);
+
+            using (var temp = new StreamsTempFile(filePath.FullPath, context.Environment))
+            using (var stream = temp.StartNewStream())
+            using (var remoteReader = _follower._connection.CreateReaderToStream(stream))
+            {
+                if (ReadSnapshot(remoteReader, context, txw, dryRun: true, token) == false)
+                    return false;
+
+                stream.Seek(0, SeekOrigin.Begin);
+                using (var fileReader = new StreamSnapshotReader(stream))
+                {
+                    ReadSnapshot(fileReader, context, txw, dryRun: false, token);
+                }
+            }
+
+            return true;
+        }
+
+        private unsafe bool ReadSnapshot(SnapshotReader reader, ClusterOperationContext context, Transaction txw, bool dryRun, CancellationToken token)
+        {
+            var type = reader.ReadInt32();
+            if (type == -1)
+                return false;
+
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+
+                int size;
+                long entries;
+                switch ((RootObjectType)type)
+                {
+                    case RootObjectType.None:
+                        return true;
+                    case RootObjectType.VariableSizeTree:
+                        size = reader.ReadInt32();
+                        reader.ReadExactly(size);
+
+                        Tree tree = null;
+                        Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice treeName); // The Slice will be freed on context close
+
+                        entries = reader.ReadInt64();
+                        var flags = TreeFlags.FixedSizeTrees;
+
+                        if (dryRun == false)
+                        {
+                            txw.DeleteTree(treeName);
+                            tree = txw.CreateTree(treeName);
+                        }
+
+                        if (_follower._connection.Features.MultiTree)
+                            flags = (TreeFlags)reader.ReadInt32();
+
+                        for (long i = 0; i < entries; i++)
+                        {
+                            token.ThrowIfCancellationRequested();
+                            // read key
+                            size = reader.ReadInt32();
+                            reader.ReadExactly(size);
+
+                            using (Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice valKey))
+                            {
+                                switch (flags)
+                                {
+                                    case TreeFlags.None:
+
+                                        // this is a very specific code to block receiving 'CompareExchangeByExpiration' which is a multi-value tree
+                                        // while here we expect a normal tree
+                                        if (SliceComparer.Equals(valKey, CompareExchangeExpirationStorage.CompareExchangeByExpiration))
+                                            throw new InvalidOperationException($"{valKey} is a multi-tree, please upgrade the leader node.");
+
+                                        // read value
+                                        size = reader.ReadInt32();
+                                        reader.ReadExactly(size);
+
+                                        if (dryRun == false)
+                                        {
+                                            using (tree.DirectAdd(valKey, size, out byte* ptr))
+                                            {
+                                                fixed (byte* pBuffer = reader.Buffer)
+                                                {
+                                                    Memory.Copy(ptr, pBuffer, size);
+                                                }
+                                            }
+                                        }
+
+                                        break;
+                                    case TreeFlags.MultiValueTrees:
+                                        var multiEntries = reader.ReadInt64();
+                                        for (int j = 0; j < multiEntries; j++)
+                                        {
+                                            token.ThrowIfCancellationRequested();
+
+                                            size = reader.ReadInt32();
+                                            reader.ReadExactly(size);
+
+                                            if (dryRun == false)
+                                            {
+                                                using (Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable, out Slice multiVal))
+                                                {
+                                                    tree.MultiAdd(valKey, multiVal);
+                                                }
+                                            }
+                                        }
+
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException($"Got unkonwn type '{type}'");
+                                }
+                            }
+                        }
+
+                        break;
+                    case RootObjectType.Table:
+
+                        size = reader.ReadInt32();
+                        reader.ReadExactly(size);
+
+                        TableValueReader tvr;
+                        Table table = null;
+                        if (dryRun == false)
+                        {
+                            Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable,
+                                out Slice tableName); //The Slice will be freed on context close
+                            var tableTree = txw.ReadTree(tableName, RootObjectType.Table);
+
+                            // Get the table schema
+                            var schemaSize = tableTree.GetDataSize(TableSchema.SchemasSlice);
+                            var schemaPtr = tableTree.DirectRead(TableSchema.SchemasSlice);
+                            if (schemaPtr == null)
+                                throw new InvalidOperationException(
+                                    "When trying to install snapshot, found missing table " + tableName);
+
+                            var schema = TableSchema.ReadFrom(txw.Allocator, schemaPtr, schemaSize);
+
+                            table = txw.OpenTable(schema, tableName);
+
+                            // delete the table
+                            while (true)
+                            {
+                                token.ThrowIfCancellationRequested();
+                                if (table.SeekOnePrimaryKey(Slices.AfterAllKeys, out tvr) == false)
+                                    break;
+                                table.Delete(tvr.Id);
+                            }
+                        }
+
+                        entries = reader.ReadInt64();
+                        for (long i = 0; i < entries; i++)
+                        {
+                            token.ThrowIfCancellationRequested();
+                            size = reader.ReadInt32();
+                            reader.ReadExactly(size);
+
+                            if (dryRun == false)
+                            {
+                                fixed (byte* pBuffer = reader.Buffer)
+                                {
+                                    tvr = new TableValueReader(pBuffer, size);
+                                    table.Insert(ref tvr);
+                                }
+                            }
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
+                }
+
+                type = reader.ReadInt32();
+            }
+        }
+
+        private void ReadInstallSnapshotAndIgnoreContent(CancellationToken token)
+        {
+            var reader = _follower._connection.CreateReader();
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+
+                var type = reader.ReadInt32();
+                if (type == -1)
+                    return;
+
+                int size;
+                long entries;
+                switch ((RootObjectType)type)
+                {
+                    case RootObjectType.None:
+                        return;
+                    case RootObjectType.VariableSizeTree:
+
+                        size = reader.ReadInt32();
+                        reader.ReadExactly(size);
+
+                        entries = reader.ReadInt64();
+                        for (long i = 0; i < entries; i++)
+                        {
+                            token.ThrowIfCancellationRequested();
+
+                            size = reader.ReadInt32();
+                            reader.ReadExactly(size);
+                            size = reader.ReadInt32();
+                            reader.ReadExactly(size);
+                        }
+
+                        break;
+                    case RootObjectType.Table:
+
+                        size = reader.ReadInt32();
+                        reader.ReadExactly(size);
+
+                        entries = reader.ReadInt64();
+                        for (long i = 0; i < entries; i++)
+                        {
+                            token.ThrowIfCancellationRequested();
+
+                            size = reader.ReadInt32();
+                            reader.ReadExactly(size);
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
+                }
+            }
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(
+            ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/FollowerApplyCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/FollowerApplyCommand.cs
@@ -1,0 +1,101 @@
+﻿using Jint;
+using Nest;
+using Raven.Client.Http;
+using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class FollowerApplyCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly long _term;
+    private readonly List<RachisEntry> _entries;
+    private readonly AppendEntries _appendEntries;
+    private readonly Stopwatch _sw;
+
+    public long LastTruncate { get; private set; }
+
+    public long LastCommit { get; private set; }
+
+    public bool RemovedFromTopology { get; private set; }
+
+    public FollowerApplyCommand([NotNull] RachisConsensus engine, long term, [NotNull] List<RachisEntry> entries, [NotNull] AppendEntries appendEntries, [NotNull] Stopwatch sw)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _term = term;
+        _entries = entries ?? throw new ArgumentNullException(nameof(entries));
+        _appendEntries = appendEntries ?? throw new ArgumentNullException(nameof(appendEntries));
+        _sw = sw ?? throw new ArgumentNullException(nameof(sw));
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        _engine.ValidateTerm(_term);
+        if (_engine.Log.IsInfoEnabled)
+        {
+            _engine.Log.Info($"{ToString()}: Tx running in {_sw.Elapsed}");
+        }
+        if (_entries.Count > 0)
+        {
+            var (lastTopology, lastTopologyIndex) = _engine.AppendToLog(context, _entries);
+            using (lastTopology)
+            {
+                if (lastTopology != null)
+                {
+                    if (_engine.Log.IsInfoEnabled)
+                    {
+                        _engine.Log.Info($"Topology changed to {lastTopology}");
+                    }
+
+                    var topology = JsonDeserializationRachis<ClusterTopology>.Deserialize(lastTopology);
+                    if (topology.Members.ContainsKey(_engine.Tag) ||
+                        topology.Promotables.ContainsKey(_engine.Tag) ||
+                        topology.Watchers.ContainsKey(_engine.Tag))
+                    {
+                        RachisConsensus.SetTopology(_engine, context, topology);
+                    }
+                    else
+                    {
+                        RemovedFromTopology = true;
+                        _engine.ClearAppendedEntriesAfter(context, lastTopologyIndex);
+                    }
+                }
+            }
+        }
+
+        var lastEntryIndexToCommit = Math.Min(
+            _engine.GetLastEntryIndex(context),
+            _appendEntries.LeaderCommit);
+
+        var lastAppliedIndex = _engine.GetLastCommitIndex(context);
+        var lastAppliedTerm = _engine.GetTermFor(context, lastEntryIndexToCommit);
+
+        // we start to commit only after we have any log with a term of the current leader
+        if (lastEntryIndexToCommit > lastAppliedIndex && lastAppliedTerm == _appendEntries.Term)
+        {
+            lastAppliedIndex = _engine.Apply(context, lastEntryIndexToCommit, null, _sw);
+        }
+
+        LastTruncate = Math.Min(_appendEntries.TruncateLogBefore, lastAppliedIndex);
+        _engine.TruncateLogBefore(context, LastTruncate);
+
+        LastCommit = lastAppliedIndex;
+        if (_engine.Log.IsInfoEnabled)
+        {
+            _engine.Log.Info($"{ToString()}: Ready to commit in {_sw.Elapsed}");
+        }
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/HardResetToNewClusterCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/HardResetToNewClusterCommand.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Voron.Impl;
+
+namespace Raven.Server.Rachis.Commands
+{
+    public class HardResetToNewClusterCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+        private readonly string _tag;
+        private readonly string _topologyId;
+        public bool Committed { get; private set; }
+
+        public HardResetToNewClusterCommand(RachisConsensus engine, string tag, string topologyId)
+        {
+            _engine = engine;
+            _topologyId = topologyId;
+            _tag = tag;
+            Committed = false;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            var topology = new ClusterTopology(
+                _topologyId,
+                new Dictionary<string, string>
+                {
+                    [_tag] = _engine.Url
+                },
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                _tag,
+                _engine.GetLastEntryIndex(context) + 1
+            );
+
+            _engine.UpdateNodeTag(context, _tag);
+
+            RachisConsensus.SetTopology(_engine, context, topology);
+
+            _engine.SetSnapshotRequest(context, false);
+
+            _engine.SwitchToSingleLeader(context);
+
+            context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
+            {
+                if (tx is LowLevelTransaction llt && llt.Committed)
+                {
+                    Committed = true;
+                }
+            };
+
+            return 1;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/HardResetToPassiveCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/HardResetToPassiveCommand.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands
+{
+    public class HardResetToPassiveCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+        private readonly string _tag;
+        private readonly string _topologyId;
+        public HardResetToPassiveCommand(RachisConsensus engine, string tag, string topologyId)
+        {
+            _engine = engine;
+            _topologyId = topologyId;
+            _tag = tag;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            _engine.UpdateNodeTag(context, RachisConsensus.InitialTag);
+            var oldTopology = _engine.GetTopology(context);
+
+            var topology = new ClusterTopology(
+                _topologyId ?? oldTopology.TopologyId,
+                new Dictionary<string, string>
+                {
+                    [_tag] = _engine.Url
+                },
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                _tag,
+                _engine.GetLastEntryIndex(context) + 1
+            );
+
+            if (_topologyId != oldTopology.TopologyId)
+                // if we are going to add this to a different cluster we must get a snapshot
+                _engine.SetSnapshotRequest(context, true);
+
+            RachisConsensus.SetTopology(_engine, context, topology);
+
+            _engine.SetNewStateInTx(context, RachisState.Passive, null, _engine.CurrentTerm, "Hard reset to passive by admin");
+
+            return 1;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+
+}

--- a/src/Raven.Server/Rachis/Commands/InsertToLeaderLogCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/InsertToLeaderLogCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class InsertToLeaderLogCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private long _term;
+    private BlittableJsonReaderObject _raftCommand;
+    private RachisEntryFlags _flags;
+
+    public long Index = -1;
+
+    public InsertToLeaderLogCommand(RachisConsensus engine, long term, BlittableJsonReaderObject cmd, RachisEntryFlags flags)
+    {
+        _engine = engine;
+        _term = term;
+        _raftCommand = cmd;
+        _flags = flags;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        Index = _engine.InsertToLeaderLog(context, _term, _raftCommand, _flags);
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/Leader.LeaderModifyTopologyCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.LeaderModifyTopologyCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
@@ -137,7 +138,7 @@ public partial class Leader
             var tcs = new TaskCompletionSource<(long Index, object Result)>(TaskCreationOptions.RunContinuationsAsynchronously);
             _leader._entries[index] = new Leader.CommandState { TaskCompletionSource = tcs, CommandIndex = index };
 
-            tcs.Task.ContinueWith(_ =>
+            tcs.Task.ContinueWith(t =>
             {
                 Interlocked.Exchange(ref _leader._topologyModification, null)?.TrySetResult(null);
             });

--- a/src/Raven.Server/Rachis/Commands/Leader.LeaderModifyTopologyCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.LeaderModifyTopologyCommand.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis;
+
+public partial class Leader
+{
+    public class LeaderModifyTopologyCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+        private readonly Leader.TopologyModification _modification;
+        private string _nodeTag;
+        private readonly string _nodeUrl;
+        public readonly Leader _leader;
+        private readonly bool _validateNotInTopology;
+
+        public LeaderModifyTopologyCommand([NotNull] RachisConsensus engine, [NotNull] Leader leader, Leader.TopologyModification modification, string nodeTag,
+            string nodeUrl, bool validateNotInTopology)
+        {
+            _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            _leader = leader ?? throw new ArgumentNullException(nameof(leader));
+            _modification = modification;
+            _nodeTag = nodeTag;
+            _nodeUrl = nodeUrl;
+            _validateNotInTopology = validateNotInTopology;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            var clusterTopology = _engine.GetTopology(context);
+
+            //We need to validate that the node doesn't exists before we generate the nodeTag
+            if (_validateNotInTopology && (_nodeTag != null && clusterTopology.Contains(_nodeTag) || clusterTopology.TryGetNodeTagByUrl(_nodeUrl).HasUrl))
+            {
+                throw new InvalidOperationException($"Was requested to modify the topology for node={_nodeTag} " +
+                                                    "with validation that it is not contained by the topology but current topology contains it.");
+            }
+
+            if (_nodeTag == null)
+            {
+                _nodeTag = GenerateNodeTag(clusterTopology);
+            }
+
+            var newVotes = new Dictionary<string, string>(clusterTopology.Members);
+            newVotes.Remove(_nodeTag);
+            var newPromotables = new Dictionary<string, string>(clusterTopology.Promotables);
+            newPromotables.Remove(_nodeTag);
+            var newNonVotes = new Dictionary<string, string>(clusterTopology.Watchers);
+            newNonVotes.Remove(_nodeTag);
+
+            var highestNodeId = newVotes.Keys.Concat(newPromotables.Keys).Concat(newNonVotes.Keys).Concat(new[] { _nodeTag }).Max();
+
+            if (_nodeTag == _engine.Tag)
+                RachisTopologyChangeException.Throw("Cannot modify the topology of the leader node.");
+
+            switch (_modification)
+            {
+                case Leader.TopologyModification.Voter:
+                    Debug.Assert(_nodeUrl != null);
+                    newVotes[_nodeTag] = _nodeUrl;
+                    break;
+                case Leader.TopologyModification.Promotable:
+                    Debug.Assert(_nodeUrl != null);
+                    newPromotables[_nodeTag] = _nodeUrl;
+                    break;
+                case Leader.TopologyModification.NonVoter:
+                    Debug.Assert(_nodeUrl != null);
+                    newNonVotes[_nodeTag] = _nodeUrl;
+                    break;
+                case Leader.TopologyModification.Remove:
+                    _leader.PeersVersion.TryRemove(_nodeTag, out _);
+                    if (clusterTopology.Contains(_nodeTag) == false)
+                    {
+                        throw new InvalidOperationException($"Was requested to remove node={_nodeTag} from the topology " +
+                                                            "but it is not contained by the topology.");
+                    }
+
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(_modification), _modification, null);
+            }
+
+            clusterTopology = new ClusterTopology(
+                clusterTopology.TopologyId,
+                newVotes,
+                newPromotables,
+                newNonVotes,
+                highestNodeId,
+                _engine.GetLastEntryIndex(context) + 1
+            );
+
+            var topologyJson = _engine.SetTopology(context, clusterTopology);
+            var index = _engine.InsertToLeaderLog(context, _leader.Term, topologyJson, RachisEntryFlags.Topology);
+
+            if (_modification == Leader.TopologyModification.Remove)
+            {
+                _engine.GetStateMachine().EnsureNodeRemovalOnDeletion(context, _leader.Term, _nodeTag);
+            }
+
+            // after commit but still under the lock
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += (tx) =>
+            {
+                AfterCommit(index);
+            };
+
+            return 1;
+        }
+
+        private static string GenerateNodeTag(ClusterTopology clusterTopology)
+        {
+            if (clusterTopology.LastNodeId.Length == 0)
+            {
+                return "A";
+            }
+
+            if (clusterTopology.LastNodeId[clusterTopology.LastNodeId.Length - 1] + 1 > 'Z')
+            {
+                return clusterTopology.LastNodeId + "A";
+            }
+
+            var lastChar = (char)(clusterTopology.LastNodeId[clusterTopology.LastNodeId.Length - 1] + 1);
+            return clusterTopology.LastNodeId.Substring(0, clusterTopology.LastNodeId.Length - 1) + lastChar;
+        }
+
+        private void AfterCommit(long index)
+        {
+            var tcs = new TaskCompletionSource<(long Index, object Result)>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _leader._entries[index] = new Leader.CommandState { TaskCompletionSource = tcs, CommandIndex = index };
+
+            tcs.Task.ContinueWith(_ =>
+            {
+                Interlocked.Exchange(ref _leader._topologyModification, null)?.TrySetResult(null);
+            });
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(
+            ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Extensions;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using System.Diagnostics.CodeAnalysis;
+using Voron.Impl;
+
+namespace Raven.Server.Rachis
+{
+    public partial class Leader
+    {
+        internal class RachisMergedCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+        {
+            public CommandBase Command;
+            public Task<(long, object)> TaskResult { get; private set; }
+            private readonly Leader _leader;
+            private readonly RachisConsensus _engine;
+            private const string _leaderDisposedMessage = "We are no longer the leader, this leader is disposed";
+
+            public RachisMergedCommand([NotNull] Leader leader, [NotNull] RachisConsensus engine)
+            {
+                _leader = leader ?? throw new ArgumentNullException(nameof(leader));
+                _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            }
+
+            protected override long ExecuteCmd(ClusterOperationContext context)
+            {
+                var lostLeadershipException = new NotLeadingException(_leaderDisposedMessage);
+
+                try
+                {
+                    _engine.GetLastCommitIndex(context, out var lastCommitted, out _);
+                    if (_leader._running.IsRaised() == false) // not longer leader
+                    {
+                        // throw lostLeadershipException;
+                        TaskResult = Task.FromException<(long, object)>(lostLeadershipException);
+                        return 1;
+                    }
+
+                    if (_engine.LogHistory.HasHistoryLog(context, Command.UniqueRequestId, out var index, out var result, out var exception))
+                    {
+                        // if this command is already committed, we can skip it and notify the caller about it
+                        if (lastCommitted >= index)
+                        {
+                            if (exception != null)
+                            {
+                                TaskResult = Task.FromException<(long, object)>(exception);
+                            }
+                            else
+                            {
+                                if (result != null)
+                                {
+                                    result = GetConvertResult(Command)?.Apply(result) ?? Command.FromRemote(result);
+                                }
+
+                                TaskResult = Task.FromResult<(long, object)>((index, result));
+                            }
+                            return 1;
+                        }
+
+                    }
+
+                    InsertCommandToLeaderLog(context);
+                }
+                catch (Exception e)
+                {
+                    if (e is AggregateException ae)
+                        e = ae.ExtractSingleInnerException();
+
+                    if (_leader._running.IsRaised() == false)
+                        e = new NotLeadingException(_leaderDisposedMessage, e);
+
+                    _leader._errorOccurred.TrySetException(e);
+
+                    TaskResult = Task.FromException<(long, object)>(e);
+                }
+
+                return 1;
+            }
+
+            private void InsertCommandToLeaderLog(ClusterOperationContext context)
+            {
+                _engine.InvokeBeforeAppendToRaftLog(context, Command);
+                var djv = Command.ToJson(context);
+                var commandJson = context.ReadObject(djv, "raft/command");
+
+                long index = _engine.InsertToLeaderLog(context, _leader.Term, commandJson, RachisEntryFlags.StateMachineCommand);
+                if (_leader._entries.TryGetValue(index, out var state))
+                {
+                    TaskResult = state.TaskCompletionSource.Task;
+                }
+                else
+                {
+                    var tcs = new TaskCompletionSource<(long, object)>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    TaskResult = tcs.Task; //will set only after leader gets consensus on this command and finish with execute 'Command'.
+                    var newState = new CommandState
+                    {
+                        // we need to add entry inside write tx lock to avoid
+                        // a situation when command will be applied (and state set)
+                        // before it is added to the entries list
+
+                        CommandIndex = index,
+                        TaskCompletionSource = tcs,
+                        ConvertResult = GetConvertResult(Command),
+                    };
+                    _leader._entries[index] = newState;
+                    context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += AfterCommit;
+                }
+            }
+
+            private void AfterCommit(LowLevelTransaction tx)
+            {
+                _leader._newEntry.Set();
+            }
+
+            public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/LeaderApplyCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/LeaderApplyCommand.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class LeaderApplyCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly long _lastCommit;
+    private readonly long _maxIndexOnQuorum;
+    private readonly Leader _leader;
+
+    public long LastAppliedCommit { get; private set; }
+
+    public LeaderApplyCommand([NotNull] Leader leader, [NotNull] RachisConsensus engine, long lastCommit, long maxIndexOnQuorum)
+    {
+        _leader = leader ?? throw new ArgumentNullException(nameof(leader));
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _lastCommit = lastCommit;
+        _maxIndexOnQuorum = maxIndexOnQuorum;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        var sw = Stopwatch.StartNew();
+
+        LastAppliedCommit = _engine.Apply(context, _maxIndexOnQuorum, _leader, sw);
+
+        var elapsed = sw.Elapsed;
+        if (RachisStateMachine.EnableDebugLongCommit && elapsed > TimeSpan.FromSeconds(5))
+            Console.WriteLine($"Commiting from {_lastCommit} to {LastAppliedCommit} took {elapsed}");
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/LeaderTruncateLogCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/LeaderTruncateLogCommand.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class LeaderTruncateLogCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly long _lowestIndexInEntireCluster;
+
+    public LeaderTruncateLogCommand([NotNull] RachisConsensus engine, long lowestIndexInEntireCluster)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _lowestIndexInEntireCluster = lowestIndexInEntireCluster;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        _engine.TruncateLogBefore(context, _lowestIndexInEntireCluster);
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/RemoveEntryFromRaftLogCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/RemoveEntryFromRaftLogCommand.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Binary;
+using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Rachis.Commands
+{
+    public class RemoveEntryFromRaftLogCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly long _index;
+        private readonly string _tag;
+        private readonly RachisLogHistory _logHistory;
+        public bool Succeeded { get; private set; }
+
+        public RemoveEntryFromRaftLogCommand(string tag, long index, RachisLogHistory logHistory)
+        {
+            _index = index;
+            _tag = tag;
+            _logHistory = logHistory;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            Succeeded = RemoveEntryFromRaftLogInTx(context, _index);
+            return 1;
+        }
+
+        private unsafe bool RemoveEntryFromRaftLogInTx(ClusterOperationContext context, long index)
+        {
+            Table table = context.Transaction.InnerTransaction.OpenTable(RachisConsensus.LogsTable, RachisConsensus.EntriesSlice);
+            long reversedIndex = Bits.SwapBytes(index);
+
+            long id;
+            long term;
+            using (Slice.External(context.Allocator, (byte*)&reversedIndex, sizeof(long), out Slice key))
+            {
+                if (table.ReadByKey(key, out TableValueReader reader))
+                {
+                    term = *(long*)reader.Read(1, out int size);
+                    id = reader.Id;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            var noopCmd = new DynamicJsonValue
+            {
+                ["Type"] = $"Noop for {_tag} in term {term}",
+                ["Command"] = "noop"
+            };
+            var cmd = context.ReadObject(noopCmd, "noop-cmd");
+
+            using (table.Allocate(out TableValueBuilder tvb))
+            {
+                tvb.Add(reversedIndex);
+                tvb.Add(term);
+                tvb.Add(cmd.BasePointer, cmd.Size);
+                tvb.Add((int)RachisEntryFlags.Noop);
+                table.Update(id, tvb, true);
+            }
+
+            _logHistory.UpdateHistoryLogPreservingGuidAndStatus(context, index, term, cmd);
+
+            return true;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/SetNewStateCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/SetNewStateCommand.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands
+{
+    public class SetNewStateCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+        private readonly RachisState _rachisState;
+        private readonly IDisposable _parent;
+        private readonly long _expectedTerm;
+        private readonly string _stateChangedReason;
+        private readonly Action _beforeStateChangedEvent;
+        private readonly bool _disposeAsync;
+
+        public SetNewStateCommand(RachisConsensus engine,
+            RachisState rachisState,
+            IDisposable parent,
+            long expectedTerm,
+            string stateChangedReason,
+            Action beforeStateChangedEvent = null,
+            bool disposeAsync = true)
+        {
+            _engine = engine;
+            _rachisState = rachisState;
+            _parent = parent;
+            _expectedTerm = expectedTerm;
+            _stateChangedReason = stateChangedReason;
+            _beforeStateChangedEvent = beforeStateChangedEvent;
+            _disposeAsync = disposeAsync;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            _engine.SetNewStateInTx(context, _rachisState, _parent, _expectedTerm, _stateChangedReason, _beforeStateChangedEvent, _disposeAsync);
+            return 1;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/Raven.Server/Rachis/Commands/SwitchToSingleLeaderCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/SwitchToSingleLeaderCommand.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands
+{
+    public class SwitchToSingleLeaderCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly RachisConsensus _engine;
+
+        public SwitchToSingleLeaderCommand(RachisConsensus engine)
+        {
+            _engine = engine;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            _engine.SwitchToSingleLeader(context);
+            return 1;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/UpdateNodeTagCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/UpdateNodeTagCommand.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class UpdateNodeTagCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly RachisConsensus _engine;
+    private readonly string _tag;
+    private readonly RachisHello _initialMessage;
+
+    public UpdateNodeTagCommand([NotNull] RachisConsensus engine, [NotNull] string tag, [NotNull] RachisHello initialMessage)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _tag = tag ?? throw new ArgumentNullException(nameof(tag));
+        _initialMessage = initialMessage ?? throw new ArgumentNullException(nameof(initialMessage));
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        if (_tag == RachisConsensus.InitialTag)// double checked locking under tx write lock
+            _engine.UpdateNodeTag(context, _initialMessage.DebugDestinationIdentifier);
+
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -5,10 +5,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Util;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
+using Raven.Server.Rachis.Commands;
 using Raven.Server.Rachis.Remote;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -26,7 +28,7 @@ using Voron.Impl;
 
 namespace Raven.Server.Rachis
 {
-    public class Follower : IDisposable
+    public partial class Follower : IDisposable
     {
         private static int _uniqueId;
 
@@ -152,12 +154,8 @@ namespace Raven.Server.Rachis
                             var task = Concurrent_SendAppendEntriesPendingToLeaderAsync(cts, _term, appendEntries.PrevLogIndex);
                             try
                             {
-                                bool hasRemovedFromTopology;
-
-                                (hasRemovedFromTopology, lastAcknowledgedIndex, lastTruncate, lastCommit) = ApplyLeaderStateToLocalState(sp,
-                                    context,
-                                    entries,
-                                    appendEntries);
+                                (bool hasRemovedFromTopology, lastAcknowledgedIndex, lastTruncate, lastCommit) =
+                                    ApplyLeaderStateToLocalState(sp, entries, appendEntries);
 
                                 if (hasRemovedFromTopology)
                                 {
@@ -193,7 +191,7 @@ namespace Raven.Server.Rachis
                                 // here we need to wait until the concurrent send pending to leader
                                 // is completed to avoid concurrent writes to the leader
                                 cts.Cancel();
-                                task.Wait(CancellationToken.None);
+                                task.Wait();
                             }
                         }
                     }
@@ -279,93 +277,29 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private (bool HasRemovedFromTopology, long LastAcknowledgedIndex, long LastTruncate, long LastCommit) ApplyLeaderStateToLocalState(Stopwatch sp, ClusterOperationContext context, List<RachisEntry> entries, AppendEntries appendEntries)
+        private (bool HasRemovedFromTopology, long LastAcknowledgedIndex, long LastTruncate, long LastCommit) ApplyLeaderStateToLocalState(Stopwatch sp, List<RachisEntry> entries, AppendEntries appendEntries)
         {
-            long lastTruncate;
-            long lastCommit;
-
-            bool removedFromTopology = false;
             // we start the tx after we finished reading from the network
             if (_engine.Log.IsInfoEnabled)
             {
                 _engine.Log.Info($"{ToString()}: Ready to start tx in {sp.Elapsed}");
             }
 
-            using (var tx = context.OpenWriteTransaction())
-            {
-                _engine.ValidateTerm(_term);
-
-                if (_engine.Log.IsInfoEnabled)
-                {
-                    _engine.Log.Info($"{ToString()}: Tx running in {sp.Elapsed}");
-                }
-
-                if (entries.Count > 0)
-                {
-                    var (lastTopology, lastTopologyIndex) = _engine.AppendToLog(context, entries);
-                    using (lastTopology)
-                    {
-                        if (lastTopology != null)
-                        {
-                            if (_engine.Log.IsInfoEnabled)
-                            {
-                                _engine.Log.Info($"Topology changed to {lastTopology}");
-                            }
-
-                            var topology = JsonDeserializationRachis<ClusterTopology>.Deserialize(lastTopology);
-                            if (topology.Members.ContainsKey(_engine.Tag) ||
-                                topology.Promotables.ContainsKey(_engine.Tag) ||
-                                topology.Watchers.ContainsKey(_engine.Tag))
-                            {
-                                RachisConsensus.SetTopology(_engine, context, topology);
-                            }
-                            else
-                            {
-                                removedFromTopology = true;
-                                _engine.ClearAppendedEntriesAfter(context, lastTopologyIndex);
-                            }
-                        }
-                    }
-                }
-
-                var lastEntryIndexToCommit = Math.Min(
-                    _engine.GetLastEntryIndex(context),
-                    appendEntries.LeaderCommit);
-
-                var lastAppliedIndex = _engine.GetLastCommitIndex(context);
-                var lastAppliedTerm = _engine.GetTermFor(context, lastEntryIndexToCommit);
-
-                // we start to commit only after we have any log with a term of the current leader
-                if (lastEntryIndexToCommit > lastAppliedIndex && lastAppliedTerm == appendEntries.Term)
-                {
-                    lastAppliedIndex = _engine.Apply(context, lastEntryIndexToCommit, null, sp);
-                }
-
-                lastTruncate = Math.Min(appendEntries.TruncateLogBefore, lastAppliedIndex);
-                _engine.TruncateLogBefore(context, lastTruncate);
-
-                lastCommit = lastAppliedIndex;
-                if (_engine.Log.IsInfoEnabled)
-                {
-                    _engine.Log.Info($"{ToString()}: Ready to commit in {sp.Elapsed}");
-                }
-
-                tx.Commit();
-            }
+            var command = new FollowerApplyCommand(_engine, _term, entries, appendEntries, sp);
+            _engine.TxMerger.EnqueueSync(command);
 
             if (_engine.Log.IsInfoEnabled)
             {
                 _engine.Log.Info($"{ToString()}: Processing entries request with {entries.Count} entries took {sp.Elapsed}");
             }
 
-            var lastAcknowledgedIndex = entries.Count == 0 ? appendEntries.PrevLogIndex : entries[entries.Count - 1].Index;
+            var lastAcknowledgedIndex = entries.Count == 0 ? appendEntries.PrevLogIndex : entries[^1].Index;
 
-            return (HasRemovedFromTopology: removedFromTopology, LastAcknowledgedIndex: lastAcknowledgedIndex, LastTruncate: lastTruncate, LastCommit: lastCommit);
+            return (HasRemovedFromTopology: command.RemovedFromTopology, LastAcknowledgedIndex: lastAcknowledgedIndex, LastTruncate: command.LastTruncate, LastCommit: command.LastCommit);
         }
 
-        public static bool CheckIfValidLeader(RachisConsensus engine, RemoteConnection connection, out LogLengthNegotiation negotiation)
+        public static (bool Success, LogLengthNegotiation Negotiation) CheckIfValidLeader(RachisConsensus engine, RemoteConnection connection)
         {
-            negotiation = null;
             using (engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             {
                 var logLength = connection.Read<LogLengthNegotiation>(context);
@@ -384,17 +318,17 @@ namespace Raven.Server.Rachis
                         CurrentTerm = engine.CurrentTerm
                     });
                     connection.Dispose();
-                    return false;
+                    return (false, null);
                 }
                 if (engine.Log.IsInfoEnabled)
                 {
-                    engine.Log.Info($"The incoming term { logLength.Term} is from a valid leader (From thread: {logLength.SendingThread})");
+                    engine.Log.Info($"The incoming term {logLength.Term} is from a valid leader (From thread: {logLength.SendingThread})");
                 }
                 engine.FoundAboutHigherTerm(logLength.Term, "Setting the term of the new leader");
                 engine.Timeout.Defer(connection.Source);
-                negotiation = logLength;
+
+                return (true, logLength);
             }
-            return true;
         }
 
         private void NegotiateWithLeader(ClusterOperationContext context, LogLengthNegotiation negotiation)
@@ -484,7 +418,7 @@ namespace Raven.Server.Rachis
             {
                 KeepAliveAndExecuteAction(() =>
                 {
-                    onFullSnapshotInstalledTask = ReadAndCommitSnapshot(context, snapshot, cts.Token);
+                    onFullSnapshotInstalledTask = ReadAndCommitSnapshotAsync(context, snapshot, cts.Token).Result;
                 }, cts, "ReadAndCommitSnapshot");
             }
 
@@ -555,93 +489,12 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private Task ReadAndCommitSnapshot(ClusterOperationContext context, InstallSnapshot snapshot, CancellationToken token)
+        private async Task<Task> ReadAndCommitSnapshotAsync(ClusterOperationContext context, InstallSnapshot snapshot, CancellationToken token)
         {
-            Task onFullSnapshotInstalledTask = null;
+            var command = new FollowerReadAndCommitSnapshotCommand(_engine, this, snapshot, token);
+            await _engine.TxMerger.Enqueue(command);
 
-            using (context.OpenWriteTransaction())
-            {
-                var lastTerm = _engine.GetTermFor(context, snapshot.LastIncludedIndex);
-                var lastCommitIndex = _engine.GetLastEntryIndex(context);
-
-                if (_engine.GetSnapshotRequest(context) == false &&
-                    snapshot.LastIncludedTerm == lastTerm && snapshot.LastIncludedIndex < lastCommitIndex)
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info(
-                            $"{ToString()}: Got installed snapshot with last index={snapshot.LastIncludedIndex} while our lastCommitIndex={lastCommitIndex}, will just ignore it");
-                    }
-
-                    //This is okay to ignore because we will just get the committed entries again and skip them
-                    ReadInstallSnapshotAndIgnoreContent(token);
-                }
-                else if (InstallSnapshot(context, token))
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info(
-                            $"{ToString()}: Installed snapshot with last index={snapshot.LastIncludedIndex} with LastIncludedTerm={snapshot.LastIncludedTerm} ");
-                    }
-
-                    _engine.SetLastCommitIndex(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
-                    _engine.ClearLogEntriesAndSetLastTruncate(context, snapshot.LastIncludedIndex, snapshot.LastIncludedTerm);
-
-                    onFullSnapshotInstalledTask = _engine.OnSnapshotInstalled(context, snapshot.LastIncludedIndex, token);
-                }
-                else
-                {
-                    var lastEntryIndex = _engine.GetLastEntryIndex(context);
-                    if (lastEntryIndex < snapshot.LastIncludedIndex)
-                    {
-                        var message =
-                            $"The snapshot installation had failed because the last included index {snapshot.LastIncludedIndex} in term {snapshot.LastIncludedTerm} doesn't match the last entry {lastEntryIndex}";
-                        if (_engine.Log.IsInfoEnabled)
-                        {
-                            _engine.Log.Info($"{ToString()}: {message}");
-                        }
-                        throw new InvalidOperationException(message);
-                    }
-                }
-
-                // snapshot always has the latest topology
-                if (snapshot.Topology == null)
-                {
-                    const string message = "Expected to get topology on snapshot";
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info($"{ToString()}: {message}");
-                    }
-
-                    throw new InvalidOperationException(message);
-                }
-
-                using (var topologyJson = context.ReadObject(snapshot.Topology, "topology"))
-                {
-                    if (_engine.Log.IsInfoEnabled)
-                    {
-                        _engine.Log.Info($"{ToString()}: topology on install snapshot: {topologyJson}");
-                    }
-
-                    var topology = JsonDeserializationRachis<ClusterTopology>.Deserialize(topologyJson);
-
-                    RachisConsensus.SetTopology(_engine, context, topology);
-                }
-
-                _engine.SetSnapshotRequest(context, false);
-
-                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += t =>
-                {
-                    if (t is LowLevelTransaction llt && llt.Committed)
-                    {
-                        // we might have moved from passive node, so we need to start the timeout clock
-                        _engine.Timeout.Start(_engine.SwitchToCandidateStateOnTimeout);
-                    }
-                };
-
-                context.Transaction.Commit();
-            }
-            return onFullSnapshotInstalledTask;
+            return command.OnFullSnapshotInstalledTask;
         }
 
         private bool InstallSnapshot(ClusterOperationContext context, CancellationToken token)
@@ -1002,7 +855,7 @@ namespace Raven.Server.Rachis
                             LastLogIndex = lastCommittedIndex,
                         });
                         return false;
-                    } 
+                    }
 
                     // the leader already truncated the suggested index
                     // Let's try to negotiate from that index upto our last appended index
@@ -1132,13 +985,13 @@ namespace Raven.Server.Rachis
                 });
         }
 
-        public void AcceptConnection(LogLengthNegotiation negotiation)
+        public async Task AcceptConnectionAsync(LogLengthNegotiation negotiation)
         {
             if (_engine.CurrentState != RachisState.Passive)
                 _engine.Timeout.Start(_engine.SwitchToCandidateStateOnTimeout);
 
             // if leader / candidate, this remove them from play and revert to follower mode
-            _engine.SetNewState(RachisState.Follower, this, _term,
+            await _engine.SetNewStateAsync(RachisState.Follower, this, _term,
                 $"Accepted a new connection from {_connection.Source} in term {negotiation.Term}");
             _engine.LeaderTag = _connection.Source;
 
@@ -1146,13 +999,14 @@ namespace Raven.Server.Rachis
 
             _followerLongRunningWork =
                 PoolOfThreads.GlobalRavenThreadPool.LongRunning(
-                    action: x => Run(x),
+                    action: Run,
                     state: negotiation,
                     ThreadNames.ForFollower($"Follower thread from {_connection} in term {negotiation.Term}", _connection.ToString(), negotiation.Term));
         }
 
         private void Run(object obj)
         {
+
             try
             {
                 ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, _debugName, _engine.Log);

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -417,7 +417,7 @@ namespace Raven.Server.Rachis
             {
                 KeepAliveAndExecuteAction(() =>
                 {
-                    onFullSnapshotInstalledTask = ReadAndCommitSnapshot(snapshot, cts.Token);
+                    onFullSnapshotInstalledTask = ReadAndCommitSnapshotAsync(snapshot, cts.Token);
                 }, cts, "ReadAndCommitSnapshot");
             }
 
@@ -488,12 +488,12 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private Task ReadAndCommitSnapshot(InstallSnapshot snapshot, CancellationToken token)
+        private async Task ReadAndCommitSnapshotAsync(InstallSnapshot snapshot, CancellationToken token)
         {
             var command = new FollowerReadAndCommitSnapshotCommand(_engine, this, snapshot, token);
-            _engine.TxMerger.EnqueueSync(command);
+            await _engine.TxMerger.Enqueue(command);
 
-            return command.OnFullSnapshotInstalledTask;
+            await command.OnFullSnapshotInstalledTask;
         }
 
         private bool InstallSnapshot(ClusterOperationContext context, CancellationToken token)

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Runtime.Internal.Util;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
@@ -418,7 +417,7 @@ namespace Raven.Server.Rachis
             {
                 KeepAliveAndExecuteAction(() =>
                 {
-                    onFullSnapshotInstalledTask = ReadAndCommitSnapshotAsync(context, snapshot, cts.Token).Result;
+                    onFullSnapshotInstalledTask = ReadAndCommitSnapshot(snapshot, cts.Token);
                 }, cts, "ReadAndCommitSnapshot");
             }
 
@@ -489,10 +488,10 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private async Task<Task> ReadAndCommitSnapshotAsync(ClusterOperationContext context, InstallSnapshot snapshot, CancellationToken token)
+        private Task ReadAndCommitSnapshot(InstallSnapshot snapshot, CancellationToken token)
         {
             var command = new FollowerReadAndCommitSnapshotCommand(_engine, this, snapshot, token);
-            await _engine.TxMerger.Enqueue(command);
+            _engine.TxMerger.EnqueueSync(command);
 
             return command.OnFullSnapshotInstalledTask;
         }

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -428,7 +428,7 @@ namespace Raven.Server.Rachis
             // going on
             using (var cts = new CancellationTokenSource())
             {
-                KeepAliveAndExecuteAction(() => _engine.AfterSnapshotInstalled(snapshot.LastIncludedIndex, onFullSnapshotInstalledTask, cts.Token)
+                KeepAliveAndExecuteAction(() => _engine.AfterSnapshotInstalledAsync(snapshot.LastIncludedIndex, onFullSnapshotInstalledTask, cts.Token)
                 , cts, "SnapshotInstalledAsync");
             }
 

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NetTopologySuite.Utilities;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -364,13 +364,6 @@ namespace Raven.Server.Rachis
 
                         if (lowestIndexInEntireCluster > lastTruncated)
                         {
-                            // _engine.TxMerger.EnqueueSync((context) =>
-                            // {
-                            //     _engine.TruncateLogBefore(context, lowestIndexInEntireCluster);
-                            //     LowestIndexInEntireCluster = lowestIndexInEntireCluster;
-                            //     return 1;
-                            // });
-
                             using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                             using (context.OpenWriteTransaction())
                             {

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -364,12 +364,20 @@ namespace Raven.Server.Rachis
 
                         if (lowestIndexInEntireCluster > lastTruncated)
                         {
-                            _engine.TxMerger.EnqueueSync((context) =>
+                            // _engine.TxMerger.EnqueueSync((context) =>
+                            // {
+                            //     _engine.TruncateLogBefore(context, lowestIndexInEntireCluster);
+                            //     LowestIndexInEntireCluster = lowestIndexInEntireCluster;
+                            //     return 1;
+                            // });
+
+                            using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                            using (context.OpenWriteTransaction())
                             {
                                 _engine.TruncateLogBefore(context, lowestIndexInEntireCluster);
                                 LowestIndexInEntireCluster = lowestIndexInEntireCluster;
-                                return 1;
-                            });
+                                context.Transaction.Commit();
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -9,7 +9,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using CsvHelper.Configuration.Attributes;
 using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
@@ -1429,24 +1428,6 @@ namespace Raven.Server.Rachis
                 throw new RachisApplyException($"Failed to remove entry number {index} from raft log", e);
             }
         }
-
-        // public long AppendToLog(CommandBase cmd, long term)
-        // {
-        //     using (ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-        //     {
-        //         var djv = cmd.ToJson(context);
-        //         var cmdJson = context.ReadObject(djv, "raft/command");
-        //
-        //         using (var tx = context.OpenWriteTransaction())
-        //         {
-        //             var index = InsertToLeaderLog(context, term, cmdJson, RachisEntryFlags.StateMachineCommand);
-        //             tx.Commit();
-        //      
-        //             return index;
-        //         }
-        //     }
-        // }
-
 
         public unsafe long InsertToLeaderLog(ClusterOperationContext context, long term, BlittableJsonReaderObject cmd,
             RachisEntryFlags flags)

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -100,9 +100,9 @@ namespace Raven.Server.Rachis
             return StateMachine.ShouldSnapshot(slice, type);
         }
 
-        public override void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
+        public override Task AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
-            StateMachine.AfterSnapshotInstalled(lastIncludedIndex, onFullSnapshotInstalledTask, token);
+            return StateMachine.AfterSnapshotInstalledAsync(lastIncludedIndex, onFullSnapshotInstalledTask, token);
         }
 
         public override Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
@@ -2223,7 +2223,7 @@ namespace Raven.Server.Rachis
 
         public abstract long Apply(ClusterOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration);
 
-        public abstract void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
+        public abstract Task AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
         public abstract Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token);
 
         internal readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -19,6 +19,7 @@ using Raven.Server.Config;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Extensions;
+using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.Rachis.Commands;
 using Raven.Server.Rachis.Remote;
@@ -433,7 +434,7 @@ namespace Raven.Server.Rachis
             Timeout.TimeoutPeriod = _rand.Next(timeout / 3 * 2, timeout);
         }
 
-        public void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, NotificationCenter.NotificationCenter notificationCenter, SystemTime time, out long clusterTopologyEtag, CancellationToken shutdown)
+        public void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, ServerNotificationCenter notificationCenter, SystemTime time, out long clusterTopologyEtag, CancellationToken shutdown)
         {
             try
             {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1154,7 +1154,7 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public void DeleteTopology(ClusterOperationContext context)
+        private void DeleteTopology(ClusterOperationContext context)
         {
             var topology = GetTopology(context);
             var newTopology = new ClusterTopology(
@@ -1205,7 +1205,7 @@ namespace Raven.Server.Rachis
             return topologyBlittable;
         }
 
-        public BlittableJsonReaderObject SetTopology(ClusterOperationContext context, ClusterTopology topology)
+        internal BlittableJsonReaderObject SetTopology(ClusterOperationContext context, ClusterTopology topology)
         {
             Debug.Assert(context.Transaction != null);
             var topologyJson = SetTopology(this, context, topology);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -100,14 +100,14 @@ namespace Raven.Server.Rachis
             return StateMachine.ShouldSnapshot(slice, type);
         }
 
-        public override Task AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
+        public override Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
             return StateMachine.AfterSnapshotInstalledAsync(lastIncludedIndex, onFullSnapshotInstalledTask, token);
         }
 
         public override Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
-            return StateMachine.OnSnapshotInstalled(context, lastIncludedIndex, token);
+            return StateMachine.OnSnapshotInstalledAsync(context, lastIncludedIndex, token);
         }
 
         public override Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate)
@@ -120,7 +120,7 @@ namespace Raven.Server.Rachis
                 throw new InvalidOperationException($"Exception was thrown for disconnecting  node {tag} - For testing purposes.");
             }
 
-            return StateMachine.ConnectToPeer(url, tag, certificate, _serverStore.ServerShutdown);
+            return StateMachine.ConnectToPeerAsync(url, tag, certificate, _serverStore.ServerShutdown);
         }
 
         private class NullDisposable : IDisposable
@@ -2223,7 +2223,7 @@ namespace Raven.Server.Rachis
 
         public abstract long Apply(ClusterOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration);
 
-        public abstract Task AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
+        public abstract Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token);
         public abstract Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token);
 
         internal readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Rachis
 
         public abstract Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate, CancellationToken token);
 
-        public virtual void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
+        public virtual async Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
         }
 

--- a/src/Raven.Server/Rachis/RachisStateMachine.cs
+++ b/src/Raven.Server/Rachis/RachisStateMachine.cs
@@ -91,13 +91,14 @@ namespace Raven.Server.Rachis
 
         public abstract bool ShouldSnapshot(Slice slice, RootObjectType type);
 
-        public abstract Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate, CancellationToken token);
+        public abstract Task<RachisConnection> ConnectToPeerAsync(string url, string tag, X509Certificate2 certificate, CancellationToken token);
 
-        public virtual async Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
+        public virtual Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
+            return Task.CompletedTask;
         }
 
-        public virtual Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public virtual Task OnSnapshotInstalledAsync(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
             return Task.CompletedTask;
         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2356,7 +2356,7 @@ namespace Raven.Server
             if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster)
             {
                 var tcpClient = tcp.TcpClient.Client;
-                ServerStore.ClusterAcceptNewConnection(tcp, header, tcp.Dispose, tcpClient.RemoteEndPoint);
+                await ServerStore.ClusterAcceptNewConnectionAsync(tcp, header, tcp.Dispose, tcpClient.RemoteEndPoint);
                 return true;
             }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -4544,17 +4544,17 @@ namespace Raven.Server.ServerWide
             return tcs.Task;
         }
 
-        public override void AfterSnapshotInstalled(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
+        public override async Task AfterSnapshotInstalledAsync(long lastIncludedIndex, Task onFullSnapshotInstalledTask, CancellationToken token)
         {
             if (onFullSnapshotInstalledTask == null)
                 return;
 
             try
             {
-                onFullSnapshotInstalledTask.Wait(token);
+                await onFullSnapshotInstalledTask.WaitAsync(token);
                 _rachisLogIndexNotifications.NotifyListenersAbout(lastIncludedIndex, null);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex)
             {
                 // will not notify here
             }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3838,7 +3838,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public override async Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate, CancellationToken token)
+        public override async Task<RachisConnection> ConnectToPeerAsync(string url, string tag, X509Certificate2 certificate, CancellationToken token)
         {
             if (url == null)
                 throw new ArgumentNullException(nameof(url));
@@ -4478,7 +4478,7 @@ namespace Raven.Server.ServerWide
         
         public const string SnapshotInstalled = "SnapshotInstalled";
 
-        public override Task OnSnapshotInstalled(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
+        public override Task OnSnapshotInstalledAsync(ClusterOperationContext context, long lastIncludedIndex, CancellationToken token)
         {
             var clusterCertificateKeys = GetCertificateThumbprintsFromCluster(context);
 
@@ -4554,7 +4554,7 @@ namespace Raven.Server.ServerWide
                 await onFullSnapshotInstalledTask.WaitAsync(token);
                 _rachisLogIndexNotifications.NotifyListenersAbout(lastIncludedIndex, null);
             }
-            catch (OperationCanceledException ex)
+            catch (OperationCanceledException)
             {
                 // will not notify here
             }

--- a/src/Raven.Server/ServerWide/Context/ClusterOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/ClusterOperationContext.cs
@@ -10,13 +10,11 @@ namespace Raven.Server.ServerWide.Context
     public class ClusterOperationContext : TransactionOperationContext<ClusterTransaction>
     {
         private readonly ClusterChanges _changes;
-        public readonly StorageEnvironment Environment;
 
         public ClusterOperationContext(ClusterChanges changes, StorageEnvironment environment, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
-            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
+            : base(environment, initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
             _changes = changes ?? throw new ArgumentNullException(nameof(changes));
-            Environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
         protected override ClusterTransaction CloneReadTransaction(ClusterTransaction previous)
@@ -51,6 +49,12 @@ namespace Raven.Server.ServerWide.Context
             _clusterChanges = clusterChanges ?? throw new System.ArgumentNullException(nameof(clusterChanges));
         }
 
+        public ClusterTransaction BeginAsyncCommitAndStartNewTransaction(ClusterOperationContext context)
+        {
+            var tx = InnerTransaction.BeginAsyncCommitAndStartNewTransaction(context.PersistentContext);
+            return new ClusterTransaction(tx, _clusterChanges);
+        }
+
         public void AddAfterCommitNotification(CompareExchangeChange change)
         {
             Debug.Assert(_clusterChanges != null, "_clusterChanges != null");
@@ -75,5 +79,6 @@ namespace Raven.Server.ServerWide.Context
                 }
             }
         }
+
     }
 }

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -4,6 +4,7 @@ using Raven.Server.Documents;
 using Raven.Server.Utils;
 using Sparrow.Threading;
 using Voron;
+using static Raven.Server.Utils.MetricCacher.Keys;
 
 namespace Raven.Server.ServerWide.Context
 {
@@ -12,7 +13,7 @@ namespace Raven.Server.ServerWide.Context
         private readonly DocumentDatabase _documentDatabase;
 
         public DocumentsOperationContext(DocumentDatabase documentDatabase, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
-            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
+            : base(documentDatabase?.DocumentsStorage?.Environment, initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
             _documentDatabase = documentDatabase;
         }
@@ -114,8 +115,6 @@ namespace Raven.Server.ServerWide.Context
 
             return tx;
         }
-
-        public StorageEnvironment Environment => _documentDatabase.DocumentsStorage.Environment;
 
         public DocumentDatabase DocumentDatabase => _documentDatabase;
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -12,12 +12,9 @@ namespace Raven.Server.ServerWide.Context
     {
         public bool IgnoreStalenessDueToReduceOutputsToDelete;
 
-        public readonly StorageEnvironment Environment;
-
         public TransactionOperationContext(StorageEnvironment environment, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
-            : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
+            : base(environment, initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
-            Environment = environment;
         }
 
         protected override RavenTransaction CloneReadTransaction(RavenTransaction previous)
@@ -53,10 +50,12 @@ namespace Raven.Server.ServerWide.Context
         private readonly int _maxOfAllocatedChangeVectors;
         private int _numberOfAllocatedChangeVectors;
         private FastList<ChangeVector> _allocatedChangeVectors;
+        public readonly StorageEnvironment Environment;
 
-        protected TransactionOperationContext(int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
+        protected TransactionOperationContext(StorageEnvironment environment, int initialSize, int longLivedSize, int maxNumberOfAllocatedStringValues, SharedMultipleUseFlag lowMemoryFlag)
             : base(initialSize, longLivedSize, maxNumberOfAllocatedStringValues, lowMemoryFlag)
         {
+            Environment = environment;
             PersistentContext = new TransactionPersistentContext();
             Allocator = new ByteStringContext(lowMemoryFlag);
 

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -59,6 +59,11 @@ namespace Raven.Server.ServerWide
             return false;
         }
 
+        protected static void ThrowInvalidTransactionUsage()
+        {
+            throw new InvalidOperationException("There is a different transaction in context.");
+        }
+
         private void AfterCommit()
         {
             if (ShouldRaiseNotifications() == false)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -821,7 +821,7 @@ namespace Raven.Server.ServerWide
             _engine.BeforeAppendToRaftLog = BeforeAppendToRaftLog;
 
             var myUrl = GetNodeHttpServerUrl();
-            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, out _lastClusterTopologyIndex);
+            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, Server.ServerStore.NotificationCenter, Server.Time, out _lastClusterTopologyIndex, ServerShutdown);
 
             using (Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
@@ -3367,7 +3367,7 @@ namespace Raven.Server.ServerWide
             return _engine.WaitForState(rachisState, token);
         }
 
-        public void ClusterAcceptNewConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header, Action disconnect, EndPoint remoteEndpoint)
+        public async Task ClusterAcceptNewConnectionAsync(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header, Action disconnect, EndPoint remoteEndpoint)
         {
             try
             {
@@ -3381,7 +3381,7 @@ namespace Raven.Server.ServerWide
                 var features = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Cluster, tcp.ProtocolVersion);
                 var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features.Cluster, disconnect);
 
-                _engine.AcceptNewConnection(remoteConnection, remoteEndpoint);
+                await _engine.AcceptNewConnectionAsync(remoteConnection, remoteEndpoint);
             }
             catch (IOException e)
             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -821,7 +821,7 @@ namespace Raven.Server.ServerWide
             _engine.BeforeAppendToRaftLog = BeforeAppendToRaftLog;
 
             var myUrl = GetNodeHttpServerUrl();
-            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, Server.ServerStore.NotificationCenter, Server.Time, out _lastClusterTopologyIndex, ServerShutdown);
+            _engine.Initialize(_env, Configuration, clusterChanges, myUrl, Server.Time, out _lastClusterTopologyIndex, ServerShutdown);
 
             using (Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -91,12 +91,17 @@ namespace Raven.Server.ServerWide
 
         public void ClearPublishedUrls()
         {
-            using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
-            using (var tx = ctx.OpenWriteTransaction())
+            // using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            // using (var tx = ctx.OpenWriteTransaction())
+            // {
+            //     PublishedServerUrls.Clear(ctx);
+            //     tx.Commit();
+            // }
+            _serverStore.Engine.TxMerger.EnqueueSync(ctx =>
             {
                 PublishedServerUrls.Clear(ctx);
-                tx.Commit();
-            }
+                return 1;
+            });
         }
 
         public DocumentConventions DocumentConventionsForShard =>

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -91,12 +91,6 @@ namespace Raven.Server.ServerWide
 
         public void ClearPublishedUrls()
         {
-            // using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
-            // using (var tx = ctx.OpenWriteTransaction())
-            // {
-            //     PublishedServerUrls.Clear(ctx);
-            //     tx.Commit();
-            // }
             _serverStore.Engine.TxMerger.EnqueueSync(ctx =>
             {
                 PublishedServerUrls.Clear(ctx);

--- a/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
+++ b/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using Raven.Client.Util;
+using Raven.Server.Config;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Platform;
+
+namespace Raven.Server.ServerWide.TransactionMerger;
+
+public class ClusterTransactionOperationsMerger : AbstractTransactionOperationsMerger<ClusterOperationContext, ClusterTransaction>
+{
+    public ClusterTransactionOperationsMerger(RachisConsensus engine, RavenConfiguration configuration, SystemTime time, CancellationToken shutdown)
+        : base("Cluster", configuration, time, shutdown)
+    {
+        IsEncrypted = engine.IsEncrypted;
+        Is32Bits = PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager;
+    }
+
+    protected override bool IsEncrypted { get; }
+    protected override bool Is32Bits { get; }
+
+    internal override ClusterTransaction BeginAsyncCommitAndStartNewTransaction(ClusterTransaction previousTransaction, ClusterOperationContext currentContext)
+    {
+        return previousTransaction.BeginAsyncCommitAndStartNewTransaction(currentContext);
+    }
+
+    internal override void UpdateGlobalReplicationInfoBeforeCommit(ClusterOperationContext context)
+    {
+    }
+
+    protected override void UpdateLastAccessTime(DateTime time)
+    {
+    }
+
+    public void EnqueueSync(MergedTransactionCommand<ClusterOperationContext, ClusterTransaction> cmd)
+    {
+        Enqueue(cmd).GetAwaiter().GetResult();
+    }
+
+    private readonly ManualResetEventSlim _disposeEvent = new ManualResetEventSlim();
+    public bool IsDisposed => _disposeEvent.IsSet;
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+            return;
+        _disposeEvent.Set();
+        base.Dispose();
+    }
+}

--- a/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
+++ b/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Platform;
+using Voron.Debugging;
 
 namespace Raven.Server.ServerWide.TransactionMerger;
 
@@ -31,6 +32,10 @@ public class ClusterTransactionOperationsMerger : AbstractTransactionOperationsM
     {
     }
 
+    internal override void NotifyAboutSlowWrite(CommitStats stats)
+    {
+    }
+
     protected override void UpdateLastAccessTime(DateTime time)
     {
     }
@@ -40,7 +45,7 @@ public class ClusterTransactionOperationsMerger : AbstractTransactionOperationsM
         Enqueue(cmd).GetAwaiter().GetResult();
     }
 
-    private readonly ManualResetEventSlim _disposeEvent = new ManualResetEventSlim();
+    private readonly ManualResetEventSlim _disposeEvent = new ManualResetEventSlim(false);
     public bool IsDisposed => _disposeEvent.IsSet;
 
     public override void Dispose()

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -18,6 +18,7 @@ using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Actions;
 using Raven.Server.Smuggler.Documents.Data;
@@ -530,7 +531,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public class MergedBatchPutCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
+        public class MergedBatchPutCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>, IDisposable
         {
             public bool IsRevision;
             public Action<DocumentItem> DocumentCollectionMismatchHandler;
@@ -907,7 +908,7 @@ namespace Raven.Server.Smuggler.Documents
 
             private const int SchemaSize = 2 * 1024 * 1024;
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new MergedBatchPutCommandDto
                 {
@@ -918,7 +919,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        public class MergedBatchPutCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedBatchPutCommand>
+        public class MergedBatchPutCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedBatchPutCommand>
         {
             public BuildVersionType BuildType;
             public List<DocumentItem> Documents;
@@ -940,7 +941,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        internal class MergedBatchFixDocumentMetadataCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
+        internal class MergedBatchFixDocumentMetadataCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>, IDisposable
         {
             private readonly Logger _log;
             public HashSet<string> Ids = new HashSet<string>();
@@ -1064,7 +1065,7 @@ namespace Raven.Server.Smuggler.Documents
                 _returnContext.Dispose();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new MergedBatchFixDocumentMetadataCommandDto
                 {
@@ -1072,7 +1073,7 @@ namespace Raven.Server.Smuggler.Documents
                 };
             }
 
-            internal class MergedBatchFixDocumentMetadataCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedBatchFixDocumentMetadataCommand>
+            internal class MergedBatchFixDocumentMetadataCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedBatchFixDocumentMetadataCommand>
             {
                 public HashSet<string> Ids = new HashSet<string>();
 
@@ -1091,7 +1092,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        internal class MergedBatchDeleteRevisionCommand : TransactionOperationsMerger.MergedTransactionCommand, IDisposable
+        internal class MergedBatchDeleteRevisionCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>, IDisposable
         {
             private readonly Logger _log;
             public readonly List<KeyValuePair<string, CollectionName>> Ids = new List<KeyValuePair<string, CollectionName>>();
@@ -1146,7 +1147,7 @@ namespace Raven.Server.Smuggler.Documents
                 _returnContext.Dispose();
             }
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
                 return new MergedBatchDeleteRevisionCommandDto
                 {
@@ -1155,7 +1156,7 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        internal class MergedBatchDeleteRevisionCommandDto : TransactionOperationsMerger.IReplayableCommandDto<MergedBatchDeleteRevisionCommand>
+        internal class MergedBatchDeleteRevisionCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedBatchDeleteRevisionCommand>
         {
             public List<KeyValuePair<string, CollectionName>> Ids = new List<KeyValuePair<string, CollectionName>>();
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -17,7 +17,6 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.TransactionCommands;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Actions;

--- a/src/Raven.Server/Web/Studio/StudioCollectionRunner.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionRunner.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Server.Documents;
-using Raven.Server.Documents.TransactionCommands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -27,6 +27,7 @@ using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
+using Raven.Server.Rachis.Commands;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -511,11 +512,8 @@ namespace Raven.Server.Web.System
                 // Making sure we don't have leftovers from previous setup
                 try
                 {
-                    using (var tx = context.OpenWriteTransaction())
-                    {
-                        ServerStore.Engine.DeleteTopology(context);
-                        tx.Commit();
-                    }
+                    var command = new DeleteTopologyCommand(ServerStore.Engine);
+                    await ServerStore.Engine.TxMerger.Enqueue(command);
                 }
                 catch (Exception)
                 {
@@ -532,7 +530,6 @@ namespace Raven.Server.Web.System
                     progress => SetupManager.SetupUnsecuredTask(progress,
                         unsecuredSetupInfo,
                         ServerStore,
-                        context,
                         operationCancelToken.Token),
                     token: operationCancelToken);
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -857,9 +857,14 @@ namespace RachisTests
 
             foreach (var follower in followers)
             {
-                while (cluster.Leader.ServerStore.Engine.CurrentLeader.TryModifyTopology(follower.ServerStore.NodeTag, follower.ServerStore.Engine.Url, Leader.TopologyModification.NonVoter, out var task) == false)
+                while (true)
                 {
-                    await task;
+                    var r = await cluster.Leader.ServerStore.Engine.CurrentLeader.TryModifyTopologyAsync(follower.ServerStore.NodeTag, follower.ServerStore.Engine.Url, Leader.TopologyModification.NonVoter);
+
+                    if (r.Success)
+                        break;
+
+                    await r.Task;
                 }
             }
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -627,10 +627,7 @@ namespace RachisTests
                     Name = db
                 });
 
-                using (var context = JsonOperationContext.ShortTermSingleUse())
-                {
-                    await store.GetRequestExecutor().ExecuteAsync(new WaitForRaftIndexCommand(res.Index), context);
-                }
+                await Cluster.WaitForRaftIndexToBeAppliedOnClusterNodesAsync(res.Index, cluster.Nodes);
 
                 await WaitForAssertionAsync(() =>
                 {

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -638,8 +638,7 @@ namespace RachisTests
                     using (ctx.OpenReadTransaction())
                     {
                         var record = cluster.Leader.ServerStore.Cluster.ReadDatabase(ctx, db);
-                        // Assert.Equal(0, record.DeletionInProgress?.Count ?? 0);
-                        Assert.True(0 == (record.DeletionInProgress?.Count ?? 0), GetRecordFixedString(record, cluster.Leader));
+                        Assert.True((record.DeletionInProgress?.Count ?? 0) == 0, GetRecordFixedString(record, cluster.Leader));
 
                         var topology = record.Topology;
                         Assert.Equal(3, topology.ReplicationFactor);
@@ -876,15 +875,8 @@ namespace RachisTests
 
             foreach (var follower in followers)
             {
-                while (true)
-                {
-                    var r = await cluster.Leader.ServerStore.Engine.CurrentLeader.TryModifyTopologyAsync(follower.ServerStore.NodeTag, follower.ServerStore.Engine.Url, Leader.TopologyModification.NonVoter);
-
-                    if (r.Success)
-                        break;
-
-                    await r.Task;
-                }
+                await cluster.Leader.ServerStore.Engine.ModifyTopologyAsync(follower.ServerStore.NodeTag, follower.ServerStore.Engine.Url,
+                    Leader.TopologyModification.NonVoter);
             }
 
             var result = await DisposeServerAndWaitForFinishOfDisposalAsync(cluster.Leader);

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -141,7 +141,7 @@ namespace RachisTests.DatabaseCluster
                 var result = WaitForDocument(store2, "foo/bar");
                 Assert.True(result);
 
-                cluster.Leader.ServerStore.Engine.HardResetToNewCluster(tag);
+                await cluster.Leader.ServerStore.Engine.HardResetToNewClusterAsync(tag);
 
                 var outgoingConnections = WaitForValue(() =>
                 {
@@ -214,7 +214,7 @@ namespace RachisTests.DatabaseCluster
                 var result = WaitForDocument(store2, "foo/bar");
                 Assert.True(result);
 
-                cluster.Leader.ServerStore.Engine.HardResetToPassive(Guid.NewGuid().ToString());
+                await cluster.Leader.ServerStore.Engine.HardResetToPassiveAsync(Guid.NewGuid().ToString());
                 await cluster.Leader.ServerStore.EnsureNotPassiveAsync(nodeTag: tag);
 
                 var outgoingConnections = WaitForValue(() =>

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -363,7 +363,7 @@ namespace RachisTests
         {
             var firstLeader = await CreateNetworkAndGetLeader(numberOfNodes);
             firstLeader.CurrentLeader.StepDown();
-            Assert.True(await firstLeader.WaitForState(RachisState.Follower, CancellationToken.None).WaitWithoutExceptionAsync(TimeSpan.FromSeconds(30)), "Old leader hasn't stepped down.");
+            Assert.True(await firstLeader.WaitForState(RachisState.Follower, CancellationToken.None).WaitWithoutExceptionAsync(TimeSpan.FromSeconds(30)), $"Old leader hasn't stepped down, firstLeader.CurrentState={firstLeader.CurrentState}.");
         }
 
         /// <summary>

--- a/test/RachisTests/EmergencyOperations.cs
+++ b/test/RachisTests/EmergencyOperations.cs
@@ -25,7 +25,7 @@ namespace RachisTests
             var (nodes, leader) = await CreateRaftCluster(3);
             ClusterTopology old, @new;
             old = leader.ServerStore.GetClusterTopology();
-            leader.ServerStore.Engine.HardResetToNewCluster("A");
+            await leader.ServerStore.Engine.HardResetToNewClusterAsync("A");
             await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None);
             @new = leader.ServerStore.GetClusterTopology();
             Assert.NotEqual(old.TopologyId, @new.TopologyId);

--- a/test/RachisTests/EmergencyOperations.cs
+++ b/test/RachisTests/EmergencyOperations.cs
@@ -60,7 +60,7 @@ namespace RachisTests
             await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
             
             var old = GetDatabaseTopology();
-            leader.ServerStore.Engine.HardResetToNewCluster();
+            await leader.ServerStore.Engine.HardResetToNewClusterAsync();
             await leader.ServerStore.WaitForState(RachisState.Leader, CancellationToken.None);
 
             var @new = GetDatabaseTopology();

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -159,13 +159,13 @@ namespace RachisTests
             using (ctx.OpenReadTransaction())
             {
                 id = node1.GetTopology(ctx).TopologyId;
-    }
+            }
 
-            node2.HardResetToPassive(id);
+            await node2.HardResetToPassiveAsync(id);
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
             {
                 await node2.WaitForState(RachisState.Passive, cts.Token);
-}
+            }
 
             await node1.AddToClusterAsync(url);
             await node2.WaitForTopology(Leader.TopologyModification.Voter);

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace RachisTests
             var followers = GetFollowers();
             var newServer = SetupServer();
             DisconnectFromNode(leader);
-            await leader.AddToClusterAsync(newServer.Url);
+            await Assert.ThrowsAnyAsync<Exception>(() => leader.AddToClusterAsync(newServer.Url));
             var newLeader = WaitForAnyToBecomeLeader(followers);
 
             Assert.NotNull(newLeader);

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.ServerWide;

--- a/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
+++ b/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
@@ -530,13 +530,54 @@ namespace SlowTests.Blittable
                 {
                     return;
                 }
-                Assert.Equal(expectedValue, actualValue);
+
+                if (type == typeof(BatchRequestParser.CommandData[]))
+                {
+                    var a1 = (BatchRequestParser.CommandData[])expectedValue;
+                    var a2 = (BatchRequestParser.CommandData[])actualValue;
+
+                    Assert.Equal(a1.Length, a2.Length);
+                    for (int i = 0; i < a1.Length; i++)
+                    {
+                        Assert.True(ObjectsAreEquals(a1[i], a2[i]));
+                    }
+                }
+                else
+                    Assert.Equal(expectedValue, actualValue);
             }
 
             public int GetHashCode(TRecordableCommand parameterValue)
             {
                 return Tuple.Create(parameterValue).GetHashCode();
             }
+
+
+            private static bool ObjectsAreEquals(object d1, object d2)
+            {
+                if ((d1 == null) || d1.GetType().Equals(d2.GetType()) == false)
+                {
+                    return false;
+                }
+
+                if (d1 != null && d2 != null)
+                {
+                    Type type = d1.GetType();
+                    foreach (System.Reflection.PropertyInfo pi in type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+                    {
+                        object selfValue = type.GetProperty(pi.Name).GetValue(d1, null);
+                        object toValue = type.GetProperty(pi.Name).GetValue(d2, null);
+
+                        if (selfValue != toValue && (selfValue == null || !selfValue.Equals(toValue)))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+                return d1 == d2;
+            }
+
         }
     }
 }

--- a/test/SlowTests/Client/Attachments/AttachmentsSession.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSession.cs
@@ -8,6 +8,8 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Server.Config;
 using Raven.Server.Documents;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -593,10 +595,10 @@ namespace SlowTests.Client.Attachments
             }
         }
 
-        private class ThrowCommand : TransactionOperationsMerger.MergedTransactionCommand
+        private class ThrowCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             protected override long ExecuteCmd(DocumentsOperationContext context) => throw new Exception();
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) 
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
                 => throw new NotImplementedException();
             
         }

--- a/test/SlowTests/Cluster/NServiceBusCaseTest.cs
+++ b/test/SlowTests/Cluster/NServiceBusCaseTest.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Cluster
 
         const string SagaDataIdPrefix = "SampleSagaDatas";
         const int NumberOfConcurrentUpdates = 50;
-        const int MaxRetryAttempts = 150;
+        const int MaxRetryAttempts = 50;
 
         [Fact]
         public async Task ConcurrentArrayUpdate()

--- a/test/SlowTests/Cluster/NServiceBusCaseTest.cs
+++ b/test/SlowTests/Cluster/NServiceBusCaseTest.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Cluster
 
         const string SagaDataIdPrefix = "SampleSagaDatas";
         const int NumberOfConcurrentUpdates = 50;
-        const int MaxRetryAttempts = 50;
+        const int MaxRetryAttempts = 150;
 
         [Fact]
         public async Task ConcurrentArrayUpdate()

--- a/test/SlowTests/Issues/RavenDB-15900.cs
+++ b/test/SlowTests/Issues/RavenDB-15900.cs
@@ -199,7 +199,7 @@ namespace SlowTests.Issues
 
             foreach (var server in Servers)
             {
-                var res = await WaitForValueAsync(() => server.ServerStore.Engine.RemoveEntryFromRaftLog(testCmdIndex), true);
+                var res = await WaitForValueAsync(() => server.ServerStore.Engine.RemoveEntryFromRaftLogAsync(testCmdIndex), true);
 
                 Assert.True(res);
             }

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -41,6 +41,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -48,6 +49,7 @@ using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using DeleteDocumentCommand = Raven.Client.Documents.Commands.DeleteDocumentCommand;
 
 namespace SlowTests.Server
 {
@@ -62,21 +64,21 @@ namespace SlowTests.Server
         {
             var exceptions = new[]
             {
-                typeof(TransactionOperationsMerger.MergedTransactionCommand),
+                typeof(MergedTransactionCommand<,>),
                 typeof(ExecuteRateLimitedOperations<>),
-                typeof(StartTransactionsRecordingCommand),
-                typeof(StopTransactionsRecordingCommand),
+                typeof(StartTransactionsRecordingCommand<,>),
+                typeof(StopTransactionsRecordingCommand<,>),
                 typeof(TransactionMergedCommand),
                 typeof(AbstractDatabaseQueryRunner.BulkOperationCommand<>)
             };
 
-            var commandBaseType = typeof(TransactionOperationsMerger.MergedTransactionCommand);
+            var commandBaseType = typeof(MergedTransactionCommand<,>);
             var types = commandBaseType.Assembly.GetTypes();
             var commandDeriveTypes = types
                 .Where(t => commandBaseType.IsAbstract == false && commandBaseType.IsAssignableFrom(t) && exceptions.Contains(t) == false)
                 .ToList();
 
-            var iRecordableType = typeof(TransactionOperationsMerger.IReplayableCommandDto<>);
+            var iRecordableType = typeof(IReplayableCommandDto<,,>);
             var genericTypes = iRecordableType.Assembly.GetTypes()
                 .Select(t => t
                     .GetInterfaces()

--- a/test/SlowTests/Server/TransactionMergerTests.cs
+++ b/test/SlowTests/Server/TransactionMergerTests.cs
@@ -9,6 +9,8 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Server.Config;
 using Raven.Server.Documents;
+using Raven.Server.Documents.TransactionMerger;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Xunit;
@@ -173,11 +175,11 @@ from TestObjs as o where o.Prop = null update
         
         }
     
-        private class FailedCommand : TransactionOperationsMerger.MergedTransactionCommand
+        private class FailedCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             protected override long ExecuteCmd(DocumentsOperationContext context) => throw new TestException();
 
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context) =>
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context) =>
                 throw new NotImplementedException();
         }
 

--- a/test/StressTests/Cluster/ClusterTransactionTestsStress.cs
+++ b/test/StressTests/Cluster/ClusterTransactionTestsStress.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Session;
+using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -23,7 +24,10 @@ public class ClusterTransactionTestsStress : ClusterTestBase
     public async Task CanCreateClusterTransactionRequest2(Options options)
     {
         DebuggerAttachedTimeout.DisableLongTimespan = true;
-        var (_, leader) = await CreateRaftCluster(2);
+        var (_, leader) = await CreateRaftCluster(2, customSettings: new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.Cluster.LogHistoryMaxEntries)] = "4096"
+        });
         options.Server = leader;
         options.ReplicationFactor = 2;
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -881,9 +881,14 @@ namespace Tests.Infrastructure
             if(votersCount > 0)
                 await ActionWithLeader(async (leader1) =>
                 {
+                    var sw = Stopwatch.StartNew();
                     while (leader1.ServerStore.Engine.CurrentLeader.CurrentVoters.Count < votersCount)
                     {
                         await Task.Delay(100);
+                        if (sw.ElapsedMilliseconds > 15_000)
+                        {
+                            throw new TimeoutException("waited too much to leader voters.");
+                        }
                     }
                 }, clusterNodes);
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -876,6 +876,17 @@ namespace Tests.Infrastructure
             }
             Assert.True(condition, states);
             Assert.True(await WaitForNotHavingPromotables(clusterNodes));
+
+            var votersCount = watcherCluster ? 0 : numberOfNodes - 1;
+            if(votersCount > 0)
+                await ActionWithLeader(async (leader1) =>
+                {
+                    while (leader1.ServerStore.Engine.CurrentLeader.CurrentVoters.Count < votersCount)
+                    {
+                        await Task.Delay(100);
+                    }
+                }, clusterNodes);
+
             return (clusterNodes, leader, certificates);
         }
 

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -552,7 +552,7 @@ namespace Tests.Infrastructure
                 return slice.ToString() == "values";
             }
 
-            public override async Task<RachisConnection> ConnectToPeer(string url, string tag, X509Certificate2 certificate, CancellationToken token)
+            public override async Task<RachisConnection> ConnectToPeerAsync(string url, string tag, X509Certificate2 certificate, CancellationToken token)
             {
                 TimeSpan time;
                 using (ContextPoolForReadOnlyOperations.AllocateOperationContext(out ClusterOperationContext ctx))

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -105,9 +106,14 @@ namespace Tests.Infrastructure
             if(votersCount>0)
                 await ActionWithLeader(async (leader1) =>
                 {
+                    var sw = Stopwatch.StartNew();
                     while (leader1.CurrentLeader.CurrentVoters.Count < votersCount)
                     {
                         await Task.Delay(100);
+                        if (sw.ElapsedMilliseconds > 15_000)
+                        {
+                            throw new TimeoutException("waited too much to leader voters.");
+                        }
                     }
                 });
 

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -222,7 +222,7 @@ namespace Tests.Infrastructure
             serverStore.Initialize();
             var rachis = new RachisConsensus<CountingStateMachine>(serverStore, seed);
             var storageEnvironment = new StorageEnvironment(server);
-            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], new DummyNotificationCenter(), new SystemTime(), out _, CancellationToken.None);
+            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], new DummyNotificationCenter(serverStore), new SystemTime(), out _, CancellationToken.None);
             rachis.OnDispose += (sender, args) =>
             {
                 serverStore.Dispose();
@@ -629,9 +629,9 @@ namespace Tests.Infrastructure
             }
         }
 
-        private class DummyNotificationCenter : NotificationCenter
+        private class DummyNotificationCenter : ServerNotificationCenter
         {
-            public DummyNotificationCenter() : base(null, null, CancellationToken.None, null)
+            public DummyNotificationCenter(ServerStore serverStore) : base(serverStore, serverStore.NotificationCenter.Storage)
             {
             }
         }

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -39,7 +39,6 @@ using Voron.Data.BTrees;
 using Voron.Exceptions;
 using Xunit;
 using Xunit.Abstractions;
-using static FastTests.TestBase;
 using NativeMemory = Sparrow.Utils.NativeMemory;
 
 namespace Tests.Infrastructure
@@ -102,9 +101,16 @@ namespace Tests.Infrastructure
                         currentState == RachisState.LeaderElect,
                 "The leader has changed while waiting for cluster to become stable, it is now " + currentState + " Beacuse: " + leader.LastStateChangeReason);
 
+            await WaitForVoters(nodeCount, watcherCluster);
+
+            return leader;
+        }
+
+        private Task WaitForVoters(int nodeCount, bool watcherCluster)
+        {
             var votersCount = watcherCluster ? 0 : nodeCount - 1;
-            if(votersCount>0)
-                await ActionWithLeader(async (leader1) =>
+            if (votersCount > 0)
+                return ActionWithLeader(async (leader1) =>
                 {
                     var sw = Stopwatch.StartNew();
                     while (leader1.CurrentLeader.CurrentVoters.Count < votersCount)
@@ -117,7 +123,7 @@ namespace Tests.Infrastructure
                     }
                 });
 
-            return leader;
+            return Task.CompletedTask;
         }
 
         protected RachisConsensus<CountingStateMachine> GetRandomFollower()

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Tests.Infrastructure;
 using FastTests.Voron.Sets;
 using FastTests.Corax.Bugs;
+using FastTests.Sharding;
 using RachisTests.DatabaseCluster;
 using Raven.Server.Utils;
 using SlowTests.Cluster;
@@ -30,10 +31,10 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ReshardingTests(testOutputHelper))
+                using (var test = new RavenDB_17760(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration();
+                    await test.CanGetTombstonesByBucket();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Additional description

Move all the server store operations to a Tx Merger mode.
Basically, where ever we have ServerStore.OpenWriteTransaction() should be modified.

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
