### PR TITLE
RavenDB-20356 - SlowTests.Sharding.Replication.ShardedExternalReplica…

### DIFF
--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -223,9 +223,6 @@ namespace SlowTests.Sharding.Replication
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store1);
 
-                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store1.Database);
-                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);
-
                 for (int i = 0; i < 50; i++)
                 {
                     var id = $"foo/bar/{i}";
@@ -237,6 +234,9 @@ namespace SlowTests.Sharding.Replication
                     var id = $"users/{i}";
                     Assert.True(WaitForDocument<User>(store1, id, predicate: null, timeout: 30_000));
                 }
+
+                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store1.Database);
+                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);
             }
         }
 
@@ -264,11 +264,12 @@ namespace SlowTests.Sharding.Replication
                 await SetupReplicationAsync(store2, store1);
                 await EnsureReplicatingAsync(store2, store1);
 
-                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store1.Database);
-                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);
-
                 Assert.True(WaitForDocument<User>(store1, "users/1", predicate: u => u.Name == "Queeni", timeout: 30_000));
                 Assert.True(WaitForDocument<User>(store2, "users/1", predicate: u => u.Name == "Queeni", timeout: 30_000));
+
+
+                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store1.Database);
+                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);
             }
         }
 


### PR DESCRIPTION
…tionTests.EnsureNoReplicationLoopInExternalReplicationBetweenTwoShardedDBs

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20356/SlowTests.Sharding.Replication.ShardedExternalReplicationTests.EnsureNoReplicationLoopInExternalReplicationBetweenTwoShardedDBs

### Additional description

I couldn't reproduce the failure, but I added small changes (we should wait for the documents and only then check for replication loops)
Waiting to see if it fails again...


### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
