### PR TITLE
RavenDB-20449: RavenBooleanQuery - Ensure we're not merging boosted clauses together into one clause.

### DIFF
--- a/src/Raven.Server/Documents/Queries/RavenBooleanQuery.cs
+++ b/src/Raven.Server/Documents/Queries/RavenBooleanQuery.cs
@@ -52,9 +52,9 @@ namespace Raven.Server.Documents.Queries
                 canMergeClauses = false;
                 buildSteps?.Add($"Cannot perform merging `{rightRbq}` into `{ToString()}` since this {nameof(rightRbq)} has operator `{rightRbq._operator} and this {nameof(RavenBooleanQuery)} has {_operator}.");
             }
-            // If this RavenBooleanQuery or the incoming Rbq has a boost, we cannot merge it.
-            // When the right query is not a RavenBooleanQuery, we can merge it since it won't be boosted by this parent. 
-            else if (IsBoosted || right is RavenBooleanQuery {IsBoosted: true}) 
+            // If this RavenBooleanQuery we cannot merge it.
+            // When `right` is RavenBooleanQuery we can merge it but we cannot perform unboxing.
+            else if (IsBoosted) 
             {
                 canMergeClauses = false;
                 buildSteps?.Add($"Cannot perform merging `{right}` into `{ToString()}` since boost is non-default. Left: {Boost} Right: {right.Boost}");
@@ -91,7 +91,9 @@ namespace Raven.Server.Documents.Queries
                 canMergeClauses = false;
                 buildSteps?.Add($"Cannot perform merging `{rightRbq}` into `{ToString()}` since this {nameof(rightRbq)} has operator `{rightRbq._operator} and this {nameof(RavenBooleanQuery)} has {_operator}.");
             }
