### PR TITLE
RavenDB-20519 We cannot rely on order without ordering in case of ShardedDB test.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-12359.cs
+++ b/test/SlowTests/Issues/RavenDB-12359.cs
@@ -123,18 +123,19 @@ namespace SlowTests.Issues
                     var query = from d in s.Query<MyDoc>()
                                 select new
                                 {
+                                    Id = d.Id,
                                     HasValue = d.NullableInt >= 0
                                 };
 
-                    Assert.Equal("from 'MyDocs' as d select { " +
+                    Assert.Equal("from 'MyDocs' as d select { Id : id(d), " +
                                  "HasValue : d.NullableInt>0||d.NullableInt===0 }"
-                                 , query.ToString());
+                        , query.ToString());
 
                     var results = query.ToList();
 
                     Assert.Equal(results.Count, 2);
-                    Assert.False(results[0].HasValue);
-                    Assert.True(results[1].HasValue);
+                    Assert.False(results.First(d => d.Id == "1").HasValue);
+                    Assert.True(results.First(d => d.Id == "2").HasValue);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_12030.cs
+++ b/test/SlowTests/Issues/RavenDB_12030.cs
@@ -86,7 +86,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void SimpleProximity(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20519 

### Additional description

In that file, most of the tests contain the "order by" clause, but this one was failing because it does not have it. As a result, it was possible that the result was "reversed".