### PR TITLE
RavenDB-20550 we were setting IsEncrypted inside AbstractTransactionOperationsMerger too early, database loads this value in DocumentDatabase.Initialize

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -362,7 +362,7 @@ namespace Raven.Server.Documents
                 _addToInitLog("Initializing DocumentStorage");
                 DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
                 _addToInitLog("Starting Transaction Merger");
-                TxMerger.Initialize(DocumentsStorage.ContextPool, NotificationCenter);
+                TxMerger.Initialize(DocumentsStorage.ContextPool, IsEncrypted, Is32Bits);
                 TxMerger.Start();
                 _addToInitLog("Initializing ConfigurationStorage");
                 ConfigurationStorage.Initialize();

--- a/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/DocumentsTransactionOperationsMerger.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using JetBrains.Annotations;
-using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
-using Voron.Debugging;
-using Voron.Util;
 
 namespace Raven.Server.Documents.TransactionMerger;
 
@@ -12,24 +8,10 @@ public class DocumentsTransactionOperationsMerger : AbstractTransactionOperation
 {
     private readonly DocumentDatabase _database;
 
-    protected AbstractDatabaseNotificationCenter NotificationCenter;
-
     public DocumentsTransactionOperationsMerger([NotNull] DocumentDatabase database)
         : base(database.Name, database.Configuration, database.Time, database.DatabaseShutdown)
     {
         _database = database ?? throw new ArgumentNullException(nameof(database));
-        IsEncrypted = database.IsEncrypted;
-        Is32Bits = database.Is32Bits;
-    }
-
-    protected override bool IsEncrypted { get; }
-
-    protected override bool Is32Bits { get; }
-
-    public void Initialize([NotNull] JsonContextPoolBase<DocumentsOperationContext> contextPool, [NotNull] AbstractDatabaseNotificationCenter notificationCenter)
-    {
-        NotificationCenter = notificationCenter ?? throw new ArgumentNullException(nameof(notificationCenter));
-        base.Initialize(contextPool);
     }
 
     internal override DocumentsTransaction BeginAsyncCommitAndStartNewTransaction(DocumentsTransaction previousTransaction, DocumentsOperationContext currentContext)

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -30,6 +30,7 @@ using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
@@ -448,8 +449,8 @@ namespace Raven.Server.Rachis
                 DebuggerAttachedTimeout.LongTimespanIfDebugging(ref _electionTimeout);
 
                 ContextPool = new ClusterContextPool(changes, _persistentState, configuration.Memory.MaxContextSizeToKeep);
-                TxMerger = new ClusterTransactionOperationsMerger(this, configuration, time, shutdown);
-                TxMerger.Initialize(ContextPool);
+                TxMerger = new ClusterTransactionOperationsMerger(configuration, time, shutdown);
+                TxMerger.Initialize(ContextPool, IsEncrypted, PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager);
                 TxMerger.Start();
 
                 ClusterTopology topology;

--- a/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
+++ b/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
@@ -5,24 +5,16 @@ using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents.TransactionMerger;
 using Raven.Server.Documents.TransactionMerger.Commands;
-using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Platform;
-using Voron.Debugging;
 
 namespace Raven.Server.ServerWide.TransactionMerger;
 
 public class ClusterTransactionOperationsMerger : AbstractTransactionOperationsMerger<ClusterOperationContext, ClusterTransaction>
 {
-    public ClusterTransactionOperationsMerger(RachisConsensus engine, RavenConfiguration configuration, SystemTime time, CancellationToken shutdown)
+    public ClusterTransactionOperationsMerger(RavenConfiguration configuration, SystemTime time, CancellationToken shutdown)
         : base("Cluster", configuration, time, shutdown)
     {
-        IsEncrypted = engine.IsEncrypted;
-        Is32Bits = PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager;
     }
-
-    protected override bool IsEncrypted { get; }
-    protected override bool Is32Bits { get; }
 
     internal override ClusterTransaction BeginAsyncCommitAndStartNewTransaction(ClusterTransaction previousTransaction, ClusterOperationContext currentContext)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20550

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
