### PR TITLE
RavenDB-19745 account attachment stream by bucket

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -1,11 +1,14 @@
-﻿using Raven.Server.Documents.Replication.ReplicationItems;
+﻿using System;
+using Raven.Server.Documents.Replication.ReplicationItems;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
 using Sparrow.Server;
-using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
@@ -40,41 +43,125 @@ namespace Raven.Server.Documents
                 (int)AttachmentsTable.Etag, ref tvr, out slice);
         }
 
+        [StorageIndexEntryKeyGenerator]
+        internal static ByteStringContext.Scope GenerateBucketAndHashForAttachments(Transaction tx, ref TableValueReader tvr, out Slice slice)
+        {
+            return GenerateBucketAndHash(tx, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType, (int)AttachmentsTable.Hash, ref tvr, out slice);
+        }
+
+        private static ByteStringContext.Scope GenerateBucketAndHash(Transaction tx, int keyIndex, int hashIndex, ref TableValueReader tvr, out Slice slice)
+        {
+            var docsCtx = tx.Owner as DocumentsOperationContext;
+            var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(docsCtx!.DocumentDatabase);
+
+            var bucket = GetBucketFromAttachmentKey(keyIndex, tvr, database);
+            bucket = Bits.SwapBytes(bucket);
+
+            var hashPtr = tvr.Read(hashIndex, out var hashSize);
+            var scope = tx.Allocator.Allocate(sizeof(int) + hashSize, out var buffer);
+
+            var span = new Span<byte>(buffer.Ptr, buffer.Length);
+            MemoryMarshal.AsBytes(new Span<int>(ref bucket)).CopyTo(span);
+            new ReadOnlySpan<byte>(hashPtr, hashSize).CopyTo(span[sizeof(int)..]);
+
+            slice = new Slice(buffer);
+            return scope;
+        }
+
+        private static int GetBucketFromAttachmentKey(int keyIndex, TableValueReader tvr, ShardedDocumentDatabase database)
+        {
+            var keyPtr = tvr.Read(keyIndex, out var keySize);
+            int sizeOfDocId = GetSizeOfDocId(new ReadOnlySpan<byte>(keyPtr, keySize));
+            var keySpan = new ReadOnlySpan<byte>(keyPtr, sizeOfDocId);
+            return ShardHelper.GetBucketFor(database.ShardingConfiguration, keySpan);
+        }
+
+        public (long TotalSize, int UniqueAttachmets) GetStreamInfoForBucket(Transaction tx, int bucket)
+        {
+            var table = tx.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
+            var rawBucket = stackalloc byte[sizeof(int)];
+            *(int*)rawBucket = Bits.SwapBytes(bucket);
+
+            var total = 0L;
+            var count = 0;
+            var tree = tx.CreateTree(AttachmentsSlice);
+
+            using (Slice.External(tx.Allocator, rawBucket, sizeof(int), ByteStringType.Immutable, out var bucketSlice))
+            {
+                var startSlice = bucketSlice;
+                foreach (var result in table.SeekForwardFromPrefix(AttachmentsSchema.DynamicKeyIndexes[AttachmentsBucketAndHashSlice], startSlice, bucketSlice, skip: 0))
+                {
+                    if (SliceStructComparer.Instance.Equals(startSlice, result.Key))
+                        continue;
+
+                    count++;
+                    var key = result.Key.Content;
+                    using (Slice.External(tx.Allocator, key.Ptr + sizeof(int), key.Length - sizeof(int), out var hash))
+                    {
+                        var info = tree.GetStreamInfo(hash, writable: false);
+                        total += info->TotalSize;
+                    }
+
+                    startSlice = result.Key.Clone(tx.Allocator);
+                }
+            }
+
+            return (total, count);
+        }
+
         internal static void UpdateBucketStatsForAttachments(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)AttachmentsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size);
