### PR TITLE
RavenDB-20339 - Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FastTests;
-using FastTests.Server.Replication;
 using Orders;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
@@ -31,7 +29,7 @@ namespace SlowTests.Sharding.BucketMigration
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_SimpleCase()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -75,7 +73,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_MultipleWrongBuckets()
         {
             Server.ServerStore.Sharding.BlockPrefixedSharding = false;
@@ -148,7 +146,7 @@ namespace SlowTests.Sharding.BucketMigration
             }, true, 30_000, 333);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_ClusterCase()
         {
             var dbName = GetDatabaseName();
@@ -263,7 +261,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_ExternalReplicationShardedAndNonSharded()
         {
             using (var source = Sharding.GetDocumentStore())
@@ -314,7 +312,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded()
         {
             using (var source = Sharding.GetDocumentStore())
@@ -365,7 +363,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToSharded2()
         {
             using (var source = Sharding.GetDocumentStore())
@@ -416,7 +414,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_ExternalReplicationFromShardedToShardedWithConflict()
         {
             using (var source = Sharding.GetDocumentStore())
@@ -488,7 +486,7 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task DocumentsMigrationShouldWork()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -533,24 +531,17 @@ namespace SlowTests.Sharding.BucketMigration
             }
         }
 
-        [Fact]
-        public void DocumentsMigrationCommandShouldThrowForNotShardedInstance()
+        [Theory]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void DocumentsMigrationCommandShouldThrowForNotShardedDatabase(Options options)
         {
-            using (var store = Sharding.GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
-                Assert.Throws<NotSupportedInShardingException>(() =>
-                {
-                    store.Maintenance.Send(new ShardedExecuteDocumentsMigrationOperation());
-                });
-            }
-        }
+                var exceptionType = options.DatabaseMode == RavenDatabaseMode.Single ? 
+                    typeof(RavenException) : 
+                    typeof(NotSupportedInShardingException);
 
-        [Fact]
-        public void DocumentsMigrationCommandShouldThrowForNotShardedDatabase()
-        {
-            using (var store = GetDocumentStore())
-            {
-                Assert.Throws<RavenException>(() =>
+                Assert.Throws(exceptionType, () =>
                 {
                     store.Maintenance.Send(new ShardedExecuteDocumentsMigrationOperation());
                 });

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -727,7 +727,7 @@ namespace SlowTests.Sharding.Cluster
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding)]
+        [RavenFact(RavenTestCategory.Replication |RavenTestCategory.Sharding)]
         public async Task ShouldNotReplicateTombstonesCreatedByBucketDeletion()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -771,7 +771,7 @@ namespace SlowTests.Sharding.Cluster
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding)]
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Sharding)]
         public async Task IndexesShouldTakeIntoAccountArtificialTombstones()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -830,7 +830,7 @@ namespace SlowTests.Sharding.Cluster
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding, Skip = "RavenDB-19696")]
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding, Skip = "RavenDB-19696")]
         public async Task EtlShouldNotSendTombstonesCreatedByBucketDeletion()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -1330,7 +1330,7 @@ namespace SlowTests.Sharding.Cluster
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task GetDocuments()
         {
             using var store = Sharding.GetDocumentStore();
@@ -1380,7 +1380,7 @@ namespace SlowTests.Sharding.Cluster
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Sharding)]
         public async Task GetDocuments2()
         {
             using var store = Sharding.GetDocumentStore();

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
@@ -20,7 +19,6 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server;
-using Raven.Server.Documents.Commands.OngoingTasks;
 using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Replication.Outgoing;
@@ -48,7 +46,7 @@ namespace SlowTests.Sharding.Replication
                                                   DatabaseItemType.TimeSeries;
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task EnsureCantChooseMentorNodeForShardedExternalReplication()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -62,7 +60,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task GetReplicationActiveConnectionsShouldWork()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -99,7 +97,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromNonShardedToShardedShouldWork()
         {
             using (var store1 = GetDocumentStore())
@@ -125,7 +123,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromNonShardedToShardedShouldWork2()
         {
             using (var store1 = GetDocumentStore(new Options
@@ -147,7 +145,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromShardedToShardedShouldWork()
         {
             using (var store1 = Sharding.GetDocumentStore(new Options
@@ -179,7 +177,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromShardedToShardedShouldWork2()
         {
             using (var store1 = Sharding.GetDocumentStore(new Options
@@ -207,7 +205,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task EnsureNoReplicationLoopInExternalReplicationBetweenTwoShardedDBs()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -256,7 +254,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task EnsureNoReplicationLoopInExternalReplicationBetweenTwoShardedDBs2()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -289,7 +287,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task EnsureNoReplicationLoopInExternalReplicationFromNonShardedToSharded()
         {
             using (var store1 = GetDocumentStore())
@@ -327,7 +325,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromShardedToNonShardedShouldWork()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -353,7 +351,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFromShardedToNonShardedShouldWork2()
         {
             using (var store1 = Sharding.GetDocumentStore(new Options
@@ -372,7 +370,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ServerWideExternalReplicationShouldWork_NonShardedToSharded()
         {
             var clusterSize = 3;
@@ -418,7 +416,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationWithRevisionTombstones_NonShardedToNonSharded()
         {
             using (var store1 = GetDocumentStore())
@@ -496,7 +494,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ServerWideExternalReplicationShouldWork_ShardedToNonSharded()
         {
             var clusterSize = 3;
@@ -542,7 +540,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFailOverFromNonShardedToShardedDatabase()
         {
             var clusterSize = 3;
@@ -644,7 +642,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFailOverFromShardedToNonShardedDatabase()
         {
             var clusterSize = 3;
@@ -756,7 +754,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFailOverWithReshardingFromShardedToNonShardedDatabase()
         {
             var clusterSize = 3;
@@ -830,7 +828,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationFailOverFromShardedToShardedDatabase()
         {
             var clusterSize = 3;
@@ -902,7 +900,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task BidirectionalReplicationWithFailOver_NonShardedAndShardedDatabases()
         {
             var clusterSize = 3;
@@ -1029,7 +1027,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task BidirectionalReplicationWithReshardingShouldWork_NonShardedAndShardedDatabases()
         {
             var clusterSize = 3;
@@ -1153,7 +1151,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task BidirectionalReplicationWithReshardingShouldWork_ShardedDatabases()
         {
             var clusterSize = 3;
@@ -1291,7 +1289,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ReplicationShouldResumeAfterDeletingAndRestartingShardDatabase()
         {
             var src = GetDocumentStore(options: new Options
@@ -1341,7 +1339,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ReplicationShouldResumeAfterDeletingAndRestartingShardDatabase2()
         {
             var src = Sharding.GetDocumentStore(options: new Options
@@ -1391,7 +1389,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ReplicationWithReshardingShouldWorkFromNonShardedToSharded()
         {
             using (var store = GetDocumentStore())
@@ -1435,7 +1433,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ShouldNotReplicateTombstonesCreatedByBucketDeletionFromShardedToSharded()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -1485,7 +1483,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ShouldNotReplicateTombstonesCreatedByBucketDeletionFromShardedToSharded2()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -1557,7 +1555,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ShouldNotReplicateTombstonesCreatedByBucketDeletionFromShardedToNonSharded()
         {
             using (var store = Sharding.GetDocumentStore())
@@ -1599,7 +1597,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ShouldNotReplicateTombstonesCreatedByBucketDeletionFromShardedToNonSharded2()
         {
             var record = new DatabaseRecord("dummy")
@@ -1668,7 +1666,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationWithRevisionTombstones_NonShardedToSharded()
         {
             using (var store1 = GetDocumentStore())
@@ -1719,7 +1717,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationWithRevisionTombstones_NonShardedAndSharded()
         {
             using (var store1 = GetDocumentStore())
@@ -1772,7 +1770,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationWithRevisionTombstones_ShardedToSharded()
         {
             using (var store1 = Sharding.GetDocumentStore())
@@ -1832,7 +1830,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task ExternalReplicationWithRevisionTombstonesAndResharding_ShardedToSharded()
         {
             using (var store1 = Sharding.GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:
- `SlowTests.Sharding.BucketMigration.DocumentsMigrationTests.cs`
- `SlowTests.Sharding.Cluster.ReshardingTests.cs`
- `SlowTests.Sharding.Replication.ShardedExternalReplicationTests.cs`

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
