### PR TITLE
RavenDB-19529: Missing compression dictionary handling (export of corrupted database)

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -74,6 +74,8 @@ namespace Raven.Client.Documents.Smuggler
         public string EncryptionKey { get; set; }
 
         public List<string> Collections { get; set; }
+
+        public bool IgnoreCorruptedDocumentsErrors { get; set; }
     }
 
     internal interface IDatabaseSmugglerOptions

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -75,7 +75,13 @@ namespace Raven.Client.Documents.Smuggler
 
         public List<string> Collections { get; set; }
 
-        public bool IgnoreCorruptedDocumentsErrors { get; set; }
+        /// <summary>
+        /// In case the database is corrupted (for example, Compression Dictionaries are lost), it is possible to export all the remaining data.
+        /// If '<c>true</c>', the process will continue in the presence of corrupted data, with an entry of error data into the export result report.
+        /// If '<c>false</c>', the process of export will be interrupted in the presence of corrupted data. 
+        /// The default value is '<c>false</c>'.
+        /// </summary>
+        public bool SkipCorruptedData { get; set; }
     }
 
     internal interface IDatabaseSmugglerOptions

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -17,7 +17,6 @@ namespace Raven.Client.Documents.Smuggler
         protected SmugglerProgress _progress;
         private readonly Stopwatch _sw;
         private DatabaseItemType _itemTypeInProgress;
-        public EventHandler<InvalidOperationException> OnCorruptedDataHandler;
         
         public SmugglerResult()
         {
@@ -100,12 +99,7 @@ namespace Raven.Client.Documents.Smuggler
             _itemTypeInProgress = DatabaseItemType.None;
         }
 
-        public void HandleCorruptedData()
-        {
-            OnCorruptedDataHandler = OnCorruptedData;
-        }
-
-        private void OnCorruptedData(object sender, InvalidOperationException e)
+        public void OnCorruptedData(object sender, InvalidOperationException e)
         {
             switch (_itemTypeInProgress)
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -68,7 +68,6 @@ namespace Raven.Server.Documents
         public static readonly TableSchema CollectionsSchema = new TableSchema();
 
         public readonly DocumentDatabase DocumentDatabase;
-        public EventHandler<InvalidOperationException> OnCorruptedDocumentHandler;
 
         private Dictionary<string, CollectionName> _collectionsCache;
 
@@ -931,9 +930,10 @@ namespace Raven.Server.Documents
             public ManualResetEventSlim DelayDocumentLoad;
         }
 
-        public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All)
+        public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
         {
-            var table = new Table(DocsSchema, context.Transaction.InnerTransaction, OnCorruptedDocumentHandler);
+            var table = new Table(DocsSchema, context.Transaction.InnerTransaction, onCorruptedDataHandler);
+
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice], etag, start))
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -68,6 +68,7 @@ namespace Raven.Server.Documents
         public static readonly TableSchema CollectionsSchema = new TableSchema();
 
         public readonly DocumentDatabase DocumentDatabase;
+        public EventHandler<InvalidOperationException> OnCorruptedDocumentHandler;
 
         private Dictionary<string, CollectionName> _collectionsCache;
 
