### PR TITLE
RavenDB-18997 - Failing InterversionTests InterversionTests.MixedClus…

### DIFF
--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -194,7 +194,16 @@ namespace InterversionTests
         {
             try
             {
-                var result = await stores[0].Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(database), size));
+                var databaseRecord = new DatabaseRecord(database)
+                {
+                    Settings =
+                    {
+                        [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1",
+                        [RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter)] = "1"
+                    }
+                };
+
+                var result = await stores[0].Maintenance.Server.SendAsync(new CreateDatabaseOperation(databaseRecord, size));
                 foreach (var store in stores)
                 {
                     using (var context = JsonOperationContext.ShortTermSingleUse())


### PR DESCRIPTION
…terTests.UpgradeDirectlyFrom41X & InterversionTests.MixedClusterTests.UpgradeToLatest

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18997/Failing-InterversionTests-InterversionTests.MixedClusterTests.UpgradeDirectlyFrom41X

### Additional description

This PR contains a minor fix required after handling the main issue (https://github.com/ravendb/ravendb/pull/16479)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
