### PR TITLE
RavenDB-20414 - PostgreSQL: Add a configuration option in order to migrate non-public schemas

### DIFF
--- a/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
+++ b/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.SqlMigration
 {
     public static class DatabaseDriverDispatcher
     {
-        public static IDatabaseDriver CreateDriver(MigrationProvider provider, string connectionString)
+        public static IDatabaseDriver CreateDriver(MigrationProvider provider, string connectionString, string[] schemas = null)
         {
             switch (provider)
             {
@@ -19,7 +19,7 @@ namespace Raven.Server.SqlMigration
                     return new MySqlDatabaseMigrator(connectionString);
 
                 case MigrationProvider.NpgSQL:
-                    return new NpgSqlDatabaseMigrator(connectionString);
+                    return new NpgSqlDatabaseMigrator(connectionString, schemas);
 
                 case MigrationProvider.Oracle:
                     return new OracleDatabaseMigrator(connectionString);

--- a/src/Raven.Server/SqlMigration/Model/SourceSqlDatabase.cs
+++ b/src/Raven.Server/SqlMigration/Model/SourceSqlDatabase.cs
@@ -3,6 +3,9 @@
     public class SourceSqlDatabase
     {
         public MigrationProvider Provider { get; set; }
-        public string ConnectionString { get; set;}
+
+        public string ConnectionString { get; set; }
+
+        public string[] Schemas { get; set; }
     }
 }

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlDatabaseMigrator.Schema.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlDatabaseMigrator.Schema.cs
@@ -6,11 +6,6 @@ namespace Raven.Server.SqlMigration.NpgSQL
 {
     internal partial class NpgSqlDatabaseMigrator : GenericDatabaseMigrator
     {
-        public const string SelectColumns = "SELECT C.TABLE_SCHEMA, C.TABLE_NAME, C.COLUMN_NAME, C.DATA_TYPE" +
-                                            " FROM INFORMATION_SCHEMA.COLUMNS C JOIN INFORMATION_SCHEMA.TABLES T " +
-                                            " ON C.TABLE_CATALOG = T.TABLE_CATALOG AND C.TABLE_SCHEMA = T.TABLE_SCHEMA AND C.TABLE_NAME = T.TABLE_NAME " +
-                                            " WHERE T.TABLE_TYPE <> 'VIEW' AND T.TABLE_SCHEMA = 'public'";
-
         public const string SelectPrimaryKeys = "SELECT TC.TABLE_SCHEMA, TC.TABLE_NAME, COLUMN_NAME " +
                                                 "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC " +
                                                 "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU " +
@@ -45,7 +40,7 @@ namespace Raven.Server.SqlMigration.NpgSQL
         {
             using (var cmd = connection.CreateCommand())
             {
-                cmd.CommandText = SelectColumns;
+                cmd.CommandText = _selectColumns;
                 using (var reader = cmd.ExecuteReader())
                 {
                     while (reader.Read())

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Web.Studio
             {
                 var sourceSqlDatabase = JsonDeserializationServer.SourceSqlDatabase(sourceSqlDatabaseBlittable);
 
-                var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString);
+                var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                 var schema = dbDriver.FindSchema();
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
@@ -54,7 +54,7 @@ namespace Raven.Server.Web.Studio
 
                     var sourceSqlDatabase = migrationRequest.Source;
 
-                    var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString);
+                    var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
                     var token = CreateOperationToken();
 
@@ -113,7 +113,7 @@ namespace Raven.Server.Web.Studio
 
                     var sourceSqlDatabase = testRequest.Source;
 
-                    var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString);
+                    var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
 
                     var (testResultDocument, documentId) = dbDriver.Test(testRequest.Settings, schema, context);

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -328,7 +328,8 @@ class sqlMigration {
     toSourceDto(): Raven.Server.SqlMigration.Model.SourceSqlDatabase {
         return {
             ConnectionString: this.getConnectionString(),
-            Provider: this.databaseType()
+            Provider: this.databaseType(),
+            Schemas: null //TODO
         }
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -21,7 +21,8 @@ class sqlMigration {
         trimSuffix: ko.observable<boolean>(true),
         suffixToTrim: ko.observable<string>("_id"),
         detectManyToMany: ko.observable<boolean>(true),
-        includeUnsupported: ko.observable<boolean>(false)
+        includeUnsupported: ko.observable<boolean>(false),
+        
     };
 
     // cache connection strings between page views
@@ -45,7 +46,9 @@ class sqlMigration {
     mySqlValidationGroup: KnockoutValidationGroup;
 
     npgSql = {
-        connectionString: ko.observable<string>(sqlMigration.savedNpgsqlConnectionString)
+        connectionString: ko.observable<string>(sqlMigration.savedNpgsqlConnectionString),
+        includeSchemas: ko.observable<boolean>(false),
+        schemas: ko.observable<string>()
     };
 
     npgSqlValidationGroup: KnockoutValidationGroup;
@@ -94,6 +97,12 @@ class sqlMigration {
         this.npgSql.connectionString.extend({
             required: true
         });
+        
+        this.npgSql.schemas.extend({
+            required: {
+                onlyIf: () => this.npgSql.includeSchemas()
+            }
+        });
 
         this.oracle.connectionString.extend({
             required: true
@@ -114,7 +123,8 @@ class sqlMigration {
         this.npgSqlValidationGroup = ko.validatedObservable({
             connectionString: this.npgSql.connectionString,
             batchSize: this.batchSize,
-            maxDocumentsToImportPerTable: this.maxDocumentsToImportPerTable
+            maxDocumentsToImportPerTable: this.maxDocumentsToImportPerTable,
+            schemas: this.npgSql.schemas
         });
 
         this.oracleValidationGroup = ko.validatedObservable({
@@ -326,10 +336,12 @@ class sqlMigration {
     }
     
     toSourceDto(): Raven.Server.SqlMigration.Model.SourceSqlDatabase {
+        const schemas = this.databaseType() === "NpgSQL" && this.npgSql.includeSchemas() ? this.npgSql.schemas().split(",") : null;
+        
         return {
             ConnectionString: this.getConnectionString(),
             Provider: this.databaseType(),
-            Schemas: null //TODO
+            Schemas: schemas
         }
     }
     

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromSql.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/importDatabaseFromSql.ts
@@ -235,14 +235,9 @@ class importDatabaseFromSql extends viewModelBase {
             return false;
         }
         
-        const connectionString = this.model.getConnectionString(); 
-        
         this.spinners.schema(true);
         
-        const schemaRequestDto = {
-            Provider: this.model.databaseType(),
-            ConnectionString: connectionString
-        } as Raven.Server.SqlMigration.Model.SourceSqlDatabase;
+        const schemaRequestDto = this.model.toSourceDto();
         
         new fetchSqlDatabaseSchemaCommand(this.activeDatabase(), schemaRequestDto)
             .execute()
@@ -291,7 +286,10 @@ class importDatabaseFromSql extends viewModelBase {
         const searchText = this.searchText();
         if (searchText) {
             const queryLower = searchText.toLocaleLowerCase();
-            this.filteredTables(this.model.tables().filter(x => x.tableName.toLocaleLowerCase().includes(queryLower) && x.collectionName().toLocaleLowerCase().includes(queryLower)));
+            this.filteredTables(
+                this.model.tables().filter(x => x.tableName.toLocaleLowerCase().includes(queryLower) 
+                    || x.tableSchema.toLocaleLowerCase().includes(queryLower)
+                    || x.collectionName().toLocaleLowerCase().includes(queryLower)));
         } else {
             this.filteredTables(this.model.tables());
         }

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -177,6 +177,16 @@
                                         <label for="includeUnsupported">Include <strong>unsupported</strong> data types</label>
                                     </div>
                                 </div>
+                                <div class="form-group" data-bind="visible: databaseType() === 'NpgSQL'">
+                                    <label class="control-label">&nbsp;</label>
+                                    <div class="toggle">
+                                        <input id="includeSchemaList" type="checkbox" data-bind="checked: npgSql.includeSchemas">
+                                        <label for="includeSchemaList">
+                                            Specify schemas to use <small>(comma separated)</small>
+                                            <input class="form-control" placeholder="public" data-bind="textInput: npgSql.schemas, enable: npgSql.includeSchemas" />
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <div data-bind="with: testConnectionResult">
@@ -272,6 +282,7 @@
                                 <label data-bind="attr: { for: 'table_' + $index() }">&nbsp;</label>
                             </div>
                             <div class="flex-horizontal flex-wrap table-header">
+                                <span class="with-top-label" data-label="Schema" data-bind="text: tableSchema"></span>
                                 <span class="with-top-label js-sql-table-name" data-label="Table" data-bind="text: tableName"></span>
                                 <i class="icon-arrow-filled-right"></i>
                                 <div class="with-top-label raven-property-name inline-edit" data-bind="css: { 'edit-disabled': !checked() }" data-label="Collection">
@@ -331,7 +342,7 @@
                 <div class="padding">
                     <div>
                         <label>
-                            <strong>SQL Table:</strong> <span data-bind="text: tableName"></span>
+                            <strong>SQL Table:</strong> <span data-bind="text: tableSchema"></span> / <span data-bind="text: tableName"></span>
                         </label>
                     </div>
                     <div class="toggle">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20414/PostgreSQL-Add-a-configuration-option-in-order-to-migrate-non-public-schemas

### Additional description

PostgreSQL: Add a configuration option in order to migrate non-public schemas

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
