### PR TITLE
RavenDB-18179 Mark query results as stale if resharding is happening during query execution

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
@@ -33,4 +33,15 @@ public class ShardingConfiguration
 
         return false;
     }
+
+    internal bool HasActiveMigrations()
+    {
+        foreach (var m in BucketMigrations)
+        {
+            if (m.Value.IsActive)
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedFacetedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedFacetedQueryOperation.cs
@@ -30,7 +30,8 @@ public class ShardedFacetedQueryOperation : AbstractShardedQueryOperation<Facete
     {
         var result = new FacetedQueryResult
         {
-            ResultEtag = CombinedResultEtag
+            ResultEtag = CombinedResultEtag,
+            IsStale = HadActiveMigrationsBeforeQueryStarted
         };
 
         var facets = new Dictionary<string, CombinedFacet>();
@@ -43,7 +44,7 @@ public class ShardedFacetedQueryOperation : AbstractShardedQueryOperation<Facete
 
             CombineExplanations(result, cmdResult);
             CombineTimings(shardNumber, cmdResult);
-            CombineSingleShardResultProperties(result, queryResult, isDistinct: false);
+            CombineSingleShardResultProperties(result, queryResult);
 
             if (queryResult.Includes is { Count: > 0 })
             {

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedIndexEntriesQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedIndexEntriesQueryOperation.cs
@@ -41,14 +41,15 @@ public class ShardedIndexEntriesQueryOperation : AbstractShardedQueryOperation<S
         var result = new ShardedIndexEntriesQueryResult
         {
             Results = new List<BlittableJsonReaderObject>(),
-            ResultEtag = CombinedResultEtag
+            ResultEtag = CombinedResultEtag,
+            IsStale = HadActiveMigrationsBeforeQueryStarted
         };
 
         foreach (var (_, cmdResult) in results)
         {
             var queryResult = cmdResult.Result;
 
-            CombineSingleShardResultProperties(result, queryResult, _query.Metadata.IsDistinct);
+            CombineSingleShardResultProperties(result, queryResult);
         }
 
         // all the results from each command are already ordered

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
@@ -11,7 +11,6 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Sharding;
 using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Sharding.Commands.Querying;
-using Raven.Server.Documents.Sharding.Comparers;
 using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Extensions;
@@ -59,7 +58,8 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
         var result = new ShardedQueryResult
         {
             Results = new List<BlittableJsonReaderObject>(),
-            ResultEtag = CombinedResultEtag
+            ResultEtag = CombinedResultEtag,
+            IsStale = HadActiveMigrationsBeforeQueryStarted
         };
 
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "Check if we could handle this in streaming manner so we won't need to materialize all blittables and do Clone() here");
@@ -75,7 +75,7 @@ public class ShardedQueryOperation : AbstractShardedQueryOperation<ShardedQueryR
 
             CombineExplanations(result, cmdResult);
             CombineTimings(shardNumber, cmdResult);
-            CombineSingleShardResultProperties(result, queryResult, _query.Metadata.IsDistinct);
+            CombineSingleShardResultProperties(result, queryResult);
 
             // For includes, we send the includes to all shards, then we merge them together. We do explicitly
             // support including from another shard, so we'll need to do that again for missing includes

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedSuggestionQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedSuggestionQueryOperation.cs
@@ -35,7 +35,8 @@ public class ShardedSuggestionQueryOperation : AbstractShardedQueryOperation<Sug
     {
         var result = new SuggestionQueryResult
         {
-            ResultEtag = CombinedResultEtag
+            ResultEtag = CombinedResultEtag,
+            IsStale = HadActiveMigrationsBeforeQueryStarted
         };
 
         var suggestions = new Dictionary<string, CombinedSuggestions>();
@@ -48,7 +49,7 @@ public class ShardedSuggestionQueryOperation : AbstractShardedQueryOperation<Sug
 
             CombineExplanations(result, cmdResult);
             CombineTimings(shardNumber, cmdResult);
-            CombineSingleShardResultProperties(result, queryResult, isDistinct: false);
+            CombineSingleShardResultProperties(result, queryResult);
 
             foreach (BlittableJsonReaderObject suggestionJson in cmdResult.Result.Results)
             {

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -80,13 +80,8 @@ namespace Raven.Server.ServerWide
         public bool HasActiveMigrations(string database)
         {
             var config = _serverStore.Cluster.ReadShardingConfiguration(database);
-            foreach (var m in config.BucketMigrations)
-            {
-                if (m.Value.IsActive) 
-                    return true;
-            }
 
-            return false;
+            return config.HasActiveMigrations();
         }
 
         public void ClearPublishedUrls()

--- a/test/SlowTests/Sharding/Issues/RavenDB_18179.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18179.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Core.Utils.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_18179 : ClusterTestBase
+{
+    public RavenDB_18179(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Querying)]
+    public async Task ShouldMarkQueryResultsAsStaleIfBucketsAreBeingMigrated()
+    {
+        DoNotReuseServer();
+        using (var store = Sharding.GetDocumentStore())
+        {
+            Server.ServerStore.Sharding.ManualMigration = true;
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+
+            var id = "foo/bar";
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User
+                {
+                    Name = "Arek"
+                };
+                await session.StoreAsync(user, id);
+                await session.SaveChangesAsync();
+            }
+
+            new Users_ByName().Execute(store);
+
+            Indexes.WaitForIndexing(store);
+
+            var bucket = Sharding.GetBucket(record.Sharding, id);
+            var shardNumber = ShardHelper.GetShardNumberFor(record.Sharding, bucket);
+            var toShard = ShardingTestBase.GetNextSortedShardNumber(record.Sharding.Shards, shardNumber);
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, shardNumber)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                Assert.NotNull(user);
+            }
+
+            var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, toShard, RaftIdGenerator.NewId());
+
+            var exists = WaitForDocument<User>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, toShard));
+            Assert.True(exists);
+
+            using (var session = store.OpenSession())
+            {
+                List<User> users = session.Query<User, Users_ByName>().Statistics(out var stats).ToList();
+
+                Assert.True(stats.IsStale);
+            }
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, toShard)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                var changeVector = session.Advanced.GetChangeVectorFor(user);
+                await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, result.Index, changeVector, RaftIdGenerator.NewId());
+            }
+
+            result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, result.Index);
+            await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+            using (var session = store.OpenSession())
+            {
+                List<User> users = session.Query<User, Users_ByName>().Statistics(out var stats).ToList();
+
+                Assert.False(stats.IsStale);
+            }
+        }
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from u in users select new {u.Name};
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18179/Sharding-Resharding-Queries

### Additional description

In order to indicate that results might contain duplicates because of running buckets migration (resharding) we mark the query results as stale. It might be racy so in order to get better accuracy we do the check before we send the requests to shards and on each shard individually as well.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