@@ -932,7 +933,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All)
         {
-            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+            var table = new Table(DocsSchema, context.Transaction.InnerTransaction, OnCorruptedDocumentHandler);
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice], etag, start))
             {

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -8,6 +8,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Data.Fixed;
@@ -330,6 +331,65 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             var index = Database.IndexStore.GetIndex(environment.Name);
             return index.GenerateStorageReport(details);
+        }
+
+        [RavenAction("/databases/*/debug/storage/compression-dictionaries", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = false)]
+        public async Task CompressionDictionary()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.Environment.ReadTransaction())
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName("DatabaseName");
+                writer.WriteString(Database.Name);
+                writer.WriteComma();
+
+                var inMemoryCompressionDictionaries = context.Environment.CompressionDictionariesHolder.CompressionDictionaries;
+                WriteCompressionDictionaries(writer, inMemoryCompressionDictionaries.Values.ToArray(), "InMemory");
+
+                writer.WriteComma();
+                
+                var inStorageDictionaries = context.Environment.CompressionDictionariesHolder.GetInStorageDictionaries(tx);
+                WriteCompressionDictionaries(writer, inStorageDictionaries.ToArray(), "InStorage");
+                
+                writer.WriteEndObject();
+            }
+        }
+
+        private static void WriteCompressionDictionaries(AsyncBlittableJsonTextWriter writer, ZstdLib.CompressionDictionary[] dictionaries, string sourceName)
+        {
+            writer.WritePropertyName(sourceName);
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("NumberOfEntries");
+            writer.WriteInteger(dictionaries.Length);
+            writer.WriteComma();
+
+            writer.WritePropertyName("Entries");
+            writer.WriteStartArray();
+
+            bool firstInMemoryEntry = true;
+            foreach (var dict in dictionaries)
+            {
+                if (firstInMemoryEntry == false)
+                    writer.WriteComma();
+                firstInMemoryEntry = false;
+
+                writer.WriteStartObject();
+                writer.WritePropertyName("Id");
+                writer.WriteInteger(dict.Id);
+#if DEBUG
+                writer.WriteComma();
+                writer.WritePropertyName("DictionaryHash");
+                writer.WriteString(dict.DictionaryHash);
+#endif
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
         }
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2370,9 +2370,9 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, long etag, long take, DocumentFields fields = DocumentFields.All)
+        public IEnumerable<Document> GetRevisionsFrom(DocumentsOperationContext context, long etag, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
         {
-            var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
+            var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction, onCorruptedDataHandler);
 
             foreach (var tvr in table.SeekForwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], etag, 0))
             {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -186,7 +186,7 @@ namespace Raven.Server.Smuggler.Documents
                 }
             }
 
-            result.AddInfo($"Started processing {type}.");
+            result.StartProcessingForType(type);
             _onProgress.Invoke(result.Progress);
 
             SmugglerProgressBase.Counts counts;
@@ -287,7 +287,7 @@ namespace Raven.Server.Smuggler.Documents
                 }
             }
 
