### PR TITLE
RavenDB-20500 - Get the correct document size for the HugeDocuments notification

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -652,9 +652,10 @@ namespace Raven.Server.Documents.Handlers
                                             }
                                         }
 
-                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document.Clone(context), changeVector: changeVector,
+                                        var document = cmd.Document.Clone(context);
+                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
-                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);
+                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, document.Size);
                                         AddPutResult(putResult);
                                     }
                                     else


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20500/Huge-documents-notification-reports-small-documents

### Additional description

Get the correct document size and not the parent document size.
In this case, the parent is a `BlittableJsonReaderArray`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing
