### PR TITLE
RavenDB-20443 Apply boost to inner query inside `CachingQuery` instead of applying it to `CachingQuery`,

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
@@ -118,6 +118,12 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
         private readonly Raven.Server.Documents.Indexes.Index _index;
         private readonly string _query;
 
+        public override float Boost 
+        { 
+            get => _inner.Boost; 
+            set => _inner.Boost = value;
+        }
+
         public CachingQuery(Query inner, Raven.Server.Documents.Indexes.Index index, string query)
         {
             _inner = inner;

--- a/test/SlowTests/Issues/RavenDB-20444.cs
+++ b/test/SlowTests/Issues/RavenDB-20444.cs
@@ -1,5 +1,9 @@
+using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Queries.Explanation;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,6 +40,44 @@ public class RavenDB_20444 : RavenTestBase
 
         var rql = query.ToString();
         Assert.Equal("from 'Docs' where boost(search(StrVal, $p0) and (NumVal >= $p1 or NumVal = $p2), $p3) order by score(), NumVal as long desc include explanations()", rql);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = new object[] {"true"})]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = new object[] { "false" })]
+    public void QueryCacheHasNoImpactOnCalculatingScoring(Options options, string queryClauseCacheDisabled)
+    {
+        using var store = GetDocumentStore(new Options()
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                options.ModifyDatabaseRecord(record);
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.QueryClauseCacheDisabled)] = queryClauseCacheDisabled;
+            }
+        });
+
+        store.Maintenance.Send(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Indexes ));
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var queryObject = session.Advanced.DocumentQuery<object>("Product/Search")
+                .Search("Name", "De*").Boost(0)
+                .AndAlso()
+                .OpenSubclause()
+                .WhereLessThanOrEqual("PricePerUnit", 20).Boost(100)
+                .OrElse()
+                .WhereGreaterThan("PricePerUnit", 20).Boost(1)
+                .CloseSubclause()
+                .OrderByScore()
+                .OrderByDescending("PricePerUnit", OrderingType.Double)
+                .IncludeExplanations(out var explanations)
+                .ToList();
+
+            Assert.Contains("0.499975", explanations.GetExplanations("products/58-A").First());
+            Assert.Contains("0.00499975", explanations.GetExplanations("products/38-A").First());
+        }
     }
 
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20443 

### Additional description

Apply boost to inner query inside `CachingQuery` instead of applying it to `CachingQuery`.

### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility


- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
