### PR TITLE
RavenDB-20479 - SlowTests.Client.TimeSeries.Replication.TimeSeriesRep…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Operations;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using SlowTests.Core.Utils.Entities;
@@ -607,8 +606,8 @@ namespace SlowTests.Client.TimeSeries.Replication
 
                 await Task.Delay(3000); // wait for replication ping-pong to settle down
 
-                EnsureReplicating(storeA, storeB);
-                EnsureReplicating(storeB, storeA);
+                EnsureReplicating(storeA, storeB, "marker1$users/ayende");
+                EnsureReplicating(storeB, storeA, "marker2$users/ayende");
 
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())


### PR DESCRIPTION
…licationTests.CanReplicateManyWithDeletions(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20479/SlowTests.Client.TimeSeries.Replication.TimeSeriesReplicationTests.CanReplicateManyWithDeletionsoptions-DatabaseMode-Sharded

### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
