### PR TITLE
RavenDB-20202: Cluster node health check issue when experiencing a timeout and topology update simultaneously (Test fix)

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -23,6 +23,7 @@ public class RavenDB_20202 : ClusterTestBase
     {
     }
 
+    [Fact]
     public async Task ShouldGettingBackToTheNodeAfterExperiencingTimeoutAndTopologyUpdateSimultaneously()
     {
         const string databaseName = "testDb";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20202/Cluster-node-health-check-issue-when-experiencing-a-timeout-and-topology-update-simultaneously.

### Additional description

The `[Fact]` attribute was missed for the test method

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- A test has been added that proves the fix is effective

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed