### PR TITLE
RavenDB-20319 Fixing the problem with dynamic fields creation during re-reduce of map-reduce results on the orchestrator

### DIFF
--- a/src/Corax/Utils/CoraxSpatialPointEntry.cs
+++ b/src/Corax/Utils/CoraxSpatialPointEntry.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using Sparrow;
 
 namespace Corax.Utils;
 
-public readonly struct CoraxSpatialPointEntry
+public class CoraxSpatialPointEntry
 {
     public readonly double Latitude;
 
@@ -16,5 +17,19 @@ public readonly struct CoraxSpatialPointEntry
         Latitude = latitude;
         Longitude = longitude;
         Geohash = geohash;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(this ,obj))
+            return true;
+        if (obj is CoraxSpatialPointEntry csp == false)
+            return false;
+        return Latitude.Equals(csp.Latitude) && Longitude.Equals(csp.Longitude) && Geohash == csp.Geohash;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Latitude, Longitude, Geohash);
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -70,10 +70,8 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
                     //Notice: we are always saving values inside Corax index. This method is explicitly for MapReduce because we have to have JSON as the last item.
                     var blittableValue = TypeConverter.ToBlittableSupportedType(value, out TypeConverter.BlittableSupportedReturnType returnType, flattenArrays: true);
 
-                    if (returnType == TypeConverter.BlittableSupportedReturnType.Ignored)
-                        continue;
-
-                    storedValue[property.Key] = blittableValue;
+                    if (returnType != TypeConverter.BlittableSupportedReturnType.Ignored)
+                        storedValue[property.Key] = blittableValue;
                 }
 
                 InsertRegularField(field, value, indexContext, ref entryWriter, scope);

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -73,6 +73,9 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public virtual bool SupportsDynamicFieldsCreation => true;
 
+        public virtual bool SupportsSpatialFieldsCreation => true;
+
+
         public void SetSourceCollection(string collection, IndexingStatsScope stats)
         {
             SourceCollection = collection;

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -71,6 +71,8 @@ namespace Raven.Server.Documents.Indexes.Static
             _getSpatialField = getSpatialField;
         }
 
+        public virtual bool SupportsDynamicFieldsCreation => true;
+
         public void SetSourceCollection(string collection, IndexingStatsScope stats)
         {
             SourceCollection = collection;
@@ -351,7 +353,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return true;
         }
 
-        public virtual SpatialField GetOrCreateSpatialField(string name)
+        public SpatialField GetOrCreateSpatialField(string name)
         {
             return _getSpatialField(name);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
@@ -12,4 +12,6 @@ public class OrchestratorIndexingScope : CurrentIndexingScope
     }
 
     public override bool SupportsDynamicFieldsCreation => false;
+
+    public override bool SupportsSpatialFieldsCreation => false;
 }

--- a/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Sharding/OrchestratorIndexingScope.cs
@@ -11,8 +11,5 @@ public class OrchestratorIndexingScope : CurrentIndexingScope
     {
     }
 
-    public override SpatialField GetOrCreateSpatialField(string name)
-    {
-        return null;
-    }
+    public override bool SupportsDynamicFieldsCreation => false;
 }

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -661,7 +661,7 @@ namespace Raven.Server.Documents.Indexes.Static
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
 
-            if (CurrentIndexingScope.Current.SupportsDynamicFieldsCreation == false)
+            if (CurrentIndexingScope.Current.SupportsSpatialFieldsCreation == false)
                 return null;
 
             if (lng == null || double.IsNaN(lng.Value))
@@ -680,7 +680,7 @@ namespace Raven.Server.Documents.Indexes.Static
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
 
-            if (CurrentIndexingScope.Current.SupportsDynamicFieldsCreation == false)
+            if (CurrentIndexingScope.Current.SupportsSpatialFieldsCreation == false)
                 return null;
 
             return CurrentIndexingScope.Current.Index.SearchEngineType is SearchEngineType.Lucene
@@ -693,7 +693,7 @@ namespace Raven.Server.Documents.Indexes.Static
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
 
-            if (CurrentIndexingScope.Current.SupportsDynamicFieldsCreation == false)
+            if (CurrentIndexingScope.Current.SupportsSpatialFieldsCreation == false)
                 return null;
 
             return CurrentIndexingScope.Current.GetOrCreateSpatialField(name);

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Corax.Utils;
 using Jint;
 using Jint.Native;
 using Jint.Native.Array;
@@ -225,6 +226,12 @@ namespace Raven.Server.Utils
                 return BlittableSupportedReturnType.Javascript;
 
             if (value is IEnumerable<IFieldable> || value is IFieldable)
+                return BlittableSupportedReturnType.Ignored;
+
+            if (value is IEnumerable<CoraxDynamicItem> || value is CoraxDynamicItem)
+                return BlittableSupportedReturnType.Ignored;
+
+            if (value is IEnumerable<CoraxSpatialPointEntry> || value is CoraxSpatialPointEntry)
                 return BlittableSupportedReturnType.Ignored;
 
             if (value is IDictionary)

--- a/test/SlowTests/Issues/RavenDB-17123.cs
+++ b/test/SlowTests/Issues/RavenDB-17123.cs
@@ -17,9 +17,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded, Skip = "RavenDB-20319 Sharding - Queries - Dynamic fields creation during reduce part in-map reduce indexes")]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19388")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CreateFieldsShouldNotDisplayAsIgnored(Options options)
         {
             var createFieldIndex = new CreateFieldIndex();
@@ -79,8 +77,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19388")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CoraxCanIndexSimpleMap(Options options)
         {
             var simpleIndex = new SimpleIndex();
@@ -112,8 +109,7 @@ namespace SlowTests.Issues
 
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19388")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void SpatialCreateFieldsShouldNotDisplayAsIgnored(Options options)
         {
             var createSpatialFieldIndex = new CreateSpatialFieldIndex();

--- a/test/SlowTests/Issues/RavenDB_16236.cs
+++ b/test/SlowTests/Issues/RavenDB_16236.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "Complex")]
         public void Can_Index_In_Map_Reduce_Nested_Json_Values_That_Are_In_Array(Options options)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20319

### Additional description

Also fixing a problem on Corax where we didn't ignore dynamic / spatial fields during ToBlittableSupportedType() and we put empty arrays in the reduce result.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
