### PR TITLE
RavenDB-20375 use proper cert validation for sharded database changes

### DIFF
--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
@@ -77,7 +77,7 @@ internal abstract class AbstractDatabaseChanges<TDatabaseConnectionState> : IDis
 
     protected abstract TDatabaseConnectionState CreateDatabaseConnectionState(Func<Task> onConnect, Func<Task> onDisconnect);
 
-    private static ClientWebSocket CreateClientWebSocket(RequestExecutor requestExecutor)
+    protected virtual ClientWebSocket CreateClientWebSocket(RequestExecutor requestExecutor)
     {
         var clientWebSocket = new ClientWebSocket();
         if (requestExecutor.Certificate != null)

--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
@@ -79,7 +79,7 @@ public class ShardedChangesClientConnection : AbstractChangesClientConnection<Tr
         _changes = new Dictionary<int, ShardedDatabaseChanges>();
         foreach (var shardToTopology in _context.ShardsTopology)
         {
-            _changes[shardToTopology.Key] = new ShardedDatabaseChanges(_context.ShardExecutor.GetRequestExecutorAt(shardToTopology.Key), ShardHelper.ToShardName(_context.DatabaseName, shardToTopology.Key), onDispose: null, nodeTag: null, _throttleConnection);
+            _changes[shardToTopology.Key] = new ShardedDatabaseChanges(_context.ServerStore, _context.ShardExecutor.GetRequestExecutorAt(shardToTopology.Key), ShardHelper.ToShardName(_context.DatabaseName, shardToTopology.Key), onDispose: null, nodeTag: null, _throttleConnection);
             tasks.Add(_changes[shardToTopology.Key].EnsureConnectedNow());
         }
 

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -118,16 +118,18 @@ namespace Raven.Server.ServerWide
 
         public DocumentConventions DocumentConventionsForOrchestrator => DocumentConventionsForShard;
 
-        private bool ShardingCustomValidationCallback(HttpRequestMessage message, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
+        public bool ShardingCustomValidationCallback(object message, X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
         {
             // We only care about the certificate that the orchestrator going to use and the shard is going to respond
             // In most cases is simply going to be the same certificate
 
-            if (cert.Thumbprint == _serverStore.Server.Certificate.Certificate.Thumbprint)
+            var cert2 = cert as X509Certificate2;
+
+            if (cert2!.Thumbprint == _serverStore.Server.Certificate.Certificate.Thumbprint)
                 return true;
 
             // Here we handle the case of the server certificate replacement 
-            if (cert.GetPublicKeyPinningHash() == _serverStore.Server.Certificate.Certificate.GetPublicKeyPinningHash())
+            if (cert2.GetPublicKeyPinningHash() == _serverStore.Server.Certificate.Certificate.GetPublicKeyPinningHash())
                 return true;
 
             return RequestExecutor.OnServerCertificateCustomValidationCallback(message, cert, chain, errors);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20375

### Additional description

For the database changes on the orchestrator use the same cert validation as for the shard request executor

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
