### PR TITLE
RavenDB-20332 Truncate long index/database name

### DIFF
--- a/src/Raven.Studio/typescript/components/common/RichPanel.scss
+++ b/src/Raven.Studio/typescript/components/common/RichPanel.scss
@@ -69,6 +69,12 @@
             min-height: auto;
         }
 
+        .rich-panel-info {
+            .max-width-heading {
+                max-width: 640px;
+            }
+        }
+
         .rich-panel-info,
         .rich-panel-actions {
             padding: bs5variables.$gutter-xs bs5variables.$gutter-sm;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -210,8 +210,8 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                             )}
                         </RichPanelSelect>
 
-                        <RichPanelName>
-                            <a href={editUrl} title={index.name}>
+                        <RichPanelName className="max-width-heading">
+                            <a href={editUrl} title={index.name} className="d-block text-truncate">
                                 {index.name}
                             </a>
                         </RichPanelName>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.scss
@@ -20,12 +20,6 @@
 
 .indexes {
     .indexes-list {
-        .index-name {
-            margin: 0;
-            flex-grow: 1;
-            margin-right: sizes.$gutter;
-        }
-
         .index-properties {
             .properties-value {
                 margin-right: sizes.$gutter-sm;

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -241,11 +241,12 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                 <Input type="checkbox" checked={selected} onChange={toggleSelection} />
                             </RichPanelSelect>
 
-                            <RichPanelName>
+                            <RichPanelName className="max-width-heading">
                                 {canNavigateToDatabase ? (
                                     <a
                                         href={documentsUrl}
                                         className={classNames(
+                                            "d-block text-truncate",
                                             { "link-disabled": db.currentNode.isBeingDeleted },
                                             { "link-shard": db.sharded }
                                         )}
@@ -260,7 +261,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                         {db.name}
                                     </a>
                                 ) : (
-                                    <span title="Database is disabled">
+                                    <span title="Database is disabled" className="d-block text-truncate">
                                         <Icon
                                             icon="database"
                                             addon={db.currentNode.relevant ? "home" : null}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20332

### Additional description
Added max width to the index/database names to prevent overflow

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
