### PR TITLE
RavenDB-20416: fix updating subscription with LastDocument if last doc is from replication

### DIFF
--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Handlers
                         case Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument:
                             using (context.OpenReadTransaction())
                             {
-                                state.ChangeVectorForNextBatchStartingPoint = Database.DocumentsStorage.GetLastDocumentChangeVector(context.Transaction.InnerTransaction, context, sub.Collection);
+                                state.ChangeVectorForNextBatchStartingPoint = GetLastDocumentChangeVectorForSubscription(context, sub);
                             }
                             break;
                     }
@@ -589,7 +589,7 @@ namespace Raven.Server.Documents.Handlers
                         break;
 
                     case Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument:
-                        options.ChangeVector = Database.DocumentsStorage.GetLastDocumentChangeVector(context.Transaction.InnerTransaction, context, sub.Collection);
+                        options.ChangeVector = GetLastDocumentChangeVectorForSubscription(context, sub);
                         break;
                 }
             }
@@ -619,6 +619,15 @@ namespace Raven.Server.Documents.Handlers
                     [nameof(CreateSubscriptionResult.Name)] = name
                 });
             }
+        }
+
+        private string GetLastDocumentChangeVectorForSubscription(DocumentsOperationContext context, SubscriptionConnection.ParsedSubscription sub)
+        {
+            long lastEtag = sub.Collection == Constants.Documents.Collections.AllDocumentsCollection 
+                ? DocumentsStorage.ReadLastDocumentEtag(context.Transaction.InnerTransaction) 
+                : Database.DocumentsStorage.GetLastDocumentEtag(context.Transaction.InnerTransaction, sub.Collection);
+
+            return Database.DocumentsStorage.GetNewChangeVector(context, lastEtag);
         }
     }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -85,9 +85,14 @@ namespace Raven.Server.Documents.Subscriptions
                     _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
                 }
 
-                LastChangeVectorSent = connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint;
+                InitializeLastChangeVectorSent(connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint);
                 PreviouslyRecordedChangeVector = LastChangeVectorSent;
             }
+        }
+
+        internal void InitializeLastChangeVectorSent(string changeVectorForNextBatchStartingPoint)
+        {
+            LastChangeVectorSent = changeVectorForNextBatchStartingPoint;
         }
 
         public IEnumerable<DocumentRecord> GetDocumentsFromResend(ClusterOperationContext context, HashSet<long> activeBatches)

