### PR TITLE
RavenDB-20550 Adding debug assertions to ensure that we don't use async commit feature with encryption or on 32 bits

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -235,6 +235,11 @@ namespace Voron.Impl
             var env = previous._env;
             env.Options.AssertNoCatastrophicFailure();
 
+            Debug.Assert(env.Options.Encryption.IsEnabled == false,
+                $"Async commit isn't supported in encrypted environments. We don't carry {nameof(IPagerLevelTransactionState.CryptoPagerTransactionState)} from previous tx");
+            Debug.Assert((PlatformDetails.Is32Bits || env.Options.ForceUsing32BitsPager) == false,
+                $"Async commit isn't supported in 32bits environments. We don't carry {nameof(IPagerLevelTransactionState.PagerTransactionState32Bits)} from previous tx");
+
             FlushInProgressLockTaken = previous.FlushInProgressLockTaken;
             CurrentTransactionHolder = previous.CurrentTransactionHolder;
             TxStartTime = DateTime.UtcNow;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20550/TxMerger-does-not-set-IsEncrypted-properly

### Additional description

Additional checks that would helped us to figure out the cause of AVE much easier - https://github.com/ravendb/ravendb/pull/16533

### Type of change

- Debug assert

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Not relevant

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
