### PR TITLE
RavenDB-20505 Don't clone patch parameters

### DIFF
--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -362,14 +362,12 @@ namespace Raven.Server.Documents.Patch
             return value;
         }
 
-        internal JsValue TranslateToJs(Engine engine, JsonOperationContext context, object o)
+        internal JsValue TranslateToJs(Engine engine, JsonOperationContext context, object o, bool needsClone = true)
         {
             if (o is TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult tsrr)
             { 
                 // we are passing a streaming value to the JS engine, so we need
-                // // to materialize all the results
-                
-                
+                // to materialize all the results
                 var results = new DynamicJsonArray(tsrr.Stream);
                 var djv = new DynamicJsonValue
                 {
@@ -400,7 +398,9 @@ namespace Raven.Server.Documents.Patch
 
             if (o is BlittableJsonReaderObject json)
             {
-                return new BlittableObjectInstance(engine, null, Clone(json, context), null, null, null);
+                // check if clone is really required, we don't want to clone patch arguments
+                BlittableJsonReaderObject blittable = needsClone ? Clone(json, context) : json;
+                return new BlittableObjectInstance(engine, null, blittable, null, null, null);
             }
 
             if (o == null)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1976,7 +1976,7 @@ namespace Raven.Server.Documents.Patch
                 if (_args.Length != args.Length)
                     _args = new JsValue[args.Length];
                 for (var i = 0; i < args.Length; i++)
-                    _args[i] = JavaScriptUtils.TranslateToJs(ScriptEngine, jsonCtx, args[i]);
+                    _args[i] = JavaScriptUtils.TranslateToJs(ScriptEngine, jsonCtx, args[i], needsClone: false);
 
                 if (method != QueryMetadata.SelectOutput &&
                     _args.Length == 2 &&

--- a/test/FastTests/Issues/RavenDB-20505.cs
+++ b/test/FastTests/Issues/RavenDB-20505.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_20505 : RavenTestBase
+    {
+        public RavenDB_20505(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task PatchingPerformanceWithLargeCollectionParameter()
+        {
+            var documents = Enumerable.Range(1, 2_000)
+                .Select(x => new Document
+                {
+                    Id = "documents/" + x, Number = x
+                })
+                .ToList();
+
+            // create a lookup to demonstrate large dictionary being passed in to patching
+            Dictionary<string, int> lookup = new(documents.Count);
+            foreach (var doc in documents)
+            {
+                lookup.Add(doc.Id, 42);
+            }
+
+            using (var store = GetDocumentStore())
+            {
+                await using (var insert = store.BulkInsert())
+                {
+                    foreach (var document in documents)
+                    {
+                        await insert.StoreAsync(document);
+                    }
+                }
+
+                var query = new IndexQuery
+                {
+                    Query = "from Documents update { this.Number = $lookup[id(this)]; }",
+                    QueryParameters = new Parameters
+                    {
+                        { "lookup", lookup }
+                    }
+                };
+
+                var sw = Stopwatch.StartNew();
+
+                var operation = await store.Operations.SendAsync(new PatchByQueryOperation(query));
+                await operation.WaitForCompletionAsync();
+
+                sw.Stop();
+
+                Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), "Took more than allowed: " + sw.Elapsed);
+
+                // check that patch worked
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<Document>(documents[0].Id);
+                    Assert.Equal(42, doc.Number);
+                }
+            }
+        }
+
+        private class Document
+        {
+            public string Id { get; set; }
+            public int Number { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20505

### Additional description

Performance improvement to patching which uses parameters by not cloning parameters for each invocation. The included test case went from `00:00:06.9395690` to `00:00:00.3512777` to complete the patch operation. Change is more dramatic when we try to migrate large production databases.

### Type of change

- Optimization

### How risky is the change?

- Low 

As long as people don't expect the parameters to be somehow immutable, but that would sound odd.

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
