### PR TITLE
RavenDB-20496 Fix Manage Database Group styling for non-default themes

### DIFF
--- a/src/Raven.Studio/typescript/components/common/DatabaseGroup.scss
+++ b/src/Raven.Studio/typescript/components/common/DatabaseGroup.scss
@@ -16,14 +16,14 @@
         .dbgroup-item {
             min-width: 150px;
             margin: sizes.$gutter-xs/2;
-            background-color: colors.$panel-bg-2;
+            background-color: colors.$panel-bg-2-var;
             border-radius: sizes.$gutter-xxs;
             max-width: 200px;
             & > div {
                 text-align: center;
                 padding: sizes.$gutter-xs sizes.$gutter-sm;
                 & + div {
-                    border-top: sizes.$border-width solid colors.$border-color-light;
+                    border-top: sizes.$border-width solid colors.$border-color-light-var;
                 }
             }
 
@@ -39,14 +39,14 @@
 
             strong {
                 font-weight: 800;
-                color: colors.$text-emphasis-color;
+                color: colors.$text-emphasis-var;
             }
 
             &.item-new {
                 .dbgroup-node {
                     min-height: 90px;
                     font-size: 40px;
-                    color: colors.$text-emphasis-color;
+                    color: colors.$text-emphasis-var;
                 }
             }
         }

--- a/src/Raven.Studio/typescript/components/common/DatabaseGroup.tsx
+++ b/src/Raven.Studio/typescript/components/common/DatabaseGroup.tsx
@@ -105,7 +105,7 @@ export function DatabaseGroupType(props: DatabaseGroupTypeProps) {
                 <Icon icon={cssIcon(node)} /> {node.type}
             </div>
             <div>
-                <Badge color={nodeBadgeColor(node)} className="ms-1">
+                <Badge color={nodeBadgeColor(node)}>
                     {nodeBadgeText(node)}
                     {node.responsibleNode && (
                         <span

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
@@ -86,7 +86,7 @@ export function ManageDatabaseGroupPage(props: ManageDatabaseGroupPageProps) {
                         <UncontrolledButtonWithDropdownPanel buttonText="Settings">
                             <>
                                 <Label className="dropdown-item-text m-0" htmlFor={settingsUniqueId}>
-                                    <div className="form-switch form-check-reverse">
+                                    <div className="d-flex gap-3 form-switch">
                                         <Input
                                             id={settingsUniqueId}
                                             type="switch"


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20496/Manage-database-group-items-do-not-have-styling-updated-on-non-default-themes

### Additional description
Fixed coloring issues for the Manage Database Group items on non-default themes

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
