### PR TITLE
RavenDB-20098: Allow to pass specific client certificate thumbprints in `TrafficWatch` logging filter

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/TrafficWatch/PutTrafficWatchConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/TrafficWatch/PutTrafficWatchConfigurationOperation.cs
@@ -85,6 +85,11 @@ namespace Raven.Client.ServerWide.Operations.TrafficWatch
             /// Traffic Watch change types by which the Traffic Watch logging entities will be filtered.
             /// </summary>
             public List<TrafficWatchChangeType> ChangeTypes { get; set; }
+
+            /// <summary>
+            /// Traffic Watch certificate thumbprints by which the Traffic Watch logging entities will be filtered.
+            /// </summary>
+            public List<string> CertificateThumbprints { get; set; }
         }
     }
 }

--- a/src/Raven.Server/Config/Categories/TrafficWatchConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/TrafficWatchConfiguration.cs
@@ -57,4 +57,8 @@ public class TrafficWatchConfiguration : ConfigurationCategory
     [ConfigurationEntry("TrafficWatch.ChangeTypes", ConfigurationEntryScope.ServerWideOnly)]
     public List<TrafficWatchChangeType> ChangeTypes { get; set; }
 
+    [Description("Semicolon seperated list of specific client certificate thumbprints by which the Traffic Watch logging entities will be filtered. If not specified, Traffic Watch entities with any certificate thumbprint will be included, including those without any thumbprint. Example list: \"0123456789ABCDEF0123456789ABCDEF01234567;FEDCBA9876543210FEDCBA9876543210FEDCBA98\".")]
+    [DefaultValue(null)]
+    [ConfigurationEntry("TrafficWatch.CertificateThumbprints", ConfigurationEntryScope.ServerWideOnly)]
+    public List<string> CertificateThumbprints { get; set; }
 }

--- a/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
@@ -24,7 +24,8 @@ internal class TrafficWatchToLog : IDynamicJson
     private long _minimumDurationInMs;
     private List<string> _httpMethods;
     private List<TrafficWatchChangeType> _changeTypes;
-    
+    private List<string> _certificateThumbprints;
+
     public bool LogToFile => _trafficWatchMode == TrafficWatchMode.ToLogFile && Logger.IsOperationsEnabled;
 
     private TrafficWatchToLog() { }
@@ -43,25 +44,25 @@ internal class TrafficWatchToLog : IDynamicJson
         
         if (trafficWatchData is TrafficWatchHttpChange twhc)
         {
-            if (_databases != null)
-                if (_databases.Count > 0 &&
-                    _databases.Contains(twhc.DatabaseName) == false)
-                    return;
+            if (_databases is { Count: > 0 } &&
+                _databases.Contains(twhc.DatabaseName) == false)
+                return;
 
-            if (_httpMethods != null)
-                if (_httpMethods.Count > 0 &&
-                    _httpMethods.Contains(twhc.HttpMethod) == false)
-                    return;
+            if (_httpMethods is { Count: > 0 } &&
+                _httpMethods.Contains(twhc.HttpMethod) == false)
+                return;
 
-            if (_changeTypes != null)
-                if (_changeTypes.Count > 0 &&
-                    _changeTypes.Contains(twhc.Type) == false)
-                    return;
+            if (_changeTypes is { Count: > 0 } &&
+                _changeTypes.Contains(twhc.Type) == false)
+                return;
 
-            if (_statusCodes != null)
-                if (_statusCodes.Count > 0 &&
-                    _statusCodes.Contains(twhc.ResponseStatusCode) == false)
-                    return;
+            if (_statusCodes is { Count: > 0 } &&
+                _statusCodes.Contains(twhc.ResponseStatusCode) == false)
+                return;
+
+            if(_certificateThumbprints is { Count: > 0 } &&
+               _certificateThumbprints.Contains(twhc.CertificateThumbprint) == false)
+                return;
 
             if (_minimumResponseSizeInBytes > twhc.ResponseSizeInBytes)
                 return;
@@ -118,6 +119,7 @@ internal class TrafficWatchToLog : IDynamicJson
         _minimumDurationInMs = configuration.MinimumDuration.GetValue(TimeUnit.Milliseconds);
         _httpMethods = configuration.HttpMethods;
         _changeTypes = configuration.ChangeTypes;
+        _certificateThumbprints = configuration.CertificateThumbprints;
     }
 
     public void UpdateConfiguration(PutTrafficWatchConfigurationOperation.Parameters configuration)
@@ -130,6 +132,7 @@ internal class TrafficWatchToLog : IDynamicJson
         _minimumDurationInMs = configuration.MinimumDurationInMs;
         _httpMethods = configuration.HttpMethods;
         _changeTypes = configuration.ChangeTypes;
+        _certificateThumbprints = configuration.CertificateThumbprints;
     }
 
     public DynamicJsonValue ToJson()
