### PR TITLE
RavenDB-20162 : bucket migration commands should update EtagForBackup

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/SingleShardRestoreBackupTask.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
                 "RavenDB-19202 : consider using the most up-to-date database record");
             
-            // add the subscription data to all but one of the shards
+            // add the subscription data to just one of the shards
             // get the minimum in order to ensure we get the same shard every time we reach here
             if (GetMinShard(RestoreSettings.DatabaseRecord.Sharding) != _shardNumber)
                 smuggler._options.OperateOnTypes &= ~DatabaseItemType.Subscriptions;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -69,7 +69,6 @@ using Voron.Data.BTrees;
 using Voron.Data.Tables;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
-//using ShardingConfiguration = Raven.Client.ServerWide.Sharding.ShardingConfiguration;
 
 namespace Raven.Server.ServerWide
 {
@@ -2711,7 +2710,11 @@ namespace Raven.Server.ServerWide
                 case nameof(EditLockModeCommand):
                 case nameof(EditPostgreSqlConfigurationCommand):
                 case nameof(PutIndexHistoryCommand):    
-                case nameof(DeleteIndexHistoryCommand):    
+                case nameof(DeleteIndexHistoryCommand):
+                case nameof(StartBucketMigrationCommand):
+                case nameof(SourceMigrationSendCompletedCommand):
+                case nameof(DestinationMigrationConfirmCommand):
+                case nameof(SourceMigrationCleanupCommand):
                     databaseRecord.EtagForBackup = index;
                     break;
             }

--- a/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/SourceMigrationSendCompletedCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
-using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Sharding

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -49,7 +49,6 @@ using Raven.Server.Documents.Indexes.Sorting;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Indexing;
 using Raven.Server.Integrations.PostgreSQL.Commands;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter;

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -8,7 +8,6 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Raven.Client;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -23,7 +23,6 @@ using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Iteration;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Enumerators;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Voron;

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Utils
         {
             var bucket = GetBucketFor(lowerId);
 
-            if (configuration.Prefixed != null)
+            if (configuration?.Prefixed != null)
             {
                 foreach (var setting in configuration.Prefixed)
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -140,9 +140,9 @@ public partial class RavenTestBase
             return toShard;
         }
 
-        public async Task<ShardingConfiguration> GetShardingConfigurationAsync(IDocumentStore store)
+        public async Task<ShardingConfiguration> GetShardingConfigurationAsync(IDocumentStore store, string database = null)
         {
-            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));
             return record.Sharding;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20162

### Additional description

- changes in `BucketMigrations` and `BucketRanges` should affect the `EtagForBackup`, otherwise incremental backups won't recognize this change in db-record, and sharded restore might end up with a db-record that has wrong `ShardingConfiguration`
- this change fixes flaky test `RestoreShardedDatabaseFromIncrementalBackupAfterBucketMigration`

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
