### PR TITLE
RavenDB-18198 Migrate tests for Corax & Sharding. 

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.Search.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Search.cs
@@ -4,7 +4,9 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using Corax.Mappings;
+using Corax.Pipeline;
 using Corax.Queries;
+using Sparrow;
 using Voron;
 
 namespace Corax;
@@ -23,54 +25,60 @@ public partial class IndexSearcher
         IQueryMatch searchQuery = null;
 
         List<Slice> termMatches = null;
-        foreach (var value in values)
+        foreach (var word in values)
         {
-            var termType = GetTermType(value);
-            (int startIncrement, int lengthIncrement) = termType switch
+            foreach (var token in GetTokens(word))
             {
-                Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
-                Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
-                Constants.Search.SearchMatchOptions.Contains => (1, -1),
-                Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
-                _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
-            };
+                var value = word.AsSpan(token.Offset, (int)token.Length);
+                var termType = GetTermType(value);
+                (int startIncrement, int lengthIncrement) = termType switch
+                {
+                    Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
+                    Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
+                    Constants.Search.SearchMatchOptions.Contains => (1, -1),
+                    Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
+                    _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
+                };
 
-            var termReadyToAnalyze = value.AsSpan(startIncrement, value.Length - startIncrement + lengthIncrement);
-            var analyzedTerm = EncodeAndApplyAnalyzer(field, termReadyToAnalyze, canReturnEmptySlice: true);
+                var termReadyToAnalyze = value.Slice(startIncrement, value.Length - startIncrement + lengthIncrement);
+                var analyzedTerm = EncodeAndApplyAnalyzer(field, termReadyToAnalyze, canReturnEmptySlice: true);
 
-            if (analyzedTerm.Size == 0)
-                continue; //skip empty results
+                if (analyzedTerm.Size == 0)
+                    continue; //skip empty results
             
-            if (termType is Constants.Search.SearchMatchOptions.TermMatch)
-            {
-                termMatches ??= new();
-                termMatches.Add(analyzedTerm);
-                continue;
+                if (termType is Constants.Search.SearchMatchOptions.TermMatch)
+                {
+                    termMatches ??= new();
+                    termMatches.Add(analyzedTerm);
+                    continue;
+                }
+            
+                var query = termType switch
+                {
+                    Constants.Search.SearchMatchOptions.TermMatch => throw new InvalidDataException($"{nameof(TermMatch)} is handled in different part of evaluator. This is a bug."),
+                    Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, analyzedTerm),
+                    Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, analyzedTerm),
+                    Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, analyzedTerm),
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+
+                if (searchQuery is null)
+                {
+                    searchQuery = query;
+                    continue;
+                }
+            
+                searchQuery = @operator switch
+                {
+                    Constants.Search.Operator.Or => Or(searchQuery, query),
+                    Constants.Search.Operator.And => And(searchQuery, query),
+                    _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
+                };
             }
-            
-            var query = termType switch
-            {
-                Constants.Search.SearchMatchOptions.TermMatch => throw new InvalidDataException($"{nameof(TermMatch)} is handled in different part of evaluator. This is a bug."),
-                Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, analyzedTerm),
-                Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, analyzedTerm),
-                Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, analyzedTerm),
-                _ => throw new ArgumentOutOfRangeException()
-            };
 
-            if (searchQuery is null)
-            {
-                searchQuery = query;
-                continue;
-            }
             
-            searchQuery = @operator switch
-            {
-                Constants.Search.Operator.Or => Or(searchQuery, query),
-                Constants.Search.Operator.And => And(searchQuery, query),
-                _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
-            };
         }
-        
+
         if (termMatches?.Count > 0)
         {
             var termMatchesQuery = @operator switch
@@ -103,9 +111,9 @@ public partial class IndexSearcher
         return searchQuery ?? TermMatch.CreateEmpty(this, Allocator);
         
         
-        Constants.Search.SearchMatchOptions GetTermType(string termValue)
+        Constants.Search.SearchMatchOptions GetTermType(ReadOnlySpan<char> termValue)
         {
-            if (string.IsNullOrEmpty(termValue))
+            if (termValue.IsEmpty)
                 return Constants.Search.SearchMatchOptions.TermMatch;
             Constants.Search.SearchMatchOptions mode = default;
             if (termValue[0] == '*')
@@ -119,5 +127,33 @@ public partial class IndexSearcher
 
             return mode;
         }
+        
+        IEnumerable<Token> GetTokens(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                yield return new Token() {Offset = 0, Length = 0};
+                yield break;
+            }
+            
+            //TODO This code in from `WhitespaceTokenizer`. We can optimize it later but for now it should be OK.
+            int i = 0;
+
+            while (i < source.Length)
+            {
+                while (i < source.Length && source[i] == ' ')
+                    i++;
+
+                int start = i;
+                while (i < source.Length && source[i] != ' ')
+                    i++;
+
+                if (start != i)
+                {
+                    yield return new Token() {Offset = start, Length = (uint)(i - start), Type = TokenType.Word};
+                }
+            } 
+        }
+        
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4694,7 +4694,7 @@ namespace Raven.Server.Documents.Indexes
         public void Compact(Action<IOperationProgress> onProgress, CompactionResult result, bool shouldSkipOptimization, CancellationToken token)
         {
             if (IndexPersistence is CoraxIndexPersistence)
-                throw new NotSupportedException($"{nameof(Compact)} is supported for Corax indexes.");
+                throw new NotSupportedException($"{nameof(Compact)} is not supported for Corax indexes.");
 
             AssertCompactionOrOptimizationIsNotInProgress(Name, nameof(Compact));
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
         protected readonly Index _index;
         protected readonly Dictionary<string, IndexField> _fields;
         protected readonly bool _indexImplicitNull;
-        protected readonly bool _indexEmptyEntries;
+        internal readonly bool _indexEmptyEntries;
         protected readonly string _keyFieldName;
         protected readonly bool _storeValue;
         protected readonly string _storeValueFieldName;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -31,7 +31,7 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
 
     public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
         LazyStringValue key, LazyStringValue sourceDocumentId,
-        object doc, JsonOperationContext indexContext, out LazyStringValue id,
+        object doc, JsonOperationContext indexContext, object sourceDocument, out LazyStringValue id,
         out ByteString output, out float? documentBoost, out int fields)
     {
         var boostedValue = doc as BoostedValue;
@@ -67,7 +67,7 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
                     throw new InvalidOperationException($"Field '{property.Key}' is not defined. Available fields: {string.Join(", ", _fields.Keys)}.");
 
                 
-                InsertRegularField(field, value, indexContext, ref entryWriter, scope, out var innerShouldSkip);
+                InsertRegularField(field, value, indexContext, ref entryWriter, sourceDocument, scope, out var innerShouldSkip);
                 shouldSkip &= innerShouldSkip;
                 
                 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -27,7 +27,7 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
     public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
         LazyStringValue key, LazyStringValue sourceDocumentId,
         object doc, JsonOperationContext indexContext, out LazyStringValue id,
-        out ByteString output, out float? documentBoost)
+        out ByteString output, out float? documentBoost, out int fields)
     {
         documentBoost = null; // documents in autoindexes cannot have document boost
         var document = (Document)doc;
@@ -96,7 +96,8 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
                 }
             }
 
-            return entryWriter.Finish(out output);
+            fields = entryWriter.CurrentFieldCount();
+            return entryWriter.Finish(out output, _indexImplicitNull);
         }
         catch
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -26,7 +26,7 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
 
     public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(
         LazyStringValue key, LazyStringValue sourceDocumentId,
-        object doc, JsonOperationContext indexContext, out LazyStringValue id,
+        object doc, JsonOperationContext indexContext, object sourceDocument, out LazyStringValue id,
         out ByteString output, out float? documentBoost, out int fields)
     {
         documentBoost = null; // documents in autoindexes cannot have document boost
@@ -68,11 +68,11 @@ public class CoraxDocumentConverter : CoraxDocumentConverterBase
                             throw new ArgumentOutOfRangeException($"{spatialOptions.MethodType} is not implemented.");
                     }
 
-                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope, out var _);
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, sourceDocument, scope, out var _);
                 }
                 else if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, indexField.OriginalName ?? indexField.Name, out value))
                 {
-                    InsertRegularField(indexField, value, indexContext, ref entryWriter, scope, out var _);
+                    InsertRegularField(indexField, value, indexContext, ref entryWriter, sourceDocument, scope, out var _);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -88,9 +88,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             ByteStringContext<ByteStringMemoryCache>.InternalScope scope = default;
             ByteString data;
             float? documentBoost = null;
+            bool shouldSkip;
             using (Stats.ConvertStats.Start())
             {
-                scope = _converter.SetDocumentFields(key, sourceDocumentId, document, indexContext, out lowerId, out data, out documentBoost);
+                scope = _converter.SetDocument(key, sourceDocumentId, document, indexContext, out lowerId, out data, out documentBoost, out shouldSkip);
             }
             
             if (_dynamicFieldsBuilder != null && _dynamicFieldsBuilder.Count != _indexingScope.CreatedFieldsCount)
@@ -101,7 +102,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             using(scope)
             using (Stats.AddStats.Start())
             {
-                if (data.Length == 0)
+                if (data.Length == 0 || shouldSkip)
                 {
                     DeleteByField(keyFieldName, key, stats);
                     return;
@@ -122,14 +123,15 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             ByteString data;
             ByteStringContext<ByteStringMemoryCache>.InternalScope scope = default;
             float? documentBoost;
+            bool shouldSkip;
             using (Stats.ConvertStats.Start())
             {
-                scope = _converter.SetDocumentFields(key, sourceDocumentId, document, indexContext, out lowerId, out data, out documentBoost);
+                scope = _converter.SetDocument(key, sourceDocumentId, document, indexContext, out lowerId, out data, out documentBoost, out shouldSkip);
             }
             
             using (scope)
             {
-                if (data.Length == 0)
+                if (data.Length == 0 || shouldSkip)
                     return;
 
                 using (Stats.AddStats.Start())

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -43,7 +43,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
         definition.Fields.TryGetValue(Constants.Documents.Indexing.Fields.AllFields, out _allFields);
     }
 
-    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext, out LazyStringValue id, out ByteString output, out float? documentBoost)
+    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext, out LazyStringValue id, out ByteString output, out float? documentBoost, out int fields)
     {
         documentBoost = null;
         // We prepare for the next entry.
@@ -56,7 +56,8 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
             {
                 //nothing to index, finish the job
                 id = null;
-                entryWriter.Finish(out output);
+                entryWriter.Finish(out output, _indexEmptyEntries);
+                fields = 0;
                 return default;
             }
 
@@ -115,7 +116,8 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                 StoreValue(indexContext, ref entryWriter, singleEntryWriterScope, documentToProcess);
             }
 
-            return entryWriter.Finish(out output);
+            fields = entryWriter.CurrentFieldCount();
+            return entryWriter.Finish(out output, _indexEmptyEntries);
         }
         catch
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -43,7 +43,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
         definition.Fields.TryGetValue(Constants.Documents.Indexing.Fields.AllFields, out _allFields);
     }
 
-    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext, out LazyStringValue id, out ByteString output, out float? documentBoost, out int fields)
+    public override ByteStringContext<ByteStringMemoryCache>.InternalScope SetDocumentFields(LazyStringValue key, LazyStringValue sourceDocumentId, object doc, JsonOperationContext indexContext, object sourceDocument, out LazyStringValue id, out ByteString output, out float? documentBoost, out int fields)
     {
         documentBoost = null;
         // We prepare for the next entry.
@@ -131,7 +131,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
         {
             var value = TypeConverter.ToBlittableSupportedType(actualValue, flattenArrays: false, forIndexing: true, engine: documentToProcess.Engine,
                 context: indexContext);
-            InsertRegularField(field, value, indexContext, ref entryWriter, writerScope, out shouldSkip);
+            InsertRegularField(field, value, indexContext, ref entryWriter, sourceDocument, writerScope, out shouldSkip);
         }
 
         static bool TryGetBoostedValue(ObjectInstance valueToCheck, out JsValue value, out float? boost)
@@ -187,7 +187,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                         value = TypeConverter.ToBlittableSupportedType(val, flattenArrays: false, forIndexing: true, engine: documentToProcess.Engine,
                             context: indexContext);
 
-                        InsertRegularField(field, value, indexContext, ref entryWriter, writerScope, out shouldSkip);
+                        InsertRegularField(field, value, indexContext, ref entryWriter, sourceDocument, writerScope, out shouldSkip);
 
                         if (value is IDisposable toDispose1)
                         {
@@ -231,7 +231,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                         return; //Ignoring bad spatial field
                     }
 
-                    InsertRegularField(field, spatial, indexContext, ref entryWriter, writerScope, out shouldSkip);
+                    InsertRegularField(field, spatial, indexContext, ref entryWriter, sourceDocument, writerScope, out shouldSkip);
 
                     shouldProcessAsBlittable = false;
                     return;

--- a/test/FastTests/Client/Queries/RangeQuery.cs
+++ b/test/FastTests/Client/Queries/RangeQuery.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,10 +12,11 @@ namespace FastTests.Client.Queries
         {
         }
 
-        [Fact]
-        public void RangeQuery()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void RangeQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.ExecuteIndex(new AccommodationsIndex());
 

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
@@ -311,7 +311,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void BasicMapIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -472,7 +472,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task BasicMapIndexWithLoad(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -633,7 +633,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void BasicMapReduceIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -815,7 +815,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task BasicMapReduceIndexWithLoad(Options options)
         {
             {
@@ -965,7 +965,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1112,7 +1112,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1304,7 +1304,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task BasicMultiMapIndex(Options options)
         {
             var now = DateTime.UtcNow.Date;
@@ -1518,7 +1518,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void TimeSeriesNamesFor(Options options)
         {
             var now = DateTime.UtcNow.Date;
@@ -1576,7 +1576,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanCalculateNumberOfReferencesCorrectly(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1674,7 +1674,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void ShouldUseOriginalTimeSeriesName(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
@@ -311,7 +311,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void BasicMapIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -472,7 +472,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task BasicMapIndexWithLoad(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -633,7 +633,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void BasicMapReduceIndex(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -815,7 +815,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task BasicMapReduceIndexWithLoad(Options options)
         {
             {
@@ -965,7 +965,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1112,7 +1112,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1576,7 +1576,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task CanCalculateNumberOfReferencesCorrectly(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
+++ b/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
@@ -55,7 +55,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetResultsUsingTermVectors(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -79,7 +79,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetResultsUsingTermVectorsWithDocumentQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -113,7 +113,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanGetResultsUsingTermVectorsAsync(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -137,7 +137,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetResultsUsingStorage(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -161,7 +161,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetResultsUsingTermVectorsAndStorage(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -185,7 +185,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanCompareDocumentsWithIntegerIdentifiers(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -223,7 +223,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanGetResultsWhenIndexHasSlashInIt(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -245,7 +245,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_On_Document_That_Does_Not_Have_High_Enough_Word_Frequency(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -283,7 +283,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Test_With_Lots_Of_Random_Data(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -308,7 +308,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Do_Not_Pass_FieldNames(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -340,7 +340,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Each_Field_Should_Use_Correct_Analyzer(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -400,7 +400,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_Use_Min_Doc_Freq_Param(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -486,7 +486,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_Use_Stop_Words(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -536,7 +536,7 @@ namespace SlowTests.Client.MoreLikeThis
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanMakeDynamicDocumentQueries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
+++ b/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
@@ -54,8 +54,8 @@ namespace SlowTests.Client.MoreLikeThis
             return list;
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetResultsUsingTermVectors(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -78,8 +78,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetResultsUsingTermVectorsWithDocumentQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -112,8 +112,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanGetResultsUsingTermVectorsAsync(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -136,8 +136,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetResultsUsingStorage(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -160,8 +160,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetResultsUsingTermVectorsAndStorage(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -184,8 +184,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanCompareDocumentsWithIntegerIdentifiers(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -222,8 +222,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanGetResultsWhenIndexHasSlashInIt(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -244,8 +244,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Query_On_Document_That_Does_Not_Have_High_Enough_Word_Frequency(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -282,8 +282,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Test_With_Lots_Of_Random_Data(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -307,8 +307,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Do_Not_Pass_FieldNames(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -339,8 +339,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Each_Field_Should_Use_Correct_Analyzer(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -399,8 +399,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Can_Use_Min_Doc_Freq_Param(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -440,7 +440,7 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "No support for boosting")]
         public void Can_Use_Boost_Param(Options options)
@@ -485,8 +485,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void Can_Use_Stop_Words(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -535,8 +535,8 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanMakeDynamicDocumentQueries(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -569,7 +569,7 @@ namespace SlowTests.Client.MoreLikeThis
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "Complex objects are not supposed to be indexed inside Corax.")]
         public void CanMakeDynamicDocumentQueriesWithComplexProperties(Options options)

--- a/test/SlowTests/Core/Indexing/MultiMap.cs
+++ b/test/SlowTests/Core/Indexing/MultiMap.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Core.Indexing
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All )]
         public void CanCreateAndSearchMultiMapIndex(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Core/Streaming/QueryStreaming.cs
+++ b/test/SlowTests/Core/Streaming/QueryStreaming.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanStreamQueryResults(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -85,7 +85,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanStreamQueryResultsWithQueryStatistics(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -139,7 +139,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanStreamQueryResultsWithQueryStatisticsAsync(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -333,7 +333,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryStreamingGetIds(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -371,7 +371,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryStreamingLoadIds(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -410,7 +410,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Streaming_Results_Should_Sort_Properly(Options options)
         {
             using (var documentStore = GetDocumentStore(options))
@@ -458,7 +458,7 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Streaming_Query_Sort_By_Name(Options options)
         {
             using (var documentStore = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RDBC-285.cs
+++ b/test/SlowTests/Issues/RDBC-285.cs
@@ -13,10 +13,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanQueryWithBoostEqZero()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanQueryWithBoostEqZero(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
                 Indexes.WaitForIndexing(store);

--- a/test/SlowTests/Issues/RDBC_390.cs
+++ b/test/SlowTests/Issues/RDBC_390.cs
@@ -1,6 +1,8 @@
 ﻿using FastTests;
 using Orders;
 using Raven.Client.Documents.Queries.Facets;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,10 +14,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void FacetQueryShouldEscapeFieldNameAndDisplayFieldNameProperlyIfNeeded()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void FacetQueryShouldEscapeFieldNameAndDisplayFieldNameProperlyIfNeeded(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RDoc_662.cs
+++ b/test/SlowTests/Issues/RDoc_662.cs
@@ -41,10 +41,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task OfTypeShouldWorkInDocumentQuery()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task OfTypeShouldWorkInDocumentQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new CreateSampleDataOperation());
 

--- a/test/SlowTests/Issues/RavenDB-10144.cs
+++ b/test/SlowTests/Issues/RavenDB-10144.cs
@@ -4,6 +4,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,10 +17,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void DocumentQuerySelectFields()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void DocumentQuerySelectFields(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {                
                 var definition = new IndexDefinitionBuilder<Order>("OrderByCompanyCountryIndex")
                 {

--- a/test/SlowTests/Issues/RavenDB-11721.cs
+++ b/test/SlowTests/Issues/RavenDB-11721.cs
@@ -5,6 +5,8 @@ using Xunit;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
@@ -15,10 +17,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanSwitchFromDocumentQueryToStronglyTypedProjection()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanSwitchFromDocumentQueryToStronglyTypedProjection(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -63,10 +66,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task AsyncCanSwitchFromDocumentQueryToStronglyTypedProjection()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task AsyncCanSwitchFromDocumentQueryToStronglyTypedProjection(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-11796.cs
+++ b/test/SlowTests/Issues/RavenDB-11796.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,10 +14,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void ToStringOnNonStoredMissingFieldShouldNotThrow()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void ToStringOnNonStoredMissingFieldShouldNotThrow(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 // Arrange  
                 store.ExecuteIndex(new BookingIndexFullNameIsFullNameMapStartToBegin());

--- a/test/SlowTests/Issues/RavenDB-12357.cs
+++ b/test/SlowTests/Issues/RavenDB-12357.cs
@@ -1,5 +1,7 @@
-﻿using FastTests;
+﻿using System;
+using FastTests;
 using System.Linq;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -55,10 +57,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void TestProjectingNullProperty2()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void TestProjectingNullProperty2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var s = store.OpenSession())
                 {
@@ -85,7 +88,10 @@ namespace SlowTests.Issues
                     Assert.Equal(1, results.Count);
                     Assert.Null(results[0].SomeProp);
                     Assert.Null(results[0].HasValue);
-                    Assert.Equal("MyDocs/1", results[0].DocId);
+                    if (options.SearchEngineMode is RavenSearchEngineMode.Corax)
+                        Assert.Equal("MyDocs/1", results[0].DocId, StringComparer.InvariantCultureIgnoreCase);
+                    else
+                        Assert.Equal("MyDocs/1", results[0].DocId);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-15693.cs
+++ b/test/SlowTests/Issues/RavenDB-15693.cs
@@ -1,4 +1,5 @@
 ﻿using FastTests;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,10 +14,11 @@ namespace SlowTests.Issues
 #pragma warning restore 649
         }
 
-        [Fact]
-        public void CanQueryOnComplexBoost()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanQueryOnComplexBoost(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             using var s = store.OpenSession();
 
             var q = s.Advanced.DocumentQuery<Doc>()

--- a/test/SlowTests/Issues/RavenDB-16889.cs
+++ b/test/SlowTests/Issues/RavenDB-16889.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,14 +16,34 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void SelectManySimplePredicate()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SelectManySimplePredicate(Options options)
         {
-            TestCase<SelectManySimplePredicateIndex>();
+            if (options.SearchEngineMode is RavenSearchEngineMode.Corax)
+                TestCase<SelectManySimplePredicateIndexCorax>(options);
+            else
+                TestCase<SelectManySimplePredicateIndexLucene>(options);
         }
-        private class SelectManySimplePredicateIndex : AbstractIndexCreationTask<TestObj>
+        private class SelectManySimplePredicateIndexCorax : AbstractIndexCreationTask<TestObj>
         {
-            public SelectManySimplePredicateIndex()
+            public SelectManySimplePredicateIndexCorax()
+            {
+                Map = taggables =>
+                    from taggable in taggables
+                    select new
+                    {
+                        TagsResult = taggable.Tags
+                            .SelectMany((v => v.Value))
+                    };
+                Store("TagsResult", FieldStorage.Yes);
+                Index("TagsResult", FieldIndexing.No);
+            }
+        }
+
+        private class SelectManySimplePredicateIndexLucene : AbstractIndexCreationTask<TestObj>
+        {
+            public SelectManySimplePredicateIndexLucene()
             {
                 Map = taggables =>
                     from taggable in taggables
@@ -35,14 +56,19 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void SelectManyComplexPredicate()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SelectManyComplexPredicate(Options options)
         {
-            TestCase<SelectManyComplexPredicateIndex>();
+            if (options.SearchEngineMode is RavenSearchEngineMode.Corax)
+                TestCase<SelectManyComplexPredicateIndexCorax>(options);
+            else
+                TestCase<SelectManyComplexPredicateIndexLucene>(options);
         }
-        private class SelectManyComplexPredicateIndex : AbstractIndexCreationTask<TestObj>
+        
+        private class SelectManyComplexPredicateIndexLucene : AbstractIndexCreationTask<TestObj>
         {
-            public SelectManyComplexPredicateIndex()
+            public SelectManyComplexPredicateIndexLucene()
             {
                 Map = taggables =>
                     from taggable in taggables
@@ -54,15 +80,35 @@ namespace SlowTests.Issues
                 Store("TagsResult", FieldStorage.Yes);
             }
         }
-
-        [Fact]
-        public void SelectManyComplexPredicate2Args()
+        
+        private class SelectManyComplexPredicateIndexCorax : AbstractIndexCreationTask<TestObj>
         {
-            TestCase<SelectManyComplexPredicate2ArgsIndex>();
+            public SelectManyComplexPredicateIndexCorax()
+            {
+                Map = taggables =>
+                    from taggable in taggables
+                    select new
+                    {
+                        TagsResult = taggable.Tags
+                            .SelectMany((v,i) => v.Value)
+                    };
+                Store("TagsResult", FieldStorage.Yes);
+                Index("TagsResult", FieldIndexing.No);
+            }
         }
-        private class SelectManyComplexPredicate2ArgsIndex : AbstractIndexCreationTask<TestObj>
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SelectManyComplexPredicate2Args(Options options)
         {
-            public SelectManyComplexPredicate2ArgsIndex()
+            if (options.SearchEngineMode is RavenSearchEngineMode.Corax)
+                TestCase<SelectManyComplexPredicate2ArgsIndexCorax>(options);
+            else
+                TestCase<SelectManyComplexPredicate2ArgsIndexLucene>(options);
+        }
+        private class SelectManyComplexPredicate2ArgsIndexLucene : AbstractIndexCreationTask<TestObj>
+        {
+            public SelectManyComplexPredicate2ArgsIndexLucene()
             {
                 Map = taggables =>
                     from taggable in taggables
@@ -74,16 +120,36 @@ namespace SlowTests.Issues
                 Store("TagsResult", FieldStorage.Yes);
             }
         }
-
-        [Fact]
-        public void SelectManySimplePredicate2Args()
+        
+        private class SelectManyComplexPredicate2ArgsIndexCorax : AbstractIndexCreationTask<TestObj>
         {
-            TestCase<SelectManySimplePredicate2ArgsIndex>();
+            public SelectManyComplexPredicate2ArgsIndexCorax()
+            {
+                Map = taggables =>
+                    from taggable in taggables
+                    select new
+                    {
+                        TagsResult = taggable.Tags
+                            .SelectMany((v, i) => v.Value, (pair, valuePair) => valuePair)
+                    };
+                Store("TagsResult", FieldStorage.Yes);
+                Index("TagsResult", FieldIndexing.No);
+            }
         }
 
-        private class SelectManySimplePredicate2ArgsIndex : AbstractIndexCreationTask<TestObj>
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SelectManySimplePredicate2Args(Options options)
         {
-            public SelectManySimplePredicate2ArgsIndex()
+            if (options.SearchEngineMode is RavenSearchEngineMode.Corax) 
+                TestCase<SelectManySimplePredicate2ArgsIndexCorax>(options);
+            else
+                TestCase<SelectManySimplePredicate2ArgsIndexLucene>(options);
+        }
+
+        private class SelectManySimplePredicate2ArgsIndexLucene : AbstractIndexCreationTask<TestObj>
+        {
+            public SelectManySimplePredicate2ArgsIndexLucene()
             {
                 Map = taggables =>
                     from taggable in taggables
@@ -95,10 +161,26 @@ namespace SlowTests.Issues
                 Store("TagsResult", FieldStorage.Yes);
             }
         }
-
-        private void TestCase<T>() where T : AbstractIndexCreationTask<TestObj>, new()
+        
+        private class SelectManySimplePredicate2ArgsIndexCorax : AbstractIndexCreationTask<TestObj>
         {
-            using var store = GetDocumentStore();
+            public SelectManySimplePredicate2ArgsIndexCorax()
+            {
+                Map = taggables =>
+                    from taggable in taggables
+                    select new
+                    {
+                        TagsResult = taggable.Tags
+                            .SelectMany(v => v.Value, (pair, valuePair) => valuePair)
+                    };
+                Store("TagsResult", FieldStorage.Yes);
+                Index("TagsResult", FieldIndexing.No);
+            }
+        }
+
+        private void TestCase<T>(Options options) where T : AbstractIndexCreationTask<TestObj>, new()
+        {
+            using var store = GetDocumentStore(options);
             var index = new T();
             index.Execute(store);
 
@@ -147,6 +229,8 @@ namespace SlowTests.Issues
                     Assert.Equal("value1", query[0]["key2"]);
                 }
             }
+            
+            WaitForUserToContinueTheTest(store);
         }
 
         private class TestObj
@@ -161,10 +245,11 @@ namespace SlowTests.Issues
 #pragma warning restore 649
         }
 
-        [Fact]
-        public void UserTest()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void UserTest(Options options)
         {
-            TestCase<TestIndex>();
+            TestCase<TestIndex>(options);
         }
 
         private class TestIndex : AbstractIndexCreationTask<TestObj>

--- a/test/SlowTests/Issues/RavenDB-17420.cs
+++ b/test/SlowTests/Issues/RavenDB-17420.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Linq.Indexing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,10 +20,11 @@ namespace SlowTests.Issues
             public string Name;
         }
         
-        [Fact]
-        public void Can_use_boost_on_in_query()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_use_boost_on_in_query(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
 
             using (var s = store.OpenSession())
             {

--- a/test/SlowTests/Issues/RavenDB-18657.cs
+++ b/test/SlowTests/Issues/RavenDB-18657.cs
@@ -11,6 +11,8 @@ using Newtonsoft.Json.Serialization;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,10 +24,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task Can_Get_Fields_With_Different_Casing()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Get_Fields_With_Different_Casing(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
 
             var user = new User
             {

--- a/test/SlowTests/Issues/RavenDB-19016.cs
+++ b/test/SlowTests/Issues/RavenDB-19016.cs
@@ -18,7 +18,7 @@ public class RavenDB_19016 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Can_Index_Nested_Document_Change_Different_Collections(Options options)
     {
         using (var server = GetNewServer())

--- a/test/SlowTests/Issues/RavenDB-19016.cs
+++ b/test/SlowTests/Issues/RavenDB-19016.cs
@@ -18,7 +18,7 @@ public class RavenDB_19016 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
     public async Task Can_Index_Nested_Document_Change_Different_Collections(Options options)
     {
         using (var server = GetNewServer())

--- a/test/SlowTests/Issues/RavenDB_10106.cs
+++ b/test/SlowTests/Issues/RavenDB_10106.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,10 +28,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void StartsWithAndEndsWithShouldWorkWithExact()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void StartsWithAndEndsWithShouldWorkWithExact(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new Index1().Execute(store);
 

--- a/test/SlowTests/Issues/RavenDB_10750.cs
+++ b/test/SlowTests/Issues/RavenDB_10750.cs
@@ -68,8 +68,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19393")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void ShouldNotProjectPropertyValueIfOnlyViewedStoredIndexedValue(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_10986.cs
+++ b/test/SlowTests/Issues/RavenDB_10986.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using FastTests;
 using Orders;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,10 +14,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void WhereLuceneShouldAllowLeadingWildcards()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void WhereLuceneShouldAllowLeadingWildcards(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_11123.cs
+++ b/test/SlowTests/Issues/RavenDB_11123.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanUseNullInWhereLuceneOrPassExact(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_12030.cs
+++ b/test/SlowTests/Issues/RavenDB_12030.cs
@@ -33,10 +33,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void SimpleFuzzy()
+        [Theory]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void SimpleFuzzy(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -85,7 +86,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void SimpleProximity(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_12334.cs
+++ b/test/SlowTests/Issues/RavenDB_12334.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Map_reduce_results_should_not_contains_implicit_nulls_wich_were_not_indexed(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_12346.cs
+++ b/test/SlowTests/Issues/RavenDB_12346.cs
@@ -2,7 +2,9 @@
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
+using Raven.Server.Documents.Operations;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,10 +16,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanConvertFromQueryToDocumentQuery()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanConvertFromQueryToDocumentQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_12366.cs
+++ b/test/SlowTests/Issues/RavenDB_12366.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.Explanation;
 using Raven.Client.Extensions;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,10 +19,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task MetadataTest()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public async Task MetadataTest(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new DocsIndex().Execute(store);
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Issues/RavenDB_12490.cs
+++ b/test/SlowTests/Issues/RavenDB_12490.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Linq;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,10 +22,11 @@ namespace SlowTests.Issues
             public string[] Strings;
         }
 
-        [Fact]
-        public void ContainsAllWorks()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ContainsAllWorks(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_13644.cs
+++ b/test/SlowTests/Issues/RavenDB_13644.cs
@@ -460,7 +460,6 @@ namespace SlowTests.Issues
                 
                 if (options.DatabaseMode is RavenDatabaseMode.Single)
                 {
-                    //TODO I'm not sure but there is some kind of race on sharding? Sometimes this is faster than update of staleness.
                     store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
                     {
                         Assert.True(staleness.IsStale);
@@ -489,12 +488,15 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                if (options.DatabaseMode is RavenDatabaseMode.Single)
                 {
-                    Assert.True(staleness.IsStale);
-                    Assert.Equal(1, staleness.StalenessReasons.Count);
-                    Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[0]);
-                });
+                    store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                    {
+                        Assert.True(staleness.IsStale);
+                        Assert.Equal(1, staleness.StalenessReasons.Count);
+                        Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[0]);
+                    });
+                }
 
                 store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
 
@@ -521,13 +523,16 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                if (options.DatabaseMode is RavenDatabaseMode.Single)
                 {
-                    Assert.True(staleness.IsStale);
-                    Assert.Equal(2, staleness.StalenessReasons.Count);
-                    Assert.Contains("There are still some documents to process from collection", staleness.StalenessReasons[0]);
-                    Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[1]);
-                });
+                    store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                    {
+                        Assert.True(staleness.IsStale);
+                        Assert.Equal(2, staleness.StalenessReasons.Count);
+                        Assert.Contains("There are still some documents to process from collection", staleness.StalenessReasons[0]);
+                        Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[1]);
+                    });
+                }
 
                 store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
 
@@ -555,12 +560,15 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                if (options.DatabaseMode is RavenDatabaseMode.Single)
                 {
-                    Assert.True(staleness.IsStale);
-                    Assert.Equal(1, staleness.StalenessReasons.Count);
-                    Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[0]);
-                });
+                    store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                    {
+                        Assert.True(staleness.IsStale);
+                        Assert.Equal(1, staleness.StalenessReasons.Count);
+                        Assert.Contains("There are still some compare exchange references to process for collection", staleness.StalenessReasons[0]);
+                    });
+                }
 
                 store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
 
@@ -588,12 +596,15 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                if (options.DatabaseMode is RavenDatabaseMode.Single)
                 {
-                    Assert.True(staleness.IsStale);
-                    Assert.Equal(1, staleness.StalenessReasons.Count);
-                    Assert.Contains("There are still some compare exchange tombstone references to process for collection", staleness.StalenessReasons[0]);
-                });
+                    store.Maintenance.ForTesting(() => new GetIndexStalenessOperation(indexName)).AssertAny((_, staleness) =>
+                    {
+                        Assert.True(staleness.IsStale);
+                        Assert.Equal(1, staleness.StalenessReasons.Count);
+                        Assert.Contains("There are still some compare exchange tombstone references to process for collection", staleness.StalenessReasons[0]);
+                    });
+                }
 
                 store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
 

--- a/test/SlowTests/Issues/RavenDB_14084.cs
+++ b/test/SlowTests/Issues/RavenDB_14084.cs
@@ -4,6 +4,7 @@ using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Server.Config;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -43,12 +44,17 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexMissingFieldsAsNull_Auto()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanIndexMissingFieldsAsNull_Auto(Options options)
         {
             using (var store = GetDocumentStore(new Options
             {
-                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.IndexMissingFieldsAsNull)] = "true"
+                ModifyDatabaseRecord = record =>
+                {
+                    options.ModifyDatabaseRecord(record);
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.IndexMissingFieldsAsNull)] = "true";
+                }
             }))
             {
                 using (var session = store.OpenSession())
@@ -77,12 +83,13 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanIndexMissingFieldsAsNull_Static()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanIndexMissingFieldsAsNull_Static(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
-                new Companies_ByUnknown().Execute(store);
+         //       new Companies_ByUnknown().Execute(store);
                 new Companies_ByUnknown_WithIndexMissingFieldsAsNull().Execute(store);
 
                 using (var session = store.OpenSession())
@@ -104,13 +111,13 @@ namespace SlowTests.Issues
                     NoCaching = true
                 }))
                 {
-                    var companies = session
-                        .Advanced
-                        .DocumentQuery<Company, Companies_ByUnknown>()
-                        .WhereEquals("Unknown", (object)null)
-                        .ToList();
+                    // var companies = session
+                    //     .Advanced
+                    //     .DocumentQuery<Company, Companies_ByUnknown>()
+                    //     .WhereEquals("Unknown", (object)null)
+                    //     .ToList();
 
-                    Assert.Equal(0, companies.Count);
+             //       Assert.Equal(0, companies.Count);
                 }
 
                 using (var session = store.OpenSession(new SessionOptions
@@ -123,7 +130,7 @@ namespace SlowTests.Issues
                         .DocumentQuery<Company, Companies_ByUnknown_WithIndexMissingFieldsAsNull>()
                         .WhereEquals("Unknown", (object)null)
                         .ToList();
-
+//WaitForUserToContinueTheTest(store);
                     Assert.Equal(1, companies.Count);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_14084.cs
+++ b/test/SlowTests/Issues/RavenDB_14084.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-         //       new Companies_ByUnknown().Execute(store);
+                new Companies_ByUnknown().Execute(store);
                 new Companies_ByUnknown_WithIndexMissingFieldsAsNull().Execute(store);
 
                 using (var session = store.OpenSession())
@@ -111,13 +111,13 @@ namespace SlowTests.Issues
                     NoCaching = true
                 }))
                 {
-                    // var companies = session
-                    //     .Advanced
-                    //     .DocumentQuery<Company, Companies_ByUnknown>()
-                    //     .WhereEquals("Unknown", (object)null)
-                    //     .ToList();
+                    var companies = session
+                        .Advanced
+                        .DocumentQuery<Company, Companies_ByUnknown>()
+                        .WhereEquals("Unknown", (object)null)
+                        .ToList();
 
-             //       Assert.Equal(0, companies.Count);
+                   Assert.Equal(0, companies.Count);
                 }
 
                 using (var session = store.OpenSession(new SessionOptions
@@ -130,7 +130,6 @@ namespace SlowTests.Issues
                         .DocumentQuery<Company, Companies_ByUnknown_WithIndexMissingFieldsAsNull>()
                         .WhereEquals("Unknown", (object)null)
                         .ToList();
-//WaitForUserToContinueTheTest(store);
                     Assert.Equal(1, companies.Count);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_14116.cs
+++ b/test/SlowTests/Issues/RavenDB_14116.cs
@@ -3,6 +3,8 @@ using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config;
 using System.Linq;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,13 +30,13 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void ShouldIndexAllDocuments()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldIndexAllDocuments(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new Companies_ByPhone().Execute(store);
-
                 using (var commands = store.Commands())
                 {
                     commands.Put(
@@ -72,6 +74,7 @@ namespace SlowTests.Issues
                         .Not
                         .WhereExists(x => x.Phone)
                         .ToList();
+                    WaitForUserToContinueTheTest(store);
 
                     Assert.Equal(1, companies.Count);
                     Assert.Equal("CF", companies[0].Name);

--- a/test/SlowTests/Issues/RavenDB_14703.cs
+++ b/test/SlowTests/Issues/RavenDB_14703.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void ShouldWork(Options options)
         {
             const string mySeries = "I";

--- a/test/SlowTests/Issues/RavenDB_14839.cs
+++ b/test/SlowTests/Issues/RavenDB_14839.cs
@@ -16,7 +16,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "Index mixes value in dynamic array. This is not supported in Corax")]
         public void DocumentQueryWithWhereAndRangeFacetOnTheSamePropertyTest(Options options)
         {
@@ -39,7 +39,6 @@ namespace SlowTests.Issues
                 }
 
                 Indexes.WaitForIndexing(store);
-WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     var documentQuery = session.Advanced.DocumentQuery<Color, Color_ForSearch>()

--- a/test/SlowTests/Issues/RavenDB_15468.cs
+++ b/test/SlowTests/Issues/RavenDB_15468.cs
@@ -16,8 +16,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "RavenDB-19402")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void ShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -97,11 +96,11 @@ namespace SlowTests.Issues
                         .WhereEquals(x => x.SiteId, siteId)
                         .AddOrder(portfolioKey, false, OrderingType.Long);
 
-                    WaitForUserToContinueTheTest(store);
 
                     var orderedIdsList = query.ToList().Select(x => x.Id).ToList();
                     var portfoliosOrder = session.Load<Portfolio>(portfolioId1);
                     Assert.Equal(portfoliosOrder.Projects.Count, orderedIdsList.Count);
+                    WaitForUserToContinueTheTest(store);
 
                     var index = 0;
                     foreach (var id in orderedIdsList)

--- a/test/SlowTests/Issues/RavenDB_15901.cs
+++ b/test/SlowTests/Issues/RavenDB_15901.cs
@@ -53,10 +53,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanGetBoostedValues()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)] 
+        public void CanGetBoostedValues(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 new UsersByName().Execute(store);
 

--- a/test/SlowTests/Issues/RavenDB_16193.cs
+++ b/test/SlowTests/Issues/RavenDB_16193.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using static Raven.Server.Documents.Indexes.IndexStorage;
@@ -18,10 +19,10 @@ namespace SlowTests.Issues
         }
 
 
-        [Fact]
-        public async Task WillGetIndexStatsFromStorageOrReader()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Lucene)]
+        public async Task WillGetIndexStatsFromStorageOrReader(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new StopIndexingOperation());
 

--- a/test/SlowTests/Issues/RavenDB_16301.cs
+++ b/test/SlowTests/Issues/RavenDB_16301.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Queries;
+using Raven.Server.Documents.Operations;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,10 +24,11 @@ namespace SlowTests.Issues
             public string ChangeVector { get; set; }
         }
 
-        [Fact]
-        public void CanUseConditionalLoadLazily()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanUseConditionalLoadLazily(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var bulkInsert = store.BulkInsert())
                 {
@@ -108,10 +111,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanUseConditionalAsyncLoadLazily()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUseConditionalAsyncLoadLazily(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var bulkInsert = store.BulkInsert())
                 {

--- a/test/SlowTests/Issues/RavenDB_16328_Sorters.cs
+++ b/test/SlowTests/Issues/RavenDB_16328_Sorters.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanUseCustomSorter(Options options)
         {
             var sorterName = GetDatabaseName();
@@ -101,7 +101,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanOverrideCustomSorter(Options options)
         {
             var sorterName = GetDatabaseName();
@@ -145,8 +145,9 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.Querying)]
-        public void CanUseCustomSorter_Restart()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void CanUseCustomSorter_Restart(Options options)
         {
             var serverPath = NewDataPath();
             var databasePath = NewDataPath();
@@ -164,6 +165,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
+                ModifyDatabaseRecord = options.ModifyDatabaseRecord,
                 Path = databasePath,
                 RunInMemory = false,
                 Server = server,
@@ -206,6 +208,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
+                ModifyDatabaseRecord = options.ModifyDatabaseRecord,
                 Path = databasePath,
                 RunInMemory = false,
                 Server = server,
@@ -216,8 +219,9 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.Querying)]
-        public void CanUseCustomSorter_Restart_Faulty()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void CanUseCustomSorter_Restart_Faulty(Options options)
         {
             var serverPath = NewDataPath();
             var databasePath = NewDataPath();
@@ -235,6 +239,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
+                ModifyDatabaseRecord = options.ModifyDatabaseRecord,
                 Path = databasePath,
                 RunInMemory = false,
                 Server = server,
@@ -291,6 +296,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
+                ModifyDatabaseRecord = options.ModifyDatabaseRecord,
                 Path = databasePath,
                 RunInMemory = false,
                 Server = server,
@@ -325,13 +331,15 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.Querying)]
-        public void CanGetCustomSorterDiagnostics()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void CanGetCustomSorterDiagnostics(Options options)
         {
             var sorterName = GetDatabaseName();
             using (var store = GetDocumentStore(new Options
             {
-                ModifyDatabaseName = _ => sorterName
+                ModifyDatabaseName = _ => sorterName,
+                ModifyDatabaseRecord = options.ModifyDatabaseRecord
             }))
             {
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Issues/RavenDB_17973.cs
+++ b/test/SlowTests/Issues/RavenDB_17973.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
 using SlowTests.Core.Utils.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using TShirt = SlowTests.Core.Utils.Entities.TShirt;
@@ -16,10 +17,11 @@ public class RavenDB_17973 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void CanPerformIntersectQueryWithFilter()
+    [RavenTheory(RavenTestCategory.Facets | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanPerformIntersectQueryWithFilter(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             new TShirtIndex().Execute(store);
 

--- a/test/SlowTests/Issues/RavenDB_17998.cs
+++ b/test/SlowTests/Issues/RavenDB_17998.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,11 +18,13 @@ public class RavenDB_17998 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void Can_Compact_Index_With_NGram_Analyzer()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void Can_Compact_Index_With_NGram_Analyzer(Options options)
     {
         using (var store = GetDocumentStore(new Options
         {
+            ModifyDatabaseRecord = options.ModifyDatabaseRecord,
             RunInMemory = false
         }))
         {

--- a/test/SlowTests/Issues/RavenDB_3375.cs
+++ b/test/SlowTests/Issues/RavenDB_3375.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQueryPhraseWithEscapedCharacters(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_3381.cs
+++ b/test/SlowTests/Issues/RavenDB_3381.cs
@@ -53,7 +53,8 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All, Skip = "RavenDB-20378")]
         public void WorkWithPostfixWildcard(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_3525.cs
+++ b/test/SlowTests/Issues/RavenDB_3525.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void WithinRadiusOf_NamedSpatialField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_4916.cs
+++ b/test/SlowTests/Issues/RavenDB_4916.cs
@@ -2,6 +2,7 @@
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,10 +14,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void ShouldWork()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void ShouldWork(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_6558.cs
+++ b/test/SlowTests/Issues/RavenDB_6558.cs
@@ -16,7 +16,8 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Highlighting)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All, Skip = "RavenDB-20378")]
         public void CanUseDifferentPreAndPostTagsPerField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_7542.cs
+++ b/test/SlowTests/Issues/RavenDB_7542.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,10 +17,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void Wait_for_non_stale_results_as_of_now_on_index_working_on_all_docs()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Wait_for_non_stale_results_as_of_now_on_index_working_on_all_docs(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition()
                 {

--- a/test/SlowTests/Issues/RavenDB_8328.cs
+++ b/test/SlowTests/Issues/RavenDB_8328.cs
@@ -18,8 +18,8 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenExplicitData(searchEngine: RavenSearchEngineMode.All)]
-        public void SpatialOnAutoIndex(RavenTestParameters config)
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SpatialOnAutoIndex(Options options)
         {
             var databaseName = $"{nameof(SpatialOnAutoIndex)}-{Guid.NewGuid()}";
             var path = NewDataPath();
@@ -28,11 +28,7 @@ namespace SlowTests.Issues
                 Path = path,
                 ModifyDatabaseName = s => databaseName,
                 DeleteDatabaseOnDispose = false,
-                ModifyDatabaseRecord = d =>
-                {
-                    d.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
-                    d.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
-                }
+                ModifyDatabaseRecord = d => options.ModifyDatabaseRecord(d)
             }))
             {
                 using (var session = store.OpenSession())
@@ -89,11 +85,7 @@ namespace SlowTests.Issues
                 Path = path,
                 ModifyDatabaseName = s => databaseName,
                 CreateDatabase = false,
-                ModifyDatabaseRecord = d =>
-                {
-                    d.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = config.SearchEngine.ToString();
-                    d.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString();
-                }
+                ModifyDatabaseRecord = d => options.ModifyDatabaseRecord(d)
             }))
             {
                 var indexes = store.Maintenance.Send(new GetIndexesOperation(0, 10)); // checking it index survived restart

--- a/test/SlowTests/Issues/RavenDB_8462.cs
+++ b/test/SlowTests/Issues/RavenDB_8462.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
 using Orders;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,10 +13,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void Should_be_handled_by_the_same_index()
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void Should_be_handled_by_the_same_index(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_9676.cs
+++ b/test/SlowTests/Issues/RavenDB_9676.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanOrderByDistanceOnDynamicSpatialField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/Brett.cs
+++ b/test/SlowTests/MailingList/Brett.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,12 +22,13 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void TestMultiMap()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void TestMultiMap(Options options)
         {
             Guid accountId = Guid.NewGuid();
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
 
                 //Load Test Data

--- a/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
+++ b/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
@@ -16,7 +16,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanAggregateByMinAndMaxOnSameField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
+++ b/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
@@ -16,7 +16,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanAggregateByMinAndMaxOnSameField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/NicolasGarfinkiel.cs
+++ b/test/SlowTests/MailingList/NicolasGarfinkiel.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -40,10 +42,11 @@ namespace SlowTests.MailingList
 
         }
 
-        [Fact]
-        public void CanQueryDynamically()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanQueryDynamically(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] {  new IndexDefinition()
                 {

--- a/test/SlowTests/MailingList/Nullables.cs
+++ b/test/SlowTests/MailingList/Nullables.cs
@@ -31,7 +31,8 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Skip = "TODO AFTER RavenDB-20268")]
         public void InvalidShirt(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/Nullables.cs
+++ b/test/SlowTests/MailingList/Nullables.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -29,10 +30,11 @@ namespace SlowTests.MailingList
             public Dictionary<string, object> Map { get; set; }
         }
 
-        [Fact]
-        public void InvalidShirt()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void InvalidShirt(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {

--- a/test/SlowTests/MailingList/QueryingOnValueWithMultipleMinusAnalyzed .cs
+++ b/test/SlowTests/MailingList/QueryingOnValueWithMultipleMinusAnalyzed .cs
@@ -3,6 +3,7 @@ using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,10 +15,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void CanPerformQueryWithDashesInTerm()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanPerformQueryWithDashesInTerm(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var indexDefinition = new IndexDefinitionBuilder<Product>()
                 {

--- a/test/SlowTests/MailingList/Samina.cs
+++ b/test/SlowTests/MailingList/Samina.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FastTests;
 using Raven.Client;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,13 +29,14 @@ namespace SlowTests.MailingList
             public string Type { get; set; }
         }
 
-        [Fact]
-        public void Can_search_with_filters()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Can_search_with_filters(Options options)
         {
             Property property = new Property { Id = Guid.NewGuid().ToString(), Name = "Property Name", BedroomCount = 3 };
             Catalog catalog = new Catalog() { Id = Guid.NewGuid().ToString(), Type = "Waterfront", PropertyId = property.Id };
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
 

--- a/test/SlowTests/MailingList/WhereInTests.cs
+++ b/test/SlowTests/MailingList/WhereInTests.cs
@@ -5,6 +5,8 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,10 +18,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void WhereIn_using_index_notAnalyzed()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void WhereIn_using_index_notAnalyzed(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
                 new PersonsNotAnalyzed().Execute(documentStore);
 
@@ -46,11 +49,12 @@ namespace SlowTests.MailingList
             Assert.Equal(perFieldAnalyzerComparer.GetHashCode("Name"), perFieldAnalyzerComparer.GetHashCode("@in<Name>"));
             Assert.True(perFieldAnalyzerComparer.Equals("Name", "@in<Name>"));
         }
-
-        [Fact]
-        public void WhereIn_using_index_analyzed()
+        
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void WhereIn_using_index_analyzed(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
                 new PersonsAnalyzed().Execute(documentStore);
 
@@ -70,10 +74,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void WhereIn_not_using_index()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void WhereIn_not_using_index(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
 
                 string[] names = { "Person One", "PersonTwo" };
@@ -92,10 +97,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void Where_In_using_query_index_notAnalyzed()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Where_In_using_query_index_notAnalyzed(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
                 new PersonsNotAnalyzed().Execute(documentStore);
 
@@ -115,10 +121,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void Where_In_using_query_index_analyzed()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Where_In_using_query_index_analyzed(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
                 new PersonsAnalyzed().Execute(documentStore);
 
@@ -138,10 +145,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void Where_In_using_query()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Where_In_using_query(Options options)
         {
-            using (IDocumentStore documentStore = GetDocumentStore())
+            using (IDocumentStore documentStore = GetDocumentStore(options))
             {
                 string[] names = { "Person One", "PersonTwo" };
 

--- a/test/SlowTests/MailingList/ZNS.cs
+++ b/test/SlowTests/MailingList/ZNS.cs
@@ -60,7 +60,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_SortAndPageMultipleDates(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/ZNS2.cs
+++ b/test/SlowTests/MailingList/ZNS2.cs
@@ -50,7 +50,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_SortAndPageMultipleDates(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/bhiku.cs
+++ b/test/SlowTests/MailingList/bhiku.cs
@@ -23,12 +23,12 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Skip = "Document boost")]
         public void CanUseBoost_StartsWith(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
-
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Student { FirstName = "David", LastName = "Globe" });
@@ -38,7 +38,7 @@ namespace SlowTests.MailingList
                 }
 
                 new Student_ByName().Execute(store);
-
+                
                 using (var session = store.OpenSession())
                 {
                     var students = session.Advanced.DocumentQuery<Student>()
@@ -60,7 +60,8 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Skip = "Document boost")]
         public void CanUseBoost_Equal(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/bhiku.cs
+++ b/test/SlowTests/MailingList/bhiku.cs
@@ -10,6 +10,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq.Indexing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,10 +22,11 @@ namespace SlowTests.MailingList
         {
         }
 
-        [Fact]
-        public void CanUseBoost_StartsWith()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanUseBoost_StartsWith(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
 
                 using (var session = store.OpenSession())
@@ -57,10 +59,11 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
-        public void CanUseBoost_Equal()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanUseBoost_Equal(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/MailingList/chad.cs
+++ b/test/SlowTests/MailingList/chad.cs
@@ -61,7 +61,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanQuerySpatialData(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/MailingList/linmouhong.cs
+++ b/test/SlowTests/MailingList/linmouhong.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using FastTests;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,10 +33,11 @@ namespace SlowTests.MailingList
 #pragma warning restore 649
         }
 
-        [Fact]
-        public void CanCreateProperNestedQuery()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanCreateProperNestedQuery(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8761.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8761.cs
@@ -4,6 +4,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Queries;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,10 +17,11 @@ namespace SlowTests.Server.Documents.Indexing.Auto
         {
         }
 
-        [Fact]
-        public void Can_group_by_array_values()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Can_group_by_array_values(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 PutDocs(store);
 

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9292.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_9292.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,10 +14,11 @@ namespace SlowTests.Server.Documents.Indexing.Auto
         {
         }
 
-        [Fact]
-        public void Group_by_array_and_sum_by_array_items()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void Group_by_array_and_sum_by_array_items(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/Queries/Dynamic/RavenDB_8806.cs
+++ b/test/SlowTests/Server/Documents/Queries/Dynamic/RavenDB_8806.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using FastTests;
+using Raven.Server.Documents.Operations;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,10 +14,11 @@ namespace SlowTests.Server.Documents.Queries.Dynamic
         {
         }
 
-        [Fact]
-        public void Can_stream_dynamic_query()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_stream_dynamic_query(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/SlowTests/Faceted/FacetPaging.cs
+++ b/test/SlowTests/SlowTests/Faceted/FacetPaging.cs
@@ -78,7 +78,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc(Options options)
         {
             //also specify more results than we have
@@ -134,7 +134,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc(Options options)
         {
             //also specify more results than we have
@@ -191,7 +191,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc(Options options)
         {
             //also specify more results than we have
@@ -248,7 +248,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_TermDesc(Options options)
         {
             //also specify more results than we have
@@ -305,7 +305,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_TermAsc(Options options)
         {
             //also specify more results than we have
@@ -362,7 +362,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_HitsDesc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -419,7 +419,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_HitsAsc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -476,7 +476,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_TermDesc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -533,7 +533,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithPageSize_TermAsc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -590,7 +590,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithNoPageSizeNoMaxResults_HitsDesc_LuceneQuery(Options options)
         {
             //also specify more results than we have
@@ -647,7 +647,7 @@ namespace SlowTests.SlowTests.Faceted
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
         public void CanPerformFacetedPagingSearchWithNoPageSizeWithMaxResults_HitsDesc_LuceneQuery(Options options)
         {
             //also specify more results than we have

--- a/test/SlowTests/Tests/Queries/Intersection.cs
+++ b/test/SlowTests/Tests/Queries/Intersection.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Tests.Queries
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformIntersectionQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -34,7 +34,7 @@ namespace SlowTests.Tests.Queries
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformIntersectionQuery_Linq(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Queries/Intersection.cs
+++ b/test/SlowTests/Tests/Queries/Intersection.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Tests.Queries
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanPerformIntersectionQuery(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -34,7 +34,7 @@ namespace SlowTests.Tests.Queries
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanPerformIntersectionQuery_Linq(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Querying/HighlightesTests.cs
+++ b/test/SlowTests/Tests/Querying/HighlightesTests.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Tests.Querying
         }
 
         [RavenTheory(RavenTestCategory.Highlighting)]
-        [RavenData("session", SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData("session", SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void SearchWithHighlightes(Options options, string q)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Querying/HighlightesTests.cs
+++ b/test/SlowTests/Tests/Querying/HighlightesTests.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Tests.Querying
         }
 
         [RavenTheory(RavenTestCategory.Highlighting)]
-        [RavenData("session", SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData("session", SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void SearchWithHighlightes(Options options, string q)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Querying/SearchOperator.cs
+++ b/test/SlowTests/Tests/Querying/SearchOperator.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Tests.Querying
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void DynamicLuceneQuery(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
+++ b/test/SlowTests/Tests/Querying/UsingDynamicQueryWithRemoteServer.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Tests.Querying
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void CanPerformDynamicQueryUsingClientLuceneQuery(Options options)
         {
             using (var documentStore = GetDocumentStore(options))

--- a/test/SlowTests/Tests/Spatial/SpatialSorting.cs
+++ b/test/SlowTests/Tests/Spatial/SpatialSorting.cs
@@ -154,7 +154,7 @@ namespace SlowTests.Tests.Spatial
         }
 
         [RavenTheory(RavenTestCategory.Spatial)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanSortByDistanceWOFilteringWDocQueryBySpecifiedField(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Verifications/NullDynamicValues.cs
+++ b/test/SlowTests/Verifications/NullDynamicValues.cs
@@ -3,6 +3,9 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Operations;
+using SlowTests.MailingList;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,10 +23,11 @@ namespace SlowTests.Verifications
             public string Name { get; set; }
         }
 
-        [Fact]
-        public void TransformerOperationWithNullDynamicValues()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void TransformerOperationWithNullDynamicValues(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 PerformTestWithNullDynamicValues(store);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18198

### Additional description

-  Migrate tests for Corax & Sharding. 
- Support of `IndexEmptyEntries` & `IndexMissingFieldsAsNull` in Corax


### Type of change

- Bug fix
- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
