### PR TITLE
RavenDB-20177 Sending document ids instead of LoadHash in page size too big notification details

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -129,7 +129,12 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         {
             if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
             {
-                var details = CreatePerformanceHintDetails();
+                string details;
+                
+                if (ids.Count > 0)
+                    details = CreatePerformanceHintDetails();
+                else
+                    details = HttpContext.Request.QueryString.Value;
 
                 RequestHandler.AddPagingPerformanceHint(
                     PagingOperationType.Documents,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20177/Missing-info-in-the-Page-size-too-big-notification-for-documents

### Additional description

Applied changes from https://github.com/ravendb/ravendb/pull/16475 to v6.0

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
