### PR TITLE
RavenDB-20539: Improved clarity of the exception message thrown on attachment missing

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents
 
                 var stream = GetAttachmentStream(context, attachment.Base64Hash);
                 if (stream == null)
-                    ThrowMissingAttachment(attachment.Name);
+                    ThrowMissingAttachment(GetDocIdAndAttachmentName(context, attachment.Key));
 
                 attachment.Stream = stream;
 
@@ -957,9 +957,9 @@ namespace Raven.Server.Documents
             return result;
         }
 
-        private static void ThrowMissingAttachment(string attachmentName)
+        private static void ThrowMissingAttachment((LazyStringValue DocId, LazyStringValue AttachmentName) details)
         {
-            throw new FileNotFoundException($"Attachment's stream '{attachmentName}' was not found. This should never happen.");
+            throw new FileNotFoundException($"Attachment's stream for file '{details.AttachmentName}' in document '{details.DocId}' was not found. This should never happen.");
         }
 
         private static void ThrowConcurrentException(string documentId, string name, string expectedChangeVector, string oldChangeVector)
@@ -1335,11 +1335,11 @@ namespace Raven.Server.Documents
             return new StreamsTempFile(tempPath.FullPath, _documentDatabase.DocumentsStorage.Environment);
         }
 
-        public static (LazyStringValue DocId, LazyStringValue AttachmentName) ExtractDocIdAndAttachmentNameFromTombstone(JsonOperationContext context,
-            LazyStringValue attachmentTombstoneId)
+        public static (LazyStringValue DocId, LazyStringValue AttachmentName) GetDocIdAndAttachmentName(JsonOperationContext context,
+            LazyStringValue attachmentKey)
         {
-            var p = attachmentTombstoneId.Buffer;
-            var size = attachmentTombstoneId.Size;
+            var p = attachmentKey.Buffer;
+            var size = attachmentKey.Size;
 
             int sizeOfDocId = 0;
             for (; sizeOfDocId < size; sizeOfDocId++)

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven.Enumerators
 
         public static bool FilterAttachment(DocumentsOperationContext context, RavenEtlItem item)
         {
-            var documentId = AttachmentsStorage.ExtractDocIdAndAttachmentNameFromTombstone(context, item.AttachmentTombstoneId).DocId;
+            var documentId = AttachmentsStorage.GetDocIdAndAttachmentName(context, item.AttachmentTombstoneId).DocId;
             var document = context.DocumentDatabase.DocumentsStorage.Get(context, documentId);
             if (document == null)
                 return true; // document could be deleted, no need to send DELETE of tombstone, we can filter it out

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -325,7 +325,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                             }
                             else
                             {
-                                var (doc, attachmentName) = AttachmentsStorage.ExtractDocIdAndAttachmentNameFromTombstone(Context, item.AttachmentTombstoneId);
+                                var (doc, attachmentName) = AttachmentsStorage.GetDocIdAndAttachmentName(Context, item.AttachmentTombstoneId);
                                 _currentRun.DeleteAttachment(doc, attachmentName);
                             }
                         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20539/Replication-Exception-System.IO.FileNotFoundException-in-OutgoingReplicationHandler

### Additional description

The ID of the document whose `Attachment` is missing has been added in the exception text.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed