### PR TITLE
RavenDB-20042: Never-ending backup - stuck on retention policy

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
@@ -62,6 +62,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
                 while (hasMore)
                 {
+                    CancellationToken.ThrowIfCancellationRequested();
+
                     var foldersResult = GetSortedFolders();
                     var resultType = foldersResult.HasMore ? "partial " : string.Empty;
                     _onProgress.Invoke($"Got {resultType}{foldersResult.List.Count:#,#} potential backups to check.");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20042/Neverending-backup-stuck-on-retention-policy

### Additional description

All we can do now is to place `CancellationToken.ThrowIfCancellationRequested()` inside the while loop, but based on the available information, this solution is unlikely to be related to the problem at hand.

It is most likely that there was a hang-up somewhere inside the third-party `AWS client` within the `_client.ListObjectsV2Async()` method.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed