### PR TITLE
RavenDB-7070 avoid mixing async & Wait() in tests

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -590,7 +590,7 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public async Task WaitForLeaveState(RachisState rachisState, CancellationToken cts)
+        public async Task<bool> WaitForLeaveState(RachisState rachisState, CancellationToken cts)
         {
             while (cts.IsCancellationRequested == false)
             {
@@ -598,10 +598,12 @@ namespace Raven.Server.Rachis
                 var task = _stateChanged.Task.WithCancellation(cts);
 
                 if (CurrentState != rachisState)
-                    return;
+                    return true;
 
                 await task;
             }
+
+            return false;
         }
 
         public Task GetTopologyChanged()

--- a/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
@@ -133,8 +133,12 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 DataDirectory = originalResult.DataDirectory
             });
 
-            var waitForNotPassive = revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive,CancellationToken.None);
-            Assert.True(waitForNotPassive.Wait(TimeSpan.FromSeconds(10_000)));
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+            {
+                var waitForNotPassive = await mentorNode.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, cts.Token);
+                Assert.True(waitForNotPassive);
+            }
+
             using (var session = src.OpenSession())
             {
                 session.Store(new User()
@@ -233,8 +237,11 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 l.ServerStore.RemoveFromClusterAsync(responsibleNodeNodeTag);
             });
             
-            var waitForPassive = mentorNode.ServerStore.Engine.WaitForState(RachisState.Passive,CancellationToken.None);
-            Assert.True(waitForPassive.Wait(TimeSpan.FromSeconds(10_000)));
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+            {
+                var waitForNotPassive = await mentorNode.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, cts.Token);
+                Assert.True(waitForNotPassive);
+            }
             
             var val = await WaitForValueAsync(async () =>
                 {
@@ -398,8 +405,13 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 RunInMemory = true,
                 DataDirectory = disposedServer.DataDirectory
             });
-            var waitForNotPassive = revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, CancellationToken.None);
-            Assert.True(waitForNotPassive.Wait(TimeSpan.FromSeconds(20_000)));
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+            {
+                var waitForNotPassive = await revivedServer.ServerStore.Engine.WaitForLeaveState(RachisState.Passive, cts.Token);
+                Assert.True(waitForNotPassive);
+            }
+
             Assert.True(WaitForDocument<User>(sinkStore, "users/2", u => u.Name == "Arava2",30_000)); 
             Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 3));
             Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20422

### Additional description

xUnit uses a synchronization context, so we can end up deadlocking when blocking an `async` method

### Type of change

- Test fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

Running `Can_Set_Pin_To_Mentor_Node_Etl` with `CanPropagateException` through xUnit caused a deadlock

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
