### PR TITLE
RavenDB-20329 unify responsible node for subscriptions

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -503,6 +503,20 @@ namespace Raven.Client.ServerWide
             return $"{node}${shardNumber.Value}";
         }
 
+        internal static string GetKeyForDeletionInProgress(string node, string shardName)
+        {
+            if (string.IsNullOrEmpty(shardName))
+                return node;
+
+
+            var shardNumber = ClientShardHelper.GetShardNumberFromDatabaseName(shardName);
+
+            if (shardNumber.HasValue == false)
+                return node;
+
+            return $"{node}${shardNumber.Value}";
+        }
+
         internal bool IsShardBeingDeletedOnAnyNode(int shardNumber)
         {
             foreach (var deletion in DeletionInProgress)

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -50,6 +50,14 @@ namespace Raven.Client.Util
             return false;
         }
 
+        public static int? GetShardNumberFromDatabaseName(string databaseName)
+        {
+            if (TryGetShardNumberAndDatabaseName(databaseName, out _, out var shardNumber))
+                return shardNumber;
+
+            return null;
+        }
+
         public static bool IsShardName(string shardName)
         {
             return shardName.IndexOf('$') != -1;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using JetBrains.Annotations;
-using Raven.Client.Documents.Operations.OngoingTasks;
-using Raven.Client.Documents.Subscriptions;
+﻿using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Sharding.Subscriptions;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Logging;
 using Sparrow.Utils;
 
@@ -45,26 +43,14 @@ public partial class ShardedDatabaseContext
             }
         }
 
-        protected override string GetSubscriptionResponsibleNode(DatabaseRecord databaseRecord, SubscriptionState taskStatus)
-        {
-            return _serverStore.WhoseTaskIsIt(databaseRecord.Sharding.Orchestrator.Topology, taskStatus, taskStatus);
-        }
+        protected override string GetNodeFromState(SubscriptionState taskStatus) => taskStatus.NodeTag;
+
+        protected override DatabaseTopology GetTopology(ClusterOperationContext context) => _serverStore.Cluster.ReadShardingConfiguration(context, _databaseName).Orchestrator.Topology;
 
         protected override bool SubscriptionChangeVectorHasChanges(SubscriptionConnectionsStateOrchestrator state, SubscriptionState taskStatus)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Egor, DevelopmentHelper.Severity.Normal, "RavenDB-18223 Add ability to set CV by admin in sharded subscription.");
             return false;
-        }
-
-        public override (OngoingTaskConnectionStatus ConnectionStatus, string ResponsibleNodeTag) GetSubscriptionConnectionStatusAndResponsibleNode(
-            long subscriptionId,
-            SubscriptionState state,
-            [NotNull] DatabaseRecord databaseRecord)
-        {
-            if (databaseRecord == null) 
-                throw new ArgumentNullException(nameof(databaseRecord));
-
-            return GetSubscriptionConnectionStatusAndResponsibleNode(subscriptionId, state, databaseRecord.Sharding.Orchestrator.Topology);
         }
 
         public void Update(RawDatabaseRecord databaseRecord)

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
@@ -28,9 +28,10 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
         private OrchestratedSubscriptionProcessor _processor;
         private IDisposable _tokenRegisterDisposable;
 
