### PR TITLE
RavenDB-20409 : fix flaky test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -23,7 +23,7 @@ public class RavenDB_20206 : RavenTestBase
         using (var store1 = GetDocumentStore(new Options { Server = server }))
         using (var store2 = GetDocumentStore(new Options { Server = server, ModifyDatabaseName = _ => store1.Database + "_123" }))
         {
-            WaitForFirstCompareExchangeTombstonesClean(server);
+            Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
             var indexesList1 = new Dictionary<string, long>();
             var indexesList2 = new Dictionary<string, long>();
             // create 3 unique values
@@ -102,21 +102,6 @@ public class RavenDB_20206 : RavenTestBase
                 Assert.Equal(2, numOfCompareExchanges);
             }
         }
-    }
-
-    private static void WaitForFirstCompareExchangeTombstonesClean(RavenServer server)
-    {
-        Assert.True(WaitForValue(() =>
-        {
-            // wait for compare exchange tombstone cleaner run
-            if (server.ServerStore.Observer == null)
-                return false;
-
-            if (server.ServerStore.Observer._lastTombstonesCleanupTimeInTicks == 0)
-                return false;
-
-            return true;
-        }, true));
     }
 
     private static async Task<ClusterObserver.CompareExchangeTombstonesCleanupState> CleanupCompareExchangeTombstonesAsync(RavenServer server, string database, ClusterOperationContext context)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1190,7 +1190,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 options.Server = server;
                 using (var store = GetDocumentStore(new Options {Server = server}))
                 {
-                    WaitForFirstCompareExchangeTombstonesClean(server);
+                    Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
                     var count = 1;
                     var indexesList = new List<long>();
 
@@ -1299,7 +1299,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 options.Server = server;
                 using (var store = GetDocumentStore(options))
                 {
-                    WaitForFirstCompareExchangeTombstonesClean(server);
+                    Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
 
                     var count = 1;
                     var indexesList = new List<long>();
@@ -1407,7 +1407,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
             {
-                WaitForFirstCompareExchangeTombstonesClean(server);
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
 
                 var indexesList = new Dictionary<string, long>();
                 // create 3 unique values
@@ -1575,7 +1575,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
             {
-                WaitForFirstCompareExchangeTombstonesClean(server);
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
                 var indexesList = new Dictionary<string, long>();
                 // create 3 unique values
                 for (int i = 0; i < 3; i++)
@@ -1638,7 +1638,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
             {
-                WaitForFirstCompareExchangeTombstonesClean(server);
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
                 var indexesList = new Dictionary<string, long>();
                 // create 3 unique values
                 for (int i = 0; i < 3; i++)
@@ -1761,7 +1761,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
             {
-                WaitForFirstCompareExchangeTombstonesClean(server);
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
                 var indexesList = new Dictionary<string, long>();
                 // create 3 unique values
                 for (int i = 0; i < 3; i++)
@@ -1814,21 +1814,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
 
             return list;
-        }
-
-        internal static void WaitForFirstCompareExchangeTombstonesClean(RavenServer server)
-        {
-            Assert.True(WaitForValue(() =>
-            {
-                // wait for compare exchange tombstone cleaner run
-                if (server.ServerStore.Observer == null)
-                    return false;
-
-                if (server.ServerStore.Observer._lastTombstonesCleanupTimeInTicks == 0)
-                    return false;
-
-                return true;
-            }, true));
         }
 
         private static async Task<ClusterObserver.CompareExchangeTombstonesCleanupState> CleanupCompareExchangeTombstones(RavenServer server, string database, ClusterOperationContext context)

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -26,7 +26,6 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
-using SlowTests.Server.Documents.PeriodicBackup;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
@@ -724,6 +723,8 @@ namespace SlowTests.Sharding.Backup
 
             using (var store = Sharding.GetDocumentStore(options))
             {
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(cluster.Leader);
+
                 await Sharding.Backup.InsertData(store);
 
                 var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
@@ -966,7 +967,7 @@ namespace SlowTests.Sharding.Backup
             //RavenDB-19201
             using (var store = Sharding.GetDocumentStore())
             {
-                RavenDB_11139.WaitForFirstCompareExchangeTombstonesClean(Server);
+                Cluster.WaitForFirstCompareExchangeTombstonesClean(Server);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedSmugglerTests.cs
@@ -785,7 +785,7 @@ namespace SlowTests.Sharding.Backup
             using var store = GetDocumentStore();
             using var shardedStore = Sharding.GetDocumentStore();
 
-            RavenDB_11139.WaitForFirstCompareExchangeTombstonesClean(Server);
+            Cluster.WaitForFirstCompareExchangeTombstonesClean(Server);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -246,6 +246,21 @@ public partial class RavenTestBase
             ThrowTimeoutException(nodes, tasks, index, timeout.Value);
         }
 
+        public void WaitForFirstCompareExchangeTombstonesClean(RavenServer server)
+        {
+            Assert.True(WaitForValue(() =>
+            {
+                // wait for compare exchange tombstone cleaner run
+                if (server.ServerStore.Observer == null)
+                    return false;
+
+                if (server.ServerStore.Observer._lastTombstonesCleanupTimeInTicks == 0)
+                    return false;
+
+                return true;
+            }, true));
+        }
+
         private static void ThrowTimeoutException(List<RavenServer> nodes, List<Task> tasks, long index, TimeSpan timeout)
         {
             var message = $"Timed out after {timeout} waiting for index {index} because out of {nodes.Count} servers" +


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20409

### Additional description

- `RestoreShardedDatabase_ShouldHaveValidResultsAndProgress` : wait for compare exchange tombstone cleanup before inserting data, in order to ensure that tombstones are written to backup file
- move `WaitForFirstCompareExchangeTombstonesClean` to testing infrastructure 

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 