### PR TITLE
RavenDB-20370 Remove database checkbox for insufficient access levels

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
@@ -68,10 +68,9 @@ describe("DatabasesPage", function () {
     it("can render different access modes", async () => {
         const { screen } = rtlRender(<WithDifferentAccessLevel />);
 
-        expect(await screen.findAllByText(/Manage group/i)).toHaveLength(3);
-
         expect(await screen.findAllByText("9 Indexing errors")).toHaveLength(3);
 
+        expect(screen.queryByText(/Manage group/i)).not.toBeInTheDocument();
         expect(screen.queryByText(selectors.disableButton)).not.toBeInTheDocument();
         expect(screen.queryByText(selectors.enableButton)).not.toBeInTheDocument();
         expect(screen.queryByText(selectors.disableIndexing)).not.toBeInTheDocument();

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -239,9 +239,11 @@ export function DatabasePanel(props: DatabasePanelProps) {
                 <div className="flex-grow-1">
                     <RichPanelHeader onClick={(e) => onHeaderClicked(db, e)}>
                         <RichPanelInfo>
-                            <RichPanelSelect>
-                                <Input type="checkbox" checked={selected} onChange={toggleSelection} />
-                            </RichPanelSelect>
+                            {isOperatorOrAbove() && (
+                                <RichPanelSelect>
+                                    <Input type="checkbox" checked={selected} onChange={toggleSelection} />
+                                </RichPanelSelect>
+                            )}
 
                             <RichPanelName className="max-width-heading">
                                 {canNavigateToDatabase ? (
@@ -279,17 +281,19 @@ export function DatabasePanel(props: DatabasePanelProps) {
                         </RichPanelInfo>
 
                         <RichPanelActions>
-                            <Button
-                                href={manageGroupUrl}
-                                title="Manage the Database Group"
-                                target={db.currentNode.relevant ? undefined : "_blank"}
-                                className="ms-1"
-                                disabled={!canNavigateToDatabase || db.currentNode.isBeingDeleted}
-                            >
-                                <span>
-                                    <Icon icon="dbgroup" addon="settings" /> Manage group
-                                </span>
-                            </Button>
+                            {isOperatorOrAbove() && (
+                                <Button
+                                    href={manageGroupUrl}
+                                    title="Manage the Database Group"
+                                    target={db.currentNode.relevant ? undefined : "_blank"}
+                                    className="ms-1"
+                                    disabled={!canNavigateToDatabase || db.currentNode.isBeingDeleted}
+                                >
+                                    <span>
+                                        <Icon icon="dbgroup" addon="settings" /> Manage group
+                                    </span>
+                                </Button>
+                            )}
 
                             {isAdminAccessOrAbove(db) && (
                                 <UncontrolledDropdown className="ms-1">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20370/Remove-checkbox-from-database-if-user-doesnt-have-sufficient-permissions

### Additional description
Removed the database checkbox & manage group button for the insufficient access levels

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
