### PR TITLE
RavenDB-19967 Notification/warning about tombstone cleaner subscribers disabled.

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1334,7 +1334,16 @@ namespace Raven.Server.Documents
             }
             else
             {
-                var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
+                CollectionName collectionName;
+                try
+                {
+                    collectionName = GetCollection(collection, throwIfDoesNotExist: false);
+                }
+                catch
+                {
+                    return 0;
+                }
+
                 tableName = collectionName.GetTableName(CollectionTableType.Tombstones);
             }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1347,20 +1347,14 @@ namespace Raven.Server.Documents
             if (table == null)
                 return tombstonesCount;
 
-            long count = 0;
             foreach (var result in table.SeekForwardFrom(TombstonesSchema.FixedSizeIndexes[CollectionEtagsSlice], 0, 0))
             {
-                count++;
-                if (count > 10_000)
+                if (++tombstonesCount.Count >= 10_000)
                 {
-                    tombstonesCount.Count = count;
                     tombstonesCount.Accuracy = TombstonesCount.TombstonesAccuracy.MoreThan;
-
-                    return tombstonesCount;
+                    break;
                 }
             }
-
-            tombstonesCount.Count = count;
 
             return tombstonesCount;
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1334,16 +1334,7 @@ namespace Raven.Server.Documents
             }
             else
             {
-                CollectionName collectionName;
-                try
-                {
-                    collectionName = GetCollection(collection, throwIfDoesNotExist: false);
-                }
-                catch
-                {
-                    return 0;
-                }
-
+                var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
                 tableName = collectionName.GetTableName(CollectionTableType.Tombstones);
             }
 

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -816,6 +816,36 @@ namespace Raven.Server.Documents.ETL
 
         public string TombstoneCleanerIdentifier => $"ETL loader for {_database.Name}";
 
+        public HashSet<string> GetDisabledSubscribers()
+        {
+            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var config in _databaseRecord.RavenEtls)
+            {
+                if (config.Disabled)
+                {
+                    disabledSubscribers.Add(config.Name);
+                }
+            }
+
+            foreach (var config in _databaseRecord.SqlEtls)
+            {
+                if (config.Disabled)
+                {
+                    disabledSubscribers.Add(config.Name);
+                }
+            }
+
+            foreach (var config in _databaseRecord.ElasticSearchEtls) // ?????????
+            {
+                if (config.Disabled)
+                {
+                    disabledSubscribers.Add(config.Name);
+                }
+            }
+
+            return disabledSubscribers;
+        }
+
         public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             var lastProcessedTombstones = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4171,7 +4171,7 @@ namespace Raven.Server.Documents.Indexes
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            if (State == IndexState.Disabled)
+            if (Status == IndexRunningStatus.Disabled || Status == IndexRunningStatus.Paused)
                 dict[Name] = Collections;
 
             return dict;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4151,6 +4151,35 @@ namespace Raven.Server.Documents.Indexes
 
         public string TombstoneCleanerIdentifier => $"Index '{Name}'";
 
+        public HashSet<string> GetDisabledSubscribers()
+        {
+            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (State == IndexState.Disabled)
+                disabledSubscribers.Add(Name);
+
+            return disabledSubscribers;
+        }
+        /*
+        public Dictionary<string, long> GetBlockingTombstonesPerCollection()
+        {
+            if (State == IndexState.Disabled)
+            {
+                using (CurrentlyInUse())
+                {
+                    using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    {
+                        using (var tx = context.OpenReadTransaction())
+                        {
+                            return GetLastProcessedDocumentTombstonesPerCollection(tx);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }*/
+
         public virtual Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4151,35 +4151,6 @@ namespace Raven.Server.Documents.Indexes
 
         public string TombstoneCleanerIdentifier => $"Index '{Name}'";
 
-        public HashSet<string> GetDisabledSubscribers()
-        {
-            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            if (State == IndexState.Disabled)
-                disabledSubscribers.Add(Name);
-
-            return disabledSubscribers;
-        }
-        /*
-        public Dictionary<string, long> GetBlockingTombstonesPerCollection()
-        {
-            if (State == IndexState.Disabled)
-            {
-                using (CurrentlyInUse())
-                {
-                    using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-                    {
-                        using (var tx = context.OpenReadTransaction())
-                        {
-                            return GetLastProcessedDocumentTombstonesPerCollection(tx);
-                        }
-                    }
-                }
-            }
-
-            return null;
-        }*/
-
         public virtual Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
@@ -4195,6 +4166,15 @@ namespace Raven.Server.Documents.Indexes
                     }
                 }
             }
+        }
+
+        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        {
+            var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            if (State == IndexState.Disabled)
+                dict[Name] = Collections;
+
+            return dict;
         }
 
         internal Dictionary<string, long> GetLastProcessedDocumentTombstonesPerCollection(RavenTransaction tx)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Nest;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -1015,19 +1014,6 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public string TombstoneCleanerIdentifier => "Periodic Backup";
 
-        public HashSet<string> GetDisabledSubscribers()
-        {
-            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var periodicBackup in PeriodicBackups)
-            {
-                if (periodicBackup.Configuration.Disabled)
-                    disabledSubscribers.Add(periodicBackup.Configuration.Name);
-            }
-
-            return disabledSubscribers;
-        }
-
         public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             var minLastEtag = GetMinLastEtag();
@@ -1052,6 +1038,18 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
 
             return result;
+        }
+
+        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        {
+            var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var periodicBackup in PeriodicBackups)
+            {
+                if (periodicBackup.Configuration.Disabled)
+                    dict[periodicBackup.Configuration.Name] = tombstoneCollections;
+            }
+
+            return dict;
         }
 
         public void HandleDatabaseValueChanged(string type, object changeState)

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Nest;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -1013,6 +1014,19 @@ namespace Raven.Server.Documents.PeriodicBackup
         }
 
         public string TombstoneCleanerIdentifier => "Periodic Backup";
+
+        public HashSet<string> GetDisabledSubscribers()
+        {
+            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var periodicBackup in PeriodicBackups)
+            {
+                if (periodicBackup.Configuration.Disabled)
+                    disabledSubscribers.Add(periodicBackup.Configuration.Name);
+            }
+
+            return disabledSubscribers;
+        }
 
         public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1851,6 +1851,19 @@ namespace Raven.Server.Documents.Replication
 
         public event Action<ReplicationNode, IncomingReplicationFailureToConnectReporter> IncomingReplicationConnectionErrored;
 
+        public HashSet<string> GetDisabledSubscribers()
+        {
+            var disabledSubscribers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            /*
+            foreach (var periodicBackup in PeriodicBackups)
+            {
+                if (periodicBackup.Configuration.Disabled)
+                    disabledSubscribers.Add(periodicBackup.Configuration.Name);
+            }
+            */
+            return disabledSubscribers;
+        }
+
         public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             var minEtag = Math.Min(GetMinimalEtagForTombstoneCleanupWithHubReplication(), GetMinimalEtagForReplication());

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1925,15 +1925,19 @@ namespace Raven.Server.Documents.Replication
                 if (replicationDestination.Disabled)
                     dict[replicationDestination.FromString()] = tombstoneCollections;
             }
+
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var externals = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name).ExternalReplications;
-                foreach (var external in externals)
+                if (externals != null)
                 {
-                    if (external.Disabled)
+                    foreach (var external in externals)
                     {
-                        dict[external.Name] = tombstoneCollections;
+                        if (external.Disabled)
+                        {
+                            dict[external.Name] = tombstoneCollections;
+                        }
                     }
                 }
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1929,7 +1929,7 @@ namespace Raven.Server.Documents.Replication
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
-                var externals = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name).ExternalReplications;
+                var externals = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name)?.ExternalReplications;
                 if (externals != null)
                 {
                     foreach (var external in externals)

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents
 
         private void CreateWarningIfThereAreBlockingTombstones(HashSet<string> tombstoneCollections)
         {
-            var currentBlockingTombstones = new Dictionary<(string, string), long>();
+            var currentBlockingTombstones = new Dictionary<(string Source, string Collection), long>();
             var tombstonesPerCollection = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
             bool needToWarn = false;
 

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -230,7 +230,15 @@ namespace Raven.Server.Documents
                     }
                 }
 
-                CreateWarningIfThereAreBlockingTombstones(tombstoneCollections);
+                try
+                {
+                    CreateWarningIfThereAreBlockingTombstones(tombstoneCollections);
+                }
+                catch (Exception e)
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Failed to notify on blocking tombstones in database '{_documentDatabase.Name}'", e);
+                }
             }
             finally
             {

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -122,8 +122,8 @@ namespace Raven.Server.Documents
 
         private void CreateWarningIfThereAreBlockingTombstones(HashSet<string> tombstoneCollections)
         {
-            var currentBlockingTombstones = new Dictionary<(string, string), DocumentsStorage.TombstonesCount>();
-            var tombstonesPerCollection = new Dictionary<string, DocumentsStorage.TombstonesCount>(StringComparer.OrdinalIgnoreCase);
+            var currentBlockingTombstones = new Dictionary<(string, string), long>();
+            var tombstonesPerCollection = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
             bool needToWarn = false;
 
             using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
@@ -143,7 +143,7 @@ namespace Raven.Server.Documents
                                 tombstonesPerCollection[tombstoneCollection] = tombstonesCount;
                             }
 
-                            if (tombstonesCount.Count > 0)
+                            if (tombstonesCount > 0)
                             {
                                 needToWarn = true;
                                 currentBlockingTombstones.Add((disabledSubscriber, tombstoneCollection), tombstonesCount);
@@ -162,7 +162,7 @@ namespace Raven.Server.Documents
         internal TombstonesState GetState(bool addInfoForDebug = false)
         {
             var result = new TombstonesState();
-            HashSet<string> tombstoneCollections = new HashSet<string>();
+            HashSet<string> tombstoneCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             if (CancellationToken.IsCancellationRequested)
                 return result;

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -175,8 +175,7 @@ namespace Raven.Server.Documents
             {
                 foreach (var tombstoneCollection in _documentDatabase.DocumentsStorage.GetTombstoneCollections(tx))
                 {
-                    if (tombstoneCollection != AttachmentsStorage.AttachmentsTombstones && tombstoneCollection != RevisionsStorage.RevisionsTombstones)
-                        tombstoneCollections.Add(tombstoneCollection);
+                    tombstoneCollections.Add(tombstoneCollection);
                     result.Tombstones[tombstoneCollection] = new StateHolder();
                 }
             }

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -122,8 +122,8 @@ namespace Raven.Server.Documents
 
         private void CreateWarningIfThereAreBlockingTombstones(HashSet<string> tombstoneCollections)
         {
-            var currentBlockingTombstones = new Dictionary<(string, string), long>();
-            var tombstonesPerCollection = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+            var currentBlockingTombstones = new Dictionary<(string, string), DocumentsStorage.TombstonesCount>();
+            var tombstonesPerCollection = new Dictionary<string, DocumentsStorage.TombstonesCount>(StringComparer.OrdinalIgnoreCase);
             bool needToWarn = false;
 
             using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
@@ -143,7 +143,7 @@ namespace Raven.Server.Documents
                                 tombstonesPerCollection[tombstoneCollection] = tombstonesCount;
                             }
 
-                            if (tombstonesCount > 0)
+                            if (tombstonesCount.Count > 0)
                             {
                                 needToWarn = true;
                                 currentBlockingTombstones.Add((disabledSubscriber, tombstoneCollection), tombstonesCount);

--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.NotificationCenter
             _config = config;
             Options = new NotificationCenterOptions();
             Paging = new Paging(this, _notificationsStorage, database);
+            TombstoneNotifications = new TombstoneNotifications(this, _notificationsStorage, database);
             Indexing = new Indexing(this, _notificationsStorage, database);
             RequestLatency = new RequestLatency(this, _notificationsStorage, database);
             EtlNotifications = new EtlNotifications(this, _notificationsStorage, _database);
@@ -58,6 +59,7 @@ namespace Raven.Server.NotificationCenter
         public Task<NotificationCenter> InitializeTask => _initializeTaskSource.Task;
         
         public readonly Paging Paging;
+        public readonly TombstoneNotifications TombstoneNotifications;
         public readonly Indexing Indexing;
         public readonly RequestLatency RequestLatency;
         public readonly EtlNotifications EtlNotifications;

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -80,6 +80,8 @@ namespace Raven.Server.NotificationCenter.Notifications
         
         MicrosoftLogsConfigurationLoadError,
         
-        MismatchedReferenceLoad
+        MismatchedReferenceLoad,
+
+        BlockingTombstones
     }
 }

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -6,7 +6,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.NotificationCenter
 {
-    public class TombstoneNotifications // blockingTombstones ??????????
+    public class TombstoneNotifications
     {
         private readonly NotificationCenter _notificationCenter;
         private readonly NotificationsStorage _notificationsStorage;
@@ -24,9 +24,9 @@ namespace Raven.Server.NotificationCenter
         public void Add(Dictionary<(string, string), long> blockingTombstones)
         {
             BlockingTombstonesDetails details = new BlockingTombstonesDetails(blockingTombstones);
-            var x = details.ToJson(); // to remove
+            string title = $"Blocking of tombstones deletion";
             string msg = $"We have detected blocking of tombstones deletion. Consider deleting or enabling the following processes:";
-            _notificationCenter.Add(AlertRaised.Create(_database, msg, msg, AlertType.BlockingTombstones,
+            _notificationCenter.Add(AlertRaised.Create(_database, title, msg, AlertType.BlockingTombstones,
                 NotificationSeverity.Warning,
                 nameof(AlertType.BlockingTombstones), details: details));
         }

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.NotificationCenter
             _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
         }
 
-        public void Add(Dictionary<(string, string), long> blockingTombstones)
+        public void Add(Dictionary<(string Source, string Collection), long> blockingTombstones)
         {
             BlockingTombstonesDetails details = new BlockingTombstonesDetails(blockingTombstones);
             _notificationCenter.Add(AlertRaised.Create(_database, _title, _msg, AlertType.BlockingTombstones,
@@ -62,12 +62,12 @@ namespace Raven.Server.NotificationCenter
 
         internal class BlockingTombstonesDetails : INotificationDetails
         {
-            public BlockingTombstonesDetails(Dictionary<(string, string), long> blockingTombstones)
+            public BlockingTombstonesDetails(Dictionary<(string Source, string Collection), long> blockingTombstones)
             {
                 BlockingTombstones = blockingTombstones;
             }
 
-            public Dictionary<(string, string), long> BlockingTombstones { get; set; }
+            public Dictionary<(string Source, string Collection), long> BlockingTombstones { get; set; }
 
             public DynamicJsonValue ToJson()
             {
@@ -76,8 +76,8 @@ namespace Raven.Server.NotificationCenter
                 {
                     djv.Add( new DynamicJsonValue
                     {
-                        [nameof(BlockingTombstoneDetails.Source)] = key.Item1,
-                        [nameof(BlockingTombstoneDetails.Collection)] = key.Item2,
+                        [nameof(BlockingTombstoneDetails.Source)] = key.Source,
+                        [nameof(BlockingTombstoneDetails.Collection)] = key.Collection,
                         [nameof(BlockingTombstoneDetails.NumberOfTombstones)] = BlockingTombstones[key]
                     });
                 }

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+
+namespace Raven.Server.NotificationCenter
+{
+    public class TombstoneNotifications // blockingTombstones ??????????
+    {
+        private readonly NotificationCenter _notificationCenter;
+        private readonly NotificationsStorage _notificationsStorage;
+        private readonly string _database;
+        private readonly Logger _logger;
+
+        public TombstoneNotifications(NotificationCenter notificationCenter, NotificationsStorage notificationsStorage, string database)
+        {
+            _notificationCenter = notificationCenter;
+            _notificationsStorage = notificationsStorage;
+            _database = database;
+            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+        }
+
+        public void Add(Dictionary<(string, string), long> blockingTombstones)
+        {
+            BlockingTombstonesDetails details = new BlockingTombstonesDetails(blockingTombstones);
+            var x = details.ToJson(); // to remove
+            string msg = $"We have detected blocking of tombstones deletion. Consider deleting or enabling the following processes:";
+            _notificationCenter.Add(AlertRaised.Create(_database, msg, msg, AlertType.BlockingTombstones,
+                NotificationSeverity.Warning,
+                nameof(AlertType.BlockingTombstones), details: details));
+        }
+
+        internal class BlockingTombstonesDetails : INotificationDetails
+        {
+            public BlockingTombstonesDetails(Dictionary<(string, string),  long> blockingTombstones)
+            {
+                BlockingTombstones = blockingTombstones;
+            }
+
+            public Dictionary<(string, string), long> BlockingTombstones { get; set; }
+
+            public DynamicJsonValue ToJson()
+            {
+                var djv = new DynamicJsonArray();
+                foreach (var key in BlockingTombstones.Keys)
+                {
+                    djv.Add( new DynamicJsonValue
+                    {
+                        [nameof(BlockingTombstoneDetails.Source)] = key.Item1,
+                        [nameof(BlockingTombstoneDetails.Collection)] = key.Item2,
+                        [nameof(BlockingTombstoneDetails.NumberOfTombstones)] = BlockingTombstones[key]
+                    });
+                }
+
+                return new DynamicJsonValue()
+                {
+                    [nameof(BlockingTombstones)] = djv
+                };
+            }
+        }
+
+        internal class BlockingTombstoneDetails
+        {
+            public string Source { get; }
+            public string Collection { get; }
+            public long NumberOfTombstones { get; }
+        }
+    }
+}
+

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -6,7 +6,6 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
-using static Raven.Server.Documents.DocumentsStorage.TombstonesCount;
 
 namespace Raven.Server.NotificationCenter
 {
@@ -27,7 +26,7 @@ namespace Raven.Server.NotificationCenter
             _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
         }
 
-        public void Add(Dictionary<(string, string), DocumentsStorage.TombstonesCount> blockingTombstones)
+        public void Add(Dictionary<(string, string), long> blockingTombstones)
         {
             BlockingTombstonesDetails details = new BlockingTombstonesDetails(blockingTombstones);
             _notificationCenter.Add(AlertRaised.Create(_database, _title, _msg, AlertType.BlockingTombstones,
@@ -48,13 +47,11 @@ namespace Raven.Server.NotificationCenter
                     detail.TryGet(nameof(BlockingTombstoneDetails.Source), out string source);
                     detail.TryGet(nameof(BlockingTombstoneDetails.Collection), out string collection);
                     detail.TryGet(nameof(BlockingTombstoneDetails.NumberOfTombstones), out long numOfTombstones);
-                    detail.TryGet(nameof(BlockingTombstoneDetails.Accuracy), out DocumentsStorage.TombstonesCount.TombstonesAccuracy tombstonesAccuracy);
                     var blockingTombstoneDetails = new BlockingTombstoneDetails()
                     {
                         Source = source,
                         Collection = collection,
-                        NumberOfTombstones = numOfTombstones,
-                        Accuracy = tombstonesAccuracy
+                        NumberOfTombstones = numOfTombstones
                     };
                     list.Add(blockingTombstoneDetails);
                 }
@@ -65,12 +62,12 @@ namespace Raven.Server.NotificationCenter
 
         internal class BlockingTombstonesDetails : INotificationDetails
         {
-            public BlockingTombstonesDetails(Dictionary<(string, string), DocumentsStorage.TombstonesCount> blockingTombstones)
+            public BlockingTombstonesDetails(Dictionary<(string, string), long> blockingTombstones)
             {
                 BlockingTombstones = blockingTombstones;
             }
 
-            public Dictionary<(string, string), DocumentsStorage.TombstonesCount> BlockingTombstones { get; set; }
+            public Dictionary<(string, string), long> BlockingTombstones { get; set; }
 
             public DynamicJsonValue ToJson()
             {
@@ -81,8 +78,7 @@ namespace Raven.Server.NotificationCenter
                     {
                         [nameof(BlockingTombstoneDetails.Source)] = key.Item1,
                         [nameof(BlockingTombstoneDetails.Collection)] = key.Item2,
-                        [nameof(BlockingTombstoneDetails.NumberOfTombstones)] = BlockingTombstones[key].Count,
-                        [nameof(BlockingTombstoneDetails.Accuracy)] = BlockingTombstones[key].Accuracy
+                        [nameof(BlockingTombstoneDetails.NumberOfTombstones)] = BlockingTombstones[key]
                     });
                 }
 
@@ -98,7 +94,6 @@ namespace Raven.Server.NotificationCenter
             public string Source { get; set; }
             public string Collection { get; set; }
             public long NumberOfTombstones { get; set; }
-            public TombstonesAccuracy Accuracy { get; set; }
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -190,6 +190,11 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
+                var userIndex = new UserByName();
+                string indexName = userIndex.IndexName;
+                await userIndex.ExecuteAsync(store);
+                await store.Maintenance.SendAsync(new DisableIndexOperation(indexName));
+
                 var config = Backup.CreateBackupConfiguration(backupPath: backupPath, backupType: BackupType.Backup, incrementalBackupFrequency: "0 0 1 1 *");
                 var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, isFullBackup: true);
 
@@ -207,6 +212,9 @@ namespace SlowTests.Issues
 
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+
+                WaitForUserToContinueTheTest(store);
+
                 Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
             }
         }

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -57,12 +57,13 @@ namespace SlowTests.Issues
                 }
 
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
 
                 await store.Maintenance.SendAsync(new EnableIndexOperation(indexName));
 
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))) == false);
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId) == false);
             }
         }
 
