### PR TITLE
RavenDB-20387

### DIFF
--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -376,14 +376,8 @@ namespace Sparrow.Json
             var address = allocation.Address;
 
 #if DEBUG
-            var current = _ptrCurrent;
-
-            var ptrAddress = new IntPtr(address);
-            var ptrCurrent = new IntPtr(current);
-            Debug.Assert(ptrAddress != ptrCurrent, $"address != current ({ptrAddress} != {ptrCurrent} [{nameof(_ptrCurrent)} = {new IntPtr(_ptrCurrent)}])");
             Debug.Assert(allocation.IsReturned == false, "allocation.IsReturned == false");
             allocation.IsReturned = true;
-
 #endif
 
 #if MEM_GUARD
@@ -415,6 +409,14 @@ namespace Sparrow.Json
                 _freed[index] = section;
                 return;
             }
+
+#if DEBUG
+            var current = _ptrCurrent;
+
+            var ptrAddress = new IntPtr(address);
+            var ptrCurrent = new IntPtr(current);
+            Debug.Assert(ptrAddress != ptrCurrent, $"address != current ({ptrAddress} != {ptrCurrent} [{nameof(_ptrCurrent)} = {new IntPtr(_ptrCurrent)}], allocated: {_allocated}, used: {_used})");
+#endif
             // since the returned allocation is at the end of the arena, we can just move
             // the pointer back
             _used -= allocation.SizeInBytes;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20387

### Additional description

- we prematurely were checking if current allocation address is not the same as current block address, the assertion could fail in case when allocation came from _freed (with address being exactly previous _ptrStart) and current block (_ptrCurrent, _ptrStart) during GrowArena was allocated EXACTLY before previous block (and with no size left _allocated - _used = 0) so its _ptrCurrent + _allocated would actually be equal to previous block starting point, hence would equal to the address of the allocation that came from _freed
- if this allocation will go to _freed then the debug assertion is invalid in this case, we should only care about it when we want to return the memory to the end of current block

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
