### PR TITLE
RavenDB-20554 Fix Stats > Time Series popover positioning

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/EssentialDatabaseStatsComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/EssentialDatabaseStatsComponent.tsx
@@ -190,7 +190,7 @@ export function EssentialDatabaseStatsComponent(props: EssentialDatabaseStatsCom
                                 </span>
                                 <UncontrolledPopover
                                     target="js-timeseries-segments"
-                                    placement="top"
+                                    placement="right"
                                     trigger="hover"
                                     container="js-timeseries-segments"
                                 >


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20554/Studio-Time-series-explanation-is-hidden

### Additional description
Changed positioning of the popover

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