-        }
-
-        private void UpdateBucketStatsOnPutOrDeleteStream(DocumentsOperationContext context, Slice attachmentKey, long sizeChange)
-        {
-            if (_documentDatabase is not ShardedDocumentDatabase)
+            if (tx.Owner is not DocumentsOperationContext { DocumentDatabase: ShardedDocumentDatabase documentDatabase })
+            {
+                Debug.Assert(false,$"tx.Owner is not DocumentsOperationContext");
                 return;
-
-            using (GetBucketFromAttachmentKey(context, attachmentKey, out var bucketSlice))
-            {
-                ShardedDocumentsStorage.UpdateBucketStatsInternal(context.Transaction.InnerTransaction, key: bucketSlice, sizeChange: sizeChange);
-            }
-        }
-
-        private static ByteStringContext.Scope GetBucketFromAttachmentKey(DocumentsOperationContext context, Slice attachmentKey, out Slice bucketSlice)
-        {
-            int sizeOfDocId = 0;
-            for (; sizeOfDocId < attachmentKey.Size; sizeOfDocId++)
-            {
-                if (attachmentKey[sizeOfDocId] == SpecialChars.RecordSeparator)
-                    break;
             }
 
-            var database = context.DocumentDatabase as ShardedDocumentDatabase;
-            
-            var bucket = ShardHelper.GetBucketFor(database.ShardingConfiguration, attachmentKey.AsReadOnlySpan()[..sizeOfDocId]);
+            var streamSize = 0L;
+            var tree = tx.CreateTree(AttachmentsSlice);
 
-            var scope = context.Allocator.Allocate(sizeof(int), out var buffer);
-            *(int*)buffer.Ptr = Bits.SwapBytes(bucket);
+            var tvr = oldValue.Pointer != null ? oldValue : newValue;
+            var delete = oldValue.Pointer != null && newValue.Pointer == null;
 
-            bucketSlice = new Slice(buffer);
+            var oldHashPtr = tvr.Read((int)AttachmentsTable.Hash, out var oldHashSize);
+            var size = sizeof(int) + oldHashSize;
+            var buffer = stackalloc byte[size];
 
-            return scope;
+            var old = new Span<byte>(oldHashPtr, oldHashSize);
+            var bufferAsSpan = new Span<byte>(buffer, size);
+            key.AsReadOnlySpan().Slice(0, sizeof(int)).CopyTo(bufferAsSpan);
+            old.CopyTo(bufferAsSpan.Slice(sizeof(int)));
+
+            var schema = documentDatabase.ShardedDocumentsStorage.AttachmentsStorage.AttachmentsSchema;
+            var table = tx.OpenTable(schema, AttachmentsMetadataSlice);
+            using (Slice.External(tx.Allocator, buffer, sizeof(int) + oldHashSize, ByteStringType.Immutable, out var slice))
+            using (Slice.External(tx.Allocator, oldHashPtr, oldHashSize, ByteStringType.Immutable, out var hashSlice))
+            {
+                var refCount = table.GetCountOfMatchesFor(schema.DynamicKeyIndexes[AttachmentsBucketAndHashSlice], slice);
+                switch (refCount)
+                {
+                    case 1:
+                        if (delete)
+                            goto default;
+                        
+                        // unique stream for this bucket was add
+                        var info = tree.GetStreamInfo(hashSlice, writable: false);
+                        Debug.Assert(info != null, $"Try to add stream {hashSlice}, but it is missing");
+                        streamSize = info->TotalSize;
+                        break;
+                    case 0:
+                        // unique stream for this bucket was remove
+                        info = tree.GetStreamInfo(hashSlice, writable: false);
+                        Debug.Assert(info != null, $"Try to remove stream {hashSlice}, but it is missing");
+                        streamSize = -info->TotalSize;
+                        break;
+                    default:
+                        streamSize = 0; // reference to this stream was added/removed
+                        break;
+                }
+            }
+
+            ShardedDocumentsStorage.UpdateBucketStatsInternal(tx, key, ref newValue, changeVectorIndex: (int)AttachmentsTable.ChangeVector, sizeChange: newValue.Size - oldValue.Size + streamSize);
         }
     }
 }

--- a/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
+++ b/src/Voron/Data/Tables/TableSchema.IndexDefinitions.cs
@@ -209,6 +209,8 @@ namespace Voron.Data.Tables
 
             public IndexEntryKeyGenerator GenerateKey;
 
+            public bool SupportDuplicateKeys = false;
+
             public ByteStringContext.Scope GetValue(Transaction tx, ref TableValueReader value,
                 out Slice slice)
             {

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -76,7 +76,7 @@ namespace Voron
             }
         }
 
-        public Slice Clone(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
+        public readonly Slice Clone(ByteStringContext context, ByteStringType type = ByteStringType.Mutable)
         {
             return new Slice(context.Clone(this.Content, type));
         }

--- a/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
@@ -850,7 +850,7 @@ namespace SlowTests.Sharding.Backup
             Assert.Equal(10, result.Documents.ReadCount);
         }
 
-        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding | RavenTestCategory.Attachments)]
         public async Task CanImportUniqueAttachments()
         {
             await using var stream = typeof(ShardedSmugglerTests).Assembly.GetManifestResourceStream("SlowTests.Data.RavenDB_19723.RavenDB_19723.ravendbdump");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19745

### Additional description

Up until now the stream size was accounted only for the first reference based on the attachment tag, which lead to several issues
1. Wrong bucket size estimation, when 2 documents from different bucket referenced the same stream.
2. Upon resharding we might be left only with the stream as part of the bucket.
3. Relying on the tag caused issues during import

It would be more accurate to account stream by bucket and not rely on the tag at all.
To that end a new dynamic index was introduced that compose the bucket with hash, that count the references of a specific stream per bucket and update the stats accordingly.  

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- But break current v6.0 database that include attachments

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
