### PR TITLE
RavenDB-20084: Fix backup status update issue for idle databases (test improvements)

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -25,8 +27,11 @@ namespace SlowTests.Issues;
 
 public class RavenDB_20084 : ClusterTestBase
 {
+    private readonly ITestOutputHelper _output;
+
     public RavenDB_20084(ITestOutputHelper output) : base(output)
     {
+        _output = output;
     }
 
     [Fact]
@@ -53,11 +58,13 @@ public class RavenDB_20084 : ClusterTestBase
                })
         {
             leaderStore.Initialize();
+            var debugInfo = new List<string>();
+            debugInfo.Add($"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
 
             // Populating the database and forcibly transitioning it to an idle state
             await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 1, leaderStore, clusterSize);
 
-            var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 * * * *", incrementalBackupFrequency: $"*/{backupIntervalInMinutes} * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
+            var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 1", incrementalBackupFrequency: $"*/{backupIntervalInMinutes} * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
             var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, leaderStore);
 
             var onGoingTaskBackup = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
@@ -86,25 +93,57 @@ public class RavenDB_20084 : ClusterTestBase
                 DateTime lastBackupTime = default;
                 await WaitForValueAsync(async () =>
                     {
-                        var response = await client.GetAsync($"{leaderServer.WebUrl}/databases");
-                        string result = response.Content.ReadAsStringAsync().Result;
+                        try
+                        {
+                            var response = await client.GetAsync($"{leaderServer.WebUrl}/databases");
+                            string result = response.Content.ReadAsStringAsync().Result;
 
-                        var databaseResponse = serverStoreContext.Sync.ReadForMemory(result, "Databases");
+                            var databaseResponse = serverStoreContext.Sync.ReadForMemory(result, "Databases");
 
-                        if (databaseResponse.TryGet("Databases", out BlittableJsonReaderArray array) == false ||
-                            ((BlittableJsonReaderObject)array[0]).TryGet("BackupInfo", out BlittableJsonReaderObject backupInfo) == false ||
-                            backupInfo == null ||
-                            backupInfo.TryGet("LastBackup", out lastBackupTime) == false)
-                            return false;
+                            if (databaseResponse.TryGet("Databases", out BlittableJsonReaderArray array) == false)
+                            {
+                                debugInfo.Add("Unable to get Databases array from context");
+                                debugInfo.Add(result);
+                                return false;
+                            }
+
+                            if (((BlittableJsonReaderObject)array[0]).TryGet("BackupInfo", out BlittableJsonReaderObject backupInfo) == false)
+                            {
+                                debugInfo.Add("Unable to get BackupInfo from Database");
+                                debugInfo.Add(array.ToString());
+                                return false;
+                            }
+
+                            if (backupInfo == null)
+                            {
+                                debugInfo.Add("Unable to get BackupInfo from Database");
+                                debugInfo.Add(array.ToString());
+                                return false;
+                            }
+
+                            if (backupInfo.TryGet("LastBackup", out lastBackupTime) == false)
+                            {
+                                debugInfo.Add("Unable to get LastBackup from BackupInfo");
+                                debugInfo.Add(backupInfo.ToString());
+                                return false;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            debugInfo.Add(e.Message);
+                        }
 
                         return lastBackupTime >= expectedTime;
                     },
                     expectedVal: true,
-                    timeout: Convert.ToInt32(TimeSpan.FromMinutes(15).TotalMilliseconds),
+                    timeout: Convert.ToInt32(TimeSpan.FromMinutes(5).TotalMilliseconds),
                     interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
-                
-                Assert.True(lastBackupTime >= expectedTime);
-                Assert.Equal(1, leaderServer.ServerStore.IdleDatabases.Count);
+
+                debugInfo.Add($"'lastBackupTime': {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+                debugInfo.Add($"'expectedTime':   {expectedTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+
+                Assert.True(lastBackupTime >= expectedTime,$"lastBackupTime >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                Assert.True(leaderServer.ServerStore.IdleDatabases.Count == 1, $"leaderServer.ServerStore.IdleDatabases.Count == 1: Count is {leaderServer.ServerStore.IdleDatabases.Count}{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
 
                 // Verifying that the cluster storage contains the same value for consistency
                 var operation = new GetPeriodicBackupStatusOperation(taskId);
@@ -118,8 +157,8 @@ public class RavenDB_20084 : ClusterTestBase
                     ? backupStatus.LastIncrementalBackupInternal
                     : backupStatus.LastFullBackupInternal;
 
-                Assert.True(lastBackupTimeInClusterStorage >= expectedTime);
-                Assert.True(lastInternalBackupTimeInClusterStorage >= expectedTime);
+                Assert.True(lastBackupTimeInClusterStorage >= expectedTime, $"lastBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                Assert.True(lastInternalBackupTimeInClusterStorage >= expectedTime, $"lastInternalBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20084/Backup-not-up-to-date-for-offline-and-not-modifed-db-that-was-not-loaded-yet-after-reboot

### Additional description

Increase test stability and add some debugging information to better investigate the cause of failing tests in the future.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed