### PR TITLE
RavenDB-19948: prevent posting destination's external scripts without…

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -58,9 +58,10 @@ namespace Raven.Client.Documents.Operations.Backups
             TimeoutInMs = script.TimeoutInMs;
         }
 
-        [SecurityClearance(AuthenticationStatus.Allowed)]
+        [SecurityClearance(SecurityClearance.Operator)]
         public string Exec { get; set; }
-        [SecurityClearance(AuthenticationStatus.Allowed)]
+
+        [SecurityClearance(SecurityClearance.Operator)]
         public string Arguments { get; set; }
 
         public int TimeoutInMs { get; set; }

--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using Raven.Client.ServerWide.Operations.Certificates;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
@@ -57,8 +58,9 @@ namespace Raven.Client.Documents.Operations.Backups
             TimeoutInMs = script.TimeoutInMs;
         }
 
+        [SecurityClearance(AuthenticationStatus.Allowed)]
         public string Exec { get; set; }
-
+        [SecurityClearance(AuthenticationStatus.Allowed)]
         public string Arguments { get; set; }
 
         public int TimeoutInMs { get; set; }

--- a/src/Raven.Client/ServerWide/Operations/Certificates/SecurityClearanceAttribute.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/SecurityClearanceAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Util;
+using System.Reflection;
+using Raven.Client.Exceptions.Security;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.ServerWide.Operations.Certificates
+{
+
+    public enum AuthenticationStatus
+    {
+        None,
+        NoCertificateProvided,
+        UnfamiliarCertificate,
+        UnfamiliarIssuer,
+        Allowed,
+        Operator,
+        ClusterAdmin,
+        Expired,
+        NotYetValid
+    }
+    public class SecurityClearanceAttribute : Attribute
+    {
+        public AuthenticationStatus SecurityClearanceLevel { get; set; }
+        public SecurityClearanceAttribute(AuthenticationStatus name)
+        {
+            SecurityClearanceLevel = name;
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Operations/Certificates/SecurityClearanceAttribute.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/SecurityClearanceAttribute.cs
@@ -7,25 +7,14 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.ServerWide.Operations.Certificates
 {
+    [AttributeUsage(AttributeTargets.Property)]
+    internal class SecurityClearanceAttribute : Attribute
+    {
+        public SecurityClearance SecurityClearanceLevel { get; set; }
 
-    public enum AuthenticationStatus
-    {
-        None,
-        NoCertificateProvided,
-        UnfamiliarCertificate,
-        UnfamiliarIssuer,
-        Allowed,
-        Operator,
-        ClusterAdmin,
-        Expired,
-        NotYetValid
-    }
-    public class SecurityClearanceAttribute : Attribute
-    {
-        public AuthenticationStatus SecurityClearanceLevel { get; set; }
-        public SecurityClearanceAttribute(AuthenticationStatus name)
+        public SecurityClearanceAttribute(SecurityClearance level)
         {
-            SecurityClearanceLevel = name;
+            SecurityClearanceLevel = level;
         }
     }
 }

--- a/src/Raven.Server/Utils/SecurityClearanceValidator.cs
+++ b/src/Raven.Server/Utils/SecurityClearanceValidator.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.Linq.Indexing;
+using Raven.Client.Extensions;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
+
+namespace Raven.Server.Utils
+{
+    public static class SecurityClearanceValidator
+    {
+        internal static void AssertSecurityClearance(object input, RavenServer.AuthenticationStatus status)
+        {
+            if (input == null)
+                return;
+            if (status == RavenServer.AuthenticationStatus.ClusterAdmin)
+                return;
+
+            var members = ReflectionUtil.GetPropertiesAndFieldsFor(input.GetType(), BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var member in members)
+            {
+                var type = member.GetMemberType();
+                if (type.IsClass && type.IsPrimitive == false && type != typeof(string))
+                    AssertSecurityClearance(member.GetValue(input), status);
+
+                var securityClearanceAttribute = member.GetCustomAttribute<SecurityClearanceAttribute>();
+                if (securityClearanceAttribute != null)
+                    AssertSecurityClearanceLevel(securityClearanceAttribute.SecurityClearanceLevel.ToString(), status.ToString());
+            }
+
+        }
+
+        internal static void AssertSecurityClearanceOnGet(object input, RavenServer.AuthenticationStatus status)
+        {
+            if (input == null)
+                return;
+            // if (status == RavenServer.AuthenticationStatus.ClusterAdmin)
+            //     return;
+
+            var members = ReflectionUtil.GetPropertiesAndFieldsFor(input.GetType(), BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var member in members)
+            {
+                var type = member.GetMemberType();
+                if (type.IsClass && type.IsPrimitive == false && type != typeof(string))
+                    AssertSecurityClearanceOnGet(member.GetValue(input), status);
+
+                var securityClearanceAttribute = member.GetCustomAttribute<SecurityClearanceAttribute>();
+                if (securityClearanceAttribute != null)
+                    Console.WriteLine("fdfdf");
+            }
+        }
+
+
+        private static void AssertSecurityClearanceLevel(string attributeStatus, string userStatus)
+        {
+            if (attributeStatus == userStatus)
+                throw new AuthenticationException(
+                    $"Bad security clearance: '{userStatus}'. The current user does not have the necessary security clearance. " +
+                    $"External script execution is only allowed for users with '{RavenServer.AuthenticationStatus.Operator}' or higher security clearance.");
+        }
+    }
+
+}

--- a/src/Raven.Server/Utils/SecurityClearanceValidator.cs
+++ b/src/Raven.Server/Utils/SecurityClearanceValidator.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.Utils
             switch (attributeStatus, userStatus)
             {
                 case (SecurityClearance.Operator, RavenServer.AuthenticationStatus.Allowed):
+                case (SecurityClearance.ClusterAdmin, RavenServer.AuthenticationStatus.Operator):
+                case (SecurityClearance.ClusterAdmin, RavenServer.AuthenticationStatus.Allowed):
                     throw new AuthenticationException(
                         $"Bad security clearance: '{userStatus}'. The current user does not have the necessary security clearance. " +
                         $"This operation is only allowed for users with '{attributeStatus}' or higher security clearance.");

--- a/src/Raven.Server/Utils/SecurityClearanceValidator.cs
+++ b/src/Raven.Server/Utils/SecurityClearanceValidator.cs
@@ -1,15 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Reflection;
 using System.Security.Authentication;
-using System.Threading;
-using System.Threading.Tasks;
-using Jint.Native;
-using Newtonsoft.Json.Linq;
-using Raven.Client.Documents.Linq.Indexing;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.Util;
@@ -33,24 +23,18 @@ namespace Raven.Server.Utils
 
                 var securityClearanceAttribute = member.GetCustomAttribute<SecurityClearanceAttribute>();
                 if (securityClearanceAttribute != null)
-                    AssertSecurityClearanceLevel(securityClearanceAttribute.SecurityClearanceLevel, status);
+                    AssertSecurityClearanceLevel(securityClearanceAttribute.SecurityClearanceLevel, (RavenServer.AuthenticationStatus)status);
             }
         }
 
-        private static void AssertSecurityClearanceLevel(SecurityClearance attributeStatus, RavenServer.AuthenticationStatus? userStatus)
+        private static void AssertSecurityClearanceLevel(SecurityClearance attributeStatus, RavenServer.AuthenticationStatus userStatus)
         {
-
             switch (attributeStatus, userStatus)
             {
                 case (SecurityClearance.Operator, RavenServer.AuthenticationStatus.Allowed):
                     throw new AuthenticationException(
                         $"Bad security clearance: '{userStatus}'. The current user does not have the necessary security clearance. " +
                         $"This operation is only allowed for users with '{attributeStatus}' or higher security clearance.");
-
-                case (SecurityClearance.Operator, RavenServer.AuthenticationStatus.Operator):
-                case (SecurityClearance.ValidUser, RavenServer.AuthenticationStatus.Allowed):
-                    break;
-
                 default:
                     return;
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -359,9 +359,8 @@ namespace Raven.Server.Web.System
                     BackupConfigurationHelper.UpdateLocalPathIfNeeded(configuration, ServerStore);
                     BackupConfigurationHelper.AssertBackupConfiguration(configuration);
                     BackupConfigurationHelper.AssertDestinationAndRegionAreAllowed(configuration, ServerStore);
-                    if (feature != null)
-                        SecurityClearanceValidator.AssertSecurityClearance(configuration, feature.Status);
-
+                    SecurityClearanceValidator.AssertSecurityClearance(configuration, feature?.Status);
+                    
                     readerObject = context.ReadObject(configuration.ToJson(), "updated-backup-configuration");
                 },
                 fillJson: (json, readerObject, index) =>
@@ -457,8 +456,7 @@ namespace Raven.Server.Web.System
                 ServerStore.LicenseManager.AssertCanAddPeriodicBackup(backupConfiguration);
                 BackupConfigurationHelper.AssertBackupConfigurationInternal(backupConfiguration);
                 BackupConfigurationHelper.AssertDestinationAndRegionAreAllowed(backupConfiguration, ServerStore);
-                if (feature != null)
-                    SecurityClearanceValidator.AssertSecurityClearance(backupConfiguration, feature.Status);
+                SecurityClearanceValidator.AssertSecurityClearance(backupConfiguration, feature?.Status);
 
                 var sw = Stopwatch.StartNew();
                 ServerStore.ConcurrentBackupsCounter.StartBackup(backupName, Logger);
@@ -691,7 +689,6 @@ namespace Raven.Server.Web.System
                     }
                 }
 
-                var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     var result = new GetConnectionStringsResult
@@ -780,9 +777,7 @@ namespace Raven.Server.Web.System
                 beforeSetupConfiguration: (string databaseName, ref BlittableJsonReaderObject readerObject, JsonOperationContext context) =>
                 {
                     var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
-                    if (feature != null)
-                        SecurityClearanceValidator.AssertSecurityClearance(JsonDeserializationClient.OlapConnectionString(readerObject),
-                            feature.Status);
+                    SecurityClearanceValidator.AssertSecurityClearance(JsonDeserializationClient.OlapConnectionString(readerObject),feature?.Status);
                 });
         }
 

--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL.OLAP;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Xunit;
+using Xunit.Abstractions;
+using Sparrow.Platform;
+using Raven.Tests.Core.Utils.Entities;
+
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19948 : RavenTestBase
+    {
+
+        public RavenDB_19948(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /* should work:
+         * One Time Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ClusterAdmin , Operator
+         */
+        [Theory]
+        [InlineData(SecurityClearance.ClusterAdmin)]
+        [InlineData(SecurityClearance.Operator)]
+        public void CanPostOneTimeBackupConfigurationScriptWithClusterAdminClearance(SecurityClearance sc)
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value,
+                new Dictionary<string, DatabaseAccess>(), sc);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options() { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var operation = store.Maintenance.ForDatabase(dbName).Send(new BackupOperation(new BackupConfiguration
+                {
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                }));
+
+                var backupResult = (BackupResult)operation.WaitForCompletion(TimeSpan.FromSeconds(30));
+                Assert.NotEqual(0, backupResult.Documents.ReadCount);
+                Assert.NotNull(backupResult.LocalBackup.BackupDirectory);
+            }
+        }
+
+        /* shouldn't work:
+         * One Time Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostOneTimeBackupConfigurationScriptWitValidUserClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                Action act = () => store.Maintenance.ForDatabase(dbName).Send(new BackupOperation(new BackupConfiguration
+                {
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                })).WaitForCompletion(TimeSpan.FromSeconds(30));
+
+                var exception = Assert.Throws<RavenException>(act);
+                Assert.Contains(
+                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    exception.Message);
+            }
+
+        }
+
+        /* should work:
+         * Periodic Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ClusterAdmin, Operator
+         */
+        [Theory]
+        [InlineData(SecurityClearance.ClusterAdmin)]
+        [InlineData(SecurityClearance.Operator)]
+        public void CanPostPeriodicBackupConfigurationScriptWithClusterAdminClearance(SecurityClearance sc)
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), sc);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: NewDataPath(suffix: "BackupFolder"), fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                config.LocalSettings = new LocalSettings
+                {
+                    FolderPath = path,
+                    GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                };
+
+                var result = store.Maintenance.ForDatabase(dbName).Send(new UpdatePeriodicBackupOperation(config));
+
+                Assert.NotNull(result.RaftCommandIndex);
+
+            }
+
+        }
+
+        /* shouldn't work:
+         * Periodic Backup.
+         * attempt to post external configuration script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostPeriodicBackupConfigurationScriptWitValidUserClearance()
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            }))
+            {
+                using (var session = store.OpenSession(dbName))
+                {
+                    session.Store(new User() { Name = "Adeyemi" });
+                    session.SaveChanges();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath: NewDataPath(suffix: "BackupFolder"), fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                config.LocalSettings = new LocalSettings
+                {
+                    FolderPath = path,
+                    GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                };
+
+                Action act = () => store.Maintenance.ForDatabase(dbName).Send(new UpdatePeriodicBackupOperation(config));
+
+                var exception = Assert.Throws<RavenException>(act);
+                Assert.Contains(
+                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    exception.Message);
+            }
+
+        }
+
+        /* should work:
+       * Olap ETL Connection String.
+       * attempt to post external connection string script by overriding local conf. destination
+       * security clearance: ClusterAdmin, Operator
+       */
+        [Theory]
+        [InlineData(SecurityClearance.ClusterAdmin)]
+        [InlineData(SecurityClearance.Operator)]
+        public void CanPostOlapConnectionStringScriptWithClusterAdminClearance(SecurityClearance sc)
+        {
+
+            var dbName = GetDatabaseName();
+            TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>(), sc);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+                var olapConnStr = new OlapConnectionString
+                {
+                    Name = "olap-cs",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                };
+
+
+                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr));
+                Assert.NotNull(result0.RaftCommandIndex);
+
+                var result = store.Maintenance.Send(new GetConnectionStringsOperation(store.Database, ConnectionStringType.Olap));
+                Assert.NotNull(result.RavenConnectionStrings);
+
+            }
+        }
+
+        /* shouldn't work:
+         * Olap ETL Connection String.
+         * attempt to post external connection string script by overriding local conf. destination
+         * security clearance: ValidUser
+         */
+        [Fact]
+        public void CannotPostOlapConnectionStringScriptWitValidUserClearance()
+        {
+
+            var dbName = GetDatabaseName();
+            TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+                new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
+
+            var path = NewDataPath(forceCreateDir: true);
+            var scriptPath = GenerateConfigurationScript(path, out string command);
+
+            using (var store = GetDocumentStore(new Options { AdminCertificate = adminCertificate, ClientCertificate = clientCertificate, ModifyDatabaseName = s => dbName }))
+            {
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+                var olapConnStr = new OlapConnectionString
+                {
+                    Name = "olap-cs",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = path,
+                        GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
+                    }
+                };
+               
+                var exception = Assert.Throws<RavenException>(() =>
+                    store.Maintenance.ForDatabase(dbName).Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)));
+                Assert.Contains(
+                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    exception.Message);
+            }
+        }
+
+        private static string GenerateConfigurationScript(string path, out string command)
+        {
+            var scriptPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Guid.NewGuid().ToString(), ".ps1"));
+            var localSetting = new LocalSettings { FolderPath = path };
+            var localSettingsString = JsonConvert.SerializeObject(localSetting);
+
+            string script;
+            if (PlatformDetails.RunningOnPosix)
+            {
+                command = "bash";
+                script = $"#!/bin/bash\r\necho '{localSettingsString}'";
+                File.WriteAllText(scriptPath, script);
+                Process.Start("chmod", $"700 {scriptPath}");
+            }
+            else
+            {
+                command = "powershell";
+                script = $"echo '{localSettingsString}'";
+                File.WriteAllText(scriptPath, script);
+            }
+
+            return scriptPath;
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -9,8 +9,8 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Security;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server;
 using Xunit;
 using Xunit.Abstractions;
 using Sparrow.Platform;
