### PR TITLE
RavenDB-20442 Fix toasts for non-default themes

### DIFF
--- a/src/Raven.Studio/wwwroot/Content/css/styles-blue.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-blue.less
@@ -13,6 +13,8 @@
 
 @import "prism.less";
 
+@import "toastr.less";
+
 .bs3 {
     font-size: @font-size-base;
 

--- a/src/Raven.Studio/wwwroot/Content/css/styles-classic.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-classic.less
@@ -13,6 +13,8 @@
 
 @import "prism.less";
 
+@import "toastr.less";
+
 .bs3 {
     font-size: @font-size-base;
 

--- a/src/Raven.Studio/wwwroot/Content/css/styles-light.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-light.less
@@ -13,6 +13,8 @@
 
 @import "prism.less";
 
+@import "toastr.less";
+
 .bs3 {
     font-size: @font-size-base;
 

--- a/src/Raven.Studio/wwwroot/Content/css/toastr.less
+++ b/src/Raven.Studio/wwwroot/Content/css/toastr.less
@@ -186,6 +186,7 @@ button.toast-close-button {
         opacity: 1 !important;
         background-color: @near-black;
         line-height: 16px;
+        border-radius: var(--bs-border-radius);
         .slideup-style;
 
         .toast-progress {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20442/Copy-button-does-not-show-the-Toast-notification-in-other-themes-than-default

### Additional description
Fixed toasts for non-default themes

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