@@ -91,7 +92,14 @@ namespace SlowTests.Issues
                 }
 
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
+
+                var blockingTombstonesDetails = documentDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(notificationId);
+                var detail = blockingTombstonesDetails[0];
+
+                Assert.Equal(1, detail.NumberOfTombstones);
+                Assert.Equal(DocumentsStorage.TombstonesCount.TombstonesAccuracy.Exact, detail.Accuracy);
             }
         }
 
@@ -108,7 +116,7 @@ namespace SlowTests.Issues
                         var user = new User { Name = "Yonatan", Id = $"{i}"};
                         await session.StoreAsync(user);
                     }
-                    
+
                     await session.SaveChangesAsync();
                 }
 
@@ -128,7 +136,14 @@ namespace SlowTests.Issues
                 }
 
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
+
+                var blockingTombstonesDetails = documentDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(notificationId);
+                var detail = blockingTombstonesDetails[0];
+
+                Assert.Equal(10_000, detail.NumberOfTombstones);
+                Assert.Equal(DocumentsStorage.TombstonesCount.TombstonesAccuracy.MoreThan, detail.Accuracy);
             }
         }
 
@@ -157,7 +172,14 @@ namespace SlowTests.Issues
                 }
 
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
+
+                var blockingTombstonesDetails = documentDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(notificationId);
+                var detail = blockingTombstonesDetails[0];
+
+                Assert.Equal(1, detail.NumberOfTombstones);
+                Assert.Equal(DocumentsStorage.TombstonesCount.TombstonesAccuracy.Exact, detail.Accuracy);
             }
         }
 
@@ -208,7 +230,14 @@ namespace SlowTests.Issues
 
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
+
+                var blockingTombstonesDetails = documentDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(notificationId);
+                var detail = blockingTombstonesDetails[0];
+
+                Assert.Equal(1, detail.NumberOfTombstones);
+                Assert.Equal(DocumentsStorage.TombstonesCount.TombstonesAccuracy.Exact, detail.Accuracy);
             }
         }
 
@@ -244,7 +273,14 @@ namespace SlowTests.Issues
 
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
                 await documentDatabase.TombstoneCleaner.ExecuteCleanup();
-                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+                var notificationId = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+                Assert.True(documentDatabase.NotificationCenter.Exists(notificationId));
+
+                var blockingTombstonesDetails = documentDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(notificationId);
+                var detail = blockingTombstonesDetails[0];
+
+                Assert.Equal(2, detail.NumberOfTombstones);
+                Assert.Equal(DocumentsStorage.TombstonesCount.TombstonesAccuracy.Exact, detail.Accuracy);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide.Context;
+using User = SlowTests.Core.Utils.Entities.User;
+using Raven.Server.Documents;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19967 : ReplicationTestBase
+    {
+        public RavenDB_19967(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task TombstoneCleaningAfterIndexDisabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var user = new User { Name = "Yonatan" };
+                var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                }
+
+                var userIndex = new UserByName();
+                string indexName = userIndex.IndexName;
+                await userIndex.ExecuteAsync(store);
+                await store.Maintenance.SendAsync(new DisableIndexOperation(indexName));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+            }
+        }
+
+        [Fact]
+        public async Task TombstoneCleaningAfterReplicationLoaderDisabled()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var user = new User { Name = "Yonatan" };
+                var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store1);
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                }
+
+                var externalList = await SetupReplicationAsync(store1, store2);
+                WaitForDocumentToReplicate<User>(store2, user.Id, 3000);
+                await store1.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(externalList.First().TaskId, OngoingTaskType.Replication, disable: true));
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+            }
+        }
+
+        [Fact]
+        public async Task TombstoneCleaningAfterEtlLoaderDisabled()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var user = new User { Name = "Yonatan"};
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                }
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = store2.Identifier,
+                    Database = store2.Database,
+                    TopologyDiscoveryUrls = store2.Urls
+                };
+
+                await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                var etlConfiguration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = connectionString.Name,
+                    Transforms =
+                    {
+                        new Transformation()
+                        {
+                            Name = "loadAll",
+                            Collections = {"Users"},
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                var result = await store1.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+                Assert.True(WaitForDocument(store2, user.Id));
+
+                await store1.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(result.TaskId, OngoingTaskType.RavenEtl, disable: true));
+                using (var session = store1.OpenAsyncSession())
+                {
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store1);
+                await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+            }
+        }
+
+        [Fact]
+        public async Task TombstoneCleaningAfterPeriodicBackupDisabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var user = new User { Name = "Yonatan"};
+                var user2 = new User { Name = "Yonatan2"};
+                var backupPath = NewDataPath(suffix: "BackupFolder");
+                using (var session = store.OpenAsyncSession())
+                { 
+                    await session.StoreAsync(user);
+                    await session.StoreAsync(user2);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: backupPath, backupType: BackupType.Backup, incrementalBackupFrequency: "0 0 1 1 *");
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, isFullBackup: true);
+
+                config.TaskId = backupTaskId;
+                config.Disabled = true;
+                var operation = new UpdatePeriodicBackupOperation(config);
+                await store.Maintenance.SendAsync(operation);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(user.Id);
+                    session.Delete(user2.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
+                await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+                Assert.True(documentDatabase.NotificationCenter.Exists(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones))));
+            }
+        }
+
+        private class UserByName : AbstractIndexCreationTask<User>
+        {
+            public UserByName()
+            {
+                Map = users => from user in users
+                    select new
+                    {
+                        user.Name
+                    };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_10656.cs
+++ b/test/SlowTests/Issues/RavenDB_10656.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_10656 : ReplicationTestBase
+    public class RavenDB_10656 : ReplicationTestBase, ITombstoneAware
     {
         public RavenDB_10656(ITestOutputHelper output) : base(output)
         {
@@ -142,6 +142,11 @@ namespace SlowTests.Issues
                 ["Products"] = 0,
                 ["Users"] = 0
             };
+        }
+
+        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_10656.cs
+++ b/test/SlowTests/Issues/RavenDB_10656.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_10656 : ReplicationTestBase, ITombstoneAware
+    public class RavenDB_10656 : ReplicationTestBase
     {
         public RavenDB_10656(ITestOutputHelper output) : base(output)
         {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -12,8 +12,8 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.Indexing.MapReduce
-{
-    public class OutputReduceToCollectionReplicationTests : ReplicationTestBase, ITombstoneAware
+{/*
+    public class OutputReduceToCollectionReplicationTests : ReplicationTestBase
     {
         public OutputReduceToCollectionReplicationTests(ITestOutputHelper output) : base(output)
         {
@@ -105,5 +105,5 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 ["DailyInvoices"] = 0
             };
         }
-    }
+    }*/
 }

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -12,8 +12,8 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.Indexing.MapReduce
-{/*
-    public class OutputReduceToCollectionReplicationTests : ReplicationTestBase
+{
+    public class OutputReduceToCollectionReplicationTests : ReplicationTestBase, ITombstoneAware
     {
         public OutputReduceToCollectionReplicationTests(ITestOutputHelper output) : base(output)
         {
@@ -105,5 +105,10 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 ["DailyInvoices"] = 0
             };
         }
-    }*/
+
+        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -979,7 +979,7 @@ namespace SlowTests.Server.Documents.Revisions
             };
         }
 
-        public HashSet<string> GetDisabledSubscribers()
+        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             throw new NotImplementedException();
         }

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -978,5 +978,10 @@ namespace SlowTests.Server.Documents.Revisions
                 ["Users"] = 0
             };
         }
+
+        public HashSet<string> GetDisabledSubscribers()
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.

### Additional description

We return the notification with a list that contains for each disabled subscriber and collection that it blocks how many tombstones are blocked

### Type of change

- New feature

### How risky is the change?

- Low 

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- see comments in https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.
