### PR TITLE
RavenDB-19239 Prevent index deletion when index lock mode is locked

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -392,6 +392,22 @@ namespace Raven.Client.ServerWide
 
         public void DeleteIndex(string name)
         {
+            var lockMode = IndexLockMode.Unlock;
+            
+            if (Indexes.TryGetValue(name, out var definition))
+            {
+                if (definition.LockMode != null)
+                    lockMode = definition.LockMode.Value;
+            }
+            
+            if (lockMode == IndexLockMode.LockedIgnore)
+                return;
+
+            if (lockMode == IndexLockMode.LockedError)
+            {
+                throw new IndexDeletionException($"Cannot delete existing index {name} with lock mode {lockMode}");
+            }
+            
             Indexes?.Remove(name);
             AutoIndexes?.Remove(name);
             IndexesHistory?.Remove(name);

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -392,20 +392,20 @@ namespace Raven.Client.ServerWide
 
         public void DeleteIndex(string name)
         {
-            var lockMode = IndexLockMode.Unlock;
-            
             if (Indexes.TryGetValue(name, out var definition))
             {
+                var lockMode = IndexLockMode.Unlock;
+                
                 if (definition.LockMode != null)
                     lockMode = definition.LockMode.Value;
-            }
-            
-            if (lockMode == IndexLockMode.LockedIgnore)
-                return;
+                
+                if (lockMode == IndexLockMode.LockedIgnore)
+                    return;
 
-            if (lockMode == IndexLockMode.LockedError)
-            {
-                throw new IndexDeletionException($"Cannot delete existing index {name} with lock mode {lockMode}");
+                if (lockMode == IndexLockMode.LockedError)
+                {
+                    throw new IndexDeletionException($"Cannot delete existing index {name} with lock mode {lockMode}");
+                }
             }
             
             Indexes?.Remove(name);

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexDeleteController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexDeleteController.cs
@@ -39,9 +39,17 @@ public abstract class AbstractIndexDeleteController
             return true;
         }
 
-        var (index, _) = await ServerStore.SendToLeaderAsync(new DeleteIndexCommand(indexDefinition.Name, GetDatabaseName(), raftRequestId));
+        try
+        {
+            var (index, _) = await ServerStore.SendToLeaderAsync(new DeleteIndexCommand(indexDefinition.Name, GetDatabaseName(), raftRequestId));
 
-        await WaitForIndexNotificationAsync(index);
+            await WaitForIndexNotificationAsync(index);
+        }
+
+        catch (Exception e)
+        {
+            IndexStore.ThrowIndexDeletionException(name, e);
+        }
 
         return true;
     }
@@ -52,9 +60,17 @@ public abstract class AbstractIndexDeleteController
         if (indexDefinition == null)
             IndexDoesNotExistException.ThrowFor(name);
 
-        var (index, _) = await ServerStore.SendToLeaderAsync(new DeleteIndexCommand(indexDefinition.Name, GetDatabaseName(), raftRequestId));
-
-        await WaitForIndexNotificationAsync(index);
+        try
+        {
+            var (index, _) = await ServerStore.SendToLeaderAsync(new DeleteIndexCommand(indexDefinition.Name, GetDatabaseName(), raftRequestId));
+            
+            await WaitForIndexNotificationAsync(index);
+        }
+        
+        catch (Exception e)
+        {
+            IndexStore.ThrowIndexDeletionException(name, e);
+        }
     }
 
     private async ValueTask HandleSideBySideIndexDeleteAsync(string name, string raftRequestId)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2125,6 +2125,11 @@ namespace Raven.Server.Documents.Indexes
             throw new IndexCreationException($"Failed to create {indexType} index '{indexName}', {reason}. Node {serverStore.NodeTag} state is {serverStore.LastStateChangeReason()}", exception);
         }
 
+        public static void ThrowIndexDeletionException(string indexName, Exception exception)
+        {
+            throw new IndexDeletionException($"Failed to delete index '{indexName}'.", exception);
+        }
+
         internal TestingStuff ForTestingPurposes;
 
         internal TestingStuff ForTestingPurposesOnly()

--- a/test/SlowTests/Issues/RavenDB_19239.cs
+++ b/test/SlowTests/Issues/RavenDB_19239.cs
@@ -1,0 +1,125 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19239 : RavenTestBase
+{
+    public RavenDB_19239(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestLockedError()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = "Name1" };
+                var dto2 = new Dto() { Name = "Name2" };
+
+                session.Store(dto1);
+                session.Store(dto2);
+
+                session.SaveChanges();
+                
+                var index = new DummyIndex();
+
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                store.Maintenance.Send(new SetIndexesLockOperation("DummyIndex", IndexLockMode.LockedError));
+                
+                var ex = Assert.Throws<RavenException>(() => store.Maintenance.Send(new DeleteIndexOperation("DummyIndex")));
+
+                Assert.Contains("Cannot delete existing index DummyIndex with lock mode LockedError", ex.ToString());
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestLockedIgnore()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = "Name1" };
+                var dto2 = new Dto() { Name = "Name2" };
+
+                session.Store(dto1);
+                session.Store(dto2);
+
+                session.SaveChanges();
+                
+                var index = new DummyIndex();
+
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                store.Maintenance.Send(new SetIndexesLockOperation("DummyIndex", IndexLockMode.LockedIgnore));
+                
+                store.Maintenance.Send(new DeleteIndexOperation("DummyIndex"));
+                
+                var indexDefinition = store.Maintenance.Send(new GetIndexOperation("DummyIndex"));
+                
+                Assert.NotNull(indexDefinition);
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestUnlock()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = "Name1" };
+                var dto2 = new Dto() { Name = "Name2" };
+
+                session.Store(dto1);
+                session.Store(dto2);
+
+                session.SaveChanges();
+                
+                var index = new DummyIndex();
+
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                store.Maintenance.Send(new SetIndexesLockOperation("DummyIndex", IndexLockMode.Unlock));
+                
+                store.Maintenance.Send(new DeleteIndexOperation("DummyIndex"));
+                
+                var indexDefinition = store.Maintenance.Send(new GetIndexOperation("DummyIndex"));
+                
+                Assert.Null(indexDefinition);
+            }
+        }
+    }
+    
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = orders => from order in orders
+                select new Dto { Name = $"{order.Name}_new" };
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19239.cs
+++ b/test/SlowTests/Issues/RavenDB_19239.cs
@@ -40,7 +40,7 @@ public class RavenDB_19239 : RavenTestBase
                 
                 var ex = Assert.Throws<RavenException>(() => store.Maintenance.Send(new DeleteIndexOperation("DummyIndex")));
 
-                Assert.Contains("Cannot delete existing index DummyIndex with lock mode LockedError", ex.ToString());
+                Assert.Contains("IndexDeletionException: Cannot delete existing index DummyIndex with lock mode LockedError", ex.ToString());
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19239/Prevent-index-deletion-when-index-lock-mode-is-locked

### Additional description

We want to take IndexLockMode into account when trying to delete index from database.

### Type of change

- Feature improvement

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. 
