### PR TITLE
RavenDB-20339 Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Replication;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Attachments;
@@ -23,13 +21,16 @@ namespace SlowTests
         {
         }
 
-        [Fact]
-        public async Task PutDifferentAttachmentsShouldConflict()
+        [RavenTheory(RavenTestCategory.Attachments | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task PutDifferentAttachmentsShouldConflict(Options options)
         {
+            var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             using (var store1 = GetDocumentStore(options: new Options
             {
                 ModifyDatabaseRecord = record =>
                 {
+                    modifyDatabaseRecord(record);
                     record.ConflictSolverConfig = new ConflictSolver();
                 }
             }))
@@ -37,13 +38,11 @@ namespace SlowTests
             {
                 ModifyDatabaseRecord = record =>
                 {
+                    modifyDatabaseRecord(record);
                     record.ConflictSolverConfig = new ConflictSolver();
                 }
             }))
             {
-                await Databases.SetDatabaseId(store1, new Guid("00000000-48c4-421e-9466-000000000000"));
-                await Databases.SetDatabaseId(store2, new Guid("99999999-48c4-421e-9466-999999999999"));
-
                 using (var session = store1.OpenAsyncSession())
                 {
                     var x = new User { Name = "Fitzchak" };

--- a/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
+++ b/test/SlowTests/Sharding/Cluster/BucketStatsTests.cs
@@ -465,7 +465,7 @@ namespace SlowTests.Sharding.Cluster
                 var bucket2 = Sharding.GetBucket(config, id2);
 
                 var shard = ShardHelper.GetShardNumberFor(config, bucket1);
-                var shardDatabase = await Sharding.GetShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(store.Database, shard));
+                var shardDatabase = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(store.Database, shard));
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -27,7 +27,6 @@ using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Smuggler.Migration;
-using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Issues;
 using Tests.Infrastructure;
@@ -42,7 +41,7 @@ namespace SlowTests.Smuggler
         {
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
         public async Task CanExportAndImportDatabaseRecord()
         {
             var file = Path.GetTempFileName();
@@ -248,7 +247,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanMigrateDatabaseRecord()
         {
             var file = Path.GetTempFileName();
@@ -483,7 +482,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
         public async Task CanExportAndImportMergedDatabaseRecord()
         {
             var file = Path.GetTempFileName();
@@ -778,7 +777,7 @@ namespace SlowTests.Smuggler
                         AllowEtlOnNonEncryptedChannel = true,
                         Transforms = new List<Transformation> { new() { Script = "", Collections = new List<string> { "Orders" }, Name = "testScript" } }
                     };
-                    WaitForUserToContinueTheTest(store1);
+                
                     await store1.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
                     await store1.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(etlConfiguration2));
                     await store2.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(etlConfiguration3));
@@ -889,8 +888,6 @@ namespace SlowTests.Smuggler
 
                     operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
-                    WaitForUserToContinueTheTest(store2);
 
                     int disabled = 0;
 
@@ -1004,7 +1001,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
         public async Task CanBackupAndRestoreDatabaseRecord()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1200,7 +1197,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.BackupExportImport)]
+        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.Subscriptions)]
         public async Task CanRestoreSubscriptionsFromBackup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");

--- a/test/StressTests/Server/Replication/ExternalReplicationStressTests_NoDispose.cs
+++ b/test/StressTests/Server/Replication/ExternalReplicationStressTests_NoDispose.cs
@@ -1,13 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Replication;
-using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Operations.Replication;
-using Raven.Server.Config;
 using SlowTests.Server.Replication;
 using Tests.Infrastructure;
 using Xunit.Abstractions;
@@ -20,8 +13,9 @@ namespace StressTests.Server.Replication
         {
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Replication, RavenArchitecture.AllX64)]
-        public void ExternalReplicationShouldWorkWithSmallTimeoutStress()
+        [RavenMultiplatformTheory(RavenTestCategory.Replication, RavenArchitecture.AllX64)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void ExternalReplicationShouldWorkWithSmallTimeoutStress(RavenTestBase.Options options)
         {
             for (int i = 0; i < 10; i++)
             {
@@ -29,7 +23,7 @@ namespace StressTests.Server.Replication
                 {
                     using (var test = new ExternalReplicationTests(Output))
                     {
-                        test.ExternalReplicationShouldWorkWithSmallTimeoutStress(20000).Wait(TimeSpan.FromMinutes(10));
+                        test.ExternalReplicationShouldWorkWithSmallTimeoutStress(options, 20000).Wait(TimeSpan.FromMinutes(10));
                     }
                 });
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:
- `BackupDatabaseRecordTests.cs`
- `SmugglerConflicts.cs`
- `RavenDB_15796.cs`
- `TimeSeriesAndDocumentConflicts.cs`
- `ExternalReplicationTests.cs`
- `ReplicationBasicTestsSlow.cs`
- `ExternalReplicationStressTests_NoDispose.cs`

### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
