### PR TITLE
RavenDB-20241 - block choosing mentor node for ongoing tasks external replication, ETLs and periodic backup

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddEtl.cs
@@ -20,6 +20,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
             if(EtlConfiguration<ConnectionString>.GetEtlType(etlConfiguration) == EtlType.Queue)
                 throw new NotSupportedInShardingException("Queue ETLs are currently not supported in sharding");
 
+            etlConfiguration.TryGet(nameof(EtlConfiguration<ConnectionString>.Name), out string name);
+
+            if (etlConfiguration.TryGet(nameof(EtlConfiguration<ConnectionString>.MentorNode), out string mentor) && string.IsNullOrEmpty(mentor) == false)
+                throw new InvalidOperationException($"Can't add or update ETL {name}. Choosing a mentor node for an ongoing task is not supported in sharding.");
+
             base.AssertCanAddOrUpdateEtl(ref etlConfiguration);
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForUpdatePeriodicBackup.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForUpdatePeriodicBackup.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
@@ -17,6 +18,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
             if (configuration.BackupType == BackupType.Snapshot)
                 throw new NotSupportedInShardingException($"Backups of type '{nameof(BackupType.Snapshot)}' are not supported in sharding.");
+
+            if (string.IsNullOrEmpty(configuration.MentorNode) == false)
+                throw new InvalidOperationException($"Can't create or update periodic backup {configuration.Name}. Choosing a mentor node for an ongoing task is not supported in sharding");
 
             base.OnBeforeUpdateConfiguration(ref configuration, context);
         }

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
@@ -79,12 +80,82 @@ namespace Raven.Server.Smuggler.Documents
                 AddWarning(DatabaseRecordItemType.QueueEtls);
             }
 
+            //warn and remove mentor nodes
+            foreach (var externalReplication in databaseRecord.ExternalReplications)
+            {
+                if (string.IsNullOrEmpty(externalReplication.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.ExternalReplications, externalReplication.Name);
+                    externalReplication.MentorNode = null;
+                }
+            }
+            
+            foreach (var queueEtl in databaseRecord.QueueEtls)
+            {
+                if (string.IsNullOrEmpty(queueEtl.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.QueueEtls, queueEtl.Name);
+                    queueEtl.MentorNode = null;
+                }
+            }
+
+            foreach (var ravenEtl in databaseRecord.RavenEtls)
+            {
+                if (string.IsNullOrEmpty(ravenEtl.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.RavenEtls, ravenEtl.Name);
+                    ravenEtl.MentorNode = null;
+                }
+            }
+
+            foreach (var elasticEtl in databaseRecord.ElasticSearchEtls)
+            {
+                if (string.IsNullOrEmpty(elasticEtl.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.ElasticSearchEtls, elasticEtl.Name);
+                    elasticEtl.MentorNode = null;
+                }
+            }
+
+            foreach (var olapEtl in databaseRecord.OlapEtls)
+            {
+                if (string.IsNullOrEmpty(olapEtl.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.OlapEtls, olapEtl.Name);
+                    olapEtl.MentorNode = null;
+                }
+            }
+
+            foreach (var sqlEtl in databaseRecord.SqlEtls)
+            {
+                if (string.IsNullOrEmpty(sqlEtl.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.SqlEtls, sqlEtl.Name);
+                    sqlEtl.MentorNode = null;
+                }
+            }
+
+            foreach (var backup in databaseRecord.PeriodicBackups)
+            {
+                if (string.IsNullOrEmpty(backup.MentorNode) == false)
+                {
+                    AddMentorNodeWarning(DatabaseRecordItemType.PeriodicBackups, backup.Name);
+                    backup.MentorNode = null;
+                }
+            }
+
             _options.OperateOnDatabaseRecordTypes &= ~DatabaseSmugglerOptions.ShardingNotSupportedDatabaseSmugglerOptions;
 
             void AddWarning(DatabaseRecordItemType type, string name = null)
             {
                 var typeMsg = string.IsNullOrEmpty(name) ? $"{type}" : $"{type} task '{name}'";
                 result.AddWarning($"Skipped {typeMsg} - it is currently not supported in Sharding");
+            }
+
+            void AddMentorNodeWarning(DatabaseRecordItemType type, string name = null)
+            {
+                var typeMsg = string.IsNullOrEmpty(name) ? $"{type}" : $"{type} task '{name}'";
+                result.AddWarning($"Removed mentor node for {typeMsg} - it is currently not supported in Sharding");
             }
         }
 

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -675,10 +675,7 @@ namespace SlowTests.Sharding.Replication
                 }
 
                 // add watcher with invalid url to test the failOver on database topology discovery
-                var watcher = new ExternalReplication(dstDB, "connection")
-                {
-                    MentorNode = "B"
-                };
+                var watcher = new ExternalReplication(dstDB, "connection");
                 await AddWatcherToReplicationTopology((DocumentStore)srcStore, watcher, new[] { "http://127.0.0.1:1234", dstLeader.WebUrl });
 
                 using (var dstStore = new DocumentStore
@@ -790,10 +787,7 @@ namespace SlowTests.Sharding.Replication
                 }
 
                 // add watcher with invalid url to test the failOver on database topology discovery
-                var watcher = new ExternalReplication(dstDB, "connection")
-                {
-                    MentorNode = "B"
-                };
+                var watcher = new ExternalReplication(dstDB, "connection");
                 await AddWatcherToReplicationTopology((DocumentStore)srcStore, watcher, new[] { "http://127.0.0.1:1234", dstLeader.WebUrl });
 
                 using (var dstStore = new DocumentStore
@@ -867,10 +861,7 @@ namespace SlowTests.Sharding.Replication
                 }
 
                 // add watcher with invalid url to test the failover on database topology discovery
-                var watcher = new ExternalReplication(dstDB, "connection")
-                {
-                    MentorNode = "B"
-                };
+                var watcher = new ExternalReplication(dstDB, "connection");
                 await AddWatcherToReplicationTopology((DocumentStore)srcStore, watcher, new[] { "http://127.0.0.1:1234", dstLeader.WebUrl });
 
                 using (var dstStore = new DocumentStore


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20241

### Additional description

Blocking mentor node option for ongoing tasks: 
External replication
Priodic backups
Etls

Subscription will support mentor node

Removing set mentor nodes passed by importing and warning the user.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

