### PR TITLE
RavenDB-20402: SlowTests.Server.Documents.PeriodicBackup.ServerWideBackup.CanStoreAndEditServerWideBackupForIdleDatabase

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1265,6 +1265,8 @@ namespace Raven.Server.Documents
             LastEtag = lastEtag;
             Type = type;
             TaskId = taskId;
+
+            Debug.Assert(timeOfActivity?.Kind != DateTimeKind.Unspecified);
             DateTime = timeOfActivity?.ToUniversalTime();
         }
     }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1254,6 +1254,7 @@ namespace Raven.Server.ServerWide
                     }
                 }
 
+                wakeup = DateTime.SpecifyKind(wakeup, DateTimeKind.Utc);
                 var nextIdleDatabaseActivity = new IdleDatabaseActivity(IdleDatabaseActivityType.WakeUpDatabase, wakeup);
                 DatabasesLandlord.RescheduleNextIdleDatabaseActivity(db, nextIdleDatabaseActivity);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20402/SlowTests.Server.Documents.PeriodicBackup.ServerWideBackup.CanStoreAndEditServerWideBackupForIdleDatabase

### Additional description

Adjustment to properly calculate the next database attempt to wake up from the Idle state time.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed