### PR TITLE
RavenDB-13527 - Allow including timings to all queries when traffic watch is on, and make sure it's shown in the traffic watch

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -429,7 +429,7 @@ namespace Raven.Client.Documents.Changes
             json[nameof(Type)] = Type;
             
             if(QueryTimings != null)
-                json[nameof(QueryTimings)] = QueryTimings.ToJson();
+                json[nameof(QueryTimings)] = QueryTimings;
 
             return json;
         }

--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using Raven.Client.Documents.Queries.Timings;
 using Raven.Client.ServerWide.Tcp;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -412,6 +413,7 @@ namespace Raven.Client.Documents.Changes
         public long RequestSizeInBytes { get; set; }
         public long ResponseSizeInBytes { get; set; }
         public TrafficWatchChangeType Type { get; set; }
+        public QueryTimings Timings { get; set; }
 
         public override DynamicJsonValue ToJson()
         {
@@ -425,6 +427,7 @@ namespace Raven.Client.Documents.Changes
             json[nameof(RequestSizeInBytes)] = RequestSizeInBytes;
             json[nameof(ResponseSizeInBytes)] = ResponseSizeInBytes;
             json[nameof(Type)] = Type;
+            json[nameof(Timings)] = Timings;
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -413,7 +413,7 @@ namespace Raven.Client.Documents.Changes
         public long RequestSizeInBytes { get; set; }
         public long ResponseSizeInBytes { get; set; }
         public TrafficWatchChangeType Type { get; set; }
-        public QueryTimings Timings { get; set; }
+        public QueryTimings QueryTimings { get; set; }
 
         public override DynamicJsonValue ToJson()
         {
@@ -427,7 +427,10 @@ namespace Raven.Client.Documents.Changes
             json[nameof(RequestSizeInBytes)] = RequestSizeInBytes;
             json[nameof(ResponseSizeInBytes)] = ResponseSizeInBytes;
             json[nameof(Type)] = Type;
-            json[nameof(Timings)] = Timings;
+            
+            if(QueryTimings != null)
+                json[nameof(QueryTimings)] = QueryTimings.ToJson();
+
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
+++ b/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Queries.Timings
 {
-    public class QueryTimings : IFillFromBlittableJson, IDynamicJsonValueConvertible
+    public class QueryTimings : IFillFromBlittableJson, IDynamicJson
     {
         public long DurationInMs { get; set; }
 

--- a/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
+++ b/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
@@ -53,12 +53,10 @@ namespace Raven.Client.Documents.Queries.Timings
 
         public DynamicJsonValue ToJson()
         {
-            const string timings = "Timings";
-            DynamicJsonValue djv = new();
-            djv[timings] = new DynamicJsonValue
+            DynamicJsonValue djv = new DynamicJsonValue
             {
                 [nameof(DurationInMs)] = DurationInMs,
-                [timings] = InnerToJson(Timings)
+                [nameof(Timings)] = InnerToJson(Timings)
             };
 
             return djv;
@@ -74,9 +72,7 @@ namespace Raven.Client.Documents.Queries.Timings
                     {
                         [nameof(DurationInMs)] = kvp.Value.DurationInMs
                     };
-                    if (kvp.Value.Timings != null)
-                        innerJson[timings] = InnerToJson(kvp.Value.Timings);
-
+                    innerJson[nameof(Timings)] = InnerToJson(kvp.Value.Timings);
                     json[kvp.Key] = innerJson;
                 }
 

--- a/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
+++ b/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Conventions;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Queries.Timings
 {
-    public class QueryTimings : IFillFromBlittableJson
+    public class QueryTimings : IFillFromBlittableJson, IDynamicJsonValueConvertible
     {
         public long DurationInMs { get; set; }
 
@@ -48,6 +49,39 @@ namespace Raven.Client.Documents.Queries.Timings
 
             DurationInMs = queryResult.Timings.DurationInMs;
             Timings = queryResult.Timings.Timings;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            const string timings = "Timings";
+            DynamicJsonValue djv = new();
+            djv[timings] = new DynamicJsonValue
+            {
+                [nameof(DurationInMs)] = DurationInMs,
+                [timings] = InnerToJson(Timings)
+            };
+
+            return djv;
+
+            DynamicJsonValue InnerToJson(IDictionary<string, QueryTimings> queryTimings)
+            {
+                DynamicJsonValue json = new DynamicJsonValue();
+                if (queryTimings == null)
+                    return null;
+                foreach (var kvp in queryTimings)
+                {
+                    DynamicJsonValue innerJson = new DynamicJsonValue()
+                    {
+                        [nameof(DurationInMs)] = kvp.Value.DurationInMs
+                    };
+                    if (kvp.Value.Timings != null)
+                        innerJson[timings] = InnerToJson(kvp.Value.Timings);
+
+                    json[kvp.Key] = innerJson;
+                }
+
+                return json;
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -289,7 +289,7 @@ namespace Raven.Server.Documents.Queries
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SetupTimings(IndexQueryServerSide indexQuery)
         {
-            if (indexQuery.Metadata.HasTimings || TrafficWatchManager.HasRegisteredClients)
+            if (indexQuery.Metadata.HasTimings || (TrafficWatchManager.HasRegisteredClients && indexQuery.Metadata.IsCollectionQuery == false))
                 indexQuery.Timings = new QueryTimingsScope(start: false);
         }
 

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -289,7 +289,7 @@ namespace Raven.Server.Documents.Queries
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SetupTimings(IndexQueryServerSide indexQuery)
         {
-            if (indexQuery.Metadata.HasTimings)
+            if (indexQuery.Metadata.HasTimings || TrafficWatchManager.HasRegisteredClients)
                 indexQuery.Timings = new QueryTimingsScope(start: false);
         }
 

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -38,6 +38,7 @@ using Spatial4n.Shapes;
 using Spatial4n.Shapes.Nts;
 using BinaryExpression = Raven.Server.Documents.Queries.AST.BinaryExpression;
 using Circle = Raven.Server.Documents.Indexes.Spatial.Circle;
+using Raven.Server.TrafficWatch;
 
 namespace Raven.Server.Documents.Queries
 {
@@ -410,6 +411,15 @@ function execute(doc, args){
                     if (IsCollectionQuery && OrderBy.Length > 0)
                         IsCollectionQuery = false;
                 }
+            }
+
+            if (TrafficWatchManager.HasRegisteredClients)
+            {
+                Query.Include ??= new List<QueryExpression>();
+                const string timingsKeyword = "timings";
+
+                if (Query.Include.Any(x => x is MethodExpression me && me.Name.Equals(timingsKeyword, StringComparison.OrdinalIgnoreCase)) == false)
+                    Query.Include.Add(new MethodExpression(timingsKeyword, new List<QueryExpression>()));
             }
 
             if (Query.Include != null)

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -38,7 +38,6 @@ using Spatial4n.Shapes;
 using Spatial4n.Shapes.Nts;
 using BinaryExpression = Raven.Server.Documents.Queries.AST.BinaryExpression;
 using Circle = Raven.Server.Documents.Indexes.Spatial.Circle;
-using Raven.Server.TrafficWatch;
 
 namespace Raven.Server.Documents.Queries
 {
@@ -411,15 +410,6 @@ function execute(doc, args){
                     if (IsCollectionQuery && OrderBy.Length > 0)
                         IsCollectionQuery = false;
                 }
-            }
-
-            if (TrafficWatchManager.HasRegisteredClients)
-            {
-                Query.Include ??= new List<QueryExpression>();
-                const string timingsKeyword = "timings";
-
-                if (Query.Include.Any(x => x is MethodExpression me && me.Name.Equals(timingsKeyword, StringComparison.OrdinalIgnoreCase)) == false)
-                    Query.Include.Add(new MethodExpression(timingsKeyword, new List<QueryExpression>()));
             }
 
             if (Query.Include != null)

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Queries.Timings;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Commercial;
@@ -299,6 +300,8 @@ namespace Raven.Server
             (string CustomInfo, TrafficWatchChangeType Type) twTuple =
                 ((string, TrafficWatchChangeType)?)contextItem ?? ("N/A", TrafficWatchChangeType.None);
 
+            var timings = context.Items[nameof(QueryTimings)];
+
             var twn = new TrafficWatchHttpChange
             {
                 TimeStamp = DateTime.UtcNow,
@@ -310,6 +313,7 @@ namespace Raven.Server
                 AbsoluteUri = $"{context.Request.Scheme}://{context.Request.Host}",
                 DatabaseName = database ?? "N/A",
                 CustomInfo = twTuple.CustomInfo,
+                Timings = timings != null ? (QueryTimings)timings : null,
                 Type = twTuple.Type,
                 ClientIP = context.Connection.RemoteIpAddress?.ToString(),
                 CertificateThumbprint = context.Connection.ClientCertificate?.Thumbprint,

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -313,7 +313,7 @@ namespace Raven.Server
                 AbsoluteUri = $"{context.Request.Scheme}://{context.Request.Host}",
                 DatabaseName = database ?? "N/A",
                 CustomInfo = twTuple.CustomInfo,
-                Timings = timings != null ? (QueryTimings)timings : null,
+                QueryTimings = timings != null ? (QueryTimings)timings : null,
                 Type = twTuple.Type,
                 ClientIP = context.Connection.RemoteIpAddress?.ToString(),
                 CertificateThumbprint = context.Connection.ClientCertificate?.Thumbprint,

--- a/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
@@ -74,7 +74,8 @@ internal class TrafficWatchToLog : IDynamicJson
 
             var requestSize = new Size(twhc.RequestSizeInBytes, SizeUnit.Bytes);
             var responseSize = new Size(twhc.ResponseSizeInBytes, SizeUnit.Bytes);
-            var customInfo = twhc.CustomInfo?.ReplaceLineEndings(string.Empty) ?? "N/A";
+            var customInfo = twhc.CustomInfo?.ReplaceLineEndings(" ") ?? "N/A";
+            var queryTimings = twhc.QueryTimings;
 
             stringBuilder
                 .Append("HTTP, ")
@@ -91,6 +92,22 @@ internal class TrafficWatchToLog : IDynamicJson
                 .Append(twhc.Type).Append(", ")
                 .Append(twhc.ElapsedMilliseconds).Append("ms, ")
                 .Append("custom info: ").Append(customInfo);
+
+            if (queryTimings != null)
+            {
+                bool isFirst = true;
+                stringBuilder.Append(", ")
+                    .Append("query timings: ").Append(queryTimings.DurationInMs).Append("ms - ");
+                foreach (var key in queryTimings.Timings.Keys)
+                {
+                    if (isFirst == false)
+                        stringBuilder.Append(", ");
+                    stringBuilder.Append(key).Append(": ")
+                        .Append(queryTimings.Timings[key].DurationInMs).Append("ms");
+
+                    isFirst = false;
+                }
+            }
         }
         else if (trafficWatchData is TrafficWatchTcpChange twtc)
         {

--- a/src/Raven.Studio/typescript/viewmodels/manage/queryTimingsDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/queryTimingsDialog.ts
@@ -1,0 +1,37 @@
+import dialog = require("plugins/dialog");
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import timingsChart from "common/timingsChart";
+
+class queryTimingsDialog extends dialogViewModelBase {
+
+    view = require("views/manage/queryTimingsDialog.html");
+
+    timingsGraph = new timingsChart(".js-timings-container");
+    
+    private readonly query: string;
+    
+    private readonly timings: Raven.Client.Documents.Queries.Timings.QueryTimings;
+    
+    constructor(timings: Raven.Client.Documents.Queries.Timings.QueryTimings, query: string) {
+        super(null);
+        
+        this.timings = timings;
+        this.query = query;
+    }
+
+    executeQuery(query: string) {
+        dialog.close(this, query);
+    }
+    
+    compositionComplete(view?: any, parent?: any) {
+        super.compositionComplete(view, parent);
+
+        this.timingsGraph.draw(this.timings);
+    }
+
+    cancel() {
+        dialog.close(this, false);
+    }
+}
+
+export = queryTimingsDialog;

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/textColumn.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/textColumn.ts
@@ -94,7 +94,7 @@ class textColumn<T extends object> implements virtualColumn {
 
         if (this.opts.transformValue) {
             return {
-                rawText: this.opts.transformValue(cellValue),
+                rawText: this.opts.transformValue(cellValue, item),
                 typeCssClass: "token string"
             };
         }

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -687,7 +687,7 @@ interface textColumnOpts<T> {
     sortable?: "number" | "string" | valueProvider<T>;
     defaultSortOrder?: sortMode;
     customComparator?: (a: any, b: any) => number;
-    transformValue?: (a: any) => any;
+    transformValue?: ((a: any, item: T) => any) | ((a: any) => any);
 }
 
 interface hypertextColumnOpts<T> extends textColumnOpts<T> {

--- a/src/Raven.Studio/wwwroot/App/views/manage/queryTimingsDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/queryTimingsDialog.html
@@ -1,0 +1,40 @@
+<div class="modal-dialog modal-lg timings-dialog" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: cancel" aria-hidden="true" title="Click to close">
+                <i class="icon-cancel"></i>
+            </button>
+            <h4 class="modal-title">Query Timings</h4>
+        </div>
+        <div class="modal-body">
+            <div class="panel-body js-timings-container timings" style="height: 350px; width: 850px">
+                <div class="toggle toggle-right">
+                    <input id="log-scale" class="styled" type="checkbox" data-bind="checked: timingsGraph.useLogScale">
+                    <label for="log-scale" class="properties-label">
+                        Use logarithmic scale
+                    </label>
+                </div>
+               
+                <div class="legend" data-bind="with: timingsGraph.rootNode">
+                    <div class="legend-item" data-bind="template: { name: 'timing-item-template' }">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-bind="click: cancel" title="Click to close">Close</button>
+        </div>
+    </div>
+</div>
+
+<script type="text/html" id="timing-item-template">
+    <div class="timing-legend-item">
+        <i data-bind="attr: { 'class': 'item-rect ' + $root.timingsGraph.getColorClass(name) }"></i>
+        <span class="name" data-bind="text: name"></span>
+        <span class="duration" data-bind="text: duration.toLocaleString() + ' ms'"></span>
+    </div>
+    <div data-bind="foreach: children">
+        <div class="legend-item" data-bind="template: { name: 'timing-item-template' }, visible: visible">
+        </div>
+    </div>
+</script>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/query.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/query.less
@@ -134,65 +134,6 @@
         }
     }
 
-    svg {
-        .levelName {
-            fill: @text-emphasis;
-            text-anchor: middle;
-            font-weight: bold;
-            font-size: 28px;
-        }
-
-        .duration {
-            fill: @text-color;
-            font-size: 20px;
-            text-anchor: middle;
-        }
-    }
-
-    .color-def (@innerName, @color) {
-        path {
-            &.@{innerName} {
-                fill: @color;
-            }
-        }
-
-        .item-rect {
-            &.@{innerName} {
-                background-color: @color;
-            }
-        }
-    }
-
-    .timings {
-        path {
-            fill: @gray;
-        }
-
-        .item-rect {
-            background-color: @gray;
-        }
-
-        .color-def(~'optimizer', @color-5-3);
-        .color-def(~'query', @color-1);
-        .color-def(~'retriever', @color-1-2);
-        .color-def(~'projection', @color-2);
-        .color-def(~'javaScript', @color-2-2);
-        .color-def(~'load', @color-3);
-        .color-def(~'storage', @color-3-2);
-        .color-def(~'lucene', @color-4);
-        .color-def(~'corax', @color-4);
-        .color-def(~'includes', @color-4-2);
-        .color-def(~'fill', @color-5);
-        .color-def(~'gather', @color-5-2);
-        .color-def(~'highlightings', @color-1-1);
-        .color-def(~'setup', @color-1-3);
-        .color-def(~'explanations', @color-2-1);
-        .color-def(~'staleness', @color-2-3);
-        .color-def(~'filter', @color-5-1);
-        .color-def(~'terms', @color-3-1);
-        .color-def(~'aggregateBy', @color-2-2);
-    }
-
     .query-results-container {
         .results-btn {
             color: @text-color;
@@ -416,6 +357,66 @@
 }
 
 .js-timings-container {
+
+    &.timings {
+
+        svg {
+            .levelName {
+                fill: @text-emphasis;
+                text-anchor: middle;
+                font-weight: bold;
+                font-size: 28px;
+            }
+
+            .duration {
+                fill: @text-color;
+                font-size: 20px;
+                text-anchor: middle;
+            }
+        }
+        
+        .color-def (@innerName, @color) {
+            path {
+                &.@{innerName} {
+                    fill: @color;
+                }
+            }
+
+            .item-rect {
+                &.@{innerName} {
+                    background-color: @color;
+                }
+            }
+        }
+        
+        path {
+            fill: @gray;
+        }
+
+        .item-rect {
+            background-color: @gray;
+        }
+
+        .color-def(~'optimizer', @color-5-3);
+        .color-def(~'query', @color-1);
+        .color-def(~'retriever', @color-1-2);
+        .color-def(~'projection', @color-2);
+        .color-def(~'javaScript', @color-2-2);
+        .color-def(~'load', @color-3);
+        .color-def(~'storage', @color-3-2);
+        .color-def(~'lucene', @color-4);
+        .color-def(~'corax', @color-4);
+        .color-def(~'includes', @color-4-2);
+        .color-def(~'fill', @color-5);
+        .color-def(~'gather', @color-5-2);
+        .color-def(~'highlightings', @color-1-1);
+        .color-def(~'setup', @color-1-3);
+        .color-def(~'explanations', @color-2-1);
+        .color-def(~'staleness', @color-2-3);
+        .color-def(~'filter', @color-5-1);
+        .color-def(~'terms', @color-3-1);
+        .color-def(~'aggregateBy', @color-2-2);
+    }
 
     .toggle {
         position: absolute;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13527/Allow-including-timings-to-all-queries-when-traffic-watch-is-on-and-make-sure-its-shown-in-the-traffic-watch

### Additional description

We added query timings property to `TrafficWatchHttpChange`.

### Type of change

- New feature

### How risky is the change?

- Low 

### Testing by Contributor

- It has been verified by manual testing

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.