### PR TITLE
RavenDB-7070 Fixing problem with hanging FastTests due to missing base.Dispose() call in a few tests after introducing ParallelTestBase

### DIFF
--- a/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
@@ -90,12 +90,19 @@ namespace FastTests.Server.Documents.Indexing.Static
 
         public override void Dispose()
         {
-            foreach (var docReader in _docs)
+            try
             {
-                docReader.Dispose();
-            }
+                foreach (var docReader in _docs)
+                {
+                    docReader.Dispose();
+                }
 
-            _ctx.Dispose();
+                _ctx.Dispose();
+            }
+            finally
+            {
+                base.Dispose();
+            }
         }
     }
 }

--- a/test/FastTests/Voron/PostingLists/PostingListLeafPageTests.cs
+++ b/test/FastTests/Voron/PostingLists/PostingListLeafPageTests.cs
@@ -125,9 +125,16 @@ namespace FastTests.Voron.Sets
 
         public override void Dispose()
         {
-            _releaseStr.Dispose();
-            _tx?.Dispose();
-            _env?.Dispose();
+            try
+            {
+                _releaseStr.Dispose();
+                _tx?.Dispose();
+                _env?.Dispose();
+            }
+            finally
+            {
+                base.Dispose();
+            }
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_3620.cs
+++ b/test/SlowTests/Issues/RavenDB_3620.cs
@@ -52,7 +52,14 @@ namespace SlowTests.Issues
 
         public override void Dispose()
         {
-            _client.Dispose();
+            try
+            {
+                _client.Dispose();
+            }
+            finally
+            {
+                base.Dispose();
+            }
         }
     }
 }

--- a/test/Tests.Infrastructure/ParallelTestBase.cs
+++ b/test/Tests.Infrastructure/ParallelTestBase.cs
@@ -56,12 +56,12 @@ public class ParallelTestBase : LinuxRaceConditionWorkAround, IAsyncLifetime
         if (bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_WRITE_RUNNING_TESTS_TO_FILE"), out var writeToFile))
         {
             WriteToFile = writeToFile;
+        }
 
-            if (WriteToFile)
-            {
-                FileName = $"RunningTests-{Guid.NewGuid():N}.txt";
-                Console.WriteLine($"Writing running tests to '{FileName}'.");
-            }
+        if (WriteToFile)
+        {
+            FileName = $"RunningTests-{Guid.NewGuid():N}.txt";
+            Console.WriteLine($"Writing running tests to '{FileName}'.");
         }
     }
 


### PR DESCRIPTION


### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/16281

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
