### PR TITLE
RavenDB-19960: Enhance test stability - PeriodicBackupTestsSlow.Shoul…

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2783,6 +2783,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotNull(responsibleDatabase);
                 responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
+                var now = DateTime.UtcNow;
+                var expectedNextBackupDateTime = now.Date
+                    .AddHours(now.Hour)
+                    .AddMinutes(now.Minute + 1);
+
                 await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
 
                 // Just to be sure, the DelayUntil value was not set before the task delaying
@@ -2791,18 +2796,27 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Null(backupStatus.DelayUntil);
 
                 // The backup task is running on the mentor node, and the next backup should be scheduled for the next minute (based on the backup configuration) without any errors
-                var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                OngoingTaskBackup onGoingTaskInfo = null;
+                await WaitForValueAsync(async () =>
+                {
+                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+
+                    return onGoingTaskInfo != null &&
+                           leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode &&
+                           onGoingTaskInfo.Error == null &&
+                           expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime &&
+                           onGoingTaskInfo.OnGoingBackup != null &&
+                           onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active;
+                }, expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
                 Assert.NotNull(onGoingTaskInfo);
-                Assert.Equal(leaderServer.ServerStore.NodeTag, onGoingTaskInfo.MentorNode);
-                Assert.Null(onGoingTaskInfo.Error);
-
-                var expectedNextBackupDateTime = DateTime.UtcNow.Date
-                    .AddHours(DateTime.UtcNow.Hour)
-                    .AddMinutes(DateTime.UtcNow.Minute + 1);
-                Assert.Equal(expectedNextBackupDateTime, onGoingTaskInfo.NextBackup.DateTime);
-
+                Assert.True(leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode, userMessage: $"The value of 'leaderServer.ServerStore.NodeTag': {leaderServer.ServerStore.NodeTag} is not equal to 'onGoingTaskInfo.MentorNode': {onGoingTaskInfo.MentorNode}.");
+                Assert.True(onGoingTaskInfo.Error == null, userMessage: $"The onGoingTaskInfo.Error is not null: {onGoingTaskInfo.Error}.");
+                Assert.True(expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime, userMessage: $"The 'expectedNextBackupDateTime': {expectedNextBackupDateTime} is not equal to 'onGoingTaskInfo.NextBackup.DateTime': {onGoingTaskInfo.NextBackup.DateTime}.");
                 Assert.NotNull(onGoingTaskInfo.OnGoingBackup);
-                Assert.Equal(OngoingTaskConnectionStatus.Active, onGoingTaskInfo.TaskConnectionStatus);
+                Assert.True(onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active, userMessage: $"The onGoingTaskInfo.TaskConnectionStatus is {onGoingTaskInfo.TaskConnectionStatus}, which is not {nameof(OngoingTaskConnectionStatus.Active)} as expected.");
 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);
@@ -2811,16 +2825,35 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
                 // The next backup should be scheduled in almost 1 hour on the current periodic backup task
-                var periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
+                Raven.Server.Documents.PeriodicBackup.PeriodicBackup periodicBackup = null;
+                TimeSpan nextBackup = default;
+                WaitForValue(() =>
+                {
+                    periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
+                    nextBackup = periodicBackup.GetNextBackup().TimeSpan;
+
+                    return periodicBackup is { RunningTask: null, RunningBackupStatus: null } &&
+                           nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration;
+                }, expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
                 Assert.NotNull(periodicBackup);
                 Assert.Null(periodicBackup.RunningTask);
                 Assert.Null(periodicBackup.RunningBackupStatus);
-                var nextBackup = periodicBackup.GetNextBackup().TimeSpan;
-                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration, 
-                    $"NextBackup in: `{nextBackup}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
-                    $"delayDuration: `{delayDuration}`");
+                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration,
+                    $"The NextBackup is set for: {nextBackup}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
 
-                onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                await WaitForValueAsync(async () =>
+                {
+                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+
+                    return onGoingTaskInfo != null &&
+                           onGoingTaskInfo.ResponsibleNode.NodeTag == leaderServer.ServerStore.NodeTag;
+                }, expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
                 Assert.NotNull(onGoingTaskInfo);
                 Assert.Equal(onGoingTaskInfo.ResponsibleNode.NodeTag, leaderServer.ServerStore.NodeTag);
 
@@ -2888,30 +2921,43 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         private static async Task AssertNextBackupSchedule(RavenServer serverToObserve, TimeSpan delayDuration, string databaseName, long taskId, Stopwatch sw)
         {
             using (var store = new DocumentStore
-                   {
-                       Urls = new[] { serverToObserve.WebUrl }, 
-                       Conventions = new DocumentConventions { DisableTopologyUpdates = true }, 
-                       Database = databaseName
-                   })
+            {
+                Urls = new[] { serverToObserve.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
             {
                 store.Initialize();
 
                 OngoingTaskBackup onGoingTaskBackup = null;
+                PeriodicBackupStatus backupStatus = null;
                 await WaitForValueAsync(async () =>
                 {
                     onGoingTaskBackup = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return onGoingTaskBackup is { OnGoingBackup: null } &&
-                           onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                           onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration;
-                }, true);
+
+                    if (onGoingTaskBackup?.NextBackup == null ||
+                        onGoingTaskBackup.OnGoingBackup != null ||
+                        (onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
+                        onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration) == false)
+                        return false;
+
+                    backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(onGoingTaskBackup.TaskId))).Status;
+                    return backupStatus is { DelayUntil: { } } &&
+                           backupStatus.DelayUntil == onGoingTaskBackup.NextBackup.DateTime;
+                }, true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
                 Assert.NotNull(onGoingTaskBackup.NextBackup);
-                Assert.NotEqual(onGoingTaskBackup.ResponsibleNode.NodeTag, serverToObserve.ServerStore.NodeTag);
+                Assert.Null(onGoingTaskBackup.OnGoingBackup);
+                Assert.True(onGoingTaskBackup.ResponsibleNode.NodeTag != serverToObserve.ServerStore.NodeTag, userMessage: $"The strings 'onGoingTaskBackup.ResponsibleNode.NodeTag' and 'serverToObserve.ServerStore.NodeTag' are equal, with the value '{onGoingTaskBackup.ResponsibleNode.NodeTag}', but they should be different.");
+                Assert.True(onGoingTaskBackup.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && onGoingTaskBackup.NextBackup.TimeSpan <= delayDuration,
+                    $"The NextBackup is set for: {onGoingTaskBackup.NextBackup.TimeSpan}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
 
                 // DelayUntil value in backup status and the time of scheduled next backup should be equal
-                var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(onGoingTaskBackup.TaskId))).Status;
                 Assert.NotNull(backupStatus);
                 Assert.NotNull(backupStatus.DelayUntil);
-                Assert.Equal(backupStatus.DelayUntil, onGoingTaskBackup.NextBackup.DateTime);
+                Assert.True(backupStatus.DelayUntil == onGoingTaskBackup.NextBackup.DateTime, userMessage: $"The value of 'backupStatus.DelayUntil' is {backupStatus.DelayUntil}, whereas the value of 'onGoingTaskBackup.NextBackup.DateTime' is {onGoingTaskBackup.NextBackup.DateTime}. They are not equal, but they should be.");
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19960/SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.ShouldDelayBackupOnNotResponsibleNode

### Additional description

Increase test stability and add some debugging information to better investigate the cause of failing tests in the future.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed