### PR TITLE
RavenDB-20189: Delay date isn't updated after we delay backup

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -16,6 +16,8 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public DateTime? DelayUntil { get; set; }
 
+        public DateTime? OriginalBackupTime { get; set; }
+
         public DateTime? LastFullBackup { get; set; }
 
         public DateTime? LastIncrementalBackup { get; set; }
@@ -70,6 +72,7 @@ namespace Raven.Client.Documents.Operations.Backups
             json[nameof(IsFull)] = IsFull;
             json[nameof(NodeTag)] = NodeTag;
             json[nameof(DelayUntil)] = DelayUntil;
+            json[nameof(OriginalBackupTime)] = OriginalBackupTime;
             json[nameof(LastFullBackup)] = LastFullBackup;
             json[nameof(LastIncrementalBackup)] = LastIncrementalBackup;
             json[nameof(LastFullBackupInternal)] = LastFullBackupInternal;

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -9,6 +9,7 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
 {
     public long TaskId;
     public DateTime DelayUntil;
+    public DateTime OriginalBackupTime;
 
     // ReSharper disable once UnusedMember.Local
     private DelayBackupCommand()
@@ -29,6 +30,7 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
     {
         json[nameof(TaskId)] = TaskId;
         json[nameof(DelayUntil)] = DelayUntil;
+        json[nameof(OriginalBackupTime)] = OriginalBackupTime;
     }
 
     protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
@@ -37,14 +39,16 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
         {
             existingValue.Modifications = new DynamicJsonValue
             {
-                [nameof(DelayUntil)] = DelayUntil
+                [nameof(DelayUntil)] = DelayUntil,
+                [nameof(OriginalBackupTime)] = OriginalBackupTime
             };
             return context.ReadObject(existingValue, GetItemId());
         }
 
         var status = new PeriodicBackupStatus
         {
-            DelayUntil = DelayUntil
+            DelayUntil = DelayUntil,
+            OriginalBackupTime = OriginalBackupTime
         };
         return context.ReadObject(status.ToJson(), GetItemId());
     }
@@ -54,7 +58,8 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
         return new DelayBackupCommandState
         {
             TaskId = TaskId,
-            DelayUntil = DelayUntil
+            DelayUntil = DelayUntil,
+            OriginalBackupTime = OriginalBackupTime
         };
     }
 
@@ -62,5 +67,6 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
     {
         public long TaskId;
         public DateTime DelayUntil;
+        public DateTime OriginalBackupTime;
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20189/Delay-date-isnt-updated-after-we-delay-backup

### Additional description

The issue is that the `OriginalBackupTime` value is calculated from the time of the `next scheduled backup` and the amount of `Delay` we apply to the currently running backup. This calculation happens too late in the current implementation and doesn’t reach all code paths.

The present pull request is resolving the issue at hand. The calculation of `OriginalBackupTime` now occurs during the `Delay` and is saved in the cluster's `BackupStatus`, along with the `DelayUntil` property.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed