### PR TITLE
RavenDB-20289 Changed size value source when writing QueryResult for BlittableJsonReaderObject

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1616,14 +1616,21 @@ namespace Raven.Server.Json
                     continue;
                 }
 
-                totalDocumentsSizeInBytes += o.Size;
-
                 using (o)
                 {
                     writer.WriteObject(o);
+                    
+                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    
+                    if (o.HasParent)
+                    {
+                        // If blittable has a parent then its size is the parent's size
+                        // Let's use the number of actually written bytes then
+                        totalDocumentsSizeInBytes += writtenBytes;
+                    }
+                    else
+                        totalDocumentsSizeInBytes += o.Size;
                 }
-
-                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndArray();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20289/Invalid-unit-in-performance-hint

### Additional description

If `BlittableJsonReaderObject` has a parent, we assign parent size to its `_size` property. In such case, we want to return number of bytes written to stream instead.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
