### PR TITLE
RavenDB-20379 & RavenDB-20300 Test adjustment for Corax | Corax: Field configuration assertion moved into Converter.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
@@ -109,9 +109,6 @@ public static class CoraxIndexingHelpers
         
         foreach (var field in indexDefinition.IndexFields.Values)
         {
-            if (forQuerying == false && index.Type.IsMapReduce() == false && field.Indexing == FieldIndexing.No && field.Storage == FieldStorage.No)
-                throw new InvalidOperationException($"A field `{field.Name}` that is neither indexed nor stored is useless because it cannot be searched or retrieved.");
-            
             var fieldName = field.Name;
             Slice.From(context, fieldName, out Slice fieldNameSlice);
             var fieldId = field.Id;

--- a/test/SlowTests/Issues/RavenDB_14986.cs
+++ b/test/SlowTests/Issues/RavenDB_14986.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Issues
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
         public void CanSetFieldStorageNoAndFieldIndexingNoInMapReduceCorax(Options options) => CanSetFieldStorageNoAndFieldIndexingNoInMapReduce(options, simpleMapReduceErrors =>
         {
-            Assert.Equal(1, simpleMapReduceErrors.Errors.Length);
+            Assert.Equal(25, simpleMapReduceErrors.Errors.Length);
             Assert.True(simpleMapReduceErrors.Errors.All(x => x.Error.Contains("that is neither indexed nor stored is useless because it cannot be searched or retrieved.")));
         });
 

--- a/test/SlowTests/Issues/RavenDB_15568.cs
+++ b/test/SlowTests/Issues/RavenDB_15568.cs
@@ -16,28 +16,39 @@ namespace SlowTests.Issues
         {
         }
 
+        private Action<IndexErrors> _coraxAssertion = simpleMapErrors =>
+        {
+            Assert.Equal(25, simpleMapErrors.Errors.Length);
+            Assert.True(simpleMapErrors.Errors.All(x => x.Error.Contains("that is neither indexed nor stored is useless because it cannot be searched or retrieved.")));
+        };
+        
+        private Action<IndexErrors> _luceneAssertion = simpleMapErrors =>
+        {
+            Assert.Equal(25, simpleMapErrors.Errors.Length);
+            Assert.True(simpleMapErrors.Errors.All(x => x.Error.Contains("it doesn't make sense to have a field that is neither indexed nor stored")));
+        };
+        
         [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-        public void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrorsInCorax(Options options) => SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors(
-            options,
-            simpleMapErrors =>
-            {
-                Assert.Equal(1, simpleMapErrors.Errors.Length);
-                Assert.True(simpleMapErrors.Errors.All(x => x.Error.Contains("that is neither indexed nor stored is useless because it cannot be searched or retrieved.")));
-            });
+        public void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrorsInCorax(Options options) =>
+            SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors<SimpleMapIndexWithDefaultFields>(options, _coraxAssertion);
 
         [RavenTheory(RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        public void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrorsInLucene(Options options) => SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors(
-            options,
-            simpleMapErrors =>
-            {
-                Assert.Equal(25, simpleMapErrors.Errors.Length);
-                Assert.True(simpleMapErrors.Errors.All(x => x.Error.Contains("it doesn't make sense to have a field that is neither indexed nor stored")));
-            });
+        public void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrorsInLucene(Options options) =>
+            SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors<SimpleMapIndexWithDefaultFields>(options, _luceneAssertion);
         
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public void SettingDynamicFieldToNoIndexAndNoStoreShouldGenerateErrorsInCorax(Options options) =>
+            SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors<DynamicItemWhichIsNotIndexed>(options, _coraxAssertion);
+
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        public void SettingDynamicFieldToNoIndexAndNoStoreShouldGenerateErrorsInLucene(Options options) =>
+            SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors<DynamicItemWhichIsNotIndexed>(options, _luceneAssertion);
         
-        private void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors(Options options, Action<IndexErrors> assertion)
+        private void SettingDefaultFieldsToNoIndexAndNoStoreShouldGenerateErrors<TIndex>(Options options, Action<IndexErrors> assertion) where TIndex : AbstractIndexCreationTask, new()
         {
             using (var store = GetDocumentStore(options))
             {
@@ -50,7 +61,7 @@ namespace SlowTests.Issues
 
                     session.SaveChanges();
                 }
-
+                WaitForUserToContinueTheTest(store);
                 Indexes.WaitForIndexing(store, allowErrors: true);
 
                 var errors = Indexes.WaitForIndexingErrors(store);
@@ -58,6 +69,17 @@ namespace SlowTests.Issues
 
                 var simpleMapErrors = errors.Single(x => x.Name == new SimpleMapIndexWithDefaultFields().IndexName);
                 assertion(simpleMapErrors);
+            }
+        }
+
+        private class DynamicItemWhichIsNotIndexed : AbstractIndexCreationTask<Company>
+        {
+            public DynamicItemWhichIsNotIndexed()
+            {
+                Map = companies => companies.Select(doc => new
+                {
+                    Name = doc.Name, _ = CreateField("ExternalId", doc.ExternalId, new CreateFieldOptions() {Indexing = FieldIndexing.No, Storage = FieldStorage.No})
+                });
             }
         }
         

--- a/test/SlowTests/Issues/RavenDB_17130.cs
+++ b/test/SlowTests/Issues/RavenDB_17130.cs
@@ -5,6 +5,9 @@ using Orders;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq.Indexing;
 using Raven.Client.Documents.Operations;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,12 +19,19 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void GetDocumentsFromIndexWithIfEntityIs()
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        public void GetDocumentsFromIndexWithIfEntityIs_Lucene(Options options) => GetDocumentsFromIndexWithIfEntityIs<Color_ForSearch>(options);
+        
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+        public void GetDocumentsFromIndexWithIfEntityIs_Corax(Options options) => GetDocumentsFromIndexWithIfEntityIs<Color_ForSearch_Corax>(options);
+        
+        private void GetDocumentsFromIndexWithIfEntityIs<TIndex>(Options options) where TIndex : AbstractIndexCreationTask, new()
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new Color_ForSearch());
+                store.ExecuteIndex(new TIndex());
                 using (var session = store.OpenSession())
                 {
                     for (int i = 0; i < 10; i++)
@@ -40,27 +50,23 @@ namespace SlowTests.Issues
 
                     session.SaveChanges();
                 }
-
+                
                 Indexes.WaitForIndexing(store);
 
-                var stats = store.Maintenance.Send(new GetStatisticsOperation());
-                Assert.Equal(13, stats.CountOfDocuments); // 10 colors + 1 company + 2x hilo
+                var countOfDocuments = 0L;
+                store.Maintenance.ForTesting(() => new GetStatisticsOperation()).AssertAll((key, statistics) =>  countOfDocuments += statistics.CountOfDocuments);
+                Assert.Equal(13, countOfDocuments); // 10 colors + 1 company + 2x hilo
 
                 using (var session = store.OpenSession())
                 {
-                    var documentQuery = session.Advanced.DocumentQuery<Color_ForSearch.Result, Color_ForSearch>().ToList();
+                    var documentQuery = session.Advanced.DocumentQuery<Color_ForSearch_Corax.Result, TIndex>().ToList();
                     Assert.Equal(10, documentQuery.Count);
                 }
             }
         }
 
-        private class Color_ForSearch : AbstractIndexCreationTask<object, Color_ForSearch.Result>
+        private class Color_ForSearch : AbstractIndexCreationTask<object, Color_ForSearch_Corax.Result>
         {
-            public class Result : Color
-            {
-                public string Query { get; set; }
-            }
-
             public Color_ForSearch()
             {
                 Map = colors => from colorDoc in colors
@@ -72,6 +78,27 @@ namespace SlowTests.Issues
                                     color.CreatedDate,
                                     Query = AsJson(color).Select(x => x.Value),
                                 };
+            }
+        }
+        
+        private class Color_ForSearch_Corax : AbstractIndexCreationTask<object, Color_ForSearch_Corax.Result>
+        {
+            public class Result : Color
+            {
+                public string Query { get; set; }
+            }
+
+            public Color_ForSearch_Corax()
+            {
+                Map = colors => from colorDoc in colors
+                    let color = colorDoc.IfEntityIs<Color>("Colors")
+                    where color != null
+                    select new
+                    {
+                        color.Name,
+                        color.CreatedDate,
+                        Query = AsJson(color).Where(x => x.Key != "@metadata").Select(x => x.Value),
+                    };
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20379 
https://issues.hibernatingrhinos.com/issue/RavenDB-20300 


### Additional description
RavenDB-20379:
In the case of `IfEntityIs` user has to prefilter output since the enumerator returns also `@metadata`, which is a complex object.  User can call `.Select(i => i.ToString())` or just prefilter it with `Where`.

RavenDB-20300:
Moved assertion of field into `Converter` for 
a) fit in current error handling (since throwing at analyzer will not set index as `Faulty`)
b) we've to do the same assertion for dynamic fields.

### Type of change

- Bug fix
- Optimizaiton

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
