### PR TITLE
RavenDB-20240 - Public IP usage in sharding

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -19,7 +19,7 @@ namespace Raven.Client.Http
         }
 
         [Obsolete("Not supported", error: true)]
-        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
+        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool userPrivateUrls = false)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -346,24 +346,26 @@ namespace Raven.Client.Http
             UpdateConnectionLimit(initialUrls);
         }
 
-        public static RequestExecutor Create(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
+        public static RequestExecutor Create(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool usePrivateUrls = false)
         {
-            var executor = new RequestExecutor(databaseName, certificate, conventions, initialUrls);
+            var executor = new RequestExecutor(databaseName, certificate, conventions, initialUrls)
+            {
+                _usePrivateUrls = usePrivateUrls
+            };
             executor._firstTopologyUpdate = executor.FirstTopologyUpdate(initialUrls, GlobalApplicationIdentifier);
             return executor;
         }
 
-        internal static RequestExecutor CreateForServer(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
+        internal static RequestExecutor CreateForServer(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool usePrivateUrls = false)
         {
-            var executor = Create(initialUrls, databaseName, certificate, conventions);
+            var executor = Create(initialUrls, databaseName, certificate, conventions, usePrivateUrls);
             executor._disableClientConfigurationUpdates = true;
             return executor;
         }
-
+        
         internal static RequestExecutor CreateForShard(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
         {
-            var executor = CreateForServer(initialUrls, databaseName, certificate, conventions);
-            executor._usePrivateUrls = true;
+            var executor = CreateForServer(initialUrls, databaseName, certificate, conventions, usePrivateUrls: true);
             return executor;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20240

### Additional description

There was a race between the async function `FirstTopologyUpdate()` that is "fired and forgotten" and between setting `usePrivateUrls=true`. This resulted in the urls shown in the traffic watch to go back and forth between private and public unexpectedly.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
