### PR TITLE
RavenDB-20444 Skip inner subclauses when applying boosting via `DocumentQuery`.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20444.cs
+++ b/test/SlowTests/Issues/RavenDB-20444.cs
@@ -1,0 +1,41 @@
+using FastTests;
+using Raven.Client.Documents.Queries.Explanation;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20444 : RavenTestBase
+{
+    public RavenDB_20444(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private record Doc(string StrVal, int? NumVal);
+    
+    [RavenFact(RavenTestCategory.Querying)]
+    public void BoostingIsNotAppliedToCorrectSubclause()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        var query = session.Advanced.DocumentQuery<Doc>()
+            .OpenSubclause() // boost(
+                .Search(x => x.StrVal, "match") // search(StrVa;, $p0)
+                .AndAlso() // and
+                .OpenSubclause() // (
+                    .WhereGreaterThanOrEqual(x => x.NumVal, 0) //NumVal >= $p1
+                    .OrElse() // or
+                    .WhereEquals(x => x.NumVal, (int?)null) // NumVal = $p2
+                .CloseSubclause() // )
+            .CloseSubclause() // 
+            .Boost(0) // , $p3)
+            .OrderByScore()
+            .OrderByDescending(x => x.NumVal)
+            .IncludeExplanations(out Explanations explanations);
+
+        var rql = query.ToString();
+        Assert.Equal("from 'Docs' where boost(search(StrVal, $p0) and (NumVal >= $p1 or NumVal = $p2), $p3) order by score(), NumVal as long desc include explanations()", rql);
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20444

### Additional description

 Skip inner subclauses when applying boosting via `DocumentQuery`. When we found `CloseSubclause` in previous tokens (before finding any `OpenSubclause`) that means we have to skip `OpenSubclause`.

### Type of change

- Bug fix


### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
