### PR TITLE
RavenDB-20425 - Fix Enforce Revisions Configuration Unexpected behavior, Forced-Created revisions and PurgeOnDelete

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -31,8 +31,7 @@ namespace Raven.Server.Documents
 
         HasTimeSeries = 0x4000,
 
-        ForceCreated = 0x10000
-
+        ForceCreated = 0x8000
     }
 
     [Flags]

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents
 
         HasTimeSeries = 0x4000,
 
-        ForceCreated = 0x8000
+        ForceCreated = 0x10000 // 0x8000 is already taken in 6.0 branch
     }
 
     [Flags]

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -218,6 +218,12 @@ namespace Raven.Server.Documents
                     flags |= DocumentFlags.Resolved;
                 }
 
+                var revisionsCount = _documentDatabase.DocumentsStorage.RevisionsStorage.GetRevisionsCount(context, id);
+                if (revisionsCount > 0)
+                {
+                    flags |= DocumentFlags.HasRevisions;
+                }
+
                 if (collectionName.IsHiLo == false && flags.Contain(DocumentFlags.Artificial) == false)
                 {
 
@@ -230,7 +236,6 @@ namespace Raven.Server.Documents
                     {
                         var flagsBeforeVersion = flags;
                         flags |= DocumentFlags.HasRevisions;
-
 
                         if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flagsBeforeVersion, oldDoc, oldChangeVector,
                                 collectionName))

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -234,10 +234,7 @@ namespace Raven.Server.Documents
 
                     if (shouldVersion)
                     {
-                        var flagsBeforeVersion = flags;
-                        flags |= DocumentFlags.HasRevisions;
-
-                        if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flagsBeforeVersion, oldDoc, oldChangeVector,
+                        if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, oldDoc, oldChangeVector,
                                 collectionName))
                         {
                             var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
@@ -248,6 +245,7 @@ namespace Raven.Server.Documents
                                 oldChangeVector, oldTicks.Ticks, configuration, collectionName);
                         }
 
+                        flags |= DocumentFlags.HasRevisions;
                         _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks,
                             configuration, collectionName);
 

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -235,7 +235,7 @@ namespace Raven.Server.Documents
                         if (_documentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flagsBeforeVersion, oldDoc, oldChangeVector,
                                 collectionName))
                         {
-                            var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue); // = flagsBeforeVersion
+                            var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
                             var oldTicks = TableValueToDateTime((int)DocumentsTable.LastModified, ref oldValue);
 
                             _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, oldDoc,

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1792,7 +1792,7 @@ namespace Raven.Server.Documents
                     var shouldVersion = DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(
                         collectionName, nonPersistentFlags, local.Document.Data, null, context, id, lastModifiedTicks, ref flags, out var configuration);
 
-                    if (shouldVersion || flags.Contain(DocumentFlags.HasRevisions))
+                    if (shouldVersion)
                     {
 
                         if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data,

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1806,8 +1806,11 @@ namespace Raven.Server.Documents
                         }
 
                         revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
-                            modifiedTicks, nonPersistentFlags, flags);
+                            modifiedTicks, nonPersistentFlags, documentFlags == DocumentFlags.Reverted ? documentFlags : flags);
 
+                        var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.GetRevisionsCount(context, id);
+                        if (revisionsCountAfterDelete == 0)
+                            flags = flags.Strip(DocumentFlags.HasRevisions);
                     }
                 }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1794,6 +1794,8 @@ namespace Raven.Server.Documents
 
                     if (shouldVersion)
                     {
+                        var oldFlags = flags;
+                        flags |= DocumentFlags.HasRevisions;
                         if (configuration.MinimumRevisionsToKeep == 0)
                         {
                             var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
@@ -1801,26 +1803,24 @@ namespace Raven.Server.Documents
                                 flags = flags.Strip(DocumentFlags.HasRevisions);
                         }
 
-                        else if (configuration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue)
+                        else if (configuration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue &&
+                                 DocumentDatabase.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > configuration.MinimumRevisionAgeToKeep.Value.Ticks)
                         {
-                            if (DocumentDatabase.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > configuration.MinimumRevisionAgeToKeep.Value.Ticks)
-                            {
-                                var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
-                                if (revisionsCountAfterDelete == 0)
-                                    flags = flags.Strip(DocumentFlags.HasRevisions);
-                            }
+                            var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
+                            if (revisionsCountAfterDelete == 0)
+                                flags = flags.Strip(DocumentFlags.HasRevisions);
+
                         }
                         else
                         {
-                            if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data,
+                            if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, oldFlags, local.Document.Data,
                                     local.Document.ChangeVector, collectionName))
                             {
                                 DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data,
-                                    flags | DocumentFlags.HasRevisions | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
+                                    flags | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
                                     local.Document.ChangeVector, local.Document.LastModified.Ticks, configuration, collectionName);
                             }
 
