### PR TITLE
RavenDB-20372: Memory leak issue in RequestExecutor

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -313,6 +313,7 @@ namespace Raven.Client.Http
 
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
+                GC.SuppressFinalize(this);
                 Cache.Dispose();
                 ContextPool.Dispose();
                 _updateTopologyTimer?.Dispose();
@@ -355,7 +356,8 @@ namespace Raven.Client.Http
             {
 #if DEBUG
                 Console.WriteLine($"Finalizer of {GetType()} got an exception:{Environment.NewLine}{e}");
-#endif          // nothing we can do here
+#endif          
+                // nothing we can do here
             }
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -343,6 +343,22 @@ namespace Raven.Client.Http
             UpdateConnectionLimit(initialUrls);
         }
 
+        ~RequestExecutor()
+        {
+            try
+            {
+                Dispose();
+            }
+#pragma warning disable CS0168
+            catch (Exception e)
+#pragma warning restore CS0168
+            {
+#if DEBUG
+                Console.WriteLine($"Finalizer of {GetType()} got an exception:{Environment.NewLine}{e}");
+#endif          // nothing we can do here
+            }
+        }
+
         public static RequestExecutor Create(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
         {
             var executor = new RequestExecutor(databaseName, certificate, conventions, initialUrls);
@@ -1873,6 +1889,7 @@ namespace Raven.Client.Http
             if (_disposeOnceRunner.Disposed)
                 return;
 
+            GC.SuppressFinalize(this);
             _disposeOnceRunner.Dispose();
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1889,7 +1889,6 @@ namespace Raven.Client.Http
             if (_disposeOnceRunner.Disposed)
                 return;
 
-            GC.SuppressFinalize(this);
             _disposeOnceRunner.Dispose();
         }
 

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -55,11 +55,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             // When the server certificate changes, we need to start using the new one.
             // Since the request executor has the old certificate, we will re-create it and it will pick up the new certificate.
             var newRequestExecutor = CreateNewRequestExecutor(_configuration, _serverStore);
-            var oldRequestExecutor = _requestExecutor;
-
             Interlocked.Exchange(ref _requestExecutor, newRequestExecutor);
-
-            oldRequestExecutor?.Dispose();
         }
 
         internal Action<RavenEtl> BeforeActualLoad = null;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2984,9 +2984,7 @@ namespace Raven.Server.ServerWide
                 || _clusterRequestExecutor.Url.Equals(leaderUrl, StringComparison.OrdinalIgnoreCase) == false)
             {
                 var newExecutor = CreateNewClusterRequestExecutor(leaderUrl);
-                var oldExecutor = Interlocked.Exchange(ref _clusterRequestExecutor, newExecutor);
-
-                oldExecutor?.Dispose();
+                Interlocked.Exchange(ref _clusterRequestExecutor, newExecutor);
             }
 
             try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20372/Memory-leak-issue-in-RequestExecutor

### Additional description

Implementation of the RequestExecutor's destructor to address the use-after-free issue.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed