### PR TITLE
RavenDB-20358 Fixing the return (and reset) of the context used by a shard command while it was still running.

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -95,6 +95,21 @@ public abstract class AbstractExecutor : IDisposable
             {
                 try
                 {
+                    if (command.CommandTask.IsCompleted == false)
+                    {
+                        // we must not return the context if a command task is still running so we need to await it
+                        // this can happen when ThrowOnFailure mode is used and we throw on first failure
+
+                        try
+                        {
+                            await command.CommandTask;
+                        }
+                        catch
+                        {
+                            // ignore
+                        }
+                    }
+
                     command.ContextReleaser?.Dispose();
                     command.ContextReleaser = null; // we set it to null, since we pool it and might get old values if not cleared
                 }


### PR DESCRIPTION
We have to ensure that the task is already completed before its context is returned to the pool. Otherwise we were getting occasional  AVE errors.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20358

### Additional description

The issue has been revealed by the test `RavenDB_12859.Using_Invalid_Projection_Behavior_Should_Throw` since it's expected that all requests sent to shards will error. In that case we error immediately on the _first_ encountered error here:

https://github.com/ravendb/ravendb/blob/d2fb8d616904da2711bff55b5d7579e404617355/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs#L176-L185

Then we execute the code returning allocated contexts to the pool:

https://github.com/ravendb/ravendb/blob/d2fb8d616904da2711bff55b5d7579e404617355/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs#L94-L104

The problem was that at the time the command tasks talking to other shards can be still running so they used context that we were disposing here. That resulted in Access Violation Exception crashes.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
