### PR TITLE
RavenDB-20413 Add additional logs to cluster transaction database command and allow to config batch size

### DIFF
--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -128,5 +128,10 @@ namespace Raven.Server.Config.Categories
         [SizeUnit(SizeUnit.Megabytes)]
         [ConfigurationEntry("Cluster.MaxSizeOfSingleRaftCommandInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size? MaxSizeOfSingleRaftCommand { get; set; }
+        
+        [Description("EXPERT: Specifies the max size of cluster transaction batch to be executed on the database at once")]
+        [DefaultValue(256)]
+        [ConfigurationEntry("Cluster.MaxClusterTransactionBatchSize", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MaxClusterTransactionsBatchSize { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -149,5 +149,12 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Databases.RegularCleanupThresholdInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting RegularCleanupThreshold { get; set; }
+        
+        /// <summary>
+        /// specifies the max size of cluster transaction batch to be executed on the database at once
+        /// </summary>
+        [DefaultValue(256)]
+        [ConfigurationEntry("Databases.ClusterTransactionBatchSize", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int ClusterTransactionsBatchSize { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -149,12 +149,5 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Databases.RegularCleanupThresholdInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting RegularCleanupThreshold { get; set; }
-        
-        /// <summary>
-        /// specifies the max size of cluster transaction batch to be executed on the database at once
-        /// </summary>
-        [DefaultValue(256)]
-        [ConfigurationEntry("Databases.ClusterTransactionBatchSize", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public int ClusterTransactionsBatchSize { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -495,9 +495,13 @@ namespace Raven.Server.Documents
             var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
                 ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: batchSize));
 
+            Stopwatch stopwatch = null;
             if (_logger.IsInfoEnabled)
+            {
+                stopwatch = Stopwatch.StartNew();
                 //_nextClusterCommand refers to each individual put/delete while batch size refers to number of transaction (each contains multiple commands)
-                _logger.Info($"Read {batch.Count} cluster transaction commands - database:{Name}, fromCount:{_nextClusterCommand}, take:{batchSize}");
+                _logger.Info($"Read {batch.Count:#,#;;0} cluster transaction commands - fromCount: {_nextClusterCommand}, take: {batchSize}");
+            }
             
             if (batch.Count == 0)
             {
@@ -552,7 +556,12 @@ namespace Raven.Server.Documents
                     ClusterTransactionWaiter.SetException(command.Options.TaskId, command.Index, exception);
                 }
             }
-
+            finally
+            {
+                if (_logger.IsInfoEnabled && stopwatch != null)
+                    _logger.Info($"cluster transaction batch took {stopwatch.Elapsed:c}");
+            }
+            
             return batch;
         }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -471,7 +471,7 @@ namespace Raven.Server.Documents
                     using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        var batchSize = Configuration.Databases.ClusterTransactionsBatchSize;
+                        var batchSize = Configuration.Cluster.MaxClusterTransactionsBatchSize;
                         var executed = await ExecuteClusterTransaction(context, batchSize);
                         if (executed.Count == batchSize)
                         {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20413

### Additional description
We want some more information about cluster transaction database command handling to better understand future issues.
Also, a configuration to modify the batch size was added to let us mitigate when there are a lot of such commands.
### Type of change
- New feature

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