-            else if (IsBoosted || right is RavenBooleanQuery {IsBoosted: true})
+            // If this RavenBooleanQuery we cannot merge it.
+            // When `right` is RavenBooleanQuery we can merge it but we cannot perform unboxing.
+            else if (IsBoosted)
             {
                 canMergeClauses = false;
                 buildSteps?.Add($"Cannot perform merging `{right}` into `{ToString()}` since boost is non-default. Left: {Boost} Right: {right.Boost}");
@@ -119,7 +121,7 @@ namespace Raven.Server.Documents.Queries
         {
             if (query is RavenBooleanQuery booleanQuery)
             {
-                if (booleanQuery._operator == @operator && booleanQuery.IsBoosted == false && IsBoosted == false)
+                if (booleanQuery._operator == @operator && booleanQuery.IsBoosted == false)
                 {
                     foreach (var booleanClause in booleanQuery.Clauses)
                         Add(booleanClause);

--- a/test/FastTests/Issues/RavenBooleanQueryTests.cs
+++ b/test/FastTests/Issues/RavenBooleanQueryTests.cs
@@ -1,0 +1,81 @@
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
+using Xunit;
+using Query = Lucene.Net.Search.Query;
+
+namespace FastTests.Issues;
+
+//Low-level query optimization tests. 
+public class RavenBooleanQueryTests
+{
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void CanMergeTwoRavenBooleanQueryWithoutBoosting(OperatorType operatorType, Occur occur)
+    {
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{GetExampleTerm("1"), occur}, {GetExampleTerm("2"), occur}};
+
+        var rbqRight = new RavenBooleanQuery(operatorType) {{GetExampleTerm("3"), occur}, {GetExampleTerm("4"), occur}};
+
+        Assert.True(operatorType is OperatorType.And
+            ? rbqLeft.TryAnd(rbqRight, null)
+            : rbqLeft.TryOr(rbqRight, null));
+
+        var merged = rbqLeft;
+        Assert.Equal(4, merged.Clauses.Count);
+        for (int i = 0; i < 4; ++i)
+        {
+            var clause = merged.Clauses[i].Query as TermQuery;
+            Assert.NotNull(clause);
+            Assert.Equal($"{i + 1}", clause.Term.Text);
+        }
+    }
+
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void ShouldNotMergeTwoDifferentBoosting(OperatorType operatorType, Occur occur)
+    {
+        //this is boosted (even it's 0)
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{GetExampleTerm("1"), occur}, {GetExampleTerm("2"), occur}};
+        rbqLeft.Boost = 0f;
+
+        var third = GetExampleTerm("3");
+
+        var resultOfMerge = operatorType is OperatorType.And
+            ? rbqLeft.TryAnd(third, null)
+            : rbqLeft.TryOr(third, null);
+
+        var mode = occur is Occur.MUST ? "+" : "";
+        Assert.NotEqual($"({mode}exampleField:1 {mode}exampleField:2 {mode}exampleField:3)^.0", rbqLeft.ToString());
+        Assert.Equal($"({mode}exampleField:1 {mode}exampleField:2)^.0", rbqLeft.ToString());
+
+        Assert.Equal(false, resultOfMerge);
+    }
+
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void TwoBoostedRavenBooleanQueriesShouldNotBeMerged(OperatorType operatorType, Occur occur)
+    {
+        var firstTerm = GetExampleTerm("1");
+        var secondTerm = GetExampleTerm("2");
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{firstTerm, occur}, {secondTerm, occur}};
+        rbqLeft.Boost = 2.0f;
+        var rbqRight = new RavenBooleanQuery(operatorType) {{GetExampleTerm("2"), occur}, {GetExampleTerm("3"), occur}};
+        rbqRight.Boost = 3.0f;
+        
+        
+        Assert.False(operatorType is OperatorType.And 
+            ? rbqLeft.TryAnd(rbqRight, null) 
+            : rbqLeft.TryOr(rbqRight, null));
+
+        Assert.Equal(2, rbqLeft.Clauses.Count);
+        Assert.Equal(firstTerm, rbqLeft.Clauses[0].Query);
+        Assert.Equal(secondTerm, rbqLeft.Clauses[1].Query);
+    }
+
+    private static Query GetExampleTerm(string term, float? boost = null) => LuceneQueryHelper.Term("exampleField", term, LuceneTermType.String);
+}

--- a/test/FastTests/Issues/RavenBooleanQueryTests.cs
+++ b/test/FastTests/Issues/RavenBooleanQueryTests.cs
@@ -1,14 +1,16 @@
-using Lucene.Net.Index;
+using System.Linq;
 using Lucene.Net.Search;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
+using Sparrow.Extensions;
 using Xunit;
+using Xunit.Abstractions;
 using Query = Lucene.Net.Search.Query;
 
 namespace FastTests.Issues;
 
 //Low-level query optimization tests. 
-public class RavenBooleanQueryTests
+public class RavenBooleanQueryTests : RavenTestBase
 {
     [Theory]
     [InlineData(OperatorType.And, Occur.MUST)]
@@ -76,6 +78,80 @@ public class RavenBooleanQueryTests
         Assert.Equal(firstTerm, rbqLeft.Clauses[0].Query);
         Assert.Equal(secondTerm, rbqLeft.Clauses[1].Query);
     }
+    
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void CanMergeTwoNotBoostedRbq(OperatorType operatorType, Occur occur)
+    {
+        var firstTerm = GetExampleTerm("1");
+        var secondTerm = GetExampleTerm("2");
+        var thirdTerm = GetExampleTerm("3", boost: 10);
+        var fourthTerm = GetExampleTerm("4", boost: 15);
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{firstTerm, occur}, {secondTerm, occur}};
+        var rbqRight = new RavenBooleanQuery(operatorType) {{thirdTerm, occur}, {fourthTerm, occur}};
 
-    private static Query GetExampleTerm(string term, float? boost = null) => LuceneQueryHelper.Term("exampleField", term, LuceneTermType.String);
+
+        Assert.True(operatorType is OperatorType.And 
+            ? rbqLeft.TryAnd(rbqRight, null) 
+            : rbqLeft.TryOr(rbqRight, null));
+
+        Assert.Equal(4, rbqLeft.Clauses.Count);
+        Assert.Equal(firstTerm, rbqLeft.Clauses[0].Query);
+        Assert.Equal(secondTerm, rbqLeft.Clauses[1].Query);
+        Assert.Equal(thirdTerm, rbqLeft.Clauses[2].Query);
+        Assert.True(thirdTerm.Boost.AlmostEquals(10));
+        Assert.Equal(fourthTerm, rbqLeft.Clauses[3].Query);
+        Assert.True(fourthTerm.Boost.AlmostEquals(15));
+    }
+    
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void LeftBoostedRightNotBoostedWillNotBeMerged(OperatorType operatorType, Occur occur)
+    {
+        var firstTerm = GetExampleTerm("1");
+        var secondTerm = GetExampleTerm("2");
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{firstTerm, occur}, {secondTerm, occur}};
+        rbqLeft.Boost = 2.0f;
+        var rbqRight = new RavenBooleanQuery(operatorType) {{GetExampleTerm("2"), occur}, {GetExampleTerm("3"), occur}};
+
+
+        Assert.False(operatorType is OperatorType.And 
+            ? rbqLeft.TryAnd(rbqRight, null) 
+            : rbqLeft.TryOr(rbqRight, null));
+
+        Assert.Equal(2, rbqLeft.Clauses.Count);
+        Assert.Equal(firstTerm, rbqLeft.Clauses[0].Query);
+        Assert.Equal(secondTerm, rbqLeft.Clauses[1].Query);
+    }
+    
+    [Theory]
+    [InlineData(OperatorType.And, Occur.MUST)]
+    [InlineData(OperatorType.Or, Occur.SHOULD)]
+    public void LeftNotBoostedRightBoostedWillBeMerged(OperatorType operatorType, Occur occur)
+    {
+        var firstTerm = GetExampleTerm("1");
+        var secondTerm = GetExampleTerm("2");
+        var rbqLeft = new RavenBooleanQuery(operatorType) {{firstTerm, occur}, {secondTerm, occur}};
+        var rbqRight = new RavenBooleanQuery(operatorType) {{GetExampleTerm("2"), occur}, {GetExampleTerm("3"), occur}};
+        rbqRight.Boost = 2.0f;
+
+        var mergingResult = operatorType is OperatorType.And
+            ? rbqLeft.TryAnd(rbqRight, null)
+            : rbqLeft.TryOr(rbqRight, null);
+        Assert.True(mergingResult);
+
+        Assert.Equal(3, rbqLeft.Clauses.Count);
+        Assert.Equal(firstTerm, rbqLeft.Clauses[0].Query);
+        Assert.Equal(secondTerm, rbqLeft.Clauses[1].Query);
+        Assert.Equal(rbqRight, rbqLeft.Clauses[2].Query); // boxed
+    }
+
+    private static Query GetExampleTerm(string term, float? boost = null) => LuceneQueryHelper.Term("exampleField", term, LuceneTermType.String, boost: boost);
+
+    public RavenBooleanQueryTests(ITestOutputHelper output) : base(output)
+    {
+    }
 }
+                                                                                                                                                                                                


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20449

### Additional description

We cannot merge two RavenBooleanQueries when at least one of them is boosted.

For example, consider the following queries:
```
(field0:term0 field1:term1)^bF (field3:term3)^bF
```
In this case, the calculation of scoring is different from:
```
(field0:term0 field1:term1 field3:term3)^bF
```

We have to ensure also when we merge `Query` (other than `RavenBooleanQuery`) we've to check if our `RavenBooleanQuery` is not boosted too.

### Type of change

- Bug fix


### How risky is the change?


- High


### Backward compatibility


- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- no tests required

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation: some queries will have different scoring.

### UI work

- No UI work is needed
