### PR TITLE
RavenDB-19948: prevent posting destination's external scripts without…

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
@@ -82,6 +82,29 @@ namespace Raven.Client.Documents.Operations.Backups
             return backupDestinations;
         }
 
+        public List<BackupSettings> GetBackupSettingsDestinations()
+        {
+            var backupDestinations = new List<BackupSettings>();
+
+            AddBackupDestination(LocalSettings, BackupDestination.Local);
+            AddBackupDestination(S3Settings, BackupDestination.AmazonS3);
+            AddBackupDestination(GlacierSettings, BackupDestination.AmazonGlacier);
+            AddBackupDestination(AzureSettings, BackupDestination.Azure);
+            AddBackupDestination(GoogleCloudSettings, BackupDestination.GoogleCloud);
+            AddBackupDestination(FtpSettings, BackupDestination.FTP);
+
+            void AddBackupDestination(BackupSettings backupSettings, BackupDestination backupDestination)
+            {
+                if (backupSettings == null || backupSettings.Disabled)
+                    return;
+
+                backupDestinations.Add(backupSettings);
+            }
+
+            return backupDestinations;
+        }
+
+
         internal enum BackupDestination
         {
             None,

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
             return sb.ToString();
         }
 
-        public List<BackupSettings> GetBackupSettingsDestinations()
+        internal List<BackupSettings> GetBackupSettingsDestinations()
         {
             var backupDestinations = new List<BackupSettings>();
 

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
@@ -127,9 +127,9 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
             return sb.ToString();
         }
 
-        internal List<BackupSettings> GetBackupSettingsDestinations()
+        internal List<string> GetBackupDestinations()
         {
-            var backupDestinations = new List<BackupSettings>();
+            var backupDestinations = new List<string>();
 
             AddBackupDestination(LocalSettings, BackupDestination.Local);
             AddBackupDestination(S3Settings, BackupDestination.AmazonS3);
@@ -140,10 +140,11 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
             void AddBackupDestination(BackupSettings backupSettings, BackupDestination backupDestination)
             {
-                if (backupSettings == null || backupSettings.Disabled)
+                if (backupSettings == null)
                     return;
-
-                backupDestinations.Add(backupSettings);
+                if (backupSettings.GetBackupConfigurationScript == null)
+                    return;
+                backupDestinations.Add(backupDestination.ToString());
             }
 
             return backupDestinations;

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
@@ -127,6 +127,28 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
             return sb.ToString();
         }
 
+        public List<BackupSettings> GetBackupSettingsDestinations()
+        {
+            var backupDestinations = new List<BackupSettings>();
+
+            AddBackupDestination(LocalSettings, BackupDestination.Local);
+            AddBackupDestination(S3Settings, BackupDestination.AmazonS3);
+            AddBackupDestination(GlacierSettings, BackupDestination.AmazonGlacier);
+            AddBackupDestination(AzureSettings, BackupDestination.Azure);
+            AddBackupDestination(GoogleCloudSettings, BackupDestination.GoogleCloud);
+            AddBackupDestination(FtpSettings, BackupDestination.FTP);
+
+            void AddBackupDestination(BackupSettings backupSettings, BackupDestination backupDestination)
+            {
+                if (backupSettings == null || backupSettings.Disabled)
+                    return;
+
+                backupDestinations.Add(backupSettings);
+            }
+
+            return backupDestinations;
+        }
+
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -1,12 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Security;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Json;
@@ -240,6 +245,42 @@ namespace Raven.Server.Documents
             }
 
             return null;
