### PR TITLE
RavenDB-20555 - High unmanaged memory during querying of an encrypted database

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -366,6 +366,8 @@ namespace Voron.Data.BTrees
                     if (CryptoPager.CanReturnBuffer(buffer) == false)
                         return;
 
+                    buffer.ReleaseRef();
+
                     _llt._pageLocator.Reset(page.PageNumber);
                     pagerStates.RemoveBuffer(page.PageNumber);
 

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -37,7 +37,7 @@ namespace Voron.Data
 
             _index = 0;
             _llt = llt;
-            _encrypted = _llt.Environment.Options.Encryption.IsEnabled;
+            _encrypted = _llt.Environment.Options.Encryption.IsEnabled && _llt.Transaction.IsWriteTransaction == false;
             _lastPage = default(Page);
             _position = 0;
 

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -758,6 +758,10 @@ namespace Voron.Impl.Paging
             return AcquirePagePointer(tx, pageNumber, pagerState);
         }
 
+        public virtual void TryReleasePage(IPagerLevelTransactionState tx, long page)
+        {
+        }
+
         public void LowMemory(LowMemorySeverity lowMemorySeverity)
         {
             // We could check for nested calls to LowMemory here, but we 

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -307,7 +307,6 @@ namespace Voron.Impl.Paging
                     buffer.Modified = true;
                 }
 
-                buffer.AddRef();
                 state[valuePositionInScratchBuffer + i] = buffer;
             }
 

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -83,18 +83,19 @@ namespace Voron.Impl.Paging
         public NativeMemory.ThreadStats AllocatingThread;
         public long Generation;
         public bool SkipOnTxCommit;
-        private int _usages;
 
-        public bool CanRelease => _usages == 0;
+        public int Usages { get; private set; }
+
+        public bool CanRelease => Usages == 0;
 
         public void AddRef()
         {
-            _usages++;
+            Usages++;
         }
 
         public void ReleaseRef()
         {
-            _usages--;
+            Usages--;
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20555/High-unmanaged-memory-during-querying-of-an-encrypted-database

### Additional description

The `Lucene` files are stored in Voron. When we read from those files, we do it in chunks.
For an encrypted database that means that we decrypt the chunk into the `EncryptionBuffer`.
When we request the next chunk, the previous one can be released since we aren't going to need it anymore.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Moderate

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
