### PR TITLE
RavenDB-20468 clicking "List of Indexes" button sometimes doesn't display the view

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -209,7 +209,7 @@ function getState(index: IndexSharedInfo) {
 }
 
 function getIcon(index: IndexSharedInfo): IconName {
-    if (index.nodesInfo.some((x) => x.status === "failure" || x.details?.faulty || x.details.state === "Error")) {
+    if (index.nodesInfo.some((x) => x.status === "failure" || x.details?.faulty || x.details?.state === "Error")) {
         return "cancel";
     }
     if (index.nodesInfo.some((x) => x.details?.status === "Disabled")) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20468/clicking-List-of-Indexes-button-sometimes-doesnt-display-the-view

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
