### PR TITLE
RavenDB-20388 & RavenDB-20378 & RavenDB-20480 Throw on specific queries for ShardedDB / Corax.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -8,6 +8,7 @@ using Corax.Mappings;
 using Corax.Queries;
 using Corax.Utils;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -1048,7 +1049,7 @@ internal static class CoraxQueryBuilder
         {
             if (field.OrderingType == OrderByFieldType.Random)
             {
-                throw new NotSupportedException($"{nameof(Corax)} doesn't support OrderByRandom.");
+                throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support OrderByRandom.");
             }
 
             if (field.OrderingType == OrderByFieldType.Score)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
@@ -148,6 +148,9 @@ internal class ShardedQueriesHandlerProcessorForGet : AbstractQueriesHandlerProc
         
         if (indexQuery.Metadata.HasHighlightings)
             throw new NotSupportedInShardingException("Highlighting queries are currently not supported in a sharded database ");
+        
+        if (indexQuery.Metadata.HasIntersect && indexQuery.Metadata.OrderBy?.Length > 0)
+            throw new NotSupportedInShardingException("Ordered intersect queries are currently not supported in a sharded database ");
     }
 
     private static TimingsScope Timings(IndexQueryServerSide query) => new(query);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForGet.cs
@@ -145,6 +145,9 @@ internal class ShardedQueriesHandlerProcessorForGet : AbstractQueriesHandlerProc
 
         if (indexQuery.Metadata.HasMoreLikeThis)
             throw new NotSupportedInShardingException("MoreLikeThis queries are currently not supported in a sharded database ");
+        
+        if (indexQuery.Metadata.HasHighlightings)
+            throw new NotSupportedInShardingException("Highlighting queries are currently not supported in a sharded database ");
     }
 
     private static TimingsScope Timings(IndexQueryServerSide query) => new(query);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20388 
https://issues.hibernatingrhinos.com/issue/RavenDB-20378
https://issues.hibernatingrhinos.com/issue/RavenDB-20480


### Additional description

Not supported
- Corax: `OrderByRandom`
- Sharding: `Highlighting`
- Sharding: Ordered intersect queries