### PR TITLE
RavenDB-20199 - SlowTests.Sharding.Replication.ShardedExternalReplica…

### DIFF
--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -1039,7 +1039,7 @@ namespace SlowTests.Sharding.Replication
             var srcDB = GetDatabaseName();
             var dstDB = GetDatabaseName();
 
-            var srcTopology = await CreateDatabaseInCluster(srcDB, clusterSize, srcLeader.WebUrl);
+            var srcTopology = await CreateDatabaseInCluster(srcDB, replicationFactor, srcLeader.WebUrl);
             var dstTopology = await ShardingCluster.CreateShardedDatabaseInCluster(dstDB, replicationFactor, (dstNodes, dstLeader), shards: 3);
 
             using (var srcStore = new DocumentStore()
@@ -1057,6 +1057,13 @@ namespace SlowTests.Sharding.Replication
                     }, "users/1");
                     session.SaveChanges();
                 }
+
+                Assert.True(await WaitForDocumentInClusterAsync<User>(
+                    srcNodes,
+                    srcDB,
+                    "users/1",
+                    u => u.Name.Equals("Karmel"),
+                    TimeSpan.FromSeconds(60)));
 
                 var watcher = new ExternalReplication(dstDB, "connection-1");
                 await AddWatcherToReplicationTopology((DocumentStore)srcStore, watcher, new[] { dstLeader.WebUrl });


### PR DESCRIPTION
…tionTests.BidirectionalReplicationWithReshardingShouldWork_NonShardedAndShardedDatabases

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20199/SlowTests.Sharding.Replication.ShardedExternalReplicationTests.BidirectionalReplicationWithReshardingShouldWorkNonShardedAndShar

### Additional description

Waiting to see if fails again

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
