### PR TITLE
RavenDB-20411 - Display the Unmanaged memory in the threads runtime info

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -70,6 +70,8 @@ namespace Raven.Server.Dashboard
 
         public int? ManagedThreadId { get; set; }
 
+        public long? UnmanagedAllocationsInBytes { get; set; }
+
         public DateTime? StartingTime { get; set; }
 
         public double Duration { get; set; }
@@ -94,6 +96,7 @@ namespace Raven.Server.Dashboard
                 [nameof(CpuUsage)] = CpuUsage,
                 [nameof(Name)] = Name,
                 [nameof(ManagedThreadId)] = ManagedThreadId,
+                [nameof(UnmanagedAllocationsInBytes)] = UnmanagedAllocationsInBytes,
                 [nameof(StartingTime)] = StartingTime,
                 [nameof(Duration)] = Duration,
                 [nameof(TotalProcessorTime)] = TotalProcessorTime,

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -98,6 +98,7 @@ namespace Raven.Server.Utils
 
                             int? managedThreadId = null;
                             string threadName = null;
+                            long? unmanagedAllocations = null;
                             if (threadAllocations.TryGetValue((ulong)thread.Id, out var threadStats))
                             {
                                 managedThreadId = threadStats.ManagedThreadId;
@@ -110,6 +111,8 @@ namespace Raven.Server.Utils
                                 {
                                     threadName = threadStats.Name ?? "Thread Pool Thread";
                                 }
+
+                                unmanagedAllocations = threadStats.TotalAllocated;
                             }
 
                             var threadState = GetThreadInfoOrDefault<ThreadState?>(() => thread.ThreadState);
@@ -119,6 +122,7 @@ namespace Raven.Server.Utils
                                 CpuUsage = threadCpuUsage.Value,
                                 Name = threadName ?? "Unmanaged Thread",
                                 ManagedThreadId = managedThreadId,
+                                UnmanagedAllocationsInBytes = unmanagedAllocations,
 #pragma warning disable CA1416 // Validate platform compatibility
                                 StartingTime = GetThreadInfoOrDefault<DateTime?>(() => thread.StartTime.ToUniversalTime()),
 #pragma warning restore CA1416 // Validate platform compatibility

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -112,6 +112,10 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                         sortable: x => x.CpuUsage,
                         defaultSortOrder: "desc"
                     }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.UnmanagedAllocationsInBytes ? generalUtils.formatBytesToSize(x.UnmanagedAllocationsInBytes, 2) : "N/A", "Unmanged Allocations", "10%", {
+                        sortable: x => x.UnmanagedAllocationsInBytes ?? 0,
+                        defaultSortOrder: "desc",
+                    }),
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Overall CPU Time", "10%", {
                         sortable: x => x.Duration,
                         defaultSortOrder: "desc"
@@ -119,7 +123,7 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Id + " (" + (x.ManagedThreadId || "n/a") + ")", "Thread Id", "10%", {
                         sortable: x => x.Id
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "20%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "10%", {
                         sortable: x => x.StartingTime
                     }),
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.State, "State", "10%", {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20411/Display-the-Unmanaged-memory-in-the-threads-runtime-info

### Additional description

Display the Unmanaged memory in the threads runtime info

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- No UI work is needed
