### PR TITLE
RavenDB-20491 avoid concurrent usage of _queueContext

### DIFF
--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -283,20 +283,6 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
         }
     }
 
-    public readonly struct Message : IDisposable
-    {
-        public readonly object Value;
-        private readonly Action<object> _onDispose;
-
-        public Message(object value, Action<object> onDispose)
-        {
-            Value = value;
-            _onDispose = onDispose;
-        }
-
-        public void Dispose() => _onDispose?.Invoke(Value);
-    }
-
     protected virtual Message CreateMessage(object message) => new Message(message, onDispose: null);
 
     private async ValueTask<Message> GetNextMessage()
@@ -676,5 +662,19 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
     {
         public object ValueToSend;
         public bool AllowSkip;
+    }
+
+    protected readonly struct Message : IDisposable
+    {
+        public readonly object Value;
+        private readonly Action<object> _onDispose;
+
+        public Message(object value, Action<object> onDispose)
+        {
+            Value = value;
+            _onDispose = onDispose;
+        }
+
+        public void Dispose() => _onDispose?.Invoke(Value);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Changes;
+using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -16,8 +17,6 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
     where TChangesClientConnection : AbstractChangesClientConnection<TOperationContext>
 {
-    private const string StudioMarker = "fromStudio";
-
     protected AbstractChangesHandlerProcessorForGetChanges([NotNull] TRequestHandler requestHandler) : base(requestHandler)
     {
     }
@@ -32,7 +31,7 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
     {
         using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
         {
-            var fromStudio = RequestHandler.GetBoolValueQueryString(StudioMarker, false) ?? false;
+            var fromStudio = RequestHandler.HttpContext.Request.IsFromStudio();
             var throttleConnection = RequestHandler.GetBoolValueQueryString("throttleConnection", false).GetValueOrDefault(false);
 
             var connection = CreateChangesClientConnection(webSocket, throttleConnection, fromStudio);

--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedChangesClientConnection.cs
@@ -320,7 +320,7 @@ public class ShardedChangesClientConnection : AbstractChangesClientConnection<Tr
     {
     }
 
-    private static readonly object _queueContextUsageLocker = new object();
+    private readonly object _queueContextUsageLocker = new object();
 
     public void OnNext(BlittableJsonReaderObject value)
     {
@@ -339,7 +339,7 @@ public class ShardedChangesClientConnection : AbstractChangesClientConnection<Tr
 
     protected override Message CreateMessage(object message) => new Message(message, OnDispose);
 
-    private static void OnDispose(object m)
+    private void OnDispose(object m)
     {
         if (m is BlittableJsonReaderObject bjro)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20491 

### Additional description
We have here 2 threads
1. Receive message from a shard, we clone it to the `_queueContext` and add it to a queue
2. Send received messages to the client and dispose the sent message

We need to sync cloning and disposing since they use the same context (the `_queueContext`)

### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Yes. Please list the affected platforms.


### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Current test cover this issue

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
