### PR TITLE
RavenDB-20344

### DIFF
--- a/src/Sparrow.Server/Collections/SmallSet.cs
+++ b/src/Sparrow.Server/Collections/SmallSet.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using Sparrow.Utils;
 
 namespace Sparrow.Server.Collections
 {
@@ -199,8 +198,7 @@ namespace Sparrow.Server.Collections
 
             while (elementIdx >= 0)
             {
-                ref TKey current = ref keys[elementIdx];
-                if (current.Equals(key))
+                if (keys[elementIdx].Equals(key))
                     return elementIdx;
 
                 elementIdx--;
@@ -212,15 +210,16 @@ namespace Sparrow.Server.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int RequestWritableBucket()
         {
+            _currentIdx++;
+
             if (_currentIdx >= _length && _overflowStorage == null)
             {
                 var storage = new Dictionary<TKey, TValue>(_currentIdx * 2);
-                for (int i = 0; i <= _currentIdx; i++)
+                for (int i = 0; i < _length; i++)
                     storage[_keys[i]] = _values[i];
                 _overflowStorage = storage;
             }
-            
-            _currentIdx++;
+
             return _currentIdx % _length;
         }
 

--- a/test/FastTests/Sparrow/SmallSet.cs
+++ b/test/FastTests/Sparrow/SmallSet.cs
@@ -194,10 +194,10 @@ namespace FastTests.Sparrow
 
             var Nl = Vector<long>.Count;
             var llSet = new SmallSet<long, long>(Nl);
-            for (int i = 0; i < 2 * Nl; i++)
+            for (int i = 0; i < 4 * Nl; i++)
                 llSet.Add(i, i);
 
-            for (int i = 0; i < 2 * Nl; i++)
+            for (int i = 0; i < 4 * Nl; i++)
             {
                 Assert.True(llSet.TryGetValue(i, out var lv));
                 Assert.Equal(i, lv);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20344

### Additional description
Out of bounds access to the overflow storage in the small set. While unlikely to happen on real world scenarios, it needs to be solved. 

### Type of change
- Bug fix

### How risky is the change?
- Low 