### PR TITLE
RavenDB-20488 Add Snapshot disabled info to backup view

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -1,7 +1,7 @@
 ﻿class tasksCommonContent {
         
     static readonly generalBackupInfo =
-        `<div class="margin-bottom">Differences between Backup and Snapshot:</div> 
+        `<div class="margin-bottom-xs">Differences between Backup and Snapshot:</div> 
         <ul>
             <li>Data
                 <small><ul>
@@ -11,7 +11,7 @@
                 </ul></small>
             </li>
         </ul>
-        <div class="margin-bottom">Differences when Snapshot backs up both index definitions and index data:</div>
+        <div class="margin-bottom-xs">Differences when Snapshot backs up both index definitions and index data:</div>
         <ul>
             <li>Speed
                 <small><ul>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -40,6 +40,7 @@
                         <ul class="dropdown-menu" data-bind="foreach: backupOptions">
                             <li><a href="#" data-bind="text: $data, click: $parent.useBackupType.bind($parent, $data)"></a></li>
                         </ul>
+                        <div class="bg-info padding-left-xxs" data-bind="visible: $root.db.isSharded()"><small>Snapshot is not supported in sharded databases</small></div>
                     </div>
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -41,6 +41,9 @@
                         <ul class="dropdown-menu" data-bind="foreach: backupOptions">
                             <li><a href="#" data-bind="text: $data, click: $parent.useBackupType.bind($parent, $data)"></a></li>
                         </ul>
+                        <div class="bg-info padding-left-xxs" data-bind="visible: isSnapshot">
+                            <small>Snapshot is not supported in sharded databases</small>
+                        </div>
                     </div>
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20488/Unable-to-select-backup-type-for-sharded-database

### Additional description
Added a disclaimer that indicates the Snapshot backup type is not available for sharded dbs

### Type of change
- Optimization

### How risky is the change?
- Not relevant

### Backward compatibilityain how has it been implemented?
- Breaking change
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
