### PR TITLE
RavenDB-20349 - High unmanged memory usage during replication

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -945,14 +945,14 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<DocumentReplicationItem> GetDocumentsFrom(DocumentsOperationContext context, long etag)
+        public IEnumerable<DocumentReplicationItem> GetDocumentsFrom(DocumentsOperationContext context, long etag, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice], etag, 0))
             {
-                yield return DocumentReplicationItem.From(TableValueToDocument(context, ref result.Reader));
+                yield return DocumentReplicationItem.From(TableValueToDocument(context, ref result.Reader, fields));
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -179,11 +179,11 @@ namespace Raven.Server.Documents.Replication
 
         internal static IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentDatabase database, DocumentsOperationContext ctx, long etag, ReplicationStats stats, bool caseInsensitiveCounters)
         {
-            var docs = database.DocumentsStorage.GetDocumentsFrom(ctx, etag + 1);
+            var docs = database.DocumentsStorage.GetDocumentsFrom(ctx, etag + 1, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data);
             var tombs = database.DocumentsStorage.GetTombstonesFrom(ctx, etag + 1);
             var conflicts = database.DocumentsStorage.ConflictsStorage.GetConflictsFrom(ctx, etag + 1).Select(DocumentReplicationItem.From);
             var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
-            var revisions = revisionsStorage.GetRevisionsFrom(ctx, etag + 1, long.MaxValue).Select(DocumentReplicationItem.From);
+            var revisions = revisionsStorage.GetRevisionsFrom(ctx, etag + 1, long.MaxValue, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data).Select(DocumentReplicationItem.From);
             var attachments = database.DocumentsStorage.AttachmentsStorage.GetAttachmentsFrom(ctx, etag + 1);
             var counters = database.DocumentsStorage.CountersStorage.GetCountersFrom(ctx, etag + 1, caseInsensitiveCounters);
             var timeSeries = database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(ctx, etag + 1);

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
@@ -206,6 +206,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override void InnerDispose()
         {
+            Name?.Dispose();
+            ContentType?.Dispose();
             Stream?.Dispose();
         }
     }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/CounterReplicationItem.cs
@@ -105,6 +105,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public override void InnerDispose()
         {
             Values?.Dispose();
+            Collection?.Dispose();
+            Id?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -202,6 +202,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public override void InnerDispose()
         {
             Data?.Dispose();
+            Id?.Dispose();
+            Collection?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -89,6 +89,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override void InnerDispose()
         {
+            Id?.Dispose();
+            Collection?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -103,6 +103,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override void InnerDispose()
         {
+            Collection?.Dispose();
         }
     }
 
@@ -222,6 +223,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override void InnerDispose()
         {
+            Collection?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1850,7 +1850,7 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, long etag, long take)
+        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, long etag, long take, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
 
@@ -1859,12 +1859,12 @@ namespace Raven.Server.Documents.Revisions
                 if (take-- <= 0)
                     yield break;
 
-                var document = TableValueToRevision(context, ref tvr.Reader);
+                var document = TableValueToRevision(context, ref tvr.Reader, fields);
                 yield return document;
             }
         }
 
-        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, string collection, long etag, long take)
+        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, string collection, long etag, long take, DocumentFields fields = DocumentFields.All)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -1880,7 +1880,7 @@ namespace Raven.Server.Documents.Revisions
                 if (take-- <= 0)
                     yield break;
 
-                var document = TableValueToRevision(context, ref tvr.Reader);
+                var document = TableValueToRevision(context, ref tvr.Reader, fields);
                 yield return document;
             }
         }
@@ -1980,28 +1980,50 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        private static unsafe Document TableValueToRevision(JsonOperationContext context, ref TableValueReader tvr)
+        private static unsafe Document TableValueToRevision(JsonOperationContext context, ref TableValueReader tvr, DocumentFields fields = DocumentFields.All)
         {
-            var result = new Document
+            if (fields == DocumentFields.All)
             {
-                StorageId = tvr.Id,
-                LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr),
-                Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr),
-                Etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr),
-                LastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr),
-                Flags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr),
-                TransactionMarker = *(short*)tvr.Read((int)RevisionsTable.TransactionMarker, out int size),
-                ChangeVector = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr),
-                Data = TableValueToData(context, ref tvr)
-            };
+                return new Document
+                {
+                    StorageId = tvr.Id,
+                    LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr),
+                    Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr),
+                    Etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr),
+                    LastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr),
+                    Flags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr),
+                    TransactionMarker = TableValueToShort((int)RevisionsTable.TransactionMarker, nameof(RevisionsTable.TransactionMarker), ref tvr),
+                    ChangeVector = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr),
+                    Data = new BlittableJsonReaderObject(tvr.Read((int)RevisionsTable.Document, out var size), size, context)
+                };
+            }
 
-            return result;
+            return ParseRevisionPartial(context, ref tvr, fields);
         }
 
-        private static unsafe BlittableJsonReaderObject TableValueToData(JsonOperationContext context, ref TableValueReader tvr)
+        private static unsafe Document ParseRevisionPartial(JsonOperationContext context, ref TableValueReader tvr, DocumentFields fields)
         {
-            var ptr = tvr.Read((int)RevisionsTable.Document, out var size);
-            return new BlittableJsonReaderObject(ptr, size, context);
+            var result = new Document();
+
+            if (fields.Contain(DocumentFields.LowerId))
+                result.LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr);
+
+            if (fields.Contain(DocumentFields.Id))
+                result.Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr);
+
+            if (fields.Contain(DocumentFields.Data))
+                result.Data = new BlittableJsonReaderObject(tvr.Read((int)RevisionsTable.Document, out var size), size, context);
+
+            if (fields.Contain(DocumentFields.ChangeVector))
+                result.ChangeVector = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr);
+
+            result.Etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr);
+            result.LastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr);
+            result.Flags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr);
+            result.StorageId = tvr.Id;
+            result.TransactionMarker = TableValueToShort((int)RevisionsTable.TransactionMarker, nameof(RevisionsTable.TransactionMarker), ref tvr);
+
+            return result;
         }
 
         public static unsafe Document ParseRawDataSectionRevisionWithValidation(JsonOperationContext context, ref TableValueReader tvr, int expectedSize, out long etag)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
@@ -44,8 +44,6 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             {
                 foreach (var counterGroup in Counters)
                 {
-                    counterGroup.Id.Dispose();
-                    counterGroup.Collection.Dispose();
                     counterGroup.Dispose();
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20349/High-unmanged-memory-usage-during-replication

### Additional description

This is an issue when we skip a lot of replicated items.
- Dispose the `Id` when we dispose the `DocumentReplicationItem`
- Request only the relevant fields when fetching documents and revisions

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing
