### PR TITLE
RavenDB-20487 - Missing data after external replication from ShardedD…

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -284,7 +284,7 @@ namespace Raven.Server.Documents
                             nonPersistentFlags |= NonPersistentDocumentFlags.ResolveTimeSeriesConflict;
 
                         _documentsStorage.RevisionsStorage.Put(
-                            context, conflicted.Id, conflicted.Doc, conflicted.Flags | DocumentFlags.Conflicted | DocumentFlags.HasRevisions, nonPersistentFlags, conflicted.ChangeVector,
+                            context, conflicted.Id, conflicted.Doc, conflicted.Flags | DocumentFlags.Conflicted | DocumentFlags.HasRevisions, nonPersistentFlags, context.GetChangeVector(conflicted.ChangeVector),
                             conflicted.LastModified.Ticks,
                             collectionName: collection,
                             configuration: _documentsStorage.RevisionsStorage.ConflictConfiguration.Default);

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -754,7 +754,7 @@ namespace Raven.Server.Documents
             {
                 foreach (var existingConflict in conflicts)
                 {
-                    status = ChangeVectorUtils.GetConflictStatus(changeVector, existingConflict.ChangeVector);
+                    status = ChangeVectorUtils.GetConflictStatus(context.GetChangeVector(changeVector), context.GetChangeVector(existingConflict.ChangeVector));
                     if (status == ConflictStatus.Conflict)
                     {
                         ConflictManager.AssertChangeVectorNotNull(existingConflict.ChangeVector);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents
                 }
 
                 BlittableJsonReaderObject oldDoc = null;
-                string oldChangeVector = "";
+                ChangeVector oldChangeVector = null;
                 if (oldValue.Pointer == null)
                 {
                     // expectedChangeVector being null means we don't care, 
@@ -243,7 +243,7 @@ namespace Raven.Server.Documents
                         }
 
                         flags |= DocumentFlags.HasRevisions;
-                        _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector.AsString(), modifiedTicks, configuration, collectionName);
+                        _documentDatabase.DocumentsStorage.RevisionsStorage.Put(context, id, document, flags, nonPersistentFlags, changeVector, modifiedTicks, configuration, collectionName);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -94,7 +94,7 @@ public class MergedBatchCommand : TransactionMergedCommand
                                                                            existingDocument.Data.Clone(context),
                                                                            existingDocument.Flags |= DocumentFlags.HasRevisions,
                                                                            nonPersistentFlags: NonPersistentDocumentFlags.ForceRevisionCreation,
-                                                                           existingDocument.ChangeVector,
+                                                                           context.GetChangeVector(existingDocument.ChangeVector),
                                                                            existingDocument.LastModified.Ticks);
                             flags |= DocumentFlags.HasRevisions;
                         }
@@ -398,7 +398,7 @@ public class MergedBatchCommand : TransactionMergedCommand
                                                                                  clonedDocData,
                                                                                  existingDoc.Flags,
                                                                                  nonPersistentFlags: NonPersistentDocumentFlags.ForceRevisionCreation,
-                                                                                 existingDoc.ChangeVector,
+                                                                                 context.GetChangeVector(existingDoc.ChangeVector),
                                                                                  existingDoc.LastModified.Ticks);
                     if (revisionCreated)
                     {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -19,7 +19,6 @@ using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
-using Raven.Client.ServerWide.Sharding;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Config.Settings;
@@ -27,7 +26,7 @@ using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
-using Raven.Server.Documents.Sharding;
+using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Extensions;
 using Raven.Server.NotificationCenter.Notifications;
@@ -619,6 +618,16 @@ namespace Raven.Server.Documents.Replication
         {
             if (incomingPullParams == null)
             {
+                if (ShardHelper.IsShardName(Database.Name) && 
+                    getLatestEtagMessage.ReplicationsType == ReplicationLatestEtagRequest.ReplicationType.Sharded)
+                {
+                    return new IncomingExternalReplicationHandlerForShard(tcpConnectionOptions,
+                        getLatestEtagMessage,
+                        this,
+                        buffer,
+                        getLatestEtagMessage.ReplicationsType);
+                }
+
                 return new IncomingReplicationHandler(
                     tcpConnectionOptions,
                     getLatestEtagMessage,

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -618,16 +618,6 @@ namespace Raven.Server.Documents.Replication
         {
             if (incomingPullParams == null)
             {
-                if (ShardHelper.IsShardName(Database.Name) && 
-                    getLatestEtagMessage.ReplicationsType == ReplicationLatestEtagRequest.ReplicationType.Sharded)
-                {
-                    return new IncomingExternalReplicationHandlerForShard(tcpConnectionOptions,
-                        getLatestEtagMessage,
-                        this,
-                        buffer,
-                        getLatestEtagMessage.ReplicationsType);
-                }
-
                 return new IncomingReplicationHandler(
                     tcpConnectionOptions,
                     getLatestEtagMessage,

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -536,6 +536,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
                     if (doc.Flags.Contain(DocumentFlags.Revision) || doc.Flags.Contain(DocumentFlags.DeleteRevision))
                     {
+                        // RavenDB-20487: we let all revision documents to pass to the other side
                         return false;
                     }
 

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -536,13 +536,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
                     if (doc.Flags.Contain(DocumentFlags.Revision) || doc.Flags.Contain(DocumentFlags.DeleteRevision))
                     {
-                        // we let pass all the conflicted revisions, since we keep them with their original change vector which might be `AlreadyMerged` at the destination.
-                        if (doc.Flags.Contain(DocumentFlags.Conflicted) ||
-                            doc.Flags.Contain(DocumentFlags.FromClusterTransaction) ||
-                            doc.Flags.Contain(DocumentFlags.FromOldDocumentRevision))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
 
                     break;

--- a/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
@@ -9,6 +9,7 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Sharding;
+using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
@@ -39,6 +40,15 @@ public class ShardReplicationLoader : ReplicationLoader
         PullReplicationParams incomingPullParams,
         ReplicationLatestEtagRequest getLatestEtagMessage)
     {
+        if (getLatestEtagMessage.ReplicationsType == ReplicationLatestEtagRequest.ReplicationType.Sharded)
+        {
+            return new IncomingExternalReplicationHandlerForShard(tcpConnectionOptions,
+                getLatestEtagMessage,
+                this,
+                buffer,
+                getLatestEtagMessage.ReplicationsType);
+        }
+
         if (getLatestEtagMessage.ReplicationsType == ReplicationLatestEtagRequest.ReplicationType.Migration)
         {
             return new IncomingMigrationReplicationHandler(

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -295,6 +295,7 @@ namespace Raven.Server.Documents.Revisions
                 if (configuration.MinimumRevisionsToKeep == 0)
                     return false;
 
+                changeVector = context.GetChangeVector(changeVector).Version;
                 using (Slice.From(context.Allocator, changeVector, out Slice changeVectorSlice))
                 {
                     var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
@@ -315,6 +316,7 @@ namespace Raven.Server.Documents.Revisions
             Debug.Assert(changeVector != null, "Change vector must be set");
             Debug.Assert(lastModifiedTicks != DateTime.MinValue.Ticks, "last modified ticks must be set");
 
+            changeVector = context.GetChangeVector(changeVector).Version;
             BlittableJsonReaderObject.AssertNoModifications(document, id, assertChildren: true);
 
             if (collectionName == null)
@@ -677,6 +679,7 @@ namespace Raven.Server.Documents.Revisions
             Table writeTable = null;
             string currentCollection = null;
             var deletedRevisionsCount = 0;
+            changeVector = context.GetChangeVector(changeVector).Version;
 
             while (true)
             {
@@ -884,6 +887,8 @@ namespace Raven.Server.Documents.Revisions
             var configuration = GetRevisionsConfiguration(collectionName.Name, flags);
             if (configuration.Disabled && fromReplication == false)
                 return;
+
+            changeVector = context.GetChangeVector(changeVector).Version;
 
             var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -1,0 +1,69 @@
+﻿using Raven.Client.Documents.Replication.Messages;
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.TcpHandlers;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public class IncomingExternalReplicationHandlerForShard : IncomingReplicationHandler
+    {
+        private readonly ShardedDocumentDatabase _shardedDatabase;
+
+        public IncomingExternalReplicationHandlerForShard(
+            TcpConnectionOptions options,
+            ReplicationLatestEtagRequest replicatedLastEtag,
+            ReplicationLoader parent, JsonOperationContext.MemoryBuffer bufferToCopy,
+            ReplicationLatestEtagRequest.ReplicationType replicationType) : base(options, replicatedLastEtag, parent, bufferToCopy, replicationType)
+        {
+            _shardedDatabase = ShardedDocumentDatabase.CastToShardedDocumentDatabase(parent.Database);
+        }
+
+        protected override DocumentMergedTransactionCommand GetMergeDocumentsCommand(DocumentsOperationContext context,
+            DataForReplicationCommand data, long lastDocumentEtag)
+        {
+            return new MergedDocumentReplicationForShardCommand(_shardedDatabase, data, lastDocumentEtag);
+        }
+
+        internal class MergedDocumentReplicationForShardCommand : MergedDocumentReplicationCommand
+        {
+            private readonly ShardedDocumentDatabase _database;
+
+            public MergedDocumentReplicationForShardCommand(ShardedDocumentDatabase database, DataForReplicationCommand replicationInfo, long lastEtag) : base(replicationInfo, lastEtag)
+            {
+                _database = database;
+            }
+
+            protected override ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
+            {
+                var changeVector = context.GetChangeVector(item.ChangeVector).Order;
+
+                if (ShouldUpdateOrder(context, changeVector) == false)
+                    return base.PreProcessItem(context, item);
+
+
+                var order = _database.DocumentsStorage.GetNewChangeVector(context).ChangeVector;
+                order = order.MergeOrderWith(changeVector, context);
+                item.ChangeVector = context.GetChangeVector(changeVector.Version, order.Order).AsString();
+
+                return order;
+            }
+
+            private bool ShouldUpdateOrder(DocumentsOperationContext context, ChangeVector changeVector)
+            {
+                var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
+                if (current.IsNullOrEmpty)
+                    return true;
+
+                if (changeVector.Contains(_database.DbBase64Id) == false)
+                    return true;
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Raven.Client.Documents.Attachments;
+﻿using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.Incoming;
@@ -47,19 +46,10 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 if (ShouldSkip(item) || HasConflicts(context, item))
                     return changeVector.Order;
 
-                var shouldUpdateDatabaseCv = true;
                 var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
-
-                if (current.IsNullOrEmpty == false && current.CheckIfDbIdExists(changeVector.Order))
-                {
-                    // the destination dbId already exists in the database change vector
-                    // so we can avoid generating a new database change vector
-                    shouldUpdateDatabaseCv = false;
-                }
-
                 var etag = _database.DocumentsStorage.GenerateNextEtag();
 
-                if (shouldUpdateDatabaseCv)
+                if (current.IsNullOrEmpty)
                     context.LastDatabaseChangeVector = _database.DocumentsStorage.GetNewChangeVector(context, etag);
 
                 var dbId = _database.DbBase64Id;

--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -41,28 +41,11 @@ namespace Raven.Server.Documents.Sharding.Handlers
             protected override ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
             {
                 var changeVector = context.GetChangeVector(item.ChangeVector).Order;
-
-                if (ShouldUpdateOrder(context, changeVector) == false)
-                    return base.PreProcessItem(context, item);
-
-
                 var order = _database.DocumentsStorage.GetNewChangeVector(context).ChangeVector;
                 order = order.MergeOrderWith(changeVector, context);
                 item.ChangeVector = context.GetChangeVector(changeVector.Version, order.Order).AsString();
 
                 return order;
-            }
-
-            private bool ShouldUpdateOrder(DocumentsOperationContext context, ChangeVector changeVector)
-            {
-                var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
-                if (current.IsNullOrEmpty)
-                    return true;
-
-                if (changeVector.Contains(_database.DbBase64Id) == false)
-                    return true;
-
-                return false;
             }
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -50,16 +50,11 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 var shouldUpdateDatabaseCv = true;
                 var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
 
-                if (current.IsNullOrEmpty == false)
+                if (current.IsNullOrEmpty == false && current.CheckIfDbIdExists(changeVector.Order))
                 {
-                    var dbIdsFromDestCv = ChangeVector.ExtractDbIdsFromChangeVector(changeVector.Order);
-                    if (dbIdsFromDestCv != null &&
-                        dbIdsFromDestCv.Any(x => current.Order.Contains(x)))
-                    {
-                        // the destination dbId already exists in the database change vector
-                        // so we can avoid generating a new database change vector
-                        shouldUpdateDatabaseCv = false;
-                    }
+                    // the destination dbId already exists in the database change vector
+                    // so we can avoid generating a new database change vector
+                    shouldUpdateDatabaseCv = false;
                 }
 
                 var etag = _database.DocumentsStorage.GenerateNextEtag();

--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             {
                 var changeVector = context.GetChangeVector(item.ChangeVector);
 
-                if (ShouldSkip(item) || HasConflicts(context, item))
+                if (IsRevisionType(item) || HasConflicts(context, item))
                     return changeVector.Order;
 
                 var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 return changeVector.Order;
             }
 
-            private bool ShouldSkip(ReplicationBatchItem item)
+            private bool IsRevisionType(ReplicationBatchItem item)
             {
                 if (item is AttachmentReplicationItem attachment &&
                     AttachmentsStorage.GetAttachmentTypeByKey(attachment.Key) == AttachmentType.Revision)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -178,7 +178,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
                     throw new MissingAttachmentException(missingAttachmentMessage);
 
                 var cvs = new List<string>();
-                var minEtag = long.MaxValue;
                 foreach (var (shardNumber, batch) in batches)
                 {
                     // ignore change vectors from heartbeat

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -651,6 +651,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     var document = documentType.Document;
                     var id = document.Id;
+                    var documentChangeVector = context.GetChangeVector(document.ChangeVector);
 
                     if (IsRevision)
                     {
@@ -674,15 +675,15 @@ namespace Raven.Server.Smuggler.Documents
                         {
                             _missingDocumentsForRevisions?.TryRemove(id, out _);
                             _database.DocumentsStorage.RevisionsStorage.Delete(context, id, document.Data, document.Flags,
-                                document.NonPersistentFlags, document.ChangeVector, document.LastModified.Ticks);
+                                document.NonPersistentFlags, documentChangeVector, document.LastModified.Ticks);
                         }
                         else
                         {
                             _database.DocumentsStorage.RevisionsStorage.Put(context, id, document.Data, document.Flags,
-                                document.NonPersistentFlags, document.ChangeVector, document.LastModified.Ticks);
+                                document.NonPersistentFlags, documentChangeVector, document.LastModified.Ticks);
                         }
 
-                        databaseChangeVector = ChangeVector.Merge(databaseChangeVector, context.GetChangeVector(document.ChangeVector), context);
+                        databaseChangeVector = ChangeVector.Merge(databaseChangeVector, documentChangeVector, context);
 
                         continue;
                     }
@@ -713,12 +714,12 @@ namespace Raven.Server.Smuggler.Documents
 
                         document.Flags |= DocumentFlags.HasRevisions;
                         _database.DocumentsStorage.RevisionsStorage.Put(context, newId, document.Data, document.Flags,
-                            document.NonPersistentFlags, document.ChangeVector, document.LastModified.Ticks);
+                            document.NonPersistentFlags, documentChangeVector, document.LastModified.Ticks);
 
                         if (parentDocument != null)
                         {
                             // the change vector of the document must be identical to the one of the last revision
-                            databaseChangeVector = ChangeVector.Merge(databaseChangeVector, context.GetChangeVector(document.ChangeVector), context);
+                            databaseChangeVector = ChangeVector.Merge(databaseChangeVector, documentChangeVector, context);
 
                             using (parentDocument.Data)
                                 parentDocument.Data = parentDocument.Data.Clone(context);

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -272,6 +272,25 @@ public class ChangeVector
         return newChangeVector.SerializeVector();
     }
 
+    public static List<string> ExtractDbIdsFromChangeVector(ChangeVector changeVector)
+    {
+        return ExtractDbIdsFromChangeVector(changeVector.Order.AsString());
+    }
+
+    public static List<string> ExtractDbIdsFromChangeVector(string changeVector)
+    {
+        if (string.IsNullOrEmpty(changeVector))
+            return null;
+
+        var dbIds = new List<string>();
+        var cvs = changeVector.ToChangeVectorList();
+
+        foreach (var entry in cvs)
+            dbIds.Add(entry.DbId);
+
+        return dbIds;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureValid()
     {

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
@@ -273,39 +272,11 @@ public class ChangeVector
         return newChangeVector.SerializeVector();
     }
 
-    private static IEnumerable<string> ExtractDbIdsFromChangeVector(ChangeVector changeVector)
-    {
-        return ExtractDbIdsFromChangeVector(changeVector.Order.AsString());
-    }
-
-    private static IEnumerable<string> ExtractDbIdsFromChangeVector(string changeVector)
-    {
-        if (string.IsNullOrEmpty(changeVector))
-            yield break;
-
-        var cvs = changeVector.ToChangeVectorList();
-        foreach (var entry in cvs)
-            yield return entry.DbId;
-    }
-
-    public bool CheckIfDbIdExists(ChangeVector changeVector)
-    {
-        var dbIdsFromRemote = ExtractDbIdsFromChangeVector(changeVector.Order);
-
-        if (dbIdsFromRemote.Any(x => Order.Contains(x)))
-            return true;
-
-        return false;
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureValid()
     {
         if (_order == null && _version == null)
         {
-            /*if (_changeVector == null)
-                    ThrowEmptyChangeVector();*/
-
             return;
         }
 

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1182,6 +1182,8 @@ namespace SlowTests.Client.Attachments
             string name, string hash, string contentType, long size)
         {
             await store1.Commands().PutAsync("users/1", null, document);
+
+            await Task.Delay(3000); // wait for the replication ping-pong to settle down
             await AssertConflictResolved(store1, name, hash, contentType, size);
 
             WaitForMarker(store1, store2);

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Client.Attachments
         public AttachmentsReplication(ITestOutputHelper output) : base(output)
         {
         }
-        
+
         [RavenTheory(RavenTestCategory.Attachments | RavenTestCategory.Replication)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
@@ -97,7 +97,7 @@ namespace SlowTests.Client.Attachments
                     await SetupAttachmentReplicationAsync(store1, store2, false);
                 }
                 Assert.True(WaitForDocument(store2, "marker$users/1"));
-                
+
                 using (var session = store2.OpenSession())
                 {
                     var user = session.Load<User>("users/1");
@@ -226,7 +226,7 @@ namespace SlowTests.Client.Attachments
                 }
             }
         }
-        
+
         [RavenTheory(RavenTestCategory.Attachments | RavenTestCategory.Replication)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task DeleteAttachments(Options options)
@@ -335,7 +335,7 @@ namespace SlowTests.Client.Attachments
                     store1.Operations.Send(new PutAttachmentOperation("users/1", "big-file", stream2, "image/png"));
 
                 await SetupAttachmentReplicationAsync(store1, store2);
-                
+
                 await AssertAttachmentCount(store2, 2, 4);
 
                 using (var session = store2.OpenSession())
@@ -501,7 +501,7 @@ namespace SlowTests.Client.Attachments
                     configuration.Collections["Users"].PurgeOnDelete = false;
                     configuration.Collections["Users"].MinimumRevisionsToKeep = 4;
                 });
-                
+
                 await SetupAttachmentReplicationAsync(store1, store2);
                 await SetupAttachmentReplicationAsync(store2, store1);
 
@@ -550,7 +550,7 @@ namespace SlowTests.Client.Attachments
                     u.Age = 50;
                     session.SaveChanges();
                 }
-                
+
                 using (var session = store1.OpenSession())
                 {
                     var u = session.Load<User>("users/1");
@@ -632,7 +632,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Age == 30, 15_000));
-                
+
                 await store1.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
 
@@ -811,7 +811,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 3"));
-              
+
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
                 WaitForMarker(store1, store2);
 
@@ -1141,7 +1141,7 @@ namespace SlowTests.Client.Attachments
                         await store1.Operations.SendAsync(new PutAttachmentOperation("users/1", "a1", a1, "a1/png"));
                     }
                 }
-                
+
                 using (var session = store2.OpenAsyncSession())
                 {
                     await session.StoreAsync(new User { Name = "Fitzchak" }, "users/2$users/1");
@@ -1390,14 +1390,14 @@ namespace SlowTests.Client.Attachments
             var co = new ServerCreationOptions
             {
                 RunInMemory = false,
-                CustomSettings = new Dictionary<string, string> {[RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString()},
+                CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = 1.ToString() },
                 RegisterForDisposal = false
             };
 
             using (var server = GetNewServer(co))
-            using (var store1 = GetDocumentStore(new Options(options) {Server = server, RunInMemory = false}))
-            using (var store2 = GetDocumentStore(new Options(options) {Server = server, RunInMemory = false}))
-            using (var store3 = GetDocumentStore(new Options(options) {Server = server, RunInMemory = false}))
+            using (var store1 = GetDocumentStore(new Options(options) { Server = server, RunInMemory = false }))
+            using (var store2 = GetDocumentStore(new Options(options) { Server = server, RunInMemory = false }))
+            using (var store3 = GetDocumentStore(new Options(options) { Server = server, RunInMemory = false }))
             {
                 using (var session = store1.OpenAsyncSession())
                 using (var a1 = new MemoryStream(new byte[2 * 1024 * 1024]))
@@ -1415,8 +1415,8 @@ namespace SlowTests.Client.Attachments
                     await session.SaveChangesAsync();
                 }
 
-                var replication = await GetReplicationManagerAsync(store1, store1.Database, options.DatabaseMode, breakReplication: true, new List<RavenServer>() {server});
-                
+                var replication = await GetReplicationManagerAsync(store1, store1.Database, options.DatabaseMode, breakReplication: true, new List<RavenServer>() { server });
+
                 await SetupReplicationAsync(store1, store2);
                 replication.ReplicateOnce("foo");
 
@@ -1468,7 +1468,7 @@ namespace SlowTests.Client.Attachments
             {
                 string docId1 = "users/1", docId2 = "users/2$users/1";
                 var replication = await GetReplicationManagerAsync(store1, store1.Database, options.DatabaseMode, breakReplication: true);
-                
+
                 using (var session = store1.OpenAsyncSession())
                 {
                     await session.StoreAsync(new User { Name = "Karmel" }, docId1);
@@ -1478,7 +1478,7 @@ namespace SlowTests.Client.Attachments
                         await session.SaveChangesAsync();
                     }
                 }
-                
+
                 using (var session = store1.OpenAsyncSession())
                 {
                     await session.StoreAsync(new User { Name = "Karmel" }, docId2);
@@ -1491,7 +1491,7 @@ namespace SlowTests.Client.Attachments
 
                 await SetupReplicationAsync(store1, store2);
                 replication.ReplicateOnce(docId1);
-                 
+
                 Assert.True(WaitForDocument(store2, docId1));
 
                 using (var session = store2.OpenAsyncSession())
@@ -1506,7 +1506,7 @@ namespace SlowTests.Client.Attachments
 
                     Assert.Null(await session.LoadAsync<User>(docId2));
                 }
-                
+
                 replication.ReplicateOnce(docId1);
                 Assert.True(WaitForDocument(store2, docId2));
 
@@ -1533,7 +1533,7 @@ namespace SlowTests.Client.Attachments
 
             var mainServer = cluster.Nodes[0];
             var toRemove = mainServer.ServerStore.NodeTag;
-            
+
             using (var store = GetDocumentStore(new Options(options)
             {
                 Server = mainServer,
@@ -1579,9 +1579,9 @@ namespace SlowTests.Client.Attachments
                 }
 
                 var replication = await GetReplicationManagerAsync(store, databaseName, options.DatabaseMode, servers: cluster.Nodes);
-                
+
                 await replication.EnsureNoReplicationLoopAsync();
-                
+
                 if (options.DatabaseMode == RavenDatabaseMode.Single)
                 {
                     var result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true, fromNode: toRemove,
@@ -1606,7 +1606,7 @@ namespace SlowTests.Client.Attachments
                     await session.SaveChangesAsync();
                 }
 
-                if(options.DatabaseMode == RavenDatabaseMode.Single)
+                if (options.DatabaseMode == RavenDatabaseMode.Single)
                     await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(databaseName, toRemove));
                 else
                 {
@@ -2578,7 +2578,7 @@ namespace SlowTests.Client.Attachments
             using (var store2 = GetDocumentStore(options))
             using (var store3 = GetDocumentStore(options))
             {
-                var user = new User {Name = "Karmel", Id = "users/1"};
+                var user = new User { Name = "Karmel", Id = "users/1" };
                 using (var session = store1.OpenSession())
                 {
                     session.Store(user, user.Id);
@@ -2620,7 +2620,6 @@ namespace SlowTests.Client.Attachments
                 var stores = new DocumentStore[] { store1, store2, store3 };
                 await WriteStatus(stores, "Stage 1");
 
-
                 using (var session = store1.OpenAsyncSession())
                 {
                     var u = await session.LoadAsync<User>("users/1");
@@ -2645,71 +2644,77 @@ namespace SlowTests.Client.Attachments
 
                 await WriteStatus(stores, "Stage 4");
 
-                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
-                Assert.True(res2);
+                var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "users/1");
+                var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
 
-                var res = await WaitForValueAsync(async () =>
+                using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    var res = await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        using (var session2 = store2.OpenAsyncSession())
+                        using (var session3 = store3.OpenAsyncSession())
+                        {
+                            var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                            if (attachment != null && attachment2 != null && attachment3 != null &&
+                                attachment.Details.Name == "foo/bar" &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment2.Details, context) &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment3.Details, context))
+                            {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    }, true, 30_000, interval: 333);
+
+                    await WriteStatus(stores, "Stage 5");
+
                     using (var session = store1.OpenAsyncSession())
                     using (var session2 = store2.OpenAsyncSession())
                     using (var session3 = store3.OpenAsyncSession())
                     {
+                        var u1 = await session.LoadAsync<User>("users/1");
+                        var u2 = await session2.LoadAsync<User>("users/1");
+                        var u3 = await session3.LoadAsync<User>("users/1");
+
+                        var cv1 = context.GetChangeVector(session.Advanced.GetChangeVectorFor(u1)).Version.AsString();
+                        var cv2 = context.GetChangeVector(session2.Advanced.GetChangeVectorFor(u2)).Version.AsString();
+                        var cv3 = context.GetChangeVector(session3.Advanced.GetChangeVectorFor(u3)).Version.AsString();
+
+                        Console.WriteLine($"\ncv1: {cv1}");
+                        Console.WriteLine($"cv2: {cv2}");
+                        Console.WriteLine($"cv3: {cv3}\n");
+
+                        Assert.True(cv1.Equals(cv2));
+                        Assert.True(cv1.Equals(cv3));
+
                         var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                        if (attachment != null && attachment2 != null && attachment3 != null &&
-                            attachment.Details.Name == "foo/bar" &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
-                        {
-                            return true;
-                        }
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment2);
+                        Assert.NotNull(attachment3);
 
-                        return false;
+                        var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector3 = context.GetChangeVector(attachment3.Details.ChangeVector).Version.AsString();
+
+                        user = await session.LoadAsync<User>("users/1");
+                        Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                    ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
+                        Assert.Equal("foo/bar", attachment.Details.Name);
+                        Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+                        Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                        Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector3, attachmentChangeVector2);
+                        Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                     }
-                }, true, 30_000, interval: 333);
-
-
-                await WriteStatus(stores, "Stage 5");
-
-                using (var session = store1.OpenAsyncSession())
-                using (var session2 = store2.OpenAsyncSession())
-                using (var session3 = store3.OpenAsyncSession())
-                {
-                    var u1 = await session.LoadAsync<User>("users/1");
-                    var u2 = await session2.LoadAsync<User>("users/1");
-                    var u3 = await session3.LoadAsync<User>("users/1");
-
-                    var cv1 = session.Advanced.GetChangeVectorFor(u1);
-                    var cv2 = session2.Advanced.GetChangeVectorFor(u2);
-                    var cv3 = session3.Advanced.GetChangeVectorFor(u3);
-
-                    Console.WriteLine($"\ncv1: {cv1}");
-                    Console.WriteLine($"cv2: {cv2}");
-                    Console.WriteLine($"cv3: {cv3}\n");
-
-                    Assert.True(cv1.Equals(cv2));
-                    Assert.True(cv1.Equals(cv3));
-
-                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-
-                    Assert.NotNull(attachment);
-                    Assert.NotNull(attachment2);
-                    Assert.NotNull(attachment3);
-
-                    user = await session.LoadAsync<User>("users/1");
-                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
-                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
-                    Assert.Equal("foo/bar", attachment.Details.Name);
-                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
-                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                 }
             }
         }
@@ -2788,46 +2793,52 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store1);
 
-                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
-                Assert.True(res2);
-
                 await WriteStatus(stores, "Stage 3");
 
-                var res = await WaitForValueAsync(async () =>
+                var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "users/1");
+                var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
+
+                using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    var res = await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        using (var session2 = store2.OpenAsyncSession())
+                        {
+                            var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                            if (attachment != null && attachment2 != null &&
+                                attachment.Details.Hash == "igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=" &&
+                                attachment.Details.Name == "foo/bar" &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment2.Details, context))
+                            {
+                                return true;
+                            }
+                            return false;
+                        }
+                    }, true, 15_000, 500);
+
+                    Assert.True(res);
+
                     using (var session = store1.OpenAsyncSession())
                     using (var session2 = store2.OpenAsyncSession())
                     {
                         var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                        if (attachment != null && attachment2 != null &&
-                            attachment.Details.Hash == "igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=" &&
-                            attachment.Details.Name == "foo/bar" &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details))
-                        {
-                            return true;
-                        }
-                        return false;
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment2);
+
+                        var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
+
+                        Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment.Details.Hash);
+                        Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment2.Details.Hash);
+                        Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+                        Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
                     }
-                }, true, 15_000, 500);
-
-                Assert.True(res);
-
-                using (var session = store1.OpenAsyncSession())
-                using (var session2 = store2.OpenAsyncSession())
-                {
-                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-
-                    Assert.NotNull(attachment);
-                    Assert.NotNull(attachment2);
-
-                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment.Details.Hash);
-                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachment2.Details.Hash);
-                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
                 }
             }
         }
@@ -2841,11 +2852,11 @@ namespace SlowTests.Client.Attachments
             {
                 using (var session = store1.OpenSession())
                 {
-                    session.Store(new User {Name = "Karmel"}, "users/1");
+                    session.Store(new User { Name = "Karmel" }, "users/1");
                     session.SaveChanges();
                 }
 
-                using (var profileStream = new MemoryStream(new byte[] {1, 2, 3}))
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
                 {
                     var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
                     Assert.Equal("foo/bar", result.Name);
@@ -2860,12 +2871,12 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store2, store1);
                 await EnsureReplicatingAsync(store1, store2);
 
-                var stores = new DocumentStore[] {store1, store2};
+                var stores = new DocumentStore[] { store1, store2 };
                 await WriteStatus(stores, "Stage 1");
 
                 var replication1 = await GetReplicationManagerAsync(store1, store1.Database, options.DatabaseMode);
                 var replication2 = await GetReplicationManagerAsync(store2, store2.Database, options.DatabaseMode);
-                
+
                 replication1.Break();
                 replication2.Break();
 
@@ -2890,57 +2901,62 @@ namespace SlowTests.Client.Attachments
                 replication1.Mend();
 
                 replication2.Mend();
-                
+
                 await EnsureReplicatingAsync(store2, store1);
                 await EnsureReplicatingAsync(store1, store2);
 
-
-                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
-                Assert.True(res2);
-
                 await WriteStatus(stores, "Stage 3");
 
-                await WaitForValueAsync(async () =>
+                var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "users/1");
+                var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
+
+                using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    await WaitForValueAsync(async () =>
+                    {
+                        using var session1 = store1.OpenAsyncSession();
+                        using var session2 = store2.OpenAsyncSession();
+                        var attachment = await session1.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                        var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                        if (attachment != null && attachment2 != null &&
+                            attachment.Details.Hash == "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" &&
+                            attachment.Details.Name == "foo/bar" &&
+                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details, context))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }, true, 10000, 500);
+
+
                     using var session1 = store1.OpenAsyncSession();
                     using var session2 = store2.OpenAsyncSession();
+
+                    var user = await session1.LoadAsync<User>("users/1");
+                    Assert.Equal(30, user.Age);
+                    var user2 = await session2.LoadAsync<User>("users/1");
+                    Assert.Equal(30, user2.Age);
+
+                    await WriteAttachmentDetails(stores);
+
                     var attachment = await session1.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                     var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                    if (attachment != null && attachment2 != null &&
-                        attachment.Details.Hash == "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" &&
-                        attachment.Details.Name == "foo/bar" &&
-                        AreAttachmentDetailsEqual(attachment.Details, attachment2.Details))
-                    {
-                        return true;
-                    }
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment2);
 
-                    return false;
-                }, true, 10000, 500);
+                    var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
+                    var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
 
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
+                    Assert.Equal("foo/bar", attachment.Details.Name);
 
-                using var session1 = store1.OpenAsyncSession();
-                using var session2 = store2.OpenAsyncSession();
-
-                var user = await session1.LoadAsync<User>("users/1");
-                Assert.Equal(30, user.Age);
-                var user2 = await session2.LoadAsync<User>("users/1");
-                Assert.Equal(30, user2.Age);
-
-                await WriteAttachmentDetails(stores);
-
-                var attachment = await session1.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-          
-                Assert.NotNull(attachment);
-                Assert.NotNull(attachment2);
-
-                Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
-                Assert.Equal("foo/bar", attachment.Details.Name);
-
-                Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
-                Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
-                Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                    Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+                }
             }
         }
 
@@ -3038,60 +3054,67 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store3, store1);
                 await EnsureReplicatingAsync(store3, store2);
 
-                var res2 = await WaitForChangeVectorInReplicationAsync(stores);
-                Assert.True(res2);
-
                 await WriteStatus(stores, "Stage 3");
 
-                await WaitForValueAsync(async () =>
+                var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "users/1");
+                var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
+
+                using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        using (var session2 = store2.OpenAsyncSession())
+                        using (var session3 = store3.OpenAsyncSession())
+                        {
+                            var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                            if (attachment != null && attachment2 != null && attachment3 != null &&
+                                attachment.Details.Name == "foo/bar" &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment2.Details, context) &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment3.Details, context))
+                            {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    }, true, 30_000, 500);
+
+                    await WriteAttachmentDetails(stores);
+
                     using (var session = store1.OpenAsyncSession())
                     using (var session2 = store2.OpenAsyncSession())
                     using (var session3 = store3.OpenAsyncSession())
                     {
+                        var user = await session.LoadAsync<User>("users/1");
+
                         var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                        if (attachment != null && attachment2 != null && attachment3 != null &&
-                            attachment.Details.Name == "foo/bar" &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
-                        {
-                            return true;
-                        }
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment2);
+                        Assert.NotNull(attachment3);
 
-                        return false;
+                        var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector3 = context.GetChangeVector(attachment3.Details.ChangeVector).Version.AsString();
+
+                        Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                    ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
+                        Assert.Equal("foo/bar", attachment.Details.Name);
+
+                        Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+                        Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+
+                        Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector3, attachmentChangeVector2);
+                        Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                     }
-                }, true, 10000, 500);
-
-                await WriteAttachmentDetails(stores);
-
-                using (var session = store1.OpenAsyncSession())
-                using (var session2 = store2.OpenAsyncSession())
-                using (var session3 = store3.OpenAsyncSession())
-                {
-                    var user = await session.LoadAsync<User>("users/1");
-
-                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-
-                    Assert.NotNull(attachment);
-                    Assert.NotNull(attachment2);
-                    Assert.NotNull(attachment3);
-
-                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
-                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0));
-                    Assert.Equal("foo/bar", attachment.Details.Name);
-
-                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
-
-                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                 }
             }
         }
@@ -3231,7 +3254,7 @@ namespace SlowTests.Client.Attachments
                 var replication1 = await GetReplicationManagerAsync(store1, store1.Database, options.DatabaseMode);
                 var replication2 = await GetReplicationManagerAsync(store2, store2.Database, options.DatabaseMode);
                 var replication3 = await GetReplicationManagerAsync(store3, store3.Database, options.DatabaseMode);
-                
+
                 replication1.Break();
                 replication2.Break();
                 replication3.Break();
@@ -3271,11 +3294,13 @@ namespace SlowTests.Client.Attachments
 
                 await EnsureReplicatingAsync(store2, store1);
                 await EnsureReplicatingAsync(store2, store3);
-                
+
                 replication3.Mend();
 
                 await EnsureReplicatingAsync(store3, store2);
                 await EnsureReplicatingAsync(store3, store1);
+
+                await Task.Delay(3000); // wait for the replication ping-pong to settle down
 
                 replication1.Mend();
 
@@ -3283,39 +3308,47 @@ namespace SlowTests.Client.Attachments
                 await EnsureReplicatingAsync(store1, store3);
 
                 var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "users/1");
-                var dbName2 = options.DatabaseMode == RavenDatabaseMode.Single ? store2.Database : await Sharding.GetShardDatabaseNameForDocAsync(store2, "users/1");
-                var dbName3 = options.DatabaseMode == RavenDatabaseMode.Single ? store3.Database : await Sharding.GetShardDatabaseNameForDocAsync(store3, "users/1");
+                var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
 
-                var res2 = await WaitForValueAsync(async () =>
+                using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    var cvs = new List<string>();
-
-                    var storage = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
-                    using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (context.OpenReadTransaction())
+                    var res = await WaitForValueAsync(async () =>
                     {
-                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                    }
-                    var storage2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName2);
-                    using (storage2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (context.OpenReadTransaction())
-                    {
-                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                    }
-                    var storage3 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName3);
-                    using (storage3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (context.OpenReadTransaction())
-                    {
-                        cvs.Add(DocumentsStorage.GetDatabaseChangeVector(context));
-                    }
+                        using (var session = store1.OpenAsyncSession())
+                        using (var session2 = store2.OpenAsyncSession())
+                        using (var session3 = store3.OpenAsyncSession())
+                        {
+                            var user = await session.LoadAsync<User>("users/1");
+                            var user2 = await session2.LoadAsync<User>("users/1");
+                            var user3 = await session3.LoadAsync<User>("users/1");
 
-                    return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
-                }, true, timeout: 30_000, interval: 333);
-                
-                Assert.True(res2);
+                            return user.Age == user2.Age && user.Age == user3.Age;
+                        }
+                    }, true, 30_000, 500);
+                    Assert.True(res);
 
-                var res = await WaitForValueAsync(async () =>
-                {
+                    res = await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        using (var session2 = store2.OpenAsyncSession())
+                        using (var session3 = store3.OpenAsyncSession())
+                        {
+                            var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                            var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+
+                            if (attachment != null && attachment2 != null && attachment3 != null &&
+                                attachment.Details.Name == "foo/bar" &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment2.Details, context) &&
+                                AreAttachmentDetailsEqual(attachment.Details, attachment3.Details, context))
+                            {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    }, true, 30_000, 500);
+
                     using (var session = store1.OpenAsyncSession())
                     using (var session2 = store2.OpenAsyncSession())
                     using (var session3 = store3.OpenAsyncSession())
@@ -3324,42 +3357,27 @@ namespace SlowTests.Client.Attachments
                         var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
                         var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
 
-                        if (attachment != null && attachment2 != null && attachment3 != null &&
-                            attachment.Details.Name == "foo/bar" &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment2.Details) &&
-                            AreAttachmentDetailsEqual(attachment.Details, attachment3.Details))
-                        {
-                            return true;
-                        }
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment2);
+                        Assert.NotNull(attachment3);
 
-                        return false;
+                        var user = await session.LoadAsync<User>("users/1");
+                        Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                    ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0), $"age: {user.Age}, hash: {attachment.Details.Hash}");
+                        Assert.Equal("foo/bar", attachment.Details.Name);
+
+                        var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
+                        var attachmentChangeVector3 = context.GetChangeVector(attachment3.Details.ChangeVector).Version.AsString();
+
+                        Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+                        Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
+
+                        Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
+                        Assert.Equal(attachmentChangeVector3, attachmentChangeVector2);
+                        Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                     }
-                }, true, 10_000, 500);
-
-                using (var session = store1.OpenAsyncSession())
-                using (var session2 = store2.OpenAsyncSession())
-                using (var session3 = store3.OpenAsyncSession())
-                {
-                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment2 = await session2.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-                    var attachment3 = await session3.Advanced.Attachments.GetAsync("users/1", "foo/bar");
-
-                    Assert.NotNull(attachment);
-                    Assert.NotNull(attachment2);
-                    Assert.NotNull(attachment3);
-
-                    var user = await session.LoadAsync<User>("users/1");
-                    Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
-                                ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0), $"age: {user.Age}, hash: {attachment.Details.Hash}");
-                    Assert.Equal("foo/bar", attachment.Details.Name);
-
-                    Assert.Equal(attachment.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment.Details.Name, attachment2.Details.Name);
-
-                    Assert.Equal(attachment3.Details.Hash, attachment2.Details.Hash);
-                    Assert.Equal(attachment3.Details.ChangeVector, attachment2.Details.ChangeVector);
-                    Assert.Equal(attachment3.Details.Name, attachment2.Details.Name);
                 }
             }
         }
@@ -3396,26 +3414,10 @@ namespace SlowTests.Client.Attachments
             Console.WriteLine("-----");
         }
 
-        private async Task<bool> WaitForChangeVectorInReplicationAsync(DocumentStore[] stores)
-        {
-            var val = await WaitForValueAsync(async () =>
-            {
-                var cvs = new List<string>();
-                foreach (var store in stores)
-                {
-                    var stats = await GetDatabaseStatisticsAsync(store);
-                    cvs.Add(stats.DatabaseChangeVector);
-                }
-                
-                return cvs.Any(x => x != cvs.FirstOrDefault()) == false;
-            }, true, timeout: 30_000, interval: 333);
-            return val;
-        }
-
-        private bool AreAttachmentDetailsEqual(AttachmentDetails attachment1, AttachmentDetails attachment2)
+        private bool AreAttachmentDetailsEqual(AttachmentDetails attachment1, AttachmentDetails attachment2, DocumentsOperationContext context)
         {
             if (attachment1.DocumentId == attachment2.DocumentId &&
-                attachment1.ChangeVector == attachment2.ChangeVector &&
+                context.GetChangeVector(attachment1.ChangeVector).Version.AsString() == context.GetChangeVector(attachment2.ChangeVector).Version.AsString() &&
                 attachment1.Hash == attachment2.Hash &&
                 attachment1.Name == attachment2.Name &&
                 attachment1.ContentType == attachment2.ContentType)

--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -991,6 +991,8 @@ namespace SlowTests.Client.TimeSeries.Replication
                 AssertValues(storeA);
                 AssertValues(storeB);
 
+                await Task.Delay(3000); // wait for the replication ping-pong to settle down
+
                 await replicationA.EnsureNoReplicationLoopAsync();
                 await replicationB.EnsureNoReplicationLoopAsync();
                 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1323,6 +1323,8 @@ namespace SlowTests.Cluster
                 Task t1, t2;
                 if (options.DatabaseMode == RavenDatabaseMode.Sharded)
                 {
+                    await Task.Delay(3000); // wait for the replication ping-pong to settle down
+
                     t1 = ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store1.Database);
                     t2 = ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);
                 }

