### PR TITLE
RavenDB-20417 Sharding - Fix LoadStartingWith not to return results from cache

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetDocs.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client;
 using Raven.Server.Documents.Handlers.Streaming;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -57,6 +58,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                         return RequestHandler.Database.DocumentsStorage.GetDocumentsInReverseEtagOrder(context, state.Start, state.Take);
                     },
                     initialState);
+
+                var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + databaseChangeVector + "\"";
 
                 await using (var writer = GetLoadDocumentsResultsWriter(format, context, RequestHandler.ResponseBodyStream(), token.Token))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20417

### Additional description

The sharded version of `LoadStartingWith` use streaming underneath which wasn't passing the `Etag` header.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- 
### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