@@ -143,7 +146,8 @@ internal class TrafficWatchToLog : IDynamicJson
             [nameof(PutTrafficWatchConfigurationOperation.Parameters.MinimumRequestSizeInBytes)] = Instance._minimumRequestSizeInBytes,
             [nameof(PutTrafficWatchConfigurationOperation.Parameters.MinimumDurationInMs)] = Instance._minimumDurationInMs,
             [nameof(PutTrafficWatchConfigurationOperation.Parameters.HttpMethods)] = Instance._httpMethods == null ? null : new DynamicJsonArray(Instance._httpMethods),
-            [nameof(PutTrafficWatchConfigurationOperation.Parameters.ChangeTypes)] = Instance._changeTypes == null ? null : new DynamicJsonArray(Instance._changeTypes.Cast<object>())
+            [nameof(PutTrafficWatchConfigurationOperation.Parameters.ChangeTypes)] = Instance._changeTypes == null ? null : new DynamicJsonArray(Instance._changeTypes.Cast<object>()),
+            [nameof(PutTrafficWatchConfigurationOperation.Parameters.CertificateThumbprints)] = Instance._certificateThumbprints == null ? null : new DynamicJsonArray(Instance._certificateThumbprints)
         };
     }
 }

--- a/src/Raven.Studio/typescript/models/resources/trafficWatchConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/resources/trafficWatchConfiguration.ts
@@ -21,12 +21,16 @@ class trafficWatchConfiguration {
 
     filterChangeTypes = ko.observable<boolean>();
     changeTypes = ko.observableArray<TrafficWatchChangeType>([]);
+
+    filterCertificateThumbprints = ko.observable<boolean>();
+    certificateThumbprints = ko.observableArray<string>();
     
     validationGroup: KnockoutValidationGroup = ko.validatedObservable({
         databases: this.databases,
         statusCodes: this.statusCodes,
         httpMethods: this.httpMethods,
-        changeTypes: this.changeTypes
+        changeTypes: this.changeTypes,
+        certificateThumbprints: this.certificateThumbprints
     })
     
     constructor(dto: Raven.Client.ServerWide.Operations.TrafficWatch.PutTrafficWatchConfigurationOperation.Parameters) {
@@ -34,7 +38,7 @@ class trafficWatchConfiguration {
         
         this.filterDatabases(dto.Databases?.length > 0);
         this.databases(dto.Databases ?? []);
-        
+
         this.filterStatusCodes(dto.StatusCodes?.length > 0);
         this.statusCodes(dto.StatusCodes ?? []);
         
@@ -47,6 +51,9 @@ class trafficWatchConfiguration {
         
         this.filterChangeTypes(dto.ChangeTypes?.length > 0);
         this.changeTypes(dto.ChangeTypes ?? []);
+
+        this.filterCertificateThumbprints(dto.CertificateThumbprints?.length > 0);
+        this.certificateThumbprints(dto.CertificateThumbprints ?? []);
         
         this.initValidation();
     }
@@ -75,6 +82,12 @@ class trafficWatchConfiguration {
                 onlyIf: () => this.filterChangeTypes()
             }
         });
+
+        this.certificateThumbprints.extend({
+            required: {
+                onlyIf: () => this.filterCertificateThumbprints()
+            }
+        });
     }
     
     
@@ -87,7 +100,8 @@ class trafficWatchConfiguration {
             MinimumResponseSizeInBytes: this.minimumRequestSize(),
             MinimumDurationInMs: this.minimumDuration(),
             HttpMethods: this.filterHttpMethods() ? this.httpMethods() : null,
-            ChangeTypes: this.filterChangeTypes() ? this.changeTypes() : null
+            ChangeTypes: this.filterChangeTypes() ? this.changeTypes() : null,
+            CertificateThumbprints: this.filterCertificateThumbprints() ? this.certificateThumbprints : null
         }
     }
 }

