### PR TITLE
RavenDB-20297 Databases view: Get current database state based on databaseStatus

### DIFF
--- a/src/Raven.Studio/typescript/components/common/shell/databasesSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/databasesSlice.ts
@@ -55,6 +55,7 @@ export function toDatabaseLocalInfo(db: StudioDatabaseState, nodeTag: string): D
         backupInfo: db.BackupInfo,
         totalSize: db.TotalSize,
         tempBuffersSize: db.TempBuffersSize,
+        databaseStatus: db.DatabaseStatus,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/models/databases.d.ts
+++ b/src/Raven.Studio/typescript/components/models/databases.d.ts
@@ -24,6 +24,7 @@ export interface DatabaseLocalInfo {
     totalSize: Raven.Client.Util.Size;
     upTime?: string;
     backupInfo: Raven.Client.ServerWide.Operations.BackupInfo;
+    databaseStatus: Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabasesState.StudioDatabaseStatus;
 }
 
 export interface OrchestratorLocalInfo {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
@@ -189,6 +189,48 @@ function selectOrchestratorState(name: string) {
     };
 }
 
+function getDatabaseLocalInfo(
+    data: DatabaseLocalInfo,
+    location: databaseLocationSpecifier
+): locationAwareLoadableData<DatabaseLocalInfo> {
+    if (!data) {
+        return {
+            location,
+            status: "idle",
+        };
+    }
+
+    if (data.loadError) {
+        return {
+            location,
+            status: "success",
+            data,
+        };
+    }
+
+    switch (data.databaseStatus) {
+        case "Online":
+        case "None":
+            return {
+                location,
+                status: "success",
+                data,
+            };
+        case "Loading":
+            return {
+                location,
+                status: "loading",
+            };
+        case "Error":
+            return {
+                location,
+                status: "failure",
+            };
+        default:
+            assertUnreachable(data.databaseStatus);
+    }
+}
+
 export function selectDatabaseState(name: string) {
     return (store: RootState) => {
         const db = databaseSelectors.databaseByName(name)(store);
@@ -218,11 +260,7 @@ export function selectDatabaseState(name: string) {
                         databasesViewSliceInternal.selectDatabaseInfoId(name, location)
                     );
 
-                    return {
-                        location,
-                        status: data ? "success" : "idle",
-                        data,
-                    };
+                    return getDatabaseLocalInfo(data, location);
                 }
             }
         });

--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
@@ -65,13 +65,13 @@ export default class DatabaseUtils {
             return "Disabled";
         }
 
-        const offLineCount = localInfo.filter((x) => x.status === "success" && !x.data.upTime).length;
-        if (offLineCount === localInfo.length) {
-            return "Offline";
+        const onlineCount = localInfo.filter((x) => x.status === "success" && x.data.upTime).length;
+        if (onlineCount === localInfo.length) {
+            return "Online";
         }
 
-        if (offLineCount === 0) {
-            return "Online";
+        if (onlineCount === 0) {
+            return "Offline";
         }
 
         return "Partially Online";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20297/Databases-view-Status-shows-Online-even-though-the-db-is-not-loaded

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/233b0b76-83d3-43d2-9db1-c749d7cf851b)

