### PR TITLE
RavenDB-20090 Compacting LOH in next GC background run if LOH takes too much memory

### DIFF
--- a/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MemoryConfiguration.cs
@@ -72,5 +72,10 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Memory.TemporaryDirtyMemoryChecksPeriodInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting TemporaryDirtyMemoryChecksPeriod { get; set; }
+
+        [Description("EXPERT: Force the compaction of Large Object Heap during the next generation 2 GC if its size exceeds the given threshold percentage of installed memory. Default: 25%")]
+        [DefaultValue(0.25f)]
+        [ConfigurationEntry("Memory.GC.LargeObjectHeapCompactionThresholdPercentage", ConfigurationEntryScope.ServerWideOnly)]
+        public float LargeObjectHeapCompactionThresholdPercentage { get; set; }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/1.6.11/ServerGcLohSize.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/1.6.11/ServerGcLohSize.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Lextm.SharpSnmpLib;
+using Raven.Server.Utils;
+using Sparrow;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server;
+
+public class ServerGcLohSize : ServerGcBase<Gauge32>
+{
+    public ServerGcLohSize(MetricCacher metricCacher, GCKind gcKind)
+        : base(metricCacher, gcKind, SnmpOids.Server.GcLohSize)
+    {
+    }
+
+    protected override Gauge32 GetData()
+    {
+        return new Gauge32(new Size(GetGCMemoryInfo().GenerationInfo[3].SizeAfterBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes));
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -174,6 +174,10 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("GC information for {0}. Gets the total committed MB of the managed heap.")]
             public const string GcTotalCommitted = "1.6.11.{0}.15";
 
+            [SnmpEnumIndex(typeof(GCKind))]
+            [Description("GC information for {0}. Gets the large object heap size (in MB) after the last garbage collection of given kind occurred.")]
+            public const string GcLohSize = "1.6.11.{0}.16.3";
+
             public const string MemInfoPrefix = "1.6.12.{0}";
 
             public const string AvailableMemoryForProcessing = "1.6.13";

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -502,6 +502,7 @@ namespace Raven.Server.Monitoring.Snmp
                 store.Add(new ServerGcPromoted(server.MetricCacher, gcKind));
                 store.Add(new ServerGcTotalAvailableMemory(server.MetricCacher, gcKind));
                 store.Add(new ServerGcTotalCommitted(server.MetricCacher, gcKind));
+                store.Add(new ServerGcLohSize(server.MetricCacher, gcKind));
             }
         }
 

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -21,6 +21,7 @@ using Raven.Server.Utils;
 using Raven.Server.Utils.Cli;
 using Sparrow;
 using Sparrow.Logging;
+using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Server.Platform;
 using Sparrow.Utils;
@@ -45,6 +46,8 @@ namespace Raven.Server
             UseOnlyInvariantCultureInRavenDB();
 
             SetCurrentDirectoryToServerPath();
+
+            LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
 
             string[] configurationArgs;
             try

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -579,6 +579,7 @@ namespace Raven.Server.ServerWide
                 Configuration.Memory.UseTotalDirtyMemInsteadOfMemUsage,
                 Configuration.Memory.EnableHighTemporaryDirtyMemoryUse,
                 Configuration.Memory.TemporaryDirtyMemoryAllowedPercentage,
+                Configuration.Memory.LargeObjectHeapCompactionThresholdPercentage,
                 new LowMemoryMonitor(), ServerShutdown);
 
             MemoryInformation.SetFreeCommittedMemory(

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -67,7 +67,8 @@ namespace Sparrow.LowMemory
                     }
 
 #if NET7_0_OR_GREATER
-                    RequestLohCompactionIfNeeded(memoryInfo, now);
+                    if (SupportsCompactionOfLargeObjectHeap)
+                        RequestLohCompactionIfNeeded(memoryInfo, now);
 #endif
                 }
                 catch
@@ -122,6 +123,8 @@ namespace Sparrow.LowMemory
         }
 
 #if NET7_0_OR_GREATER
+        internal bool SupportsCompactionOfLargeObjectHeap { get; set; }
+        
         private void RequestLohCompactionIfNeeded(MemoryInfoResult memoryInfo, DateTime now)
         {
             if (now - _lastLohCompactionRequest > _lohCompactionInterval && GCSettings.LargeObjectHeapCompactionMode != GCLargeObjectHeapCompactionMode.CompactOnce)

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -68,7 +68,7 @@ namespace Sparrow.LowMemory
                                            $"{MemoryUtils.GetExtendedMemoryInfo(memoryInfo)}");
                     }
 #if NET7_0_OR_GREATER
-                    if (isLowMemory && now - _lastLohCompaction > _lohCompactionInterval)
+                    if (now - _lastLohCompaction > _lohCompactionInterval)
                     {
                         var info = GC.GetGCMemoryInfo(GCKind.Any);
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -29,6 +29,7 @@ using Raven.Server.Utils;
 using Raven.Server.Utils.Features;
 using Sparrow.Collections;
 using Sparrow.Logging;
+using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Platform;
@@ -105,6 +106,8 @@ namespace FastTests
             {
                 Console.WriteLine($"Execution of GC due to IO failure on path '{x.Path}' took {x.Duration} (attempt: {x.Attempt})");
             };
+
+            LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
 
 #if DEBUG2
             TaskScheduler.UnobservedTaskException += (sender, args) =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20090/Consider-compacting-LOH-in-next-GC-background-run-after-Low-Memory-mode

### Additional description

During the regular memory status checkup we'll also check the size of Large Object Heap (every 15 minutes). If it takes more than 25% (configurable) we'll set `GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce` that will force LOH compaction during next blocking gen 2 garbage collection. 

This way we'll be able to recover from LOH fragmentation issues which resulted in OOM in some specific usage scenarios. Note that we don't do it during low memory because our experiments showed that it was too late already.

### Type of change

- Managed memory usage optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. It might affect any feature since it's about process wide usage of managed memory

### UI work

- No UI work is needed
