### PR TITLE
RavenDB-20149 Search - stop-words and `And` operator.

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -5,12 +5,13 @@ using System.IO;
 using System.Linq;
 using Corax.Mappings;
 using Corax.Queries;
+using Voron;
 
 namespace Corax;
 
 public partial class IndexSearcher
 {
-    public IQueryMatch SearchQuery(FieldMetadata field, List<string> termMatches, List<(string Term, Constants.Search.SearchMatchOptions Match)> prefixSuffixMatches, Constants.Search.Operator @operator)
+    public IQueryMatch SearchQuery(FieldMetadata field, IEnumerable<string> values, Constants.Search.Operator @operator)
     {
         AssertFieldIsSearched();
         var searchAnalyzer = field.IsDynamic
@@ -20,39 +21,39 @@ public partial class IndexSearcher
         field = field.ChangeAnalyzer(field.Mode, searchAnalyzer);
         
         IQueryMatch searchQuery = null;
-        
-        if (termMatches?.Count > 0)
+
+        List<Slice> termMatches = null;
+        foreach (var value in values)
         {
-            searchQuery = @operator switch
+            var termType = GetTermType(value);
+            (int startIncrement, int lengthIncrement) = termType switch
             {
-                Constants.Search.Operator.And => AllInQuery(field, termMatches.ToHashSet(), skipEmptyItems: true),
-                Constants.Search.Operator.Or => InQuery(field, termMatches),
-                _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
+                Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
+                Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
+                Constants.Search.SearchMatchOptions.Contains => (1, -1),
+                Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
+                _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
             };
-        }
 
-        for (int termIdx = 0; termIdx < prefixSuffixMatches?.Count; ++termIdx)
-        {
-            var currentItem = prefixSuffixMatches[termIdx];
+            var termReadyToAnalyze = value.AsSpan(startIncrement, value.Length - startIncrement + lengthIncrement);
+            var analyzedTerm = EncodeAndApplyAnalyzer(field, termReadyToAnalyze, canReturnEmptySlice: true);
 
-            (int startIncrement, int lengthIncrement) = currentItem.Match switch
-                {
-                    Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
-                    Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
-                    Constants.Search.SearchMatchOptions.Contains => (1, -1),
-                    Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
-                    _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
-                };
+            if (analyzedTerm.Size == 0)
+                continue; //skip empty results
             
-            var termReadyToAnalyze = prefixSuffixMatches[termIdx].Term.AsSpan(startIncrement, currentItem.Term.Length - startIncrement + lengthIncrement);
-            var term = EncodeAndApplyAnalyzer(field, termReadyToAnalyze);
-
-            var query = prefixSuffixMatches[termIdx].Match switch
+            if (termType is Constants.Search.SearchMatchOptions.TermMatch)
+            {
+                termMatches ??= new();
+                termMatches.Add(analyzedTerm);
+                continue;
+            }
+            
+            var query = termType switch
             {
                 Constants.Search.SearchMatchOptions.TermMatch => throw new InvalidDataException($"{nameof(TermMatch)} is handled in different part of evaluator. This is a bug."),
-                Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, term),
-                Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, term),
-                Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, term),
+                Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, analyzedTerm),
+                Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, analyzedTerm),
+                Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, analyzedTerm),
                 _ => throw new ArgumentOutOfRangeException()
             };
 
@@ -69,7 +70,30 @@ public partial class IndexSearcher
                 _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
             };
         }
+        
+        if (termMatches?.Count > 0)
+        {
+            var termMatchesQuery = @operator switch
+            {
+                Constants.Search.Operator.And => AllInQuery(field, termMatches.ToHashSet(SliceComparer.Instance), skipEmptyItems: true),
+                Constants.Search.Operator.Or => InQuery(field, termMatches),
+                _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
+            };
 
+            if (searchQuery is null)
+                searchQuery = termMatchesQuery;
+            else
+            {
+                searchQuery = @operator switch
+                {
+                    Constants.Search.Operator.Or => Or(termMatchesQuery, searchQuery),
+                    Constants.Search.Operator.And => And(termMatchesQuery, searchQuery),
+                    _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
+                };
+            }
+        }
+
+        
         void AssertFieldIsSearched()
         {
             if (field.Analyzer == null && field.IsDynamic == false)
@@ -77,5 +101,23 @@ public partial class IndexSearcher
         }
 
         return searchQuery ?? TermMatch.CreateEmpty(this, Allocator);
+        
+        
+        Constants.Search.SearchMatchOptions GetTermType(string termValue)
+        {
+            if (string.IsNullOrEmpty(termValue))
+                return Constants.Search.SearchMatchOptions.TermMatch;
+            Constants.Search.SearchMatchOptions mode = default;
+            if (termValue[0] == '*')
+                mode |= Constants.Search.SearchMatchOptions.EndsWith;
+
+            if (termValue[^1] == '*')
+            {
+                if (termValue[^2] != '\\')
+                    mode |= Constants.Search.SearchMatchOptions.StartsWith;
+            }
+
+            return mode;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -827,44 +827,9 @@ internal static class CoraxQueryBuilder
             else
                 QueryBuilderHelper.ThrowInvalidOperatorInSearch(metadata, queryParameters, fieldExpression);
         }
-
-
-        List<string> termMatches = null;
-        List<(string Term, Constants.Search.SearchMatchOptions Match)> othersMatches = null;
         
-        foreach (var v in GetValues())
-        {
-            var type = GetTermType(v);
-            if (type is Constants.Search.SearchMatchOptions.TermMatch)
-            {
-                termMatches ??= new();
-                termMatches.Add(v);
-                continue;
-            }
-
-            othersMatches ??= new();
-            othersMatches.Add((v, type));
-        }
-
-        return indexSearcher.SearchQuery(fieldMetadata, termMatches, othersMatches, @operator);
-
-        Constants.Search.SearchMatchOptions GetTermType(string termValue)
-        {
-            if (string.IsNullOrEmpty(termValue))
-                return Constants.Search.SearchMatchOptions.TermMatch;
-            Constants.Search.SearchMatchOptions mode = default;
-            if (termValue[0] == LuceneQueryHelper.AsteriskChar)
-                mode |= Constants.Search.SearchMatchOptions.EndsWith;
-
-            if (termValue[^1] == LuceneQueryHelper.AsteriskChar)
-            {
-                if (termValue[^2] != '\\')
-                    mode |= Constants.Search.SearchMatchOptions.StartsWith;
-            }
-
-            return mode;
-        }
-
+        return indexSearcher.SearchQuery(fieldMetadata, GetValues(), @operator);
+        
         /*
          * Here we need to deal with value that comes from the user, which means that we
          * have to be careful.

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -65,7 +65,7 @@ public class RawCoraxFlag : StorageTest
         {
             using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
             ;
-            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, null, Constants.Search.Operator.Or);
+            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, Constants.Search.Operator.Or);
             Assert.Equal(1, match.Fill(mem));
             var result = searcher.GetEntryReaderFor(mem[0]);
             result.GetFieldReaderFor(fieldName).Read(out Span<byte> blittableBinary);
@@ -126,7 +126,7 @@ public class RawCoraxFlag : StorageTest
         Span<long> mem = stackalloc long[1024];
         {
             using IndexSearcher searcher = new IndexSearcher(Env, _analyzers);
-            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, null, Constants.Search.Operator.Or);
+            var match = searcher.SearchQuery(_analyzers.GetByFieldId(0).Metadata, new List<string>(){"1"}, Constants.Search.Operator.Or);
             Assert.Equal(1, match.Fill(mem));
             var result = searcher.GetEntryReaderFor(mem[0]);
             result.GetFieldReaderFor(1).Read(out Span<byte> blittableBinary);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20149 

### Additional description

When using the AND operator in `Search`, the `ApplyAnalyzer` (when a field is searched) method removes all stop-words. However, since the words are already split, this will result in an TermMatch.Empty in such case, which is incorrect and returns zero results. To avoid this, we need to prefilter by ourselves (before building primitives). Additionally, since we are checking the results of the analyzer, we do not need to create lists inside `CoraxQueryBuilder`. Creating primitives as soon as possible is preferred to avoid unnecessary allocation of new strings and lists.

### Type of change

- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