--- a/test/SlowTests/Issues/RavenDB_20416.cs
+++ b/test/SlowTests/Issues/RavenDB_20416.cs
@@ -1,0 +1,203 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Subscriptions;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20416 : ReplicationTestBase
+    {
+        public RavenDB_20416(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [InlineData("Users", true)]
+        [InlineData("Users", false)]
+        [InlineData("@all_docs", true)]
+        [InlineData("@all_docs", false)]
+        public async Task CanRunSubscriptionWithLastDocumentAfterReplication(string collection, bool afterReplication)
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                using (var session = store2.OpenSession())
+                {
+                    session.Store(new User() { Age = 32, Name = "EGR" }, $"Users/322");
+                    session.SaveChanges();
+                }
+
+                var count = 10;
+                using (var session = store1.OpenSession())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        session.Store(new User() { Age = i }, $"Users/{i}");
+                    }
+
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                var res = await WaitForValueAsync(() =>
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        return Task.FromResult(session.Query<User>().Count());
+                    }
+                }, count + 1, interval: 333);
+
+                Assert.Equal(count + 1, res);
+
+                var id = await store2.Subscriptions.CreateAsync(new SubscriptionUpdateOptions() { Query = $"from '{collection}'" });
+                var cv = Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument.ToString();
+                await store2.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions() { Name = id, ChangeVector = cv });
+                var state = await store2.Subscriptions.GetSubscriptionStateAsync(id);
+
+                using (var subscription = store2.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
+                {
+                    await CheckSubscriptionFetchAfterUpdate(store1, store2, state, count, collection);
+
+                    var items = new List<string>();
+                    var _ = subscription.Run(x =>
+                    {
+                        foreach (var item in x.Items)
+                        {
+                            items.Add(item.Id);
+                        }
+                    });
+
+                    await CheckSubscriptionLastProcessedCVsAsync(store1, store2, state, count);
+                    Assert.Empty(items);
+                    if (afterReplication)
+                    {
+                        using (var session = store1.OpenSession())
+                        {
+                            if (collection == "Users")
+                            {
+                                session.Store(new User() { Age = 32, Name = "EGoR" }, $"Users/100");
+                            }
+                            else
+                            {
+                                session.Store(new Camera() { Megapixels = 322 }, $"Cameras/100");
+                            }
+
+                            session.SaveChanges();
+                        }
+
+                        using (var session = store2.OpenSession())
+                        {
+                            if (collection == "Users")
+                            {
+                                session.Store(new User() { Age = 32, Name = "EGoR" }, $"Users/200");
+                            }
+                            else
+                            {
+                                session.Store(new Camera() { Megapixels = 322 }, $"Cameras/200");
+                            }
+
+                            session.SaveChanges();
+                        }
+                    }
+                    else
+                    {
+                        using (var session = store2.OpenSession())
+                        {
+                            if (collection == "Users")
+                            {
+                                session.Store(new User() { Age = 32, Name = "EGoR" }, $"Users/100");
+                            }
+                            else
+                            {
+                                session.Store(new Camera() { Megapixels = 322 }, $"Cameras/100");
+                            }
+
+                            session.SaveChanges();
+                        }
+
+                        using (var session = store1.OpenSession())
+                        {
+                            if (collection == "Users")
+                            {
+                                session.Store(new User() { Age = 32, Name = "EGoR" }, $"Users/200");
+                            }
+                            else
+                            {
+                                session.Store(new Camera() { Megapixels = 322 }, $"Cameras/200");
+                            }
+
+                            session.SaveChanges();
+                        }
+                    }
+
+
+                    Assert.Equal(2, await WaitForValueAsync(() => items.Count, 2));
+                }
+            }
+        }
+        private async Task CheckSubscriptionFetchAfterUpdate(DocumentStore store1, IDocumentStore store2, SubscriptionState state, int count, string collection)
+        {
+            var db2 = await Databases.GetDocumentDatabaseInstanceFor(store2);
+
+            var connectionState = new SubscriptionConnectionsState(state.SubscriptionId, db2.SubscriptionStorage);
+            connectionState.InitializeLastChangeVectorSent(state.ChangeVectorForNextBatchStartingPoint);
+            var fetcher = new DocumentSubscriptionFetcher(db2, connectionState, collection);
+            using (db2.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx2))
+            using (ctx.OpenReadTransaction())
+            using (ctx2.OpenReadTransaction())
+            {
+                fetcher.Initialize(ctx, ctx2, new HashSet<long>());
+                foreach (var x in fetcher.GetEnumerator())
+                {
+                    Assert.False(true, $"got unexpected {x.Id}");
+                }
+            }
+        }
+
+        private async Task CheckSubscriptionLastProcessedCVsAsync(DocumentStore store1, IDocumentStore store2, SubscriptionState state, int count)
+        {
+            var db1 = await Databases.GetDocumentDatabaseInstanceFor(store1);
+            var dbId1 = db1.DbBase64Id;
+            var db2 = await Databases.GetDocumentDatabaseInstanceFor(store2);
+            var dbId2 = db2.DbBase64Id;
+
+            List<ChangeVectorEntry> cvList = null;
+            var tt = await WaitForValueAsync(() =>
+            {
+                string cvs = null;
+                using (db2.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var connectionState = db2.SubscriptionStorage.GetSubscriptionConnectionsState(ctx, state.SubscriptionName);
+                    if (connectionState != null)
+                    {
+                        cvs = ChangeVectorUtils.MergeVectors(cvs, connectionState.LastChangeVectorSent);
+                    }
+                }
+
+                if (cvs == null)
+                    return Task.FromResult(0);
+
+                cvList = cvs.ToChangeVectorList();
+                return Task.FromResult(cvList.Count);
+            }, 2, interval: 333);
+
+            Assert.Equal(2, cvList.Count);
+            Assert.Equal(count, cvList.FirstOrDefault(x => x.DbId == dbId1).Etag);
+            Assert.Equal(count + 1, cvList.FirstOrDefault(x => x.DbId == dbId2).Etag);
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20416/

### Additional description

Currenly we use last document cv from collection, which may be document from external replication and its cv won't have the current db id

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