+        }
+
+        protected void IsAllowedToExecuteExternalConfigurationScript(string name, BlittableJsonReaderObject configuration)
+        {
+            X509Certificate2 clientCert = GetCurrentCertificate();
+            CertificateDefinition newCertificateDef;
+
+            if (clientCert == null)
+                return;
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                BlittableJsonReaderObject certificate = ServerStore.Cluster.GetCertificateByThumbprint(ctx, clientCert.Thumbprint) ??
+                                                        ServerStore.Cluster.GetLocalStateByThumbprint(ctx, clientCert.Thumbprint);
+                newCertificateDef = JsonDeserializationServer.CertificateDefinition(certificate);
+            }
+
+            List<BackupSettings> settingsList = null;
+            if (name == OngoingTasksHandler.PutConnectionStringDebugTag && ConnectionString.GetConnectionStringType(configuration) == ConnectionStringType.Olap)
+                settingsList = JsonDeserializationClient.OlapConnectionString(configuration).GetBackupSettingsDestinations();
+
+            if (name is OngoingTasksHandler.UpdatePeriodicBackupDebugTag or OngoingTasksHandler.BackupDatabaseOnceTag)
+                settingsList = JsonDeserializationServer.BackupConfiguration(configuration).GetBackupSettingsDestinations();
+
+            if (settingsList == null) return;
+            foreach (var dest in settingsList)
+            {
+                if (dest.GetBackupConfigurationScript != null)
+                {
+                    if (newCertificateDef.SecurityClearance is SecurityClearance.UnauthenticatedClients or SecurityClearance.ValidUser)
+                        throw new AuthorizationException(
+                            $"Bad security clearance: {newCertificateDef.SecurityClearance}. The current user does not have the necessary security clearance. " +
+                            $"External script execution is only allowed for users with {SecurityClearance.Operator} or higher security clearance.");
+                }
+            }
         }
 
         protected void LogTaskToAudit(string description, long id, BlittableJsonReaderObject configuration)

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Raven.Client;
-using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Security;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Json;

--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -1,0 +1,465 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL.OLAP;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Xunit;
+using Xunit.Abstractions;
+using Sparrow.Platform;
+using Raven.Tests.Core.Utils.Entities;
+
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19948 : RavenTestBase
+    {
+
+        public RavenDB_19948(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /* should work:
+         * One Time Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ClusterAdmin
+         */
+        [Fact]
+        public void CanPostOneTimeBackupConfigurationScriptWithClusterAdminClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options() { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate , ModifyDatabaseName = s => dbName }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var operation = store.Maintenance.ForDatabase(dbName).Send(new BackupOperation(new BackupConfiguration
+                {
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                }));
+
+                var backupResult = (BackupResult)operation.WaitForCompletion(TimeSpan.FromSeconds(30));
+
+
+                Assert.NotEqual(0, backupResult.Documents.ReadCount);
+                Assert.NotNull(backupResult.LocalBackup.BackupDirectory);
+            }
+        }
+
+        /* should work:
+         * One Time Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: Operator
+         */
+        [Fact]
+        public void CanPostOneTimeBackupConfigurationScriptWithOperatorClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options() { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var operation = store.Maintenance.ForDatabase(dbName).Send(new BackupOperation(new BackupConfiguration
+                {
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                }));
+
+                var backupResult = (BackupResult)operation.WaitForCompletion(TimeSpan.FromSeconds(30));
+
+
+                Assert.NotEqual(0, backupResult.Documents.ReadCount);
+                Assert.NotNull(backupResult.LocalBackup.BackupDirectory);
+            }
+        }
+
+        /* shouldn't work:
+         * One Time Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostOneTimeBackupConfigurationScriptWitValidUserClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName
+                   }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                Action act = () => store.Maintenance.ForDatabase(dbName).Send(new BackupOperation(new BackupConfiguration
+                {
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path, GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                })).WaitForCompletion(TimeSpan.FromSeconds(30));
+
+                var exception = Assert.Throws<AuthorizationException>(act);
+                Assert.Contains(
+                    $"Bad security clearance: {SecurityClearance.ValidUser}. The current user does not have the necessary security clearance. External script execution is only allowed for users with {SecurityClearance.Operator} or higher security clearance.",
+                    exception.Message);
+            }
+
+        }
+
+        /* should work:
+         * Periodic Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ClusterAdmin
+         */
+        [Fact]
+        public void CanPostPeriodicBackupConfigurationScriptWithClusterAdminClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: NewDataPath(suffix: "BackupFolder"), fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                config.LocalSettings = new LocalSettings
+                {
+                    FolderPath = path,
+                    GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                };
+
+                var result =  store.Maintenance.ForDatabase(dbName).Send(new UpdatePeriodicBackupOperation(config));
+
+                Assert.NotNull(result.RaftCommandIndex);
+            
+            }
+
+        }
+
+        /* should work:
+        * Periodic Backup.
+        * attempt to post external configuration script by overriding local conf. destination
+        * security clearance: Operator
+        */
+        [Fact]
+        public void CanPostPeriodicBackupConfigurationScriptWithOperatorClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: NewDataPath(suffix: "BackupFolder"), fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                config.LocalSettings = new LocalSettings
+                {
+                    FolderPath = path,
+                    GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                };
+
+                var result = store.Maintenance.ForDatabase(dbName).Send(new UpdatePeriodicBackupOperation(config));
+
+                Assert.NotNull(result.RaftCommandIndex);
+
+            }
+
+        }
+
+        /* shouldn't work:
+         * Periodic Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostPeriodicBackupConfigurationScriptWitValidUserClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: NewDataPath(suffix: "BackupFolder"), fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                config.LocalSettings = new LocalSettings
+                {
+                    FolderPath = path, GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                };
+
+                Action act = () => store.Maintenance.ForDatabase(dbName).Send(new UpdatePeriodicBackupOperation(config));
+
+                var exception = Assert.Throws<AuthorizationException>(act);
+                Assert.Contains(
+                    $"Bad security clearance: {SecurityClearance.ValidUser}. The current user does not have the necessary security clearance. External script execution is only allowed for users with {SecurityClearance.Operator} or higher security clearance.",
+                    exception.Message);
+            }
+
+        }
+
+
+        /* should work:
+       * Olap ETL Connection String.
+       * attempt to post external connection string script by overriding local conf. destination
+       * security clearance: ClusterAdmin
+       */
+        [Fact]
+        public void CanPostOlapConnectionStringScriptWithClusterAdminClearance()
+        {
+
+            var dbName = GetDatabaseName();
+            TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+                var olapConnStr = new OlapConnectionString
+                {
+                    Name = "olap-cs",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                };
+
+
+                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)); 
+                Assert.NotNull(result0.RaftCommandIndex);
+
+                var result = store.Maintenance.Send(new GetConnectionStringsOperation(store.Database, ConnectionStringType.Olap));
+                Assert.NotNull(result.RavenConnectionStrings);
+
+            }
+        }
+
+        /* should work:
+        * Olap ETL Connection String.
+        * attempt to post external connection string script by overriding local conf. destination
+        * security clearance: Operator
+        */
+        [Fact]
+        public void CanPostOlapConnectionStringScriptWithOperatorClearance()
+        {
+
+            var dbName = GetDatabaseName();
+            TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+                var olapConnStr = new OlapConnectionString
+                {
+                    Name = "olap-cs",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                };
+
+
+                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)); 
+                Assert.NotNull(result0.RaftCommandIndex);
+
+                var result = store.Maintenance.Send(new GetConnectionStringsOperation(store.Database, ConnectionStringType.Olap));
+                Assert.NotNull(result.RavenConnectionStrings);
+
+            }
+        }
+
+
+
+        /* shouldn't work:
+         * Olap ETL Connection String.
+         * attempt to post external connection string script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostOlapConnectionStringScriptWitValidUserClearance()
+        {
+
+            var dbName = GetDatabaseName();
+            TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+         
+            using (var store = GetDocumentStore(new Options { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+                var olapConnStr = new OlapConnectionString
+                {
+                    Name = "olap-cs",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path, GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                };
+
+                var exception = Assert.Throws<AuthorizationException>(() =>
+                    store.Maintenance.ForDatabase(dbName).Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)));
+                Assert.Contains(
+                    $"Bad security clearance: {SecurityClearance.ValidUser}. The current user does not have the necessary security clearance. External script execution is only allowed for users with {SecurityClearance.Operator} or higher security clearance.",
+                    exception.Message);
+            }
+        }
+
+        private static string GenerateConfigurationScript(string path, out string command)
+        {
+            var scriptPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Guid.NewGuid().ToString(), ".ps1"));
+            var localSetting = new LocalSettings { FolderPath = path };
+            var localSettingsString = JsonConvert.SerializeObject(localSetting);
+
+            string script;
+            if (PlatformDetails.RunningOnPosix)
+            {
+                command = "bash";
+                script = $"#!/bin/bash\r\necho '{localSettingsString}'";
+                File.WriteAllText(scriptPath, script);
+                Process.Start("chmod", $"700 {scriptPath}");
+            }
+            else
+            {
+                command = "powershell";
+                script = $"echo '{localSettingsString}'";
+                File.WriteAllText(scriptPath, script);
+            }
+
+            return scriptPath;
+        }
+
+    }
+}


### PR DESCRIPTION
… having a suitable security clearance

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19948/Allow-to-limit-script-execution-to-operators-and-higher

### Additional description

prevent posting destination's external scripts without having a suitable security clearance

### Type of change

- Optimization

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
