### PR TITLE
RavenDB-20380 Allow to skip implicit null in map-reduce output from orchestrator

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/Sharding/ShardedAggregatedAnonymousObjects.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/Sharding/ShardedAggregatedAnonymousObjects.cs
@@ -9,9 +9,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static.Sharding;
 public class ShardedAggregatedAnonymousObjects : AggregatedAnonymousObjects
 {
     private static readonly DynamicJsonValue DummyDynamicJsonValue = new();
-
-    public ShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor, JsonOperationContext indexContext) : base(results, propertyAccessor, indexContext)
+    
+    public ShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor, JsonOperationContext indexContext, bool skipImplicitNullInOutput) : base(results, propertyAccessor, indexContext)
     {
+        SkipImplicitNullInOutput = skipImplicitNullInOutput;
         ModifyOutputToStore = djv =>
         {
             djv[Constants.Documents.Metadata.Key] = DummyDynamicJsonValue;

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedMapReduceIndexEntriesQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedMapReduceIndexEntriesQueryResultsMerger.cs
@@ -46,6 +46,6 @@ public class ShardedMapReduceIndexEntriesQueryResultsMerger : ShardedMapReduceQu
         return base.AggregateForStaticMapReduce(index);
     }
 
-    protected override AggregatedAnonymousObjects CreateShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor)
+    protected override AggregatedAnonymousObjects CreateShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor, bool skipImplicitNullInOutput = false)
         => new ShardedAggregatedAnonymousObjectsForIndexEntries(results, propertyAccessor, _reduceKeyHash, Context);
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -83,13 +83,13 @@ public class ShardedMapReduceQueryResultsMerger
             if (propertyAccessor == null)
                 return new List<BlittableJsonReaderObject>(0);
 
-            var objects = CreateShardedAggregatedAnonymousObjects(results, propertyAccessor);
+            var objects = CreateShardedAggregatedAnonymousObjects(results, propertyAccessor, index.Configuration.IndexMissingFieldsAsNull == false);
             return objects.GetOutputsToStore().ToList();
         }
     }
 
-    protected virtual AggregatedAnonymousObjects CreateShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor)
-        => new ShardedAggregatedAnonymousObjects(results, propertyAccessor, Context);
+    protected virtual AggregatedAnonymousObjects CreateShardedAggregatedAnonymousObjects(List<object> results, IPropertyAccessor propertyAccessor, bool skipImplicitNullInOutput = false)
+        => new ShardedAggregatedAnonymousObjects(results, propertyAccessor, Context, skipImplicitNullInOutput);
 
     internal virtual AggregationResult AggregateForAutoMapReduce(AutoMapReduceIndexDefinition indexDefinition)
     {

--- a/test/SlowTests/Issues/RavenDB_12334.cs
+++ b/test/SlowTests/Issues/RavenDB_12334.cs
@@ -17,18 +17,18 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task Map_reduce_results_should_not_contains_implicit_nulls_wich_were_not_indexed(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Doc { Id = "doc-1", StrVal = "a", });
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var result = await session.Query<BlittableJsonReaderObject, DocsIndex>().FirstAsync();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20380 

### Additional description

We've to take the configuration option (`IndexMissingFieldsAsNull`) into account when producing orchestrator result in map-reduce to ensure consistency between sharded and single database.

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
