### PR TITLE
RavenDB-19696 Raven ETL fails to send a document that has timeseries and attachments

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -472,8 +472,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 }
                 else
                 {
-                    doc.TryGetMetadata(out var metadata);
-                    var collection = metadata[Constants.Documents.Metadata.Collection].ToString();
+                    var collection = Database.DocumentsStorage.ExtractCollectionName(Context, doc.Data).Name;
                     
                     var etlExtractedItem = new RavenEtlItem(doc, collection);
                     var attachments = GetAttachmentsFor(etlExtractedItem);

--- a/test/SlowTests/Issues/RavenDB-19696.cs
+++ b/test/SlowTests/Issues/RavenDB-19696.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19696 : EtlTestBase
+    {
+        public RavenDB_19696(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [Fact]
+        public async Task EtlCanSendDocWithTimeSeriesAndAttachment()
+        {
+            const string id = "users/1";
+            using (var store = GetDocumentStore())
+            using (var replica = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "ayende"
+                    }, id);
+
+                    session.TimeSeriesFor(id, "Heartrate").Append(DateTime.Now, 1);
+
+                    await using var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 });
+                    session.Advanced.Attachments.Store(id, "profileImage", backgroundStream, "ImGgE/jPeG");
+
+                    await session.SaveChangesAsync();
+                }
+                 
+                var taskName = "etl-test";
+                var csName = "cs-test";
+
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = csName, 
+                    Name = taskName, 
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "S1", 
+                            Collections = { "Users" }
+                        }
+                    }
+                };
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = csName, 
+                    TopologyDiscoveryUrls = replica.Urls, 
+                    Database = replica.Database,
+                };
+
+                var etlDone = WaitForEtl(replica, (n, s) => s.LoadSuccesses > 0);
+                
+                var putResult = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                Assert.NotNull(putResult.RaftCommandIndex);
+                store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(configuration));
+                
+                etlDone.Wait(TimeSpan.FromSeconds(10));
+                
+                using (var session = replica.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("ayende", user.Name);
+
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    Assert.Equal("Users", metadata[Constants.Documents.Metadata.Collection]);
+                    Assert.NotEmpty(session.TimeSeriesFor(user, "Heartrate").Get());
+                }
+            }
+        }
+        
+        [Fact]
+        public async Task EtlCanSendDocWithTimeSeriesCountersAndAttachments()
+        {
+            const string id = "users/1";
+            using (var store = GetDocumentStore())
+            using (var replica = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "ayende"
+                    }, id);
+
+                    session.TimeSeriesFor(id, "Heartrate").Append(DateTime.Now, 1);
+                    session.CountersFor(id).Increment("Followers", 1000000);
+
+                    await using var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 });
+                    session.Advanced.Attachments.Store(id, "profileImage", backgroundStream, "ImGgE/jPeG");
+
+                    await session.SaveChangesAsync();
+                }
+                 
+                var taskName = "etl-test";
+                var csName = "cs-test";
+
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = csName, 
+                    Name = taskName, 
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "S1", 
+                            Collections = { "Users" }
+                        }
+                    }
+                };
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = csName, 
+                    TopologyDiscoveryUrls = replica.Urls, 
+                    Database = replica.Database,
+                };
+
+                var etlDone = WaitForEtl(replica, (n, s) => s.LoadSuccesses > 0);
+                
+                var putResult = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                Assert.NotNull(putResult.RaftCommandIndex);
+                store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(configuration));
+                
+                etlDone.Wait(TimeSpan.FromSeconds(10));
+                
+                using (var session = replica.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("ayende", user.Name);
+
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    Assert.Equal("Users", metadata[Constants.Documents.Metadata.Collection]);
+                    Assert.Equal(1000000, session.CountersFor(user).Get("Followers"));
+                    Assert.NotEmpty(session.TimeSeriesFor(user, "Heartrate").Get());
+                }
+            }
+        }
+        
+        [Fact]
+        public async Task EtlCanSendDocWithCountersAndAttachments()
+        {
+            const string id = "users/1";
+            using (var store = GetDocumentStore())
+            using (var replica = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "ayende"
+                    }, id);
+
+                    session.CountersFor(id).Increment("Followers", 1000000);
+
+                    await using var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 });
+                    session.Advanced.Attachments.Store(id, "profileImage", backgroundStream, "ImGgE/jPeG");
+
+                    await session.SaveChangesAsync();
+                }
+                 
+                var taskName = "etl-test";
+                var csName = "cs-test";
+
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = csName, 
+                    Name = taskName, 
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "S1", 
+                            Collections = { "Users" }
+                        }
+                    }
+                };
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = csName, 
+                    TopologyDiscoveryUrls = replica.Urls, 
+                    Database = replica.Database,
+                };
+
+                var etlDone = WaitForEtl(replica, (n, s) => s.LoadSuccesses > 0);
+                
+                var putResult = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                Assert.NotNull(putResult.RaftCommandIndex);
+                store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(configuration));
+                
+                etlDone.Wait(TimeSpan.FromSeconds(10));
+                
+                using (var session = replica.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("ayende", user.Name);
+
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    Assert.Equal("Users", metadata[Constants.Documents.Metadata.Collection]);
+                    Assert.Equal(1000000, session.CountersFor(user).Get("Followers"));
+                }
+            }
+        }
+    }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19696/Raven-ETL-fails-to-send-a-document-that-has-timeseries-and-attachments

### Additional description

An ETL error occurred when the document with _time series_ and other documents extensions was flushed to the ETL. The reason behind that was the cheap call of `PutFullDocument()`, which lacked the attachments and counters arguments that have also to be stored when the time series item has arrived before the document (we put the new document anyway in such case, that's why we call `PutFullDocument()`). 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