-                            flags |= DocumentFlags.HasRevisions;
                             revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
                                 modifiedTicks, nonPersistentFlags, documentFlags);
                         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1796,34 +1796,18 @@ namespace Raven.Server.Documents
                     {
                         var oldFlags = flags;
                         flags |= DocumentFlags.HasRevisions;
-                        if (configuration.MinimumRevisionsToKeep == 0)
+
+                        if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, oldFlags, local.Document.Data,
+                                local.Document.ChangeVector, collectionName))
                         {
-                            var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
-                            if (revisionsCountAfterDelete == 0)
-                                flags = flags.Strip(DocumentFlags.HasRevisions);
+                            DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data,
+                                flags | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
+                                local.Document.ChangeVector, local.Document.LastModified.Ticks, configuration, collectionName);
                         }
 
-                        else if (configuration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue &&
-                                 DocumentDatabase.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > configuration.MinimumRevisionAgeToKeep.Value.Ticks)
-                        {
-                            var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
-                            if (revisionsCountAfterDelete == 0)
-                                flags = flags.Strip(DocumentFlags.HasRevisions);
+                        revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
+                            modifiedTicks, nonPersistentFlags, flags);
 
-                        }
-                        else
-                        {
-                            if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, oldFlags, local.Document.Data,
-                                    local.Document.ChangeVector, collectionName))
-                            {
-                                DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data,
-                                    flags | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
-                                    local.Document.ChangeVector, local.Document.LastModified.Ticks, configuration, collectionName);
-                            }
-
-                            revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
-                                modifiedTicks, nonPersistentFlags, documentFlags);
-                        }
                     }
                 }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1794,10 +1794,8 @@ namespace Raven.Server.Documents
 
                     if (shouldVersion || flags.Contain(DocumentFlags.HasRevisions))
                     {
-                        var oldFlags = flags;
-                        flags |= DocumentFlags.HasRevisions;
 
-                        if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, oldFlags, local.Document.Data,
+                        if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data,
                                 local.Document.ChangeVector, collectionName))
                         {
                             DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data,
@@ -1807,10 +1805,6 @@ namespace Raven.Server.Documents
 
                         revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
                             modifiedTicks, nonPersistentFlags, documentFlags == DocumentFlags.Reverted ? documentFlags : flags);
-
-                        var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.GetRevisionsCount(context, id);
-                        if (revisionsCountAfterDelete == 0)
-                            flags = flags.Strip(DocumentFlags.HasRevisions);
                     }
                 }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1792,7 +1792,7 @@ namespace Raven.Server.Documents
                     var shouldVersion = DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(
                         collectionName, nonPersistentFlags, local.Document.Data, null, context, id, lastModifiedTicks, ref flags, out var configuration);
 
-                    if (shouldVersion)
+                    if (shouldVersion || flags.Contain(DocumentFlags.HasRevisions))
                     {
                         var oldFlags = flags;
                         flags |= DocumentFlags.HasRevisions;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1794,15 +1794,36 @@ namespace Raven.Server.Documents
 
                     if (shouldVersion)
                     {
-                        if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data, local.Document.ChangeVector, collectionName))
+                        if (configuration.MinimumRevisionsToKeep == 0)
                         {
-                            DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data, flags | DocumentFlags.HasRevisions | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
-                                local.Document.ChangeVector, local.Document.LastModified.Ticks, configuration, collectionName);
+                            var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
+                            if (revisionsCountAfterDelete == 0)
+                                flags = flags.Strip(DocumentFlags.HasRevisions);
                         }
 
-                        flags |= DocumentFlags.HasRevisions;
-                        revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
-                            modifiedTicks, nonPersistentFlags, documentFlags);
+                        else if (configuration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue)
+                        {
+                            if (DocumentDatabase.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > configuration.MinimumRevisionAgeToKeep.Value.Ticks)
+                            {
+                                var revisionsCountAfterDelete = DocumentDatabase.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
+                                if (revisionsCountAfterDelete == 0)
+                                    flags = flags.Strip(DocumentFlags.HasRevisions);
+                            }
+                        }
+                        else
+                        {
+                            if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data,
+                                    local.Document.ChangeVector, collectionName))
+                            {
+                                DocumentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, local.Document.Data,
+                                    flags | DocumentFlags.HasRevisions | DocumentFlags.FromOldDocumentRevision, NonPersistentDocumentFlags.None,
+                                    local.Document.ChangeVector, local.Document.LastModified.Ticks, configuration, collectionName);
+                            }
+
+                            flags |= DocumentFlags.HasRevisions;
+                            revisionsStorage.Delete(context, id, lowerId, collectionName, changeVector ?? local.Tombstone.ChangeVector,
+                                modifiedTicks, nonPersistentFlags, documentFlags);
+                        }
                     }
                 }
 
@@ -1810,7 +1831,7 @@ namespace Raven.Server.Documents
                     revisionsStorage.Configuration == null &&
                     flags.Contain(DocumentFlags.Resolved) == false &&
                     nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
-                    revisionsStorage.DeleteRevisionsFor(context, id);
+                    revisionsStorage.DeleteRevisionsFor(context, id, fromDelete: true);
 
                 if (flags.Contain(DocumentFlags.HasRevisions) &&
                     revisionsStorage.Configuration != null &&

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
             {
-                return new DeleteRevisionsCommandDto(_ids, _deleteOnlyForceCreated);
+                return new DeleteRevisionsCommandDto() { Ids = _ids, DeleteOnlyForceCreated = _deleteOnlyForceCreated };
             }
         }
 
@@ -67,18 +67,12 @@ namespace Raven.Server.Documents.Handlers.Admin
 
     internal class DeleteRevisionsCommandDto : TransactionOperationsMerger.IReplayableCommandDto<AdminRevisionsHandler.DeleteRevisionsCommand>
     {
-        private readonly string[] _ids;
-        private readonly bool _deleteOnlyForceCreated;
-
-        public DeleteRevisionsCommandDto(string[] ids, bool deleteOnlyForceCreated)
-        {
-            _ids = ids;
-            _deleteOnlyForceCreated = deleteOnlyForceCreated;
-        }
+        public string[] Ids;
+        public bool DeleteOnlyForceCreated;
 
         public AdminRevisionsHandler.DeleteRevisionsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var command = new AdminRevisionsHandler.DeleteRevisionsCommand(_ids, database, _deleteOnlyForceCreated);
+            var command = new AdminRevisionsHandler.DeleteRevisionsCommand(Ids, database, DeleteOnlyForceCreated);
             return command;
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             {
                 foreach (var id in _ids)
                 {
-                    _database.DocumentsStorage.RevisionsStorage.DeleteRevisionsFor(context, id);
+                    _database.DocumentsStorage.RevisionsStorage.DeleteAllRevisionsFor(context, id);
                 }
                 return 1;
             }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), "admin/revisions/delete");
                 var parameters = JsonDeserializationServer.Parameters.DeleteRevisionsParameters(json);
 
-                using (var token = CreateTimeLimitedOperationToken())
+                using (var token = CreateHttpRequestBoundTimeLimitedOperationToken())
                 {
                     var ids = parameters.DocumentIds;
                     DeleteRevisionsCommand cmd;

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -138,7 +138,7 @@ namespace Raven.Server.Documents.Handlers
                 Database,
                 $"Enforce revision configuration in database '{Database.Name}'.",
                 Operations.Operations.OperationType.EnforceRevisionConfiguration,
-                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress, includeForceCreated, token),
+                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, includeForceCreated, token),
                 operationId,
                 token: token);
 

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var token = CreateTimeLimitedBackgroundOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();
-            bool includeForceCreated = GetBoolValueQueryString("includeForceCreated", required: true) ?? true;
+            bool includeForceCreated = GetBoolValueQueryString("includeForceCreated", required: true) ?? false;
 
             var t = Database.Operations.AddOperation(
                 Database,

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var token = CreateTimeLimitedBackgroundOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();
-            bool includeForceCreated = GetBoolValueQueryString("includeForceCreated", required: true) ?? false;
+            bool includeForceCreated = GetBoolValueQueryString("includeForceCreated", required: false) ?? false;
 
             var t = Database.Operations.AddOperation(
                 Database,

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -132,12 +132,13 @@ namespace Raven.Server.Documents.Handlers
         {
             var token = CreateTimeLimitedBackgroundOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();
+            bool includeForceCreated = GetBoolValueQueryString("includeForceCreated", required: true) ?? true;
 
             var t = Database.Operations.AddOperation(
                 Database,
                 $"Enforce revision configuration in database '{Database.Name}'.",
                 Operations.Operations.OperationType.EnforceRevisionConfiguration,
-                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress, token),
+                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress, includeForceCreated, token),
                 operationId,
                 token: token);
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -311,6 +311,9 @@ namespace Raven.Server.Documents.Revisions
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResolver)
                     && nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved)==false)
                     return false;
+
+                if (documentFlags.Contain(DocumentFlags.HasRevisions) == false)
+                    return false;
             }
 
             if (configuration.Disabled)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -724,7 +724,6 @@ namespace Raven.Server.Documents.Revisions
                 var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
                 var newEtag = _documentsStorage.GenerateNextEtag();
                 var changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
-                context.LastDatabaseChangeVector = changeVector;
 
                 var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
                 var deletedRevisionsCount = 0L;
@@ -752,7 +751,6 @@ namespace Raven.Server.Documents.Revisions
                 var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
                 var newEtag = _documentsStorage.GenerateNextEtag();
                 var changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
-                context.LastDatabaseChangeVector = changeVector;
 
                 var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
                 var prevRevisionsCount = GetRevisionsCount(context, id);
@@ -1684,7 +1682,6 @@ namespace Raven.Server.Documents.Revisions
                 var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
                 var newEtag = _documentsStorage.GenerateNextEtag();
                 var changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
-                context.LastDatabaseChangeVector = changeVector;
                 var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
 
                 var prevRevisionsCount = GetRevisionsCount(context, id);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -966,9 +966,17 @@ namespace Raven.Server.Documents.Revisions
 
             void ValidateFlags(HandleConflictRevisionsFlags flags)
             {
+                if (flags == HandleConflictRevisionsFlags.None)
+                {
+                    throw new InvalidOperationException($"Cannot delete conflict revisions without deleting.");
+                }
+                if (flags.HasFlag(HandleConflictRevisionsFlags.Conflicted) == false)
+                {
+                    throw new InvalidOperationException($"Cannot delete conflict revisions without deleting conflict revisions.");
+                }
                 if (flags.HasFlag(HandleConflictRevisionsFlags.Regular) == false && flags.HasFlag(HandleConflictRevisionsFlags.ForceCreated))
                 {
-                    throw new InvalidOperationException($"Cannot delete force-created revisions without deleting also regular revisions");
+                    throw new InvalidOperationException($"Cannot delete force-created revisions without deleting also regular revisions.");
                 }
             }
 
@@ -1053,9 +1061,10 @@ namespace Raven.Server.Documents.Revisions
         [Flags]
         private enum HandleConflictRevisionsFlags
         {
-            Conflicted = 0,
+            None = 0,
+            Conflicted = 1,
             Regular = 1 << 1,
-            ForceCreated = 1 << 3
+            ForceCreated = 1 << 2
         }
 
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -853,7 +853,7 @@ namespace Raven.Server.Documents.Revisions
                         break;
 
                     var tvr = read.Result.Reader;
-                    var revision = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector);
+                    var revision = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector | DocumentFields.LowerId);
 
                     if (minimumTimeToKeep.HasValue && _database.Time.GetUtcNow() - revision.LastModified <= minimumTimeToKeep.Value)
                     {
@@ -906,7 +906,7 @@ namespace Raven.Server.Documents.Revisions
                     else
                     {
                         // We request to delete revision with the wrong collection
-                        var revisionData = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector);
+                        var revisionData = TableValueToRevision(context, ref tvr, DocumentFields.Data);
 
                         var collection = _documentsStorage.ExtractCollectionName(context, revisionData.Data);
                         if (writeTables.TryGetValue(collection.Name, out writeTable) == false)
@@ -1065,7 +1065,7 @@ namespace Raven.Server.Documents.Revisions
                     }
 
                     var tvr = read.Result.Reader;
-                    var revision = TableValueToRevision(context, ref tvr);
+                    var revision = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector | DocumentFields.LowerId);
 
                     if (revision.Flags.Contain(DocumentFlags.Conflicted) || revision.Flags.Contain(DocumentFlags.Resolved))
                     {
@@ -1134,7 +1134,7 @@ namespace Raven.Server.Documents.Revisions
                     }
 
                     var tvr = read.Result.Reader;
-                    var revision = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector);
+                    var revision = TableValueToRevision(context, ref tvr, DocumentFields.ChangeVector | DocumentFields.LowerId);
 
                     if (skipForceCreated && revision.Flags.Contain(DocumentFlags.ForceCreated))
                     {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -647,24 +647,24 @@ namespace Raven.Server.Documents.Revisions
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))
                 return false;
 
-            if (configuration.MinimumRevisionsToKeep.HasValue == false &&
-                configuration.MinimumRevisionAgeToKeep.HasValue == false)
-                return false;
-
             long numberOfRevisionsToDelete;
-
-            if (configuration == ConflictConfiguration.Default || 
-                configuration == ZeroConfiguration)
+            if (deletedDoc && configuration.PurgeOnDelete)
+            {
+                numberOfRevisionsToDelete = long.MaxValue;
+                moreRevisionToDelete = false;
+            }
+            else if (configuration == ConflictConfiguration.Default || 
+                     configuration == ZeroConfiguration)
             {
                 var handleNotConflicted = nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration);
                 var deletedCount = HandleConflictRevisionsDelete(context, table, prefixSlice, collectionName, changeVector, revisionsCount, lastModifiedTicks, handleNotConflicted, skipForceCreated, out var moreWork);
                 IncrementCountOfRevisions(context, prefixSlice, -deletedCount);
                 return moreWork;
             }
-            else if (deletedDoc && configuration.PurgeOnDelete)
+            else if (configuration.MinimumRevisionsToKeep.HasValue == false &&
+                     configuration.MinimumRevisionAgeToKeep.HasValue == false)
             {
-                numberOfRevisionsToDelete = long.MaxValue;
-                moreRevisionToDelete = false;
+                return false;
             }
             else if (configuration.MinimumRevisionsToKeep.HasValue)
             {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -638,7 +638,7 @@ namespace Raven.Server.Documents.Revisions
         }
 
         private bool DeleteOldRevisions(DocumentsOperationContext context, Table table, Slice prefixSlice, CollectionName collectionName,
-            RevisionsCollectionConfiguration configuration, long revisionsCount, NonPersistentDocumentFlags nonPersistentFlags, string changeVector, long lastModifiedTicks, bool deletedDoc = false)
+            RevisionsCollectionConfiguration configuration, long revisionsCount, NonPersistentDocumentFlags nonPersistentFlags, string changeVector, long lastModifiedTicks, bool deletedDoc = false, bool deleteForceCreated = false)
         {
             var moreRevisionToDelete = false;
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler))

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1274,14 +1274,14 @@ namespace Raven.Server.Documents.Revisions
                 return;
 
             Debug.Assert(changeVector != null, "Change vector must be set");
-
+            var hadRevisions = flags.Contain(DocumentFlags.HasRevisions);
             flags = flags.Strip(DocumentFlags.HasAttachments);
             flags |= DocumentFlags.HasRevisions;
 
             var fromReplication = nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication);
 
             var configuration = GetRevisionsConfiguration(collectionName.Name, flags);
-            if (configuration.Disabled && fromReplication == false)
+            if (configuration.Disabled && hadRevisions==false && fromReplication == false)
                 return;
 
             var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -306,6 +306,13 @@ namespace Raven.Server.Documents.Revisions
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
                 return true;
 
+            if (Configuration == null)
+            {
+                if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResolver)
+                    && nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved)==false)
+                    return false;
+            }
+
             if (configuration.Disabled)
                 return false;
 

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -622,7 +622,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -643,7 +643,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -706,7 +706,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -722,7 +722,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -771,7 +771,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -622,7 +622,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -643,7 +643,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -706,7 +706,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -722,7 +722,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -771,7 +771,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -12,7 +12,7 @@ namespace FastTests.Utils
 {
     public class RevisionsHelper
     {
-        public static async Task SetupConflictedRevisions(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RevisionsCollectionConfiguration configuration)
+        public static async Task SetupConflictedRevisionsAsync(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RevisionsCollectionConfiguration configuration)
         {
             if (store == null)
                 throw new ArgumentNullException(nameof(store));

--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -1125,7 +1125,7 @@ namespace SlowTests.Client.TimeSeries.Replication
                 }
 
                 await SetupReplicationAsync(storeA, storeB);
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 using (var session = storeB.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1238,7 +1238,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1238,7 +1238,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests/Issues/RavenDB-14724.cs
+++ b/test/SlowTests/Issues/RavenDB-14724.cs
@@ -42,14 +42,14 @@ namespace SlowTests.Issues
                     var revisions = await session.Advanced.Revisions.GetForAsync<User>(id);
                     Assert.Equal(2, revisions.Count);
 
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+
                     var configuration = new RevisionsConfiguration()
                     {
                         Default = null
                     };
                     await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration);
-
-                    session.Delete(id);
-                    await session.SaveChangesAsync();
                 }
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Issues/RavenDB-14724.cs
+++ b/test/SlowTests/Issues/RavenDB-14724.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
                     {
                         Default = null
                     };
-                    await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration);
+                    await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
                 }
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Issues/RavenDB-16961.cs
+++ b/test/SlowTests/Issues/RavenDB-16961.cs
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store, store.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
                 }
 
 
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
                 db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
                 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests/Issues/RavenDB-16961.cs
+++ b/test/SlowTests/Issues/RavenDB-16961.cs
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store, store.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
                 }
 
 
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
                 db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
                 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests/Issues/RravenDB-16949.cs
+++ b/test/SlowTests/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/RravenDB-16949.cs
+++ b/test/SlowTests/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -710,29 +710,16 @@ return oldestDoc;"
                 Assert.Equal(3, doc1RevCount); // obeys the Conflicted Config
             }
 