-        public OrchestratedSubscriptionConnection(ServerStore serverStore, TcpConnectionOptions tcpConnection, IDisposable tcpConnectionDisposable,
+        public OrchestratedSubscriptionConnection(ServerStore serverStore, ShardedDatabaseContext.ShardedSubscriptionsStorage subscriptions,
+            TcpConnectionOptions tcpConnection, IDisposable tcpConnectionDisposable,
             JsonOperationContext.MemoryBuffer buffer)
-            : base(tcpConnection, serverStore, buffer, tcpConnectionDisposable, tcpConnection.DatabaseContext.DatabaseName,
+            : base(subscriptions, tcpConnection, serverStore, buffer, tcpConnectionDisposable, tcpConnection.DatabaseContext.DatabaseName,
                 tcpConnection.DatabaseContext.DatabaseShutdown)
         {
             _databaseContext = tcpConnection.DatabaseContext;
@@ -80,8 +81,6 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
 
             return await base.WaitForChangedDocsAsync(state, pendingReply);
         }
-
-        protected override string WhosTaskIsIt(DatabaseTopology topology, SubscriptionState subscriptionState) => _serverStore.WhoseTaskIsIt(topology, subscriptionState, subscriptionState);
 
         private async Task NotifyShardAboutBatchCompletion()
         {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
@@ -28,7 +28,7 @@ public static class SubscriptionBinder
     {
         if (databaseResult.DatabaseStatus == DatabasesLandlord.DatabaseSearchResult.Status.Sharded)
         {
-            var orch = new OrchestratedSubscriptionConnection(server, tcpConnectionOptions, onDispose, buffer);
+            var orch = new OrchestratedSubscriptionConnection(server, databaseResult.DatabaseContext.SubscriptionsStorage, tcpConnectionOptions, onDispose, buffer);
             connection = orch;
             return new SubscriptionBinder<SubscriptionConnectionsStateOrchestrator, OrchestratedSubscriptionConnection, OrchestratorIncludesCommandImpl>(
                 tcpConnectionOptions.DatabaseContext.SubscriptionsStorage,

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.TcpHandlers
         public string LastSentChangeVectorInThisConnection;
 
         public SubscriptionConnection(ServerStore serverStore, TcpConnectionOptions tcpConnection, IDisposable tcpConnectionDisposable, JsonOperationContext.MemoryBuffer bufferToCopy, string database)
-            : base(tcpConnection, serverStore, bufferToCopy, tcpConnectionDisposable, database, tcpConnection.DocumentDatabase.DatabaseShutdown)
+            : base(tcpConnection.DocumentDatabase.SubscriptionStorage, tcpConnection, serverStore, bufferToCopy, tcpConnectionDisposable, database, tcpConnection.DocumentDatabase.DatabaseShutdown)
         {
             _database = tcpConnection.DocumentDatabase;
             CurrentBatchId = ISubscriptionConnection.NonExistentBatch;
@@ -464,8 +464,6 @@ namespace Raven.Server.Documents.TcpHandlers
         {
             includeDocuments?.GatherIncludesForDocument(document);
         }
-
-        protected override string WhosTaskIsIt(DatabaseTopology topology, SubscriptionState subscriptionState) => _serverStore.WhoseTaskIsIt(topology, subscriptionState, subscriptionState);
 
         protected override StatusMessageDetails GetStatusMessageDetails()
         {

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
@@ -126,13 +126,6 @@ public class SubscriptionConnectionForShard : SubscriptionConnection
         return state;
     }
 
-    protected override string WhosTaskIsIt(DatabaseTopology topology, SubscriptionState subscriptionState) => 
-        topology.WhoseTaskIsIt(_serverStore.Engine.CurrentState, subscriptionState, () =>
-        {
-            subscriptionState.ShardingState.NodeTagPerShard.TryGetValue(ShardName, out var tag);
-            return tag;
-        });
-
     protected override void FillIncludedDocuments(DatabaseIncludesCommandImpl includeDocumentsCommand, List<Document> includes)
     {
         includeDocumentsCommand.IncludeDocumentsCommand.Fill(includes, includeMissingAsNull: true);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -3,11 +3,10 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.ServerWide;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide.Commands.Subscriptions
 {
@@ -37,13 +36,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
 
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "create subscription WhosTaskIsIt");
-
-            // for sharded the topology is the orchestrator and the node-tag here is the orchestrator's responsible node
-            var topology = record.TopologyForSubscriptions();
-            var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
-
-            var appropriateNode = topology.WhoseTaskIsIt(RachisState.Follower, subscription, lastResponsibleNode);
+            var appropriateNode = AbstractSubscriptionStorage.GetSubscriptionResponsibleNodeForConnection(record, subscription, HasHighlyAvailableTasks);
 
             if (appropriateNode == null && record.DeletionInProgress.ContainsKey(NodeTag))
                 throw new DatabaseDoesNotExistException(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20329

### Additional description

Have a single place where the responsible node for subscription is decided.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Unlock some of the existing tests

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
