### PR TITLE
RavenDB-20114: `UpdateLicenseLimitsCommand` sometimes fails on startup

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -138,10 +138,10 @@ namespace Raven.Server.Commercial
                 ReloadLicense(firstRun: true);
                 ReloadLicenseLimits(firstRun: true);
 
+                ClusterCommandsVersionManager.OnClusterVersionChange += PutMyNodeInfoClusterVersionChange;
+
                 if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion > 0)
                     Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
-                else
-                    ClusterCommandsVersionManager.OnClusterVersionChange += PutMyNodeInfoClusterVersionChange;
             }
             catch (Exception e)
             {
@@ -163,7 +163,6 @@ namespace Raven.Server.Commercial
                 return;
 
             Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
-            ClusterCommandsVersionManager.OnClusterVersionChange -= PutMyNodeInfoClusterVersionChange;
         }
 
         public async Task PutMyNodeInfoAsync()
@@ -955,6 +954,7 @@ namespace Raven.Server.Commercial
         public void Dispose()
         {
             _leaseLicenseTimer?.Dispose();
+            ClusterCommandsVersionManager.OnClusterVersionChange -= PutMyNodeInfoClusterVersionChange;
         }
 
         private void ThrowIfCannotActivateLicense(LicenseStatus newLicenseStatus)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20114/UpdateLicenseLimitsCommand-sometimes-fails-on-startup

### Additional description

In order to execute the `PutMyNodeInfoAsync` method during the `LicenseManager` initialization, we need the `ClusterCommandsVersionManager` to have a non-`0` value for the cluster version.

This pull request addresses a situation where the cluster version is not set yet. It ensures that `PutMyNodeInfoAsync` will be executed after the cluster version is set.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed