### PR TITLE
RavenDB-20509 Fix temporary buffers bar in Storage widget

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/storageWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/storageWidget.html
@@ -37,7 +37,7 @@
                                     data-bind="text: $root.sizeFormatter(totalCapacity())"></div>
                             </div>
                             <div class="storage-chart" data-bind="style: { width: scaleFactor() + '%' }">
-                                <div class="storage-used" data-bind="style: { width: usedSpacePercentage() + '%' }">
+                                <div class="storage-used d-flex align-items-center" data-bind="style: { width: usedSpacePercentage() + '%' }">
                                     <div class="storage-ravendb" data-bind="style: { width: ravendbToUsedSpacePercentage() + '%' }"></div>
                                     <div class="storage-ravendb-temp-buffers" data-bind="style: { width: ravendbTempBuffersToUsedSpacePercentage() + '%' }"></div>
                                 </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20509/Cluster-Dashboard-Storage-widget-Blue-bar-is-barely-visible

### Additional description
Fixed the positioning of temporary buffers bar

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
