### PR TITLE
RavenDB-20567 / RavenDB-20550 Skipping tests using async commit on 32bits. This is not supported.

### DIFF
--- a/test/FastTests/Voron/Bugs/RavenDB_8036.cs
+++ b/test/FastTests/Voron/Bugs/RavenDB_8036.cs
@@ -1,4 +1,5 @@
-﻿using Voron;
+﻿using Tests.Infrastructure;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +16,7 @@ namespace FastTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [MultiplatformFact(RavenArchitecture.AllX64)]
         public void Flushing_should_not_throw_on_freeing_scratch_page_async_commit()
         {
             var tx1 = Env.WriteTransaction();

--- a/test/FastTests/Voron/Optimizations/EarlyLockRelease.cs
+++ b/test/FastTests/Voron/Optimizations/EarlyLockRelease.cs
@@ -2,8 +2,8 @@
 using System.Text;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Voron.Data.Tables;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Voron.Optimizations
@@ -14,7 +14,7 @@ namespace FastTests.Voron.Optimizations
         {
         }
 
-        [Fact]
+        [MultiplatformFact(RavenArchitecture.AllX64)]
         public void ShouldWork()
         {
 

--- a/test/SlowTests/Voron/Issues/RavenDB_13640.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13640.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [MultiplatformFact(RavenArchitecture.AllX64)]
         public void Should_properly_clear_transaction_after_begin_async_commit_failure()
         {
             var tx1 = Env.WriteTransaction();

--- a/test/SlowTests/Voron/Storage/RavenDB7698.cs
+++ b/test/SlowTests/Voron/Storage/RavenDB7698.cs
@@ -4,8 +4,8 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using Tests.Infrastructure;
 using Voron;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Voron.Storage
@@ -21,7 +21,7 @@ namespace SlowTests.Voron.Storage
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [MultiplatformFact(RavenArchitecture.AllX64)]
         public void CanRestartEmptyAsyncTransaction()
         {
             RequireFileBasedPager();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20567

### Additional description

They started to fails after: https://github.com/ravendb/ravendb/pull/16541

Async commit usage is not supported on 32 bits. The checks in RavenDB are here:
https://github.com/ravendb/ravendb/blob/30ba6eaa9e14fab3d2564b59eb1de4e648b2d1a6/src/Raven.Server/Documents/TransactionOperationsMerger.cs#L1027-L1041

### Type of change

- Tests fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests will verify the fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
