### PR TITLE
RavenDB-18198 Migrate queries tests for sharding

### DIFF
--- a/test/SlowTests/Issues/RavenDB-13349.cs
+++ b/test/SlowTests/Issues/RavenDB-13349.cs
@@ -69,10 +69,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Query_with_nested_JsonPropertyName_inside_select_clause()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Query_with_nested_JsonPropertyName_inside_select_clause(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -100,10 +101,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Query_with_nested_JsonPropertyName_inside_js_projection()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Query_with_nested_JsonPropertyName_inside_js_projection(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-16963.cs
+++ b/test/SlowTests/Issues/RavenDB-16963.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.Corax)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task can_use_keywords_in_include(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_15166.cs
+++ b/test/SlowTests/Issues/RavenDB_15166.cs
@@ -66,10 +66,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Using_Static_Compare()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Using_Static_Compare(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -114,10 +115,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Using_Static_Compare_When_String_Constant_Comes_First()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Using_Static_Compare_When_String_Constant_Comes_First(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -162,10 +164,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Using_Static_Compare_When_String_Constant_And_Compare_Constant_Comes_First()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Using_Static_Compare_When_String_Constant_And_Compare_Constant_Comes_First(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -210,10 +213,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_When_Constant_Comes_First()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_When_Constant_Comes_First(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -234,10 +238,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_When_Comparing_Null()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_When_Comparing_Null(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -257,10 +262,11 @@ namespace SlowTests.Issues
         }
 
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Throws_When_Comparison_Is_Not_Zero()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Throws_When_Comparison_Is_Not_Zero(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -306,10 +312,11 @@ namespace SlowTests.Issues
         }
 
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Throws_When_No_MemberAccess()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Throws_When_No_MemberAccess(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -354,10 +361,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Throws_When_Comparing_To_Non_Constant()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Throws_When_Comparing_To_Non_Constant(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {
@@ -388,10 +396,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Can_Translate_String_Compare_Throws_When_Using_Unsupported_Overload()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Translate_String_Compare_Throws_When_Using_Unsupported_Overload(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var asyncSession = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_19548.cs
+++ b/test/SlowTests/Issues/RavenDB_19548.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,10 +18,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task RawRavenQueryProjectionWithoutNewKeyword()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RawRavenQueryProjectionWithoutNewKeyword(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -125,7 +127,7 @@ from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 
                     var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
-                    Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",
+                    Assert.Contains("Query returning a single function call result must return an object",
                         exception.Result.Message);
                 }
 
@@ -158,7 +160,7 @@ from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 from 'Users' as result select output(result)", asyncDocumentQuery.ToString());
 
                     var exception = Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await asyncDocumentQuery.ToListAsync());
-                    Assert.StartsWith("System.InvalidOperationException: Query returning a single function call result must return an object",
+                    Assert.Contains("Query returning a single function call result must return an object",
                         exception.Result.Message);
                 }
 

--- a/test/SlowTests/Issues/RavenDB_3326.cs
+++ b/test/SlowTests/Issues/RavenDB_3326.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -58,10 +59,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task streaming_and_projections_with_property_rename_Async()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task streaming_and_projections_with_property_rename_Async(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var index = new Customers_ByName();
                 index.Execute(store);

--- a/test/SlowTests/MailingList/ProjectionTests.cs
+++ b/test/SlowTests/MailingList/ProjectionTests.cs
@@ -12,6 +12,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,10 +39,11 @@ namespace SlowTests.MailingList
         }
 
         //This works as expected
-        [Fact]
-        public void ActuallyGetData()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ActuallyGetData(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
                 CreateData(session);
@@ -61,10 +63,11 @@ namespace SlowTests.MailingList
         }
 
         //This works as expected
-        [Fact]
-        public void ShouldBeAbleToProjectIdOntoAnotherFieldCalledId()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldBeAbleToProjectIdOntoAnotherFieldCalledId(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
                 CreateData(session);
@@ -84,10 +87,11 @@ namespace SlowTests.MailingList
         }
 
         //Fails
-        [Fact]
-        public void ShouldBeAbleToProjectIdOntoAnotherName()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldBeAbleToProjectIdOntoAnotherName(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
                 CreateData(session);
@@ -106,10 +110,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void ShouldBeAbleToProjectIdOntoAnotherName_ButIdFieldWillBeFilledAnyway()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldBeAbleToProjectIdOntoAnotherName_ButIdFieldWillBeFilledAnyway(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
                 CreateData(session);
@@ -130,10 +135,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public async Task Projection_WhenUseMethodNotDefineForProjection_ShouldThrowInformativeException()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Projection_WhenUseMethodNotDefineForProjection_ShouldThrowInformativeException(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             using var session = store.OpenAsyncSession();
             
             _ = await session.Query<User>()

--- a/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
+++ b/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Server.Documents.Indexing
         }
 
         [Theory]
-        [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public async Task CanUseExactInAutoIndex(RavenTestParameters config)
         {            
             using (var store = GetDocumentStore(new Options


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18198/Migrate-queries-tests-for-sharding

### Additional description

Migration of querying tests to be run on sharded db

### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