-            // Create 10 force-created revisions in dst
-            for (int i = 1; i <= 10; i++)
-            {
-                using (var session = dst.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = $"FC{i}" }, "Docs/1");
-                    await session.SaveChangesAsync();
-
-                    session.Advanced.Revisions.ForceRevisionCreationFor("Docs/1");
-                    await session.SaveChangesAsync();
-                }
-            }
-
             using (var session = dst.OpenAsyncSession())
             {
                 session.Delete("Docs/1");
                 await session.SaveChangesAsync();
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(14, doc1RevCount);
+                Assert.Equal(4, doc1RevCount);
 
                 // check if delete revision has been created (even if you have no config - you have revisions so you need to create "delete revision" in delete).
                 var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync("Docs/1");
-                Assert.Equal(14, revisionsMetadata.Count);
+                Assert.Equal(4, revisionsMetadata.Count);
                 Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata[0].GetString(Constants.Documents.Metadata.Flags));
             }
 

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -1,0 +1,490 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.ServerWide;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests
+{
+    public class RavenDB_20425 : ReplicationTestBase
+    {
+        public RavenDB_20425(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public enum ChangingType
+        {
+            EnforceConfiguration,
+            UpdateDocument
+        }
+
+        private Task TriggerRevisionsDelete(ChangingType type, DocumentStore store, string docId = null)
+        {
+
+            if (type == ChangingType.UpdateDocument)
+            {
+                if (docId == null)
+                    throw new InvalidOperationException("docId cannot be null while using 'UpdateDocument' type.");
+
+                return UpdateDoc(store, docId);
+            }
+
+            if (type == ChangingType.EnforceConfiguration)
+            {
+                return EnforceConfiguration(store);
+            }
+
+            return Task.FromException(new InvalidOperationException($"Update type: {type} isn't handled"));
+        }
+
+        private async Task EnforceConfiguration(DocumentStore store)
+        {
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+        }
+
+        private async Task UpdateDoc(DocumentStore store, string docId)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(docId);
+                user.Name += "1";
+                await session.SaveChangesAsync();
+            }
+        }
+
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+        
+        // Right Behavior
+        [Theory]
+        [InlineData(ChangingType.EnforceConfiguration)] // Works
+        [InlineData(ChangingType.UpdateDocument)] // Fails
+        public async Task RemoveDefaultConfig_ThenChangingDoc_ShouldDeleteRevisions(ChangingType type)
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration);
+
+            // Create a doc with 2 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Remove all configurations except the Conflicts Config
+            var configuration1 = new RevisionsConfiguration
+            {
+                Default = null
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration1);
+
+            await TriggerRevisionsDelete(type, store, "Docs/1");
+
+            // WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                if(type==ChangingType.EnforceConfiguration)
+                    Assert.Equal(0, doc1RevCount); // EnforceConfig: 0
+                if (type == ChangingType.UpdateDocument)
+                    Assert.Equal(2, doc1RevCount); // UpdateDocument: 2 (user should use "enforce config" for delete the redundent revisions)
+            }
+        }
+
+        // Right Behavior
+        [Theory]
+        [InlineData(ChangingType.EnforceConfiguration)] // Fails
+        [InlineData(ChangingType.UpdateDocument)] // Fails
+        public async Task DisableCollectionAutoCreationConfig_ThenChangingDoc_ShouldObeyCollectionConfig(ChangingType type)
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 2
+                },
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        MinimumRevisionsToKeep = 3
+                    }
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration);
+
+            // Create doc with 3 revisions
+            for (int i = 0; i < 3; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"New{i}" }, "Docs/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount);
+            }
+
+            // disable "Users" collection config
+            var configuration1 = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 2
+                },
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = true, //!!!
+                        MinimumRevisionsToKeep = 3
+                    }
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration1);
+
+            await TriggerRevisionsDelete(type, store, "Docs/1");
+
+            // WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount);
+            }
+        }
+
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task ConfigurationWithMin10_DeleteDocWith10_changeConfigToMin3AndUponUpdate2_DeletedDocShouldRemainWith3Revisions()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 10
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration);
+
+            // Create a doc with 10 revisions
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"New{i}" }, "Docs/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            var configuration1 = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 3,
+                    MaximumRevisionsToDeleteUponDocumentUpdate = 2
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration1);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("Docs/1");
+                await session.SaveChangesAsync();
+
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(9, doc1RevCount); // 9 (10 - 2 upon update + 1 delete)
+                                               // - When it will be shrink to 3? never, because you probably wont touch this doc again
+                                               // So it should not take into account the 'UponUpdate'.
+            }
+
+            //--
+            //Enforce
+            await EnforceConfiguration(store);
+
+            //3 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount); // Old, New, Delete
+            }
+        }
+        
+
+        [Fact] // Fix - PurgeOnDelete doesnt work with Enforce Config on deleted doc
+        public async Task DeleteDocWithRevisions_ThenAddPurgeOnDeleteConfig_EnforceConfig_ShouldDeleteTheRevisionsOfTheDeletedDoc()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration);
+
+            // Create a doc with 2 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Delete the doc
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("Docs/1");
+                await session.SaveChangesAsync();
+
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount); // Old, New, Delete
+            }
+
+            var configuration1 = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 3,
+                    PurgeOnDelete = true,
+                }
+            };
+            await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database, configuration: configuration1);
+
+            await EnforceConfiguration(store);
+
+            // WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(0, doc1RevCount); // got 3
+            }
+        }
+
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+
+        //-Fix
+        [Fact] //
+        public async Task OnlyConflictConfig_EnforceConfig_ShouldntDeletesAllRevisions()
+        {
+            using var src = GetDocumentStore();
+            using var dst = GetDocumentStore();
+
+            var dstConfig = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 2
+            };
+            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+
+            // Create a doc with 2 'conflicted' (or 'resolved') revisions
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = dst.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            await SetupReplicationAsync(src, dst); // Conflicts resolved
+            await EnsureReplicatingAsync(src, dst);
+            using (var session = dst.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(2, doc1RevCount); // obeys the Conflicted Config
+            }
+
+            // WaitForUserToContinueTheTest(dst);
+
+            await EnforceConfiguration(dst);
+
+            using (var session = dst.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(2, doc1RevCount); // got 0
+            }
+        }
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+        
+        // Force-Created flag and checkbox
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+
+        [Fact] ///// regular\manual (non-conflicted) revisions shouldnt obey the conflicted-config!!!
+        public async Task ForceCreatedRevisions_ShouldntObeyToConflictedRevisions()
+        {
+            using var src = GetDocumentStore();
+            using var dst = GetDocumentStore();
+
+            var dstConfig = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 4
+            };
+            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = dst.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"New{i}" }, "Docs/1");
+                    await session.SaveChangesAsync();
+
+                    session.Advanced.Revisions.ForceRevisionCreationFor("Docs/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await SetupReplicationAsync(src, dst); // Conflicts resolved
+            await EnsureReplicatingAsync(src, dst);
+
+            WaitForUserToContinueTheTest(dst);
+
+            using (var session = dst.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(13, doc1RevCount); // 4 (3 conflicted/resolved, 1 force created) - forced created revisions obey to the config we using in the delete
+            }
+        }
+
+        //---------------------------------------------------------------------------------------------------------------------------------------
+
+        //  Fix - Talk with Karmel (add time window like in revert revisions)
+        [Fact]
+        public async Task NotDeletingOutOfDateRevisionsBecauseTheyOrderedByEtag()
+        {
+            using var src = GetDocumentStore();
+            using var dst = GetDocumentStore();
+
+            var db1 = await Databases.GetDocumentDatabaseInstanceFor(src);
+            var db2 = await Databases.GetDocumentDatabaseInstanceFor(dst);
+
+            db1.Time.UtcDateTime = () => DateTime.UtcNow.AddDays(-1);
+
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = dst.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(src, dst); // Conflicts resolved
+            await SetupReplicationAsync(dst, src); // Conflicts resolved
+            await EnsureReplicatingAsync(src, dst);
+            await EnsureReplicatingAsync(dst, src);
+
+            DateTime previusTime = DateTime.MinValue;
+            using (var session = src.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(4, doc1RevCount);
+
+                var times = (await session.Advanced.Revisions.GetMetadataForAsync("Docs/1"))
+                    .Select(metadata => DateTime.Parse(metadata["@last-modified"].ToString()));
+
+                var orderedByTime = true;
+                foreach (var currentTime in times)
+                {
+                    Console.WriteLine(currentTime.ToString("dd-MM-yyyy HH:mm:ss.fffffff"));
+
+                    if (currentTime < previusTime)
+                    {
+                        orderedByTime = false;
+                        previusTime = currentTime;
+                        // break;
+                    }
+
+                    previusTime = currentTime;
+                }
+                Assert.False(orderedByTime);
+            }
+
+            var dstConfig = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionAgeToKeep = TimeSpan.FromHours(1) };
+            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+
+            await TriggerRevisionsDelete(ChangingType.UpdateDocument, src, "Docs/1");
+
+            // WaitForUserToContinueTheTest(src);
+
+            using (var session = dst.OpenAsyncSession())
+            {
+                var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+                Assert.Equal(3, doc1RevCount);
+            }
+        }
+
+
+    }
+}

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -683,7 +683,7 @@ return oldestDoc;"
 
         }
 
-        [Theory]
+        [Theory (Skip = "Untill RavenDB-20823")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Include_ForceCreated_AlwaysOn_EnforceConfig_InCaseOf_PurgeOnDelete(bool deleteAlsoForceCreated)
@@ -746,7 +746,10 @@ return oldestDoc;"
             using (var session = dst.OpenAsyncSession())
             {
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(0, doc1RevCount);
+                if(deleteAlsoForceCreated)
+                    Assert.Equal(0, doc1RevCount);
+                else
+                    Assert.Equal(11, doc1RevCount); // 10 ForceCreated, 1 Deleted
             }
 
         }
@@ -793,7 +796,7 @@ return oldestDoc;"
                     await session.SaveChangesAsync();
                 }
 
-                WaitForUserToContinueTheTest(destination);
+                // WaitForUserToContinueTheTest(destination, false);
 
                 using (var session = destination.OpenAsyncSession())
                 {
@@ -837,7 +840,7 @@ return oldestDoc;"
             }
 
             await EnforceConfiguration(dst);
-            WaitForUserToContinueTheTest(dst);
+            // WaitForUserToContinueTheTest(dst);
             
             using (var session = dst.OpenAsyncSession())
             {
@@ -937,7 +940,8 @@ return oldestDoc;"
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: maxUponUpdateConfig);
             }
 
-            // WaitForUserToContinueTheTest(store);
+
+            // WaitForUserToContinueTheTest(store, debug: false);
 
             await store.Maintenance.SendAsync(new DeleteForceCreatedRevisionsOperation(new AdminRevisionsHandler.Parameters { DocumentIds = new[] { "Docs/2", "Docs/1" } }, includeForceCreated));
 

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -260,7 +260,7 @@ namespace SlowTests
         }
         
 
-        [Fact] // Fix - PurgeOnDelete doesnt work with Enforce Config on deleted doc
+        [Fact] // ____Fixed - PurgeOnDelete doesnt work with Enforce Config on deleted doc
         public async Task DeleteDocWithRevisions_ThenAddPurgeOnDeleteConfig_EnforceConfig_ShouldDeleteTheRevisionsOfTheDeletedDoc()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -59,7 +59,7 @@ namespace SlowTests
         {
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
         }
 
         private async Task UpdateDoc(DocumentStore store, string docId)

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -337,7 +337,7 @@ namespace SlowTests
                 Disabled = false,
                 MinimumRevisionsToKeep = 2
             };
-            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(dst, Server.ServerStore, configuration: dstConfig);
 
             // Create a doc with 2 'conflicted' (or 'resolved') revisions
             using (var session = src.OpenAsyncSession())
@@ -381,7 +381,7 @@ namespace SlowTests
                 Disabled = false,
                 MinimumRevisionsToKeep = 4
             };
-            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(dst, Server.ServerStore, configuration: dstConfig);
 
             using (var session = src.OpenAsyncSession())
             {
@@ -667,7 +667,7 @@ return oldestDoc;"
                 MinimumRevisionsToKeep = 2,
                 PurgeOnDelete = true
             };
-            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(dst, Server.ServerStore, configuration: dstConfig);
 
             await EnforceConfiguration(dst, deleteAlsoForceCreated);
             WaitForUserToContinueTheTest(dst);
@@ -739,7 +739,7 @@ return oldestDoc;"
                 MinimumRevisionsToKeep = 2,
                 PurgeOnDelete = true
             };
-            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(dst, Server.ServerStore, configuration: dstConfig);
             
             await EnforceConfiguration(dst, deleteAlsoForceCreated);
 
@@ -817,7 +817,7 @@ return oldestDoc;"
             {
                 MinimumRevisionsToKeep = 2
             };
