### PR TITLE
RavenDB-20543 Add reference key of the embedded objects

### DIFF
--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -99,12 +99,9 @@ namespace Raven.Server.SqlMigration
             if (onProgress == null)
                 onProgress = progress => { };
 
-            string CollectionNameProvider(string tableSchema, string tableName, bool isEmbeddedCollection)
-            {
-                return isEmbeddedCollection 
-                    ? settings.Collections.SelectMany(x => x.NestedCollections).Single(x => x.SourceTableSchema == tableSchema && x.SourceTableName == tableName).Name 
-                    : settings.Collections.Single(x => x.SourceTableSchema == tableSchema && x.SourceTableName == tableName).Name;
-            }
+            string CollectionNameProvider(string tableSchema, string tableName, bool isEmbeddedCollection) => isEmbeddedCollection 
+                ? settings.Collections.SelectMany(x => x.NestedCollections).Single(x => x.SourceTableSchema == tableSchema && x.SourceTableName == tableName).Name 
+                : settings.Collections.Single(x => x.SourceTableSchema == tableSchema && x.SourceTableName == tableName).Name;
 
             await using (var enumerationConnection = OpenConnection())
             await using (var referencesConnection = OpenConnection())
@@ -199,7 +196,7 @@ namespace Raven.Server.SqlMigration
                         var embeddedArrayWithLinks = (DynamicJsonArray)refInfo.EmbeddedReferenceKeyDataProvider.Provide(specialColumns);
                         value[refInfo.PropertyName + "Ids"] = embeddedArrayWithLinks;
                         
-                        if (refInfo.ChildReferences != null) // nested references
+                        if (refInfo.ChildReferences != null)
                         {
                             var idx = 0;
                             foreach (DynamicJsonValue arrayItem in arrayWithEmbeddedObjects.ArrayOfNestedObjects)
@@ -224,9 +221,7 @@ namespace Raven.Server.SqlMigration
 
                         var embeddedObjectLinkValue = (string)refInfo.EmbeddedReferenceKeyDataProvider.Provide(specialColumns);
                         if (value[refInfo.PropertyName] != null && value[refInfo.PropertyName] is DynamicJsonValue)
-                        {
                             ((DynamicJsonValue)value[refInfo.PropertyName])[refInfo.PropertyName + "Id"] = embeddedObjectLinkValue;
-                        }
                         
                         if (embeddedObjectValue != null)
                         {

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -20,16 +20,10 @@ using DbProviderFactories = Raven.Server.Documents.ETL.Providers.SQL.RelationalW
 
 namespace Raven.Server.SqlMigration
 {
-    public enum EmbeddedDocumentSqlKeysStorage
-    {
-        None,
-        OnMetadata,
-        OnDocument,
-    }
+    
     public abstract class GenericDatabaseMigrator : IDatabaseDriver
     {
         protected readonly string ConnectionString;
-        protected readonly Dictionary<string, EmbeddedDocumentSqlKeysStorage> CollectionsEmbeddedReferencesSqlKeysConfigurations = new();
 
         public abstract DatabaseSchema FindSchema();
 
@@ -128,7 +122,7 @@ namespace Raven.Server.SqlMigration
                     using (var patcher = new JsPatcher(collectionToImport, context))
                     {
                         var references = ResolveReferences(collectionToImport, dbSchema, CollectionNameProvider);
-                        CollectionsEmbeddedReferencesSqlKeysConfigurations.TryGetValue(collectionToImport.Name, out var collectionEmbeddedReferencesSqlKeysConfiguration);
+                        settings.CollectionsEmbeddedReferencesSqlKeysConfigurations.TryGetValue(collectionToImport.Name, out var collectionEmbeddedReferencesSqlKeysConfiguration);
                         InitializeDataProviders(references, referencesConnection);
 
                         try
@@ -661,7 +655,6 @@ namespace Raven.Server.SqlMigration
                 {
                     objectProperties.Add(ExtractFromReader(reader, refInfo.TargetDocumentColumns));
                     attachments.Add(ExtractAttachments(reader, refInfo.TargetAttachmentColumns));
-                    CollectionsEmbeddedReferencesSqlKeysConfigurations.TryGetValue(refInfo.SourceTableName, out var embeddedDocumentSqlKeysStorage);
                     
                     specialProperties.Add(ExtractFromReader(reader, refInfo.TargetSpecialColumnsNames));    
                 }

--- a/src/Raven.Server/SqlMigration/Model/EmbeddedCollection.cs
+++ b/src/Raven.Server/SqlMigration/Model/EmbeddedCollection.cs
@@ -6,11 +6,13 @@ namespace Raven.Server.SqlMigration.Model
     {
         public List<string> JoinColumns { get; set; }
         public RelationType Type { get; set; }
+        public EmbeddedDocumentSqlKeysStorage SqlKeysStorage { get; set; }
         
-        public EmbeddedCollection(string sourceTableSchema, string sourceTableName, RelationType type, List<string> columns, string name) : base(sourceTableSchema, sourceTableName, name)
+        public EmbeddedCollection(string sourceTableSchema, string sourceTableName, RelationType type, List<string> columns, string name, EmbeddedDocumentSqlKeysStorage sqlKeysStorage = EmbeddedDocumentSqlKeysStorage.None) : base(sourceTableSchema, sourceTableName, name)
         {
             JoinColumns = columns;
             Type = type;
+            SqlKeysStorage = sqlKeysStorage;
         }
     }
 }

--- a/src/Raven.Server/SqlMigration/Model/EmbeddedDocumentSqlKeysStorage.cs
+++ b/src/Raven.Server/SqlMigration/Model/EmbeddedDocumentSqlKeysStorage.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Server.SqlMigration.Model;
+
+public enum EmbeddedDocumentSqlKeysStorage
+{
+    None,
+    OnDocument,
+    OnMetadata
+}

--- a/src/Raven.Server/SqlMigration/Model/EmbeddedDocumentSqlKeysStorage.cs
+++ b/src/Raven.Server/SqlMigration/Model/EmbeddedDocumentSqlKeysStorage.cs
@@ -3,6 +3,6 @@
 public enum EmbeddedDocumentSqlKeysStorage
 {
     None,
-    OnDocument,
-    OnMetadata
+    AsNestedDocumentProperty,
+    OnDocumentMetadata,
 }

--- a/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
+++ b/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
@@ -8,6 +8,5 @@ namespace Raven.Server.SqlMigration.Model
         public List<RootCollection> Collections { get; set; }
         public int BatchSize { get; set; } = 1000;
         public int? MaxRowsPerTable { get; set; }
-        public Dictionary<string, EmbeddedDocumentSqlKeysStorage> CollectionsEmbeddedReferencesSqlKeysConfigurations = new();
     }
 }

--- a/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
+++ b/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
@@ -2,12 +2,6 @@
 
 namespace Raven.Server.SqlMigration.Model
 {
-    public enum EmbeddedDocumentSqlKeysStorage
-    {
-        None,
-        OnDocument,
-        OnMetadata,
-    }
     
     public class MigrationSettings
     {

--- a/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
+++ b/src/Raven.Server/SqlMigration/Model/MigrationSettings.cs
@@ -2,10 +2,18 @@
 
 namespace Raven.Server.SqlMigration.Model
 {
+    public enum EmbeddedDocumentSqlKeysStorage
+    {
+        None,
+        OnDocument,
+        OnMetadata,
+    }
+    
     public class MigrationSettings
     {
         public List<RootCollection> Collections { get; set; }
         public int BatchSize { get; set; } = 1000;
         public int? MaxRowsPerTable { get; set; }
+        public Dictionary<string, EmbeddedDocumentSqlKeysStorage> CollectionsEmbeddedReferencesSqlKeysConfigurations = new();
     }
 }

--- a/src/Raven.Server/SqlMigration/Model/ReferenceInformation.cs
+++ b/src/Raven.Server/SqlMigration/Model/ReferenceInformation.cs
@@ -15,6 +15,7 @@ namespace Raven.Server.SqlMigration.Model
         
         public string CollectionNameToUseInLinks { get; set; }
         public IDataProvider<object> DataProvider {get; set; }
+        public IDataProvider<object> EmbeddedReferenceKeyDataProvider { get; set; }
         public HashSet<string> TargetSpecialColumnsNames { get; set; }
         public Dictionary<string, string> TargetDocumentColumns { get; set; }
         public Dictionary<string, string> TargetAttachmentColumns { get; set; }

--- a/src/Raven.Server/SqlMigration/Model/ReferenceInformation.cs
+++ b/src/Raven.Server/SqlMigration/Model/ReferenceInformation.cs
@@ -16,6 +16,7 @@ namespace Raven.Server.SqlMigration.Model
         public string CollectionNameToUseInLinks { get; set; }
         public IDataProvider<object> DataProvider {get; set; }
         public IDataProvider<object> EmbeddedReferenceKeyDataProvider { get; set; }
+        public EmbeddedDocumentSqlKeysStorage EmbeddedDocumentsSqlKeysStorage { get; set; }
         public HashSet<string> TargetSpecialColumnsNames { get; set; }
         public Dictionary<string, string> TargetDocumentColumns { get; set; }
         public Dictionary<string, string> TargetAttachmentColumns { get; set; }

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/innerSqlTable.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/innerSqlTable.ts
@@ -5,6 +5,8 @@ import sqlReference = require("models/database/tasks/sql/sqlReference");
 
 class innerSqlTable extends abstractSqlTable {
     parentReference: sqlReference;
+
+    sqlKeysStorage = ko.observable<Raven.Server.SqlMigration.Model.EmbeddedDocumentSqlKeysStorage>("None");
     
     constructor(parentReference: sqlReference) {
         super();

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlReference.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlReference.ts
@@ -50,7 +50,8 @@ class sqlReference {
             ColumnsMapping: this.effectiveInnerTable().getColumnsMapping(binaryToAttachment),
             AttachmentNameMapping: this.effectiveInnerTable().getAttachmentsMapping(binaryToAttachment),
             LinkedCollections: this.effectiveInnerTable().getLinkedReferencesDto(),
-            NestedCollections: this.effectiveInnerTable().getEmbeddedReferencesDto(binaryToAttachment)
+            NestedCollections: this.effectiveInnerTable().getEmbeddedReferencesDto(binaryToAttachment),
+            SqlKeysStorage: this.effectiveInnerTable().sqlKeysStorage()
         };
     }
     

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -514,6 +514,42 @@
                         </div>
                         <input class="form-control input-sm" data-bind="textInput: $parent.name" />
                     </div>
+                    <div data-bind="with: effectiveInnerTable, visible: action() === 'embed'">
+                        <div class="btn-group link-actions">
+                            <button class="btn btn-sm btn-default" title="Skip @sql-keys" 
+                                    data-bind="css: { active: sqlKeysStorage() === 'None' }, click: _.partial(sqlKeysStorage, 'None')">
+                                <i class="icon-empty-set"></i> <!-- TODO change icons-->
+                            </button>
+                            <button class="btn btn-sm btn-default" title="Put @sql-keys as document property" 
+                                    data-bind="css: { active: sqlKeysStorage() === 'AsNestedDocumentProperty' }, click: _.partial(sqlKeysStorage, 'AsNestedDocumentProperty')">
+                                <i class="icon-document"></i> <!-- TODO change icons-->
+                            </button>
+                            <button class="btn btn-sm btn-default" title="Put @sql-keys in document metadata" 
+                                    data-bind="css: { active: sqlKeysStorage() === 'OnDocumentMetadata' }, click: _.partial(sqlKeysStorage, 'OnDocumentMetadata')">
+                                <i class="icon-backups"></i> <!-- TODO change icons-->
+                            </button>
+                        </div>
+                    </div>
+                    <div data-bind="with: effectiveInnerTable, visible: action() === 'embed'">
+                        <div class="dropdown btn-block">
+                            <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
+                                <span data-bind="text: sqlKeysStorage"></span>
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a href="#" data-bind="click: _.partial(sqlKeysStorage, 'None')">None</a>
+                                </li>
+                                <li>
+                                    <a href="#" data-bind="click: _.partial(sqlKeysStorage, 'AsNestedDocumentProperty')">AsNestedDocumentProperty</a>
+                                </li>
+                                <li>
+                                    <a href="#" data-bind="click: _.partial(sqlKeysStorage, 'OnDocumentMetadata')">OnDocumentMetadata</a>
+                                </li>
+                                
+                            </ul>
+                        </div>
+                    </div>
                 </div>
         </div>
         <div class="inner-table" data-bind="with: effectiveInnerTable">

--- a/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
+++ b/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
@@ -755,11 +755,11 @@ namespace SlowTests.Server.Documents.Migration
                     {
                         NestedCollections = new List<EmbeddedCollection>
                         {
-                            new EmbeddedCollection(schemaName, "order_item", RelationType.OneToMany, new List<string> { "order_id" }, "Items")
+                            new EmbeddedCollection(schemaName, "order_item", RelationType.OneToMany, new List<string> { "order_id" }, "Items", EmbeddedDocumentSqlKeysStorage.AsNestedDocumentProperty)
                             {
                                 NestedCollections = new List<EmbeddedCollection>
                                 {
-                                    new EmbeddedCollection(schemaName, "product", RelationType.ManyToOne, new List<string> { "product_id" }, "Product")
+                                    new EmbeddedCollection(schemaName, "product", RelationType.ManyToOne, new List<string> { "product_id" }, "Product", EmbeddedDocumentSqlKeysStorage.AsNestedDocumentProperty)
                                 }
                             }
                         }
@@ -773,8 +773,6 @@ namespace SlowTests.Server.Documents.Migration
                         {
                             collection
                         },
-                        CollectionsEmbeddedReferencesSqlKeysConfigurations =
-                            new Dictionary<string, EmbeddedDocumentSqlKeysStorage> {{"Orders", EmbeddedDocumentSqlKeysStorage.OnDocument}}
                     };
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
@@ -837,9 +835,7 @@ namespace SlowTests.Server.Documents.Migration
                         Collections = new List<RootCollection>
                         {
                             collection
-                        },
-                        CollectionsEmbeddedReferencesSqlKeysConfigurations =
-                            new Dictionary<string, EmbeddedDocumentSqlKeysStorage> {{"Orders", EmbeddedDocumentSqlKeysStorage.None}}
+                        }
                     };
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
@@ -857,6 +853,90 @@ namespace SlowTests.Server.Documents.Migration
                         Assert.NotNull(order);
                         Assert.NotNull(order["Items"]);
 
+                        var item = order["Items"][0];
+                        Assert.NotNull(item);
+                        Assert.Null(item["OrderId"]);
+
+                        var itemProduct = item["Product"];
+                        Assert.NotNull(itemProduct);
+                        Assert.Null(itemProduct["PId"]);
+                    }
+                }
+            }
+        }
+        
+        [Theory]
+        [RequiresMsSqlInlineData]
+        [RequiresNpgSqlInlineData]
+        [RequiresOracleSqlInlineData]
+        [RequiresMySqlInlineData]
+        public async Task NestedEmbeddingWithSqlKeysInHierarchicalMetadata(MigrationProvider provider)
+        {
+            using (WithSqlDatabase(provider, out var connectionString, out string schemaName, "basic"))
+            {
+                var driver = DatabaseDriverDispatcher.CreateDriver(provider, connectionString);
+                using (var store = GetDocumentStore())
+                {
+                    var collection = new RootCollection(schemaName, "order", "Orders")
+                    {
+                        NestedCollections = new List<EmbeddedCollection>
+                        {
+                            new EmbeddedCollection(schemaName, "order_item", RelationType.OneToMany, new List<string> { "order_id" }, "Items", EmbeddedDocumentSqlKeysStorage.OnDocumentMetadata)
+                            {
+                                NestedCollections = new List<EmbeddedCollection>
+                                {
+                                    new EmbeddedCollection(schemaName, "product", RelationType.ManyToOne, new List<string> { "product_id" }, "Product", EmbeddedDocumentSqlKeysStorage.OnDocumentMetadata)
+                                }
+                            }
+                        }
+                    };
+
+                    var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                    var settings = new MigrationSettings
+                    {
+                        Collections = new List<RootCollection>
+                        {
+                            collection
+                        }
+                    };
+
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+                    using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    {
+                        var schema = driver.FindSchema();
+                        ApplyDefaultColumnNamesMapping(schema, settings);
+                        await driver.Migrate(settings, schema, db, context, token: cts.Token);
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        var order = session.Load<JObject>("Orders/1");
+
+                        Assert.NotNull(order);
+                        Assert.NotNull(order["Items"]);
+                        
+                        Assert.NotNull(order);
+                        Assert.NotNull(order["Items"]);
+                        Assert.NotNull(order["@metadata"]);
+                        Assert.NotNull(order["@metadata"]["@sql-keys"]);
+                        
+                        var sqlKeysMetadata = order["@metadata"]["@sql-keys"];
+                        Assert.Equal(1, sqlKeysMetadata["o_id"]);
+                        
+                        Assert.NotNull(sqlKeysMetadata["Items"]);
+                        var sqlKeysItem10 = sqlKeysMetadata["Items"]["Items/10"];
+                        Assert.NotNull(sqlKeysItem10);
+                        Assert.Equal(10, sqlKeysItem10["oi_id"]);
+                        Assert.NotNull(sqlKeysItem10["order_id"]);
+                        Assert.NotNull(sqlKeysItem10["product_id"]);
+
+                        var sqlKeysItem11 = sqlKeysMetadata["Items"]["Items/11"];
+                        Assert.NotNull(sqlKeysItem11);
+                        Assert.Equal(11,sqlKeysItem11["oi_id"]);
+                        Assert.NotNull(sqlKeysItem11["order_id"]);
+                        Assert.NotNull(sqlKeysItem11["product_id"]);
+                        
                         var item = order["Items"][0];
                         Assert.NotNull(item);
                         Assert.Null(item["OrderId"]);

--- a/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
+++ b/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
@@ -738,5 +738,70 @@ namespace SlowTests.Server.Documents.Migration
                 }
             }
         }
+        
+        [Theory]
+        [RequiresMsSqlInlineData]
+        [RequiresNpgSqlInlineData]
+        [RequiresOracleSqlInlineData]
+        [RequiresMySqlInlineData]
+        public async Task NestedEmbeddingWithSqlKeysInDocument(MigrationProvider provider)
+        {
+            using (WithSqlDatabase(provider, out var connectionString, out string schemaName, "basic"))
+            {
+                var driver = DatabaseDriverDispatcher.CreateDriver(provider, connectionString);
+                using (var store = GetDocumentStore())
+                {
+                    var collection = new RootCollection(schemaName, "order", "Orders")
+                    {
+                        NestedCollections = new List<EmbeddedCollection>
+                        {
+                            new EmbeddedCollection(schemaName, "order_item", RelationType.OneToMany, new List<string> { "order_id" }, "Items")
+                            {
+                                NestedCollections = new List<EmbeddedCollection>
+                                {
+                                    new EmbeddedCollection(schemaName, "product", RelationType.ManyToOne, new List<string> { "product_id" }, "Product")
+                                }
+                            }
+                        }
+                    };
+
+                    var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                    var settings = new MigrationSettings
+                    {
+                        Collections = new List<RootCollection>
+                        {
+                            collection
+                        },
+                        CollectionsEmbeddedReferencesSqlKeysConfigurations =
+                            new Dictionary<string, EmbeddedDocumentSqlKeysStorage> {{"Orders", EmbeddedDocumentSqlKeysStorage.OnDocument}}
+                    };
+
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
+                    using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    {
+                        var schema = driver.FindSchema();
+                        ApplyDefaultColumnNamesMapping(schema, settings);
+                        await driver.Migrate(settings, schema, db, context, token: cts.Token);
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        var order = session.Load<JObject>("Orders/1");
+
+                        Assert.NotNull(order);
+                        Assert.NotNull(order["Items"]);
+
+                        var item = order["Items"][0];
+                        Assert.NotNull(item);
+                        Assert.NotNull(item["OrderId"]);
+
+                        var itemProduct = item["Product"];
+                        Assert.NotNull(itemProduct);
+                        Assert.NotNull(itemProduct["PId"]);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20453/Import-from-SQL-Allow-to-add-the-reference-key-of-imbeded-object

### Additional description

Importing from SQL inclines handling the relationships between SQL tables.
We're handling it by putting the ids of linked items to the doc (link) or by nesting whole referenced documents in the doc (embed).

While choosing embedding, we're losing the nested item id, because we don't need it anymore - it's in the doc, no need to go anywhere else for it... but there's a request to attach the key anyway to the doc.
I've added a option to extend embedded document by previously lost sql-keys, or to nest them in the @metadata/@sql-keys.

Embedded data will look slightly different, but only if we decide to explicitly select an option to include the keys, so I wouldn't say it's a breaking change. 

There's a documentation to add. We need to document such possibility to save sql-keys of embedded objects and the options where to do so (OnDocumentMetadata, AsNestedDocumentProperty, None (default)).

Also, there's studio work to do. I've attached a picture and description below and on youtrack as well.

### Type of change

- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Non-breaking change



### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update


### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

There's a need to provide a possibility to choose where sql-keys of embedded objects will be stored. 

Where? 
![uxidea](https://github.com/ravendb/ravendb/assets/25389585/d4ac3eeb-e599-4196-96c2-67ccc1beab1d)
