### PR TITLE
RavenDB-20328 CollectionStatistics should ignore casing

### DIFF
--- a/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
+++ b/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Util;
 using Sparrow.Json.Parsing;
 
@@ -8,7 +9,7 @@ namespace Raven.Client.Documents.Operations
     {
         public CollectionStatistics()
         {
-            Collections = new Dictionary<string, long>();
+            Collections = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         }
 
         public long CountOfDocuments { get; set; }
@@ -40,7 +41,7 @@ namespace Raven.Client.Documents.Operations
     {
         public DetailedCollectionStatistics()
         {
-            Collections = new Dictionary<string, CollectionDetails>();
+            Collections = new Dictionary<string, CollectionDetails>(StringComparer.OrdinalIgnoreCase);
         }
 
         public long CountOfDocuments { get; set; }

--- a/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
+++ b/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
@@ -85,7 +85,7 @@ namespace Raven.Client.Documents.Operations
         {
             using (GetContext(out JsonOperationContext context))
             {
-                var command = operation.GetCommand(_requestExecutor.Conventions, context);
+                var command = operation.GetCommand(RequestExecutor.Conventions, context);
                 ApplyNodeTagAndShardNumberToCommandIfSet(command);
 
                 await RequestExecutor.ExecuteAsync(command, context, sessionInfo: null, token: token).ConfigureAwait(false);
@@ -96,7 +96,7 @@ namespace Raven.Client.Documents.Operations
         {
             using (GetContext(out JsonOperationContext context))
             {
-                var command = operation.GetCommand(_requestExecutor.Conventions, context);
+                var command = operation.GetCommand(RequestExecutor.Conventions, context);
                 ApplyNodeTagAndShardNumberToCommandIfSet(command);
 
                 await RequestExecutor.ExecuteAsync(command, context, sessionInfo: null, token: token).ConfigureAwait(false);

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -108,6 +108,10 @@ namespace Raven.Server.Documents.Sharding.Executors
 
             foreach ((int shardNumber, var topology) in _databaseRecord.Sharding.Shards)
             {
+                // might be when this shard being deleted
+                if (topology.Count == 0)
+                    continue;
+
                 var urls = topology.AllNodes.Select(tag => ServerStore.PublishedServerUrls.SelectUrl(tag, clusterTopology)).ToArray();
 
                 requestExecutors[shardNumber] = RequestExecutor.CreateForShard(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20328

### Additional description

Also in this PR:
In order to inspect the `DocumentStore` in debug shouldn't initialize `RequestExecutor` in the `ctor` of 
`MaintenanceOperationExecutor` / `OperationExecutor` / `DatabaseSmuggler`
