### PR TITLE
RavenDB-20372: Memory leak issue in RequestExecutor (v5.4)

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -304,8 +304,20 @@ namespace Raven.Client.Http
             }
         }
 
+        ~RequestExecutor()
+        {
+            if (_disposed)
+                return;
+
+            Console.WriteLine($"RequestExecutor wasn't disposed,{Environment.NewLine}{_stackTrace}");
+        }
+
+        private bool _disposed;
+        private string _stackTrace;
+
         protected RequestExecutor(string databaseName, X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls)
         {
+            _stackTrace = Environment.StackTrace;
             _clearContext = new ReturnContext(_requestContexts, dispose: false);
             _doNotClearContext = new ReturnContext(_requestContexts, dispose: true);
 
@@ -313,6 +325,7 @@ namespace Raven.Client.Http
 
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
+                _disposed = true;
                 Cache.Dispose();
                 ContextPool.Dispose();
                 _updateTopologyTimer?.Dispose();

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -304,20 +304,8 @@ namespace Raven.Client.Http
             }
         }
 
-        ~RequestExecutor()
-        {
-            if (_disposed)
-                return;
-
-            Console.WriteLine($"RequestExecutor wasn't disposed,{Environment.NewLine}{_stackTrace}");
-        }
-
-        private bool _disposed;
-        private string _stackTrace;
-
         protected RequestExecutor(string databaseName, X509Certificate2 certificate, DocumentConventions conventions, string[] initialUrls)
         {
-            _stackTrace = Environment.StackTrace;
             _clearContext = new ReturnContext(_requestContexts, dispose: false);
             _doNotClearContext = new ReturnContext(_requestContexts, dispose: true);
 
@@ -325,7 +313,6 @@ namespace Raven.Client.Http
 
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
-                _disposed = true;
                 Cache.Dispose();
                 ContextPool.Dispose();
                 _updateTopologyTimer?.Dispose();

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -231,12 +231,11 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             try
             {
-                var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer);
-                var command = new SetupAliveCommand();
-
+                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
+                    var command = new SetupAliveCommand();
                     await requestExecutor.ExecuteAsync(command, context, token: cts.Token);
                     result.SetupAlive.Time = sp.ElapsedMilliseconds;
                 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3111,8 +3111,10 @@ namespace Raven.Server.ServerWide
                 || serverCertificateChanged
                 || _clusterRequestExecutor.Url.Equals(leaderUrl, StringComparison.OrdinalIgnoreCase) == false)
             {
-                _clusterRequestExecutor?.Dispose();
-                _clusterRequestExecutor = CreateNewClusterRequestExecutor(leaderUrl);
+                var newExecutor = CreateNewClusterRequestExecutor(leaderUrl);
+                var oldExecutor = Interlocked.Exchange(ref _clusterRequestExecutor, newExecutor);
+
+                oldExecutor?.Dispose();
             }
 
             try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20372/Memory-leak-issue-in-RequestExecutor

### Additional description

1. Introduced the `Interlocked.Exchange` method to safely replace the old cluster request executor with the new one and dispose of the old one, ensuring that the memory leak issue is properly addressed.
2. Modified the instantiation of `requestExecutor` to use a `using` statement in the `PingOnce` endpoint, ensuring that the resources are properly disposed after the operation is completed. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed