### PR TITLE
RavenDB-17649 Restart database - Added text info

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/databaseSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/databaseSettings.ts
@@ -564,15 +564,22 @@ class databaseSettings extends viewModelBase {
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
-    static readonly howToReloadDatabaseHtml = `<h4>There are two ways to reload the database:</h4>
+    static readonly howToReloadDatabaseHtml = `<h4>There are a few ways to reload the database:</h4>
                                                <ul>
-                                                   <li>
+                                                   <li class="margin-top-sm">
                                                        <small>
-                                                           Disable and then enable the database from the databases view in the Studio.<br>
-                                                           This will reload the database on all the cluster nodes immediately.
+                                                           Restart the database from the databases view in the Studio.<br>
+                                                           This will reload the database instance on the LOCAL node your browser is opened on.<br>
+                                                           Perform this action for each node in the cluster.
                                                        </small>
                                                    </li>
-                                                   <li class="margin-top margin-top-sm">
+                                                   <li class="margin-top-sm">
+                                                       <small>
+                                                           Disable and then enable the database from the databases view in the Studio.<br>
+                                                           This will reload the database on ALL cluster nodes immediately.
+                                                       </small>
+                                                   </li>
+                                                   <li class="margin-top-sm">
                                                        <small>
                                                            Restart RavenDB on all nodes.<br>
                                                            The database settings configuration will become effective per node that is restarted.

--- a/src/Raven.Studio/typescript/viewmodels/resources/databases.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/databases.ts
@@ -82,6 +82,8 @@ class databases extends viewModelBase {
     
     notificationCenter = notificationCenter.instance;
     
+    localNodeTag = ko.observable<string>();
+    
     constructor() {
         super();
 
@@ -155,6 +157,8 @@ class databases extends viewModelBase {
             const selected = this.getSelectedDatabases();
             return selected.filter(x => x.lockMode() === "Unlock");
         });
+
+        this.localNodeTag = this.clusterManager.localNodeTag;
     }
 
     // Override canActivate: we can always load this page, regardless of any system db prompt.
@@ -670,11 +674,15 @@ class databases extends viewModelBase {
             });
     }
 
-    restartDatabase(db: databaseInfo) {
+    restartDatabase(db: databaseInfo): void {
         eventsCollector.default.reportEvent("databases", "restart-database");
         this.changesContext.disconnectIfCurrent(db.asDatabase(), "DatabaseRestarted");
 
-        this.confirmationMessage("Are you sure?", "Restart database?")
+        this.confirmationMessage("Restart database?",
+            `The database will be restarted on <strong>node ${generalUtils.escapeHtml(this.localNodeTag())}</strong>`, {
+            buttons: ["Cancel", "Restart"],
+            html: true
+        })
             .done(result => {
                 if (result.can) {
                     db.inProgressAction("Restarting the database");

--- a/src/Raven.Studio/wwwroot/App/views/database/query/querySyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/querySyntax.html
@@ -12,7 +12,7 @@
                     <div data-bind="text: title"></div>
                     <div class="flex-separator"></div>
                     <small title="Go to RQL documentation" data-bind="visible: $index() === 0">
-                        <a target="_blank" data-bind="attr: { href: 'https://ravendb.net/l/48L1WY/' + $root.clientVersion() }">
+                        <a target="_blank" data-bind="attr: { href: 'https://ravendb.net/l/XXVECG/' + $root.clientVersion() }">
                             <i class="icon-link"></i><span>RQL tutorial</span>
                         </a>
                     </small>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17649/Restart-database-on-a-single-node-button

### Additional description
* Added the local node info in the confirmation message dialog
* Updated the 'how to reload' database text

### Type of change
- Useability fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
Opened issue: 
https://issues.hibernatingrhinos.com/issue/RDoc-2435/Add-info-about-the-new-Restart-Database-option

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