--- a/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
+++ b/test/SlowTests/Server/Replication/ReplicationSpecialCases.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
@@ -1325,7 +1324,7 @@ namespace SlowTests.Server.Replication
                 };
 
                 await SetupReplicationAsync(source, destination);
-                await EnsureReplicatingAsync(source, destination);
+                await Sharding.Replication.EnsureReplicatingAsyncForShardedDestination(source, destination);
 
                 var outgoingFailureInfo = sourceDb.ReplicationLoader.OutgoingFailureInfo.ToList();
                 Assert.Equal(1, outgoingFailureInfo.Count);

--- a/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20487 : ReplicationTestBase
+    {
+        public RavenDB_20487(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
+        public async Task ReplicationToShardedAndThenToNonShardedShouldWork()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = Sharding.GetDocumentStore(new Options()
+            {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = "10"
+            }))
+            using (var store3 = GetDocumentStore())
+            {
+                var count = 100;
+                for (int i = 0; i < count; i++)
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Store(new User() { Age = i }, $"Users/{i}");
+                        session.SaveChanges();
+                    }
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                var res = WaitForValue(() =>
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        return session.Query<User>().Count();
+                    }
+                }, count, timeout: 60_000, interval: 333);
+
+                Assert.Equal(count, res);
+
+                await SetupReplicationAsync(store2, store3);
+
+                res = WaitForValue(() =>
+                {
+                    using (var session = store3.OpenSession())
+                    {
+                        return session.Query<User>().Count();
+                    }
+                }, count, timeout: 60_000, interval: 333);
+
+                Assert.Equal(count, res);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using FastTests.Utils;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -57,6 +58,83 @@ namespace SlowTests.Sharding.Issues
                 }, count, timeout: 60_000, interval: 333);
 
                 Assert.Equal(count, res);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Sharding)]
+        public async Task ReplicationWithRevisionsToShardedAndThenToNonShardedShouldWork()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = Sharding.GetDocumentStore(new Options()
+            {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = "10"
+            }))
+            using (var store3 = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store1);
+
+                var count = 100;
+                for (int i = 0; i < count; i++)
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Store(new User() { Age = i }, $"Users/{i}");
+                        session.SaveChanges();
+                    }
+                }
+
+                // create revisions
+                for (int i = 0; i < count; i++)
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        var user = session.Load<User>($"Users/{i}");
+                        Assert.NotNull(user);
+                        user.Age = i + 1;
+                        session.SaveChanges();
+                    }
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                var res = WaitForValue(() =>
+                {
+                    using (var session = store2.OpenSession())
+                    {
+                        return session.Query<User>().Count();
+                    }
+                }, count, timeout: 60_000, interval: 333);
+
+                Assert.Equal(count, res);
+
+                var expectedRevisionsCount = count * 2;
+                res = await WaitForValueAsync(async () =>
+                {
+                    var stats = await GetDatabaseStatisticsAsync(store2);
+                    return (int)stats.CountOfRevisionDocuments;
+                }, expectedRevisionsCount, timeout: 30_000, interval: 333);
+
+                Assert.Equal(expectedRevisionsCount, res);
+
+                await SetupReplicationAsync(store2, store3);
+
+                res = WaitForValue(() =>
+                {
+                    using (var session = store3.OpenSession())
+                    {
+                        return session.Query<User>().Count();
+                    }
+                }, count, timeout: 60_000, interval: 333);
+
+                Assert.Equal(count, res);
+
+                res = await WaitForValueAsync(async () =>
+                {
+                    var stats = await GetDatabaseStatisticsAsync(store3);
+                    return (int)stats.CountOfRevisionDocuments;
+                }, expectedRevisionsCount, timeout: 30_000, interval: 333);
+
+                Assert.Equal(expectedRevisionsCount, res);
             }
         }
     }

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -1654,11 +1654,11 @@ namespace SlowTests.Sharding.Replication
                     s1.SaveChanges();
                 }
 
-                await EnsureReplicatingAsync(store1, store2);
-                await EnsureReplicatingAsync(store1, store2);
-                await EnsureReplicatingAsync(store1, store2);
-
+                await Sharding.Replication.EnsureReplicatingAsyncForShardedDestination(store1, store2);
+              
                 await CheckData(store2, location);
+
+                await Task.Delay(3000);
 
                 await EnsureNoReplicationLoop(Server, store1.Database);
                 await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store2.Database);

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -1310,6 +1310,8 @@ namespace SlowTests.Sharding.Replication
 
                 await Sharding.Resharding.MoveShardForId(replica, id);
 
+                await Task.Delay(3000);
+
                 var db = await GetDocumentDatabaseInstanceFor(replica, ShardHelper.ToShardName(replica.Database, oldLocation));
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -151,7 +151,7 @@ namespace Tests.Infrastructure
                     s.SaveChanges();
                 }
 
-                var r = await Replication.WaitForDocumentToReplicateAsync<object>(dst, id, 15 * 1000);
+                var r = await Replication.WaitForDocumentToReplicateAsync<object>(dst, id, 30 * 1000);
                 Assert.NotNull(r);
             }
         }


### PR DESCRIPTION
…B to Non-ShardedDB

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20487/Missing-data-after-external-replication-from-ShardedDB-to-Non-ShardedDB

### Additional description

In order to avoid loss of data, in the scenario of having a chain replication Non sharded1 -> sharded -> non sharded2; in `IncomingExternalReplicationHandlerForShard` we add to the incoming item's change vector the shard's DbId - only in the `Order` part.

As a result of this change, in the case of bidirectional replication, there is now needless replication ping pong, from the sharded db back to the source. The added part of the shard's DbId in the cv causes a conflict in the `ShouldSkip` function and replicates the items needlessly. BUT, this is a rare scenario :-)

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
