### PR TITLE
RavenDB-20390: fix sharded subscription with cv set to last document after replication

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -33,6 +33,15 @@ public class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDatabaseSu
         return base.CreateFetcher();
     }
 
+    protected override ConflictStatus GetConflictStatus(Document item)
+    {
+        SubscriptionState.ShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(_database.Name, out var cv);
+        var conflictStatus = ChangeVectorUtils.GetConflictStatus(
+            remoteAsString: item.ChangeVector,
+            localAsString: cv);
+        return conflictStatus;
+    }
+
     protected override bool ShouldSend(Document item, out string reason, out Exception exception, out Document result)
     {
         exception = null;

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -119,9 +119,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
 
             if (Fetcher.FetchingFrom == SubscriptionFetcher.FetchingOrigin.Storage)
             {
-                var conflictStatus = ChangeVectorUtils.GetConflictStatus(
-                    remoteAsString: item.ChangeVector,
-                    localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
+                var conflictStatus = GetConflictStatus(item);
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {
@@ -180,6 +178,14 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                 reason = $"Criteria script threw exception for document id {item.Id}";
                 return false;
             }
+        }
+
+        protected virtual ConflictStatus GetConflictStatus(Document item)
+        {
+            var conflictStatus = ChangeVectorUtils.GetConflictStatus(
+                remoteAsString: item.ChangeVector,
+                localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
+            return conflictStatus;
         }
 
         protected virtual bool ShouldFetchFromResend(DocumentsOperationContext context, string id, DocumentsStorage.DocumentOrTombstone item, string currentChangeVector, out string reason)

--- a/test/SlowTests/Sharding/Issues/RavenDB_20390.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20390.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.Replication;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20390 : ReplicationTestBase
+    {
+        public RavenDB_20390(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions)]
+        public async Task CanRunSubscriptionWithLastDocumentAfterReplication()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = Sharding.GetDocumentStore())
+            {
+                var count = 10;
+                using (var session = store1.OpenSession())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        session.Store(new User() { Age = i }, $"Users/{i}");
+                    }
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                var res = await WaitForValueAsync(() =>
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        return Task.FromResult(session.Query<User>().Count());
+                    }
+                }, count, interval: 333);
+
+                Assert.Equal(count, res);
+
+                var id = await store2.Subscriptions.CreateAsync(new SubscriptionUpdateOptions()
+                {
+                    Query = "from 'Users'"
+                });
+                var cv = Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument.ToString();
+                await store2.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions() { Name = id, ChangeVector = cv });
+                var state = await store2.Subscriptions.GetSubscriptionStateAsync(id);
+
+                using (var subscription = store2.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
+                {
+                    var items = new List<string>();
+                    var _ = subscription.Run(x =>
+                    {
+                        foreach (var item in x.Items)
+                        {
+                            items.Add(item.Id);
+                        }
+                    });
+
+                    await CheckShardSubscriptionLastProcessedCVsAsync(store1, store2, state, count);
+                    Assert.Empty(items);
+                }
+            }
+        }
+
+        private async Task CheckShardSubscriptionLastProcessedCVsAsync(DocumentStore store1, IDocumentStore store2, SubscriptionState state, int count)
+        {
+            var db1 = await Databases.GetDocumentDatabaseInstanceFor(store1);
+            var dbId = db1.DbBase64Id;
+            List<ChangeVectorEntry> cvList = null;
+            var tt = await WaitForValueAsync(async () =>
+            {
+                string cvs = null;
+                var shards = Sharding.GetShardsDocumentDatabaseInstancesFor(store2);
+                await foreach (var db in shards)
+                {
+                    using (db.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var connectionState = db.SubscriptionStorage.GetSubscriptionConnectionsState(ctx, state.SubscriptionName);
+                        if (connectionState != null)
+                        {
+                            cvs = ChangeVectorUtils.MergeVectors(cvs, connectionState.LastChangeVectorSent);
+                        }
+                    }
+                }
+
+                var c = 0;
+                cvList = cvs.ToChangeVectorList();
+                foreach (var cv in cvList)
+                {
+                    if (cv.DbId == dbId)
+                        continue;
+                    c += (int)cv.Etag;
+                }
+                return c;
+            }, count, interval: 333);
+
+            Assert.Equal(4, cvList.Count);
+            Assert.Equal(count, cvList.FirstOrDefault(x => x.DbId == dbId).Etag);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20390

### Additional description

we wasn't skipping batch items after replication

### Type of change

- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
