### PR TITLE
RavenDB-20478 - SlowTests.Client.Attachments.AttachmentsReplication.A…

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -749,7 +749,11 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal("", result.ContentType);
                     Assert.Equal("Arg5SgIJzdjSTeY6LYtQHlyNiTPmvBLHbr/Cypggeco=", result.Hash);
                 }
+
                 await SetupAttachmentReplicationAsync(store1, store2);
+                WaitForDocumentWithAttachmentToReplicate<User>(store2, "users/1", names[0], 15000);
+                WaitForDocumentWithAttachmentToReplicate<User>(store2, "users/1", names[1], 15000);
+                WaitForDocumentWithAttachmentToReplicate<User>(store2, "users/1", names[2], 15000);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -765,9 +769,11 @@ namespace SlowTests.Client.Attachments
                     session.Delete("users/1");
                     await session.SaveChangesAsync();
                 }
-                
+
+                Assert.True(WaitForDocumentDeletion(store2, "users/1"));
+
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2, "marker1$users/1");
+                WaitForMarker(store1, store2);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -784,8 +790,10 @@ namespace SlowTests.Client.Attachments
                     session.SaveChanges();
                 }
 
+                Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 2"));
+
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2, "marker2$users/1");
+                WaitForMarker(store1, store2);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -801,8 +809,10 @@ namespace SlowTests.Client.Attachments
                     session.SaveChanges();
                 }
 
+                Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 3"));
+              
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2, "marker3$users/1");
+                WaitForMarker(store1, store2);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -818,8 +828,10 @@ namespace SlowTests.Client.Attachments
                     session.SaveChanges();
                 }
 
+                Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 4"));
+
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2, "marker4$users/1");
+                WaitForMarker(store1, store2);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -835,8 +847,10 @@ namespace SlowTests.Client.Attachments
                     session.SaveChanges();
                 }
 
+                Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 5"));
+
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2, "marker5$users/1");
+                WaitForMarker(store1, store2);
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {


### PR DESCRIPTION
…ttachmentsRevisionsReplication(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20478/SlowTests.Client.Attachments.AttachmentsReplication.AttachmentsRevisionsReplicationoptions-DatabaseMode-Sharded-SearchEngineMode

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
