### PR TITLE
RavenDB-20395: SlowTests.Server.Documents.PeriodicBackup.Retention.can_delete_backups_by_date_s3

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/Retention.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Retention.cs
@@ -4,8 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
@@ -245,8 +243,16 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var status = await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: true, expectedEtag: etag, timeout: timeout);
                 sp3.Stop();
                 
-                var directoriesCount = await getDirectoriesCount(store.Database);
                 var expectedNumberOfDirectories = checkIncremental ? 2 : 1;
+                var gracePeriod = config.LocalSettings == null
+                    ? (int)TimeSpan.FromSeconds(30).TotalMilliseconds
+                    : 0;
+
+                var directoriesCount = await WaitForValueAsync(async () => await getDirectoriesCount(store.Database),
+                    expectedVal: expectedNumberOfDirectories,
+                    timeout: gracePeriod,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
                 Assert.True(expectedNumberOfDirectories == directoriesCount, 
                     $"ExpectedNumberOfDirectories: {expectedNumberOfDirectories}, ActualNumberOfDirectories: {directoriesCount}, SaveChanges() duration: {sp1.Elapsed}, GetStatisticsOperation duration: {sp2.Elapsed}, RunBackupAndReturnStatusAsync duration: {sp3.Elapsed}," +
                     $" Backup duration: {status.DurationInMs}, LocalRetentionDurationInMs: {status.LocalRetentionDurationInMs}");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20395/SlowTests.Server.Documents.PeriodicBackup.Retention.candeletebackupsbydates3backupAgeInSeconds-7-numberOfBackupsToCreate-3

### Additional description

Implemented a grace period for non-local backups to enhance test reliability.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed