### PR TITLE
RavenDB-20320 - Sharding: Failing test AlphaNumericSorting.basic_sequence_of_characters

### DIFF
--- a/test/SlowTests/Corax/CoraxSlowQueryTests.cs
+++ b/test/SlowTests/Corax/CoraxSlowQueryTests.cs
@@ -399,7 +399,7 @@ public class CoraxSlowQueryTests : RavenTestBase
     }
 
     [Theory]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void Alphanumerical(Options options)
     {
         int size = 100;

--- a/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
+++ b/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
@@ -578,7 +578,7 @@ namespace SlowTests.Tests.Sorting
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void dynamic_query_should_work(Options options)
         {
             var titles = new List<string>
@@ -640,7 +640,7 @@ namespace SlowTests.Tests.Sorting
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void OrderByPrefixes(Options options)
         {
             var localTracks = new List<Track>();
@@ -703,7 +703,7 @@ namespace SlowTests.Tests.Sorting
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void NumbersTests(Options options)
         {
             var localTracks = new List<Track>();

--- a/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
+++ b/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Documents.Indexing;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
@@ -148,8 +147,7 @@ namespace SlowTests.Tests.Sorting
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded, Skip = "RavenDB-20320 Sharding: Failing test AlphaNumericSorting.basic_sequence_of_characters")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void basic_sequence_of_characters(Options options)
         {
             var titles = new List<string>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20320

### Additional description

Use the same implementation for the alpha numeric sorter.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