--- a/src/Raven.Studio/typescript/models/resources/trafficWatchConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/resources/trafficWatchConfiguration.ts
@@ -24,6 +24,8 @@ class trafficWatchConfiguration {
 
     filterCertificateThumbprints = ko.observable<boolean>();
     certificateThumbprints = ko.observableArray<string>();
+
+    certificateThumbprintInput = ko.observable<string>();
     
     validationGroup: KnockoutValidationGroup = ko.validatedObservable({
         databases: this.databases,
@@ -56,6 +58,8 @@ class trafficWatchConfiguration {
         this.certificateThumbprints(dto.CertificateThumbprints ?? []);
         
         this.initValidation();
+        
+        _.bindAll(this, "removeCertificateThumbprint", "addCertificateThumbprint");
     }
     
     private initValidation() {
@@ -89,6 +93,15 @@ class trafficWatchConfiguration {
             }
         });
     }
+
+    addCertificateThumbprint() {
+        this.certificateThumbprints.push(this.certificateThumbprintInput());
+        this.certificateThumbprintInput("");
+    }
+
+    removeCertificateThumbprint(thumbprint: string) {
+        this.certificateThumbprints.remove(thumbprint);
+    }
     
     
     toDto(): Raven.Client.ServerWide.Operations.TrafficWatch.PutTrafficWatchConfigurationOperation.Parameters {
@@ -101,7 +114,7 @@ class trafficWatchConfiguration {
             MinimumDurationInMs: this.minimumDuration(),
             HttpMethods: this.filterHttpMethods() ? this.httpMethods() : null,
             ChangeTypes: this.filterChangeTypes() ? this.changeTypes() : null,
-            CertificateThumbprints: this.filterCertificateThumbprints() ? this.certificateThumbprints : null
+            CertificateThumbprints: this.filterCertificateThumbprints() ? this.certificateThumbprints() : null
         }
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/manage/adminLogsTrafficWatchDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/adminLogsTrafficWatchDialog.ts
@@ -11,6 +11,8 @@ class adminLogsTrafficWatchDialog extends dialogViewModelBase {
 
     private readonly model: trafficWatchConfiguration;
 
+    usingHttps = location.protocol === "https:";
+
     private allDatabaseNames = ko.observableArray<string>();
     private static allHttpMethods = ["GET", "POST", "PUT", "DELETE", "HEAD"];
     private static allChangeTypes: TrafficWatchChangeType[] = ["BulkDocs", "Counters", "Documents", "Hilo", "Index", "MultiGet", "Operations", "Queries", "Streams", "Subscriptions", "TimeSeries"];

--- a/src/Raven.Studio/wwwroot/App/views/manage/adminLogsTrafficWatchDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/adminLogsTrafficWatchDialog.html
@@ -88,6 +88,36 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="form-group" data-bind="visible: $root.usingHttps, if: $root.usingHttps">
+                            <label class="control-label">&nbsp;</label>
+                            <div class="flex-grow margin-left">
+                                <div class="toggle toggle-primary margin-top">
+                                    <input id="filterCertificateThumbprints" class="styled" type="checkbox" data-bind="checked: filterCertificateThumbprints">
+                                    <label for="filterCertificateThumbprints">
+                                        Filter by Certificate Thumbprints
+                                    </label>
+                                </div>
+                                <div class="toggle-margin" data-bind="collapse: filterCertificateThumbprints">
+                                    <!-- ko foreach: certificateThumbprints -->
+                                        <div>
+                                            <code data-bind="text: $data" class="margin-right"></code>
+                                            <button class="btn btn-sm btn-danger" title="Delete certificate thumbprint" data-bind="click: $parent.removeCertificateThumbprint">
+                                                <i class="icon-trash"></i>
+                                            </button>
+                                        </div>
+                                    <!-- /ko -->
+                                    
+                                    <div class="form-group" data-bind="validationElement: certificateThumbprints">
+                                        <input type="text" class="form-control flex-grow" data-bind="value: certificateThumbprintInput" /> 
+                                        <button data-bind="click: addCertificateThumbprint" class="btn" title="Add certificate thumbprint to watch list">
+                                            <i class="icon-plus"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        
                         <div class="margin-bottom margin-top-lg">
                             <div class="form-group">
                                 <label class="control-label">Minimum Request Size</label>

--- a/test/FastTests/Server/TrafficWatchConfigurationTests.cs
+++ b/test/FastTests/Server/TrafficWatchConfigurationTests.cs
@@ -29,6 +29,7 @@ namespace FastTests.Server
                 Assert.Equal(defaultConfiguration.MinimumDurationInMs, 0);
                 Assert.Equal(defaultConfiguration.HttpMethods, new List<string>());
                 Assert.Equal(defaultConfiguration.ChangeTypes, new List<TrafficWatchChangeType>());
+                Assert.Equal(defaultConfiguration.CertificateThumbprints, new List<string>());
 
                 var configuration1 = new PutTrafficWatchConfigurationOperation.Parameters()
                 {
@@ -42,7 +43,8 @@ namespace FastTests.Server
                     ChangeTypes = new List<TrafficWatchChangeType>
                     {
                         TrafficWatchChangeType.Queries, TrafficWatchChangeType.Counters, TrafficWatchChangeType.BulkDocs
-                    }
+                    },
+                    CertificateThumbprints = new List<string>{ "0123456789ABCDEF0123456789ABCDEF01234567", "FEDCBA9876543210FEDCBA9876543210FEDCBA98" }
                 };
 
                 await store.Maintenance.Server.SendAsync(new PutTrafficWatchConfigurationOperation(configuration1));
@@ -57,6 +59,7 @@ namespace FastTests.Server
                 Assert.Equal(configuration1.MinimumDurationInMs, configuration2.MinimumDurationInMs);
                 Assert.Equal(configuration1.HttpMethods, configuration2.HttpMethods);
                 Assert.Equal(configuration1.ChangeTypes, configuration2.ChangeTypes);
+                Assert.Equal(configuration1.CertificateThumbprints, configuration2.CertificateThumbprints);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20098/Allow-to-pass-specific-client-certificate-thumbprints-in-TrafficWatch-logging-filter

### Additional description

Implementing a new feature that enables the filtration of `TrafficWatch` entries based on specific client certificate thumbprints.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- NO