### PR TITLE
RavenDB-20053 fix sharded changes API

### DIFF
--- a/src/Raven.Client/Documents/Session/Events.cs
+++ b/src/Raven.Client/Documents/Session/Events.cs
@@ -223,9 +223,12 @@ namespace Raven.Client.Documents.Session
     {
         public Topology Topology { get; }
 
-        internal TopologyUpdatedEventArgs(Topology topology)
+        public string Reason { get; }
+
+        internal TopologyUpdatedEventArgs(Topology topology, string reason)
         {
             Topology = topology;
+            Reason = reason;
         }
     }
 

--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -127,7 +127,7 @@ namespace Raven.Client.Http
                         }
                     }
 
-                    OnTopologyUpdatedInvoke(newTopology);
+                    OnTopologyUpdatedInvoke(newTopology, parameters.DebugTag);
                 }
             }
             catch (Exception)

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -507,16 +507,17 @@ namespace Raven.Client.Http
                     await ExecuteAsync(parameters.Node, null, context, command, shouldRetry: false, sessionInfo: null, token: CancellationToken.None).ConfigureAwait(false);
                     var topology = command.Result;
 
+#if DEBUG
                     foreach (var node in topology.Nodes)
                     {
-                        if (node.Database != _databaseName)
+                        if (string.Equals(node.Database, _databaseName, StringComparison.OrdinalIgnoreCase) == false)
                         {
                             var msg = $"Expected topology for database '{_databaseName}', but got the database '{node.Database}' (reason: {parameters.DebugTag})";
                             Debug.Assert(false, msg);
-                            throw new InvalidOperationException(msg);
                         }
-                    }
-
+                    }          
+#endif
+                    
                     await DatabaseTopologyLocalCache.TrySavingAsync(_databaseName, TopologyHash, topology, Conventions, context, CancellationToken.None).ConfigureAwait(false);
 
                     if (_nodeSelector == null)

--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -191,7 +191,7 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
                                     context.Write(writer, djv);
                                     break;
                                 case BlittableJsonReaderObject bjro:
-                                    context.Write(writer, bjro);
+                                    context.Write(writer, bjro.CloneForConcurrentRead(context));
                                     break;
                             }
                             messagesCount++;

--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -191,7 +191,10 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
                                     context.Write(writer, djv);
                                     break;
                                 case BlittableJsonReaderObject bjro:
-                                    context.Write(writer, bjro.CloneForConcurrentRead(context));
+                                    using (bjro)
+                                    {
+                                        context.Write(writer, bjro.CloneForConcurrentRead(context));
+                                    }
                                     break;
                             }
                             messagesCount++;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -7,6 +7,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Smuggler;
@@ -1495,7 +1496,16 @@ namespace Raven.Server.Documents
                 }
 
                 if (_lastTopologyIndex < record.Topology.Stamp.Index)
+                {
                     _lastTopologyIndex = record.Topology.Stamp.Index;
+
+                    var clusterTopology = ServerStore.GetClusterTopology();
+                    Changes.RaiseNotifications(new TopologyChange
+                    {
+                        Url = clusterTopology.GetUrlFromTag(ServerStore.NodeTag),
+                        Database = Name
+                    });
+                }
 
                 ClientConfiguration = record.Client;
                 IdentityPartsSeparator = record.Client is { Disabled: false }

--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading;
@@ -79,7 +80,7 @@ public class ShardedChangesClientConnection : AbstractChangesClientConnection<Tr
         _changes = new Dictionary<int, ShardedDatabaseChanges>();
         foreach (var shardToTopology in _context.ShardsTopology)
         {
-            _changes[shardToTopology.Key] = new ShardedDatabaseChanges(_context.ServerStore, _context.ShardExecutor.GetRequestExecutorAt(shardToTopology.Key), ShardHelper.ToShardName(_context.DatabaseName, shardToTopology.Key), onDispose: null, nodeTag: null, _throttleConnection);
+            _changes[shardToTopology.Key] = new ShardedDatabaseChanges(this, _context.ServerStore, _context.ShardExecutor.GetRequestExecutorAt(shardToTopology.Key), ShardHelper.ToShardName(_context.DatabaseName, shardToTopology.Key), onDispose: null, nodeTag: null, _throttleConnection);
             tasks.Add(_changes[shardToTopology.Key].EnsureConnectedNow());
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1195,37 +1195,6 @@ namespace Raven.Server.ServerWide
             NotificationCenter.Add(ClusterTopologyChanged.Create(topology, LeaderTag,
                 NodeTag, _engine.CurrentTerm, _engine.CurrentState, status ?? GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));
 
-            NotifyDatabases(DatabasesLandlord.DatabasesCache, database => database.Changes.RaiseNotifications(new TopologyChange
-            {
-                Url = topology.GetUrlFromTag(NodeTag),
-                Database = database.Name
-            }));
-
-            NotifyDatabases(DatabasesLandlord.ShardedDatabasesCache, context => context.Changes.RaiseNotifications(new TopologyChange
-            {
-                Url = topology.GetUrlFromTag(NodeTag),
-                Database = context.DatabaseName
-            }));
-
-            static void NotifyDatabases<TItem>(ResourceCache<TItem> cache, Action<TItem> action)
-            {
-                foreach (var kvp in cache)
-                {
-                    TItem item;
-                    try
-                    {
-                        if (kvp.Value.IsCompletedSuccessfully == false)
-                            continue;
-                        item = kvp.Value.Result;
-                    }
-                    catch (Exception)
-                    {
-                        continue;
-                    }
-
-                    action(item);
-                }
-            }
         }
 
         private Task OnDatabaseChanged(string databaseName, long index, string type, DatabasesLandlord.ClusterDatabaseChangeType _, object state)

--- a/test/SlowTests/Client/ChangesApiFailover.cs
+++ b/test/SlowTests/Client/ChangesApiFailover.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client
+{
+    public class ChangesApiFailover : ClusterTestBase
+    {
+        public ChangesApiFailover(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ChangesApi | RavenTestCategory.Cluster)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_Subscribe_To_Single_Document_Changes_With_Failover(Options options)
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            options.Server = cluster.Leader;
+            options.ReplicationFactor = 3;
+
+            using (var store = GetDocumentStore(options))
+            {
+                store.GetRequestExecutor().OnTopologyUpdated += OnTopologyChange;
+                using (var changes = store.Changes())
+                {
+                    var re = store.GetRequestExecutor();
+                    re.OnTopologyUpdated += OnTopologyChange;
+
+                    await changes.EnsureConnectedNow();
+
+                    const int numberOfDocuments = 10;
+                    var count = 0L;
+                    var cde = new CountdownEvent(numberOfDocuments);
+
+                    for (var i = 0; i < numberOfDocuments; i++)
+                    {
+                        var forDocument = changes
+                            .ForDocument($"orders/{i}");
+
+                        forDocument.Subscribe(x =>
+                        {
+                            Interlocked.Increment(ref count);
+                            cde.Signal();
+                        });
+
+                        await forDocument.EnsureSubscribedNow();
+                    }
+
+                    for (var i = 0; i < numberOfDocuments; i++)
+                    {
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new Order(), $"orders/{i}");
+                            await session.SaveChangesAsync();
+                        }
+
+                        if (i == 0)
+                        {
+                            var s = Servers.First(s => s != cluster.Leader);
+                            await DisposeServerAndWaitForFinishOfDisposalAsync(s);
+                            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+                            {
+                                await Cluster.WaitForNodeToBeRehabAsync(store, s.ServerStore.NodeTag, token: cts.Token);
+                            }
+                        }
+                    }
+
+                    Assert.True(cde.Wait(TimeSpan.FromSeconds(60)), $"Missed {cde.CurrentCount} events.");
+                    Assert.Equal(numberOfDocuments, count);
+
+                    re.OnTopologyUpdated -= OnTopologyChange;
+                }
+            }
+        }
+
+        private void OnTopologyChange(object sender, TopologyUpdatedEventArgs args)
+        {
+            foreach (var node in args.Topology.Nodes)
+            {
+                Debug.Assert(node.Database.Contains('$') == false, $"{node.Database} must not contain '$' char.");
+            }
+        }
+    }
+}

--- a/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
+++ b/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
@@ -188,7 +188,7 @@ namespace SlowTests.Cluster
 
             if (requestExecutor.Topology != null)
             {
-                ApplyProxies(requestExecutor, new TopologyUpdatedEventArgs(requestExecutor.Topology));
+                ApplyProxies(requestExecutor, new TopologyUpdatedEventArgs(requestExecutor.Topology, "apply-proxies"));
             }
 
             requestExecutor.OnTopologyUpdated += ApplyProxies;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20053

### Additional description

This PR fix the following issues:

- Concurrent usage of context used by the queue
- `TopologyChange` message from a shard was sent to the client while it should affect only the sharded changes API
- Messages from a shard were sent several times instead only once

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
