### PR TITLE
RavenDB-20466 Set the transaction holder for read transactions as well

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -732,6 +732,10 @@ namespace Voron
                         tx.CurrentTransactionHolder = _currentWriteTransactionHolder;
                         tx.AfterCommitWhenNewTransactionsPrevented += AfterCommitWhenNewTransactionsPrevented;
                     }
+                    else
+                    {
+                        tx.CurrentTransactionHolder = NativeMemory.CurrentThreadStats;
+                    }
 
                     ActiveTransactions.Add(tx);
 


### PR DESCRIPTION
This way we'll be able to find id / name of a thread that runs a read transaction for very long time.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20466/

### Additional description

Originally the current transaction holder was introduced only for write transactions in order to detect that a write tx has been already opened on the same thread:
https://github.com/ravendb/ravendb/pull/4819/commits/bb716ebe00742fe06040b20358fd57e4aca60a70

Now we're adding the same for read transactions so once we detect an issue with a long running transaction then we'll be able to find the thread causing this.

### Type of change

- Debugging improvement

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?
- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
