### PR TITLE
RDBQA-82 - Add option to run encrypted database when authentication is off

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -885,7 +885,7 @@ namespace Raven.Server.Documents
                     return null;
 
                 var record = databaseRecord.MaterializedRecord;
-                if (record.Encrypted)
+                if (record.Encrypted && _serverStore.Server.AllowEncryptedDatabasesOverHttp == false)
                 {
                     if (_serverStore.Server.WebUrl?.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false)
                     {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -111,6 +111,12 @@ namespace Raven.Server
 
         internal bool ThrowOnLicenseActivationFailure;
 
+#if ALLOW_ENCRYPTED_OVER_HTTP
+        internal bool AllowEncryptedDatabasesOverHttp = true;
+#else
+        internal bool AllowEncryptedDatabasesOverHttp = false;
+#endif
+
         internal Action<StorageEnvironment> BeforeSchemaUpgrade;
 
         internal string DebugTag;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2708,7 +2708,7 @@ namespace Raven.Server.ServerWide
                 .Concat(clusterTopology.Watchers.Keys)
                 .ToList();
 
-            if (record.Encrypted)
+            if (record.Encrypted && Server.AllowEncryptedDatabasesOverHttp == false)
             {
                 clusterNodes.RemoveAll(n => AdminDatabasesHandler.NotUsingHttps(clusterTopology.GetUrlFromTag(n)));
                 if (clusterNodes.Count < topology.ReplicationFactor)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Web
             return false;
         }
 
-        public static void ValidateNodeForAddingToDb(string databaseName, string node, DatabaseRecord databaseRecord, ClusterTopology clusterTopology, string baseMessage = null)
+        public static void ValidateNodeForAddingToDb(string databaseName, string node, DatabaseRecord databaseRecord, ClusterTopology clusterTopology, RavenServer server, string baseMessage = null)
         {
             baseMessage ??= "Can't execute the operation";
 
@@ -175,7 +175,7 @@ namespace Raven.Server.Web
             if (url == null)
                 throw new InvalidOperationException($"{baseMessage}, because node {node} (which is in the new topology) is not part of the cluster");
 
-            if (databaseRecord.Encrypted && url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false)
+            if (databaseRecord.Encrypted && url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false && server.AllowEncryptedDatabasesOverHttp == false)
                 throw new InvalidOperationException($"{baseMessage}, because database {databaseName} is encrypted but node {node} (which is in the new topology) doesn't have an SSL certificate.");
         }
 

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Web.System
 
                     if (databaseRecord.Topology.RelevantFor(node) == false)
                     {
-                        ValidateNodeForAddingToDb(dbName, node, databaseRecord, clusterTopology, baseMessage: $"Can't modify database {dbName} topology");
+                        ValidateNodeForAddingToDb(dbName, node, databaseRecord, clusterTopology, Server, baseMessage: $"Can't modify database {dbName} topology");
                     }
                 }
                 databaseTopology.ReplicationFactor = Math.Min(databaseTopology.Count, clusterTopology.AllNodes.Count);

--- a/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
@@ -109,13 +109,16 @@ public partial class RavenTestBase
         public string SetupEncryptedDatabase(out TestCertificatesHolder certificates, out byte[] masterKey, [CallerMemberName] string caller = null)
         {
             certificates = _parent.Certificates.SetupServerAuthentication();
-            var dbName = _parent.GetDatabaseName(caller);
             _parent.Certificates.RegisterClientCertificate(certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
+            return SetupEncryptedDatabaseOnNonAuthenticatedServer(out masterKey, caller);
+        }
+
+        public string SetupEncryptedDatabaseOnNonAuthenticatedServer(out byte[] masterKey, [CallerMemberName] string caller = null)
+        {
+            var dbName = _parent.GetDatabaseName(caller);
             string base64Key = CreateMasterKey(out masterKey);
-
             EnsureServerMasterKeyIsSetup(_parent.Server);
-
             _parent.Server.ServerStore.PutSecretKey(base64Key, dbName, true);
             return dbName;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBQA-82/Add-option-to-run-encrypted-database-when-authentication-is-off

### Additional description

Allow creating an encrypted database when authentication is off

### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.