-            await RevisionsHelper.SetupConflictedRevisions(dst, Server.ServerStore, configuration: dstConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(dst, Server.ServerStore, configuration: dstConfig);
 
             // Create a doc with 3 'conflicted' (or 'resolved') revisions in 'dst'
             using (var session = src.OpenAsyncSession())
@@ -1006,7 +1006,7 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Theory]
+        [Theory (Skip = "Untill RavenDB-20823")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task DocWithRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete(bool disableConfiguration)
@@ -1087,7 +1087,7 @@ return oldestDoc;"
              */
         }
 
-        [Fact]
+        [Fact (Skip = "Untill RavenDB-20823")]
         public async Task DocWithForceCreatedRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete()
         {
             using var store = GetDocumentStore();
@@ -1127,7 +1127,7 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Fact]
+        [Fact (Skip = "Untill RavenDB-20823")]
         public async Task RevivedDocumentShouldHaveTheRevisionsOfTheDeletedDoc()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -683,7 +683,7 @@ return oldestDoc;"
 
         }
 
-        [Theory (Skip = "Untill RavenDB-20823")]
+        [Theory (Skip = "Until RavenDB-20823")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Include_ForceCreated_AlwaysOn_EnforceConfig_InCaseOf_PurgeOnDelete(bool deleteAlsoForceCreated)
@@ -1006,7 +1006,7 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Theory (Skip = "Untill RavenDB-20823")]
+        [Theory (Skip = "Until RavenDB-20823")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task DocWithRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete(bool disableConfiguration)
@@ -1087,7 +1087,7 @@ return oldestDoc;"
              */
         }
 
-        [Fact (Skip = "Untill RavenDB-20823")]
+        [Fact (Skip = "Until RavenDB-20823")]
         public async Task DocWithForceCreatedRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete()
         {
             using var store = GetDocumentStore();
@@ -1127,7 +1127,7 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Fact (Skip = "Untill RavenDB-20823")]
+        [Fact (Skip = "Until RavenDB-20823")]
         public async Task RevivedDocumentShouldHaveTheRevisionsOfTheDeletedDoc()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -281,7 +281,7 @@ namespace SlowTests.Server.Documents.Revisions
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
 
                 WaitForMarker(store1, store2);
 
@@ -935,7 +935,7 @@ namespace SlowTests.Server.Documents.Revisions
                 EnforceConfigurationResult result;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress: null, token: token);
+                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(onProgress: null, token: token);
                 }
 
                 Assert.Equal(11, result.ScannedRevisions);

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -297,7 +297,7 @@ namespace SlowTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
 
                 WaitForMarker(store1, store2);
 
@@ -951,7 +951,7 @@ namespace SlowTests.Server.Documents.Revisions
                 EnforceConfigurationResult result;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(onProgress: null, token: token);
+                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(onProgress: null, token: token);
                 }
 
                 Assert.Equal(11, result.ScannedRevisions);

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -271,7 +271,7 @@ namespace SlowTests.Server.Documents.Revisions
                     Disabled = false,
                     MinimumRevisionsToKeep = 0
                 };
-                await RevisionsHelper.SetupConflictedRevisions(store1, Server.ServerStore, configuration: config2);
+                await RevisionsHelper.SetupConflictedRevisionsAsync(store1, Server.ServerStore, configuration: config2);
 
                 await PutDocument(store1);
                 await PutDocument(store2);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -458,7 +458,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress: null, token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(onProgress: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -458,7 +458,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreated(onProgress: null, token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(onProgress: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20425/Revisions-Fixes

### Additional description

Added flag for Force-Created revisions.
Now when we do 'enforce-configuration', we need to pass also an argument called 'includeForceCreated' (bool),
which is telling us whether to include or exclude ForceCreated revisions on deletion in case of no revisions configuration (only conflict revisions config is exist).

Now when you have only conflict config you won't touch (delete) non-conflict revisions, only when you perform 'enforce-configuration', and then you'll also need to choose whether delete or skip also the 'Force-Created' revisions.

Non-conflict revisions now don't obey the conflict config (which caused the non-conflict revisions to be deleted when you get 'conflicted'/'resolved' revisions because of a conflict - this was a bug).
We fixed the unexpected behavior of the 'enforce-configuration' which is deleting all the revisions when we have only conflict-revisions config.
Now the 'enforce-configuration' delete deleted doc revisions after we change the configuration to be with PurgeOnDelete=true.
Fixed PurgeOnDelete on Conflict config (which didn't work).

Now you can exclude the Force-Created revisions by the 'DeleteRevisionsFor' end-point.

Now if we delete a document with revisions and we create it again (doc with the same id), it'll have the revisions of the old (deleted) doc. this will happen regardless of whether the document has a configuration or not.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- UI work is needed:
Need to add a check box in the Enforce-Configuration window (the pop-up window which is opened after we push the Enforce-Configuration button), with the label "In case of no revisions configuration (except the conflict revisions configuration), delete also the force created",  which tells if the parameter "includeForceCreated"  - in the EP "EnforceConfigRevisions" ("/databases/*/admin/revisions/config/enforce", "POST"), will be true (if it's checked) or false (if it's unchecked).

- _UI Bug:_ you can not see the "Revisions Bin" when you don't have default/collection revisions configuration.
