### PR TITLE
RavenDB-20346 Test fix - `CanUpdateFanout`

### DIFF
--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -559,8 +559,7 @@ public class RavenIntegration : RavenTestBase
         }
 
         Indexes.WaitForIndexing(store);
-        long entriesCount = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount;
-        Assert.Equal(count, entriesCount);
+        Assert.Equal(count, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount, count));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -572,8 +571,7 @@ public class RavenIntegration : RavenTestBase
         }
 
         Indexes.WaitForIndexing(store);
-        entriesCount = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount;
-        Assert.Equal(count/2, entriesCount);
+        Assert.Equal(count/2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount, count/2));
     }
 
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20346

### Additional description

 We have to wait for the value since EntriesCount is updated in another transaction than Indexing (Indexes.WaitForIndexing() does not guarantee that EntriesCount will be already updated too).


### Type of change
- bug - race in test


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team
.
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
