### PR TITLE
RavenDB-20351 Catch indexing OOM Exception in encrypted database low memory state.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1778,6 +1778,10 @@ namespace Raven.Server.Documents.Indexes
                                 }
                             }
                         }
+                        catch (Exception e) when (e.IsOutOfMemory())
+                        {
+                            HandleOutOfMemoryException(null, storageEnvironment, e);
+                        }
                         catch (OperationCanceledException)
                         {
                             return;
@@ -2175,7 +2179,7 @@ namespace Raven.Server.Documents.Indexes
                     exception = new OutOfMemoryException("The paging file is too small for this operation to complete, consider increasing the size of the page file", exception);
                 }
 
-                scope.AddMemoryError(exception);
+                scope?.AddMemoryError(exception);
                 var outOfMemoryErrors = Interlocked.Add(ref _lowMemoryPressure, LowMemoryPressure);
                 _lowMemoryFlag.Raise();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20351 

### Additional description

https://github.com/ravendb/ravendb/blob/5f5e42022ba2fcaf8c610c733aab2750c3374ccc/src/Raven.Server/Documents/Indexes/Index.cs#L1744-L1754

This can throw an EarlyOutOfMemoryException, and we have to catch it because at that location, the entire index will be immediately set as Errored.

### Type of change

- Bug fix

### How risky is the change?
 
- Moderate 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
