### PR TITLE
RavenDB-20386  track facet results by DisplayName instead of FieldName in first place because we can use the same field multiple times with different aggregating methods.

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/Facets/ShardedFacetedQueryProcessor.cs
@@ -67,7 +67,7 @@ public class ShardedFacetedQueryProcessor : AbstractShardedQueryProcessor<Sharde
 
                 foreach (var facet in facetSetupDocument.Facets) // options aren't applicable for range facets
                 {
-                    AddFacetOptions(facet.FieldName, facet.Options ?? FacetOptions.Default);
+                    AddFacetOptions(facet.DisplayFieldName ?? facet.FieldName, facet.Options ?? FacetOptions.Default);
                 }
             }
             else if (facetField.Ranges == null || facetField.Ranges.Count == 0) // options aren't applicable for range facets

--- a/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
+++ b/test/SlowTests/MailingList/FacetsMultipleAggregation.cs
@@ -16,7 +16,7 @@ namespace SlowTests.MailingList
         }
 
         [RavenTheory(RavenTestCategory.Facets)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanAggregateByMinAndMaxOnSameField(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20386  
### Additional description
track facet results by DisplayName instead of FieldName in first place because we can use the same field multiple times with different aggregating methods.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
