### PR TITLE
RavenDB-20437 : Sharding - fix bug in prefixed deletes

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
@@ -147,7 +147,7 @@ public class ShardedBatchCommand : IBatchCommand
             if (cmd.Type == CommandType.DELETE && cmd.IdPrefixed)
             {
                 if (behavior == ShardedBatchBehavior.TransactionalSingleBucketOnly)
-                    throw new ShardedBatchBehaviorViolationException($"Batch command '{nameof(DeletePrefixedCommandData)}' (prefixed id : '{cmd.Id}') does not operate on a single bucket as this is a multi-sharded operation," +
+                    throw new ShardedBatchBehaviorViolationException($"Batch command '{nameof(DeletePrefixedCommandData)}' (prefixed id : '{cmd.Id}') does not operate on a single bucket as this is a multi-shard operation," +
                                                                      "which violates the requested sharded batch behavior to operate on a single bucket only.");
                 // send delete-prefixed-command to all shards
                 var keys = _databaseContext.DatabaseRecord.Sharding.Shards.Keys;

--- a/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
@@ -9,7 +9,6 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
-using Sparrow.Utils;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
@@ -81,15 +80,11 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
         public void WithDocumentPrefix(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
-            //https://issues.hibernatingrhinos.com/issue/RavenDB-20437
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
-                "uncomment the InlineData with 'RavenDatabaseMode.Sharded' when RavenDB-20437 is fixed");
-
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
             {
@@ -395,13 +390,9 @@ loadToUsers(
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
-        //[RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Loading_to_different_collections(Options dstOptions)
         {
-            //https://issues.hibernatingrhinos.com/issue/RavenDB-20437
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal, "change to DatabaseMode = RavenDatabaseMode.All when RavenDB-20437 is fixed");
-
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore(dstOptions))
             {
@@ -499,14 +490,11 @@ loadToAddresses(load(this.AddressId));
 
         [RavenTheory(RavenTestCategory.Etl)]
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
         public void Loading_to_different_collections_using_this(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
-            //https://issues.hibernatingrhinos.com/issue/RavenDB-20437
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal, "uncomment the InlineData with 'RavenDatabaseMode.Sharded' when RavenDB-20437 is fixed");
-
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
             {
@@ -636,15 +624,11 @@ loadToUsers({Name: this.Name + ' ' + this.LastName });
 
         [RavenTheory(RavenTestCategory.Etl)]
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
         public void Update_of_disassembled_document(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
-            //https://issues.hibernatingrhinos.com/issue/RavenDB-20437
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal, 
-                "uncomment the InlineData with 'RavenDatabaseMode.Sharded' when RavenDB-20437 is fixed");
-
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
             {

--- a/test/SlowTests/Server/Documents/ETL/Raven/MultipleCollectionsRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/MultipleCollectionsRavenEtlTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
-using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,15 +15,11 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
-        //[InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
+        [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
         public void Docs_from_two_collections_loaded_to_single_one(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
-            //https://issues.hibernatingrhinos.com/issue/RavenDB-20437
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
-                "uncomment the InlineData with 'RavenDatabaseMode.Sharded' when RavenDB-20437 is fixed");
-
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
             {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11157_Raven.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11157_Raven.cs
@@ -31,16 +31,12 @@ function loadCountersOfUsersBehavior(doc, counter)
 ";
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [InlineData(RavenDatabaseMode.Single, "Users", null)]
-        [InlineData(RavenDatabaseMode.Single, null, null)]
-        [InlineData(RavenDatabaseMode.Single, "Users", BasicScript)]
-        [InlineData(RavenDatabaseMode.Sharded, "Users", null)]
-        [InlineData(RavenDatabaseMode.Sharded, null, null)]
-        [InlineData(RavenDatabaseMode.Sharded, "Users", BasicScript)]
-
-        public void Should_load_all_counters_when_no_script_is_defined_or_load_counter_behavior_sends_everyting_internal(RavenDatabaseMode dbMode, string collection, string script)
+        [RavenData("Users", null, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(null, null, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData("Users", BasicScript, DatabaseMode = RavenDatabaseMode.All)]
+        public void Should_load_all_counters_when_no_script_is_defined_or_load_counter_behavior_sends_everyting_internal(Options options, string collection, string script)
         {
-            using (var src = GetDocumentStore(Options.ForMode(dbMode)))
+            using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
             {
                 if (collection == null)
@@ -713,14 +709,11 @@ if (hasCounter('down')) {
             }
         }
 
-        [Theory]
-        [InlineData("Users", RavenDatabaseMode.Single)]
-        [InlineData("Users", RavenDatabaseMode.Sharded)]
-        [InlineData(null, RavenDatabaseMode.Single)]
-        [InlineData(null, RavenDatabaseMode.Sharded)]
-        public void Should_send_all_counters_on_doc_update(string collection, RavenDatabaseMode dbMode)
+        [RavenTheory(RavenTestCategory.Etl)]
+        [RavenData("Users", DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(null, DatabaseMode = RavenDatabaseMode.All)]
+        public void Should_send_all_counters_on_doc_update(Options options, string collection)
         {
-            var options = Options.ForMode(dbMode);
             options.ModifyDatabaseRecord +=
                 x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxNumberOfExtractedDocuments)] = "2";
 
@@ -767,7 +760,7 @@ if (hasCounter('down')) {
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Should_handle_counters_according_to_behavior_defined_in_script(Options options)
         {
             using (var src = GetDocumentStore(options))
@@ -856,7 +849,7 @@ function loadCountersOfUsersBehavior(docId, counter)
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Should_not_send_counters_if_load_counters_behavior_isnt_defined(Options options)
         {
             using (var src = GetDocumentStore(options))
@@ -905,7 +898,7 @@ loadToUsers(this);");
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Should_send_all_counters_on_doc_update_if_load_counters_behavior_set(Options options)
         {
             using (var src = GetDocumentStore(new Options()
@@ -998,7 +991,7 @@ function loadCountersOfCustomersBehavior(docId, counter) // it's ok
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Load_counters_behavior_function_can_use_other_function_defined_in_script(Options options)
         {
             using (var src = GetDocumentStore(options))
@@ -1038,7 +1031,7 @@ function loadCountersOfUsersBehavior(docId, counter)
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Should_override_counter_value(Options options)
         {
             using (var src = GetDocumentStore())
@@ -1090,7 +1083,7 @@ function loadCountersOfUsersBehavior(docId, counter)
         }
 
         [RavenTheory(RavenTestCategory.Etl)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void Can_define_multiple_load_counter_behavior_functions(Options options)
         {
             using (var src = GetDocumentStore(options))

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13288.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13288.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ConnectionStrings;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20437

### Additional description

- in `ShardedBatchHandler`, when we encounter a `DeletePrefixedCommandData`  we should not rely on the *prefixed* id to decide which shard to send the command to, but instead send the command to all of the shards
- unskip related raven ETL tests + other minor fixes

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
