### PR TITLE
RavenDB-20524 Database create button sometimes doesn't work

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
@@ -17,6 +17,8 @@ type shardTopologyItem = {
     replicas: KnockoutObservableArray<clusterNode>;
 }
 
+const defaultReplicationFactor = 2;
+
 class databaseCreationModel {
     static storageExporterPathKeyName = storageKeyProvider.storageKeyFor("storage-exporter-path");
 
@@ -86,14 +88,16 @@ class databaseCreationModel {
     });
     
     replicationAndSharding = {
-        replicationFactor: ko.observable<number>(2),
+        replicationFactor: ko.observable<number>(defaultReplicationFactor),
         manualMode: ko.observable<boolean>(false),
         dynamicMode: ko.observable<boolean>(true),
         nodes: ko.observableArray<clusterNode>([]),
         orchestrators: ko.observableArray<clusterNode>([]),
         enableSharding: ko.observable<boolean>(false),
         numberOfShards: ko.observable<number>(1),
-        shardTopology: ko.observableArray<shardTopologyItem>([])
+        shardTopology: ko.observableArray<shardTopologyItem>([{
+            replicas: ko.observableArray(new Array(defaultReplicationFactor).fill(null))
+        }])
     };
     
     replicationValidationGroup = ko.validatedObservable({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20524/Database-create-button-sometimes-doesnt-work

### Additional description

shardTopology was a empty array when the initial replication factor was 2, so validation fails

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