@@ -112,7 +112,7 @@ namespace SlowTests.Issues
 
                 var exception = Assert.Throws<RavenException>(act);
                 Assert.Contains(
-                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    $"Bad security clearance: '{RavenServer.AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. This operation is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
                     exception.Message);
             }
 
@@ -208,7 +208,7 @@ namespace SlowTests.Issues
 
                 var exception = Assert.Throws<RavenException>(act);
                 Assert.Contains(
-                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    $"Bad security clearance: '{RavenServer.AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. This operation is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
                     exception.Message);
             }
 
@@ -303,7 +303,7 @@ namespace SlowTests.Issues
                 var exception = Assert.Throws<RavenException>(() =>
                     store.Maintenance.ForDatabase(dbName).Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)));
                 Assert.Contains(
-                    $"Bad security clearance: '{AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. External script execution is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
+                    $"Bad security clearance: '{RavenServer.AuthenticationStatus.Allowed}'. The current user does not have the necessary security clearance. This operation is only allowed for users with '{SecurityClearance.Operator}' or higher security clearance.",
                     exception.Message);
             }
         }


### PR DESCRIPTION
… having a suitable auth status

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19948/Allow-to-limit-script-execution-to-operators-and-higher

### Additional description

prevent posting destination's external scripts without having a suitable auth status

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