-            result.AddInfo($"Finished processing {type}. {counts}");
+            result.StopProcessingActualType(counts);
             _onProgress.Invoke(result.Progress);
         }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -31,7 +31,7 @@ class exportDatabaseModel {
 
     includeAllCollections = ko.observable(true);
     includedCollections = ko.observableArray<string>([]);
-    ignoreCorruptedDocumentsErrors = ko.observable(false);
+    skipCorruptedData = ko.observable(false);
 
     transformScript = ko.observable<string>();
 
@@ -184,7 +184,7 @@ class exportDatabaseModel {
             SkipRevisionCreation: undefined,
             AuthorizationStatus: undefined,
             CompressionAlgorithm: this.compressionAlgorithm(),
-            IgnoreCorruptedDocumentsErrors: this.ignoreCorruptedDocumentsErrors()
+            SkipCorruptedData: this.skipCorruptedData()
         };
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -31,6 +31,7 @@ class exportDatabaseModel {
 
     includeAllCollections = ko.observable(true);
     includedCollections = ko.observableArray<string>([]);
+    ignoreCorruptedDocumentsErrors = ko.observable(true);
 
     transformScript = ko.observable<string>();
 
@@ -183,6 +184,7 @@ class exportDatabaseModel {
             SkipRevisionCreation: undefined,
             AuthorizationStatus: undefined,
             CompressionAlgorithm: this.compressionAlgorithm(),
+            IgnoreCorruptedDocumentsErrors: this.ignoreCorruptedDocumentsErrors()
         };
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -31,7 +31,7 @@ class exportDatabaseModel {
 
     includeAllCollections = ko.observable(true);
     includedCollections = ko.observableArray<string>([]);
-    ignoreCorruptedDocumentsErrors = ko.observable(true);
+    ignoreCorruptedDocumentsErrors = ko.observable(false);
 
     transformScript = ko.observable<string>();
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
@@ -150,6 +150,14 @@ class exportDatabase extends viewModelBase {
                         "<span class=\"token keyword\">this</span>.Freight = <span class=\"token number\">15.3</span>;<br />" +
                         "</pre>"
             });
+        
+        popoverUtils.longWithHover($("#skipCorruptedDataPopover"), {
+            content: 
+            "<div>" +
+                "<strong>Checked</strong>: continues export despite corrupted data and logs errors in the report. <br />" +
+                "<strong>Unchecked</strong>: halts export upon encountering corrupted data." +
+                "</div>"
+        })
 
         popoverUtils.longWithHover($("#js-ongoing-tasks-disabled"), {
             content: "Imported ongoing tasks will be disabled by default."

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
@@ -173,6 +173,11 @@
                                 <div class="help-block" data-bind="validationMessage: model.transformScript"></div>
                             </div>
                         </div>
+                        <div class="toggle">
+                            <input id="skipCorruptedData" type="checkbox" data-bind="checked: model.skipCorruptedData" />
+                            <label for="skipCorruptedData" class="margin-right margin-right-sm">Skip Corrupted Data </label>
+                            <a id="skipCorruptedDataPopover" tabindex="0"><small><i class="icon-info text-info"></i></small></a>
+                        </div>
                         <div data-bind="with: model.databaseModel">
                             <div data-bind="compose: $root.smugglerDatabaseRecordView"></div>
                         </div>

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -743,19 +743,39 @@ namespace Voron.Data.Tables
 
         public class CompressionDictionariesHolder : IDisposable
         {
-            private readonly ConcurrentDictionary<int, ZstdLib.CompressionDictionary> _compressionDictionaries = new ConcurrentDictionary<int, ZstdLib.CompressionDictionary>();
+            public ConcurrentDictionary<int, ZstdLib.CompressionDictionary> CompressionDictionaries { get; } = new();
 
             public ZstdLib.CompressionDictionary GetCompressionDictionaryFor(Transaction tx, int id)
             {
-                if (_compressionDictionaries.TryGetValue(id, out var current))
+                if (CompressionDictionaries.TryGetValue(id, out var current))
                     return current;
 
                 current = CreateCompressionDictionary(tx, id);
 
-                var result = _compressionDictionaries.GetOrAdd(id, current);
+                var result = CompressionDictionaries.GetOrAdd(id, current);
                 if (result != current)
                     current.Dispose();
                 return result;
+            }
+
+            public IEnumerable<ZstdLib.CompressionDictionary> GetInStorageDictionaries(Transaction tx)
+            {
+                var tree = tx.ReadTree(TableSchema.CompressionDictionariesSlice);
+                if (tree == null)
+                    yield break;
+
+                using (var iterator = tree.Iterate(true))
+                {
+                    if (iterator.Seek(Slices.BeforeAllKeys) == false)
+                        yield break;
+
+                    do
+                    {
+                        var id = iterator.CurrentKey.CreateReader().ReadBigEndianInt32();
+                        var dict = CreateCompressionDictionary(tx, id);
+                        yield return dict;
+                    } while (iterator.MoveNext());
+                }
             }
 
             private ZstdLib.CompressionDictionary CreateCompressionDictionary(Transaction tx, int id)
@@ -788,22 +808,20 @@ namespace Voron.Data.Tables
 
             public void Dispose()
             {
-                foreach (var (_, dic) in _compressionDictionaries)
+                foreach (var (_, dic) in CompressionDictionaries)
                 {
                     dic.Dispose();
 
                 }
             }
 
-            public void Remove(int id)
+            public bool Remove(int id)
             {
                 // Intentionally orphaning the dictionary here, we'll let the 
                 // GC's finalizer to clear it up, this is a *very* rare operation.
-                _compressionDictionaries.TryRemove(id, out _);
+                return CompressionDictionaries.TryRemove(id, out _);
             }
         }
-
-
 
         private void UpdateValuesFromIndex(long id, ref TableValueReader oldVer, TableValueBuilder newVer, bool forceUpdate)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19529/Missing-compression-dictionary

### Additional description

We've come across an issue titled `Missing compression dictionary`, which calls for particular areas to be addressed:

1. To improve the detail and insight of our logs, additional logging points have been integrated at the stages of `Compression Dictionary` creation, deletion, and replacement. We need this data to investigate future analogous issues.
2. A new endpoint has been added, providing information about the existing `Сompression Dictionary`, both in-memory and in storage.
3. We aim to retain the possibility of exporting a database with a `Missing compression dictionary`. To accommodate this, a new parameter has been implemented into the export parameters, allowing to skip of corrupted documents.

This pull request manages to address these areas.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio.