### PR TITLE
RavenDB-20372: Memory leak issue in RequestExecutor (v5.2)

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2983,8 +2983,10 @@ namespace Raven.Server.ServerWide
                 || serverCertificateChanged
                 || _clusterRequestExecutor.Url.Equals(leaderUrl, StringComparison.OrdinalIgnoreCase) == false)
             {
-                _clusterRequestExecutor?.Dispose();
-                _clusterRequestExecutor = CreateNewClusterRequestExecutor(leaderUrl);
+                var newExecutor = CreateNewClusterRequestExecutor(leaderUrl);
+                var oldExecutor = Interlocked.Exchange(ref _clusterRequestExecutor, newExecutor);
+
+                oldExecutor?.Dispose();
             }
 
             try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20372/Memory-leak-issue-in-RequestExecutor

### Additional description

Introduced the `Interlocked.Exchange` method to safely replace the old cluster request executor with the new one and dispose of the old one, ensuring that the memory leak issue is properly addressed.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed