### PR TITLE
RavenDB-20451 - add the document id to the error message

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1994,7 +1994,7 @@ namespace Raven.Server.Documents.Patch
 
             private Client.Exceptions.Documents.Patching.JavaScriptException CreateFullError(string documentId, JavaScriptException e)
             {
-                string msg = $"Script failed for document id '{documentId}'. ";
+                string msg = $"Script failed for document ID '{documentId}'. ";
                 if (e.Error.IsString())
                     msg += e.Error.AsString();
                 else if (e.Error.IsObject())

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1951,7 +1951,7 @@ namespace Raven.Server.Documents.Patch
                 {
                     //ScriptRunnerResult is in charge of disposing of the disposable but it is not created (the clones did)
                     JavaScriptUtils.Clear();
-                    throw CreateFullError(e);
+                    throw CreateFullError(documentId, e);
                 }
                 catch (Exception)
                 {
@@ -1992,17 +1992,17 @@ namespace Raven.Server.Documents.Patch
                 throw new ArgumentNullException("jsonCtx");
             }
 
-            private Client.Exceptions.Documents.Patching.JavaScriptException CreateFullError(JavaScriptException e)
+            private Client.Exceptions.Documents.Patching.JavaScriptException CreateFullError(string documentId, JavaScriptException e)
             {
-                string msg;
+                string msg = $"Script failed for document id '{documentId}'. ";
                 if (e.Error.IsString())
-                    msg = e.Error.AsString();
+                    msg += e.Error.AsString();
                 else if (e.Error.IsObject())
-                    msg = JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, e.Error.AsObject()).ToString();
+                    msg += JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, e.Error.AsObject()).ToString();
                 else
-                    msg = e.Error.ToString();
+                    msg += e.Error.ToString();
 
-                msg = "At " + e.Column + ":" + e.LineNumber + " " + msg;
+                msg += " At " + e.Column + ":" + e.LineNumber + " " + msg;
                 var javaScriptException = new Client.Exceptions.Documents.Patching.JavaScriptException(msg, e);
                 return javaScriptException;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20451/Missing-document-ID-when-we-get-a-JavaScriptException-error

### Additional description

Add the document id to the error message

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing

### UI work

- No UI work is needed
