### PR TITLE
RavenDB-20398 - fix parsing the thread id when the thread name is included in the thread frame

### DIFF
--- a/tools/Raven.Debug/StackTrace/StackTracer.cs
+++ b/tools/Raven.Debug/StackTrace/StackTracer.cs
@@ -71,9 +71,13 @@ namespace Raven.Debug.StackTrace
 
                         // long form for: int.Parse(threadFrame["Thread (".Length..^1)])
                         // Thread id is in the frame name as "Thread (<ID>)"
-                        string template = "Thread (";
+                        const string template = "Thread (";
                         string threadFrame = stackSource.GetFrameName(stackSource.GetFrameIndex(stackIndex), false);
-                        int threadId = int.Parse(threadFrame.Substring(template.Length, threadFrame.Length - (template.Length + 1)));
+
+                        // we are looking for the first index of ) because
+                        // we need to handle a thread name like this: Thread (4008) (.NET IO ThreadPool Worker)
+                        var firstIndex = threadFrame.IndexOf(")"); 
+                        var threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
 
                         if (samplesForThread.TryGetValue(threadId, out var samples))
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20398/Couldnt-get-the-stack-traces

### Additional description

This will parse a thread with a name like `Thread (4008) (.NET IO ThreadPool Worker)`.
(Thread (4008) - we were expecting only this)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing