### PR TITLE
RavenDB-20177 Sending document ids instead of LoadHash in page size too big notification details

### DIFF
--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -285,7 +285,7 @@ namespace Raven.Server.Documents.Handlers
                 var addedIdsCount = 0;
                 var first = true;
 
-                while (sb.Length < 1024)
+                while (sb.Length < 1024 && addedIdsCount < ids.Count)
                 {
                     if (first == false)
                         sb.Append(", ");

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands;
@@ -270,8 +271,38 @@ namespace Raven.Server.Documents.Handlers
                 var (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsJsonAsync(context, metadataOnly, documents, includes, includeCounters?.Results, includeRevisions?.RevisionsChangeVectorResults, includeRevisions?.IdByRevisionsByDateTimeResults, includeTimeSeries?.Results,
                     includeCompareExchangeValues?.Results);
 
-                AddPagingPerformanceHint(PagingOperationType.Documents, nameof(GetDocumentsByIdAsync), HttpContext.Request.QueryString.Value, numberOfResults,
-                    documents.Count, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
+                if (ShouldAddPagingPerformanceHint(numberOfResults))
+                {
+                    var details = CreatePerformanceHintDetails();
+
+                    AddPagingPerformanceHint(PagingOperationType.Documents, nameof(GetDocumentsByIdAsync), details, numberOfResults, documents.Count, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
+                }
+            }
+
+            string CreatePerformanceHintDetails()
+            {
+                var sb = new StringBuilder();
+                var addedIdsCount = 0;
+                var first = true;
+
+                while (sb.Length < 1024)
+                {
+                    if (first == false)
+                        sb.Append(", ");
+                    else
+                        first = false;
+                    
+                    sb.Append($"{ids[addedIdsCount++]}");
+                }
+
+                var idsLeftCount = ids.Count - addedIdsCount;
+
+                if (idsLeftCount > 0)
+                {
+                    sb.Append($" ... (and {idsLeftCount} more)");
+                }
+
+                return sb.ToString();
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20177/Missing-info-in-the-Page-size-too-big-notification-for-documents

### Additional description

Now we're sending a concatenation of some initial document IDs and the number of remaining IDs in the notification details field.
I couldn't reproduce the issue with displaying `n/a` in `Docs Size` field in studio, but I think it happens when we send `totalDocumentsSizeInBytes` equal to `0`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
