### PR TITLE
RavenDB-20574 imported counters should get new change vector

### DIFF
--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -385,13 +385,18 @@ namespace Raven.Server.Documents.Handlers
 
                 foreach (var cgd in _counterGroups)
                 {
+                    var etag = _database.DocumentsStorage.GenerateNextEtag();
+                    var localCv = _database.DocumentsStorage.GetNewChangeVector(context, etag);
                     using (cgd.Values)
+                    using (var lazyCv = context.GetLazyString(localCv))
                     {
+                        cgd.ChangeVector = lazyCv;
                         PutCounters(context, cgd);
                     }
                 }
 
                 UpdateDocumentsMetadata(context);
+
 
                 return _counterGroups.Count;
             }

--- a/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
@@ -35,6 +36,12 @@ namespace Raven.Server.Documents.Sharding.Operations
 
             foreach (var shardResult in results.Values)
             {
+                if (shardResult.Command.StatusCode == HttpStatusCode.NotFound)
+                {
+                    //lipstick on a pig 
+                    continue;
+                }
+
                 var operationResult = shardResult.Result.Result;
 
                 switch (operationResult)

--- a/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/GetShardedOperationStateOperation.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
@@ -36,12 +35,6 @@ namespace Raven.Server.Documents.Sharding.Operations
 
             foreach (var shardResult in results.Values)
             {
-                if (shardResult.Command.StatusCode == HttpStatusCode.NotFound)
-                {
-                    //lipstick on a pig 
-                    continue;
-                }
-
                 var operationResult = shardResult.Result.Result;
 
                 switch (operationResult)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -418,8 +418,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:7-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:8-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.DoesNotContain(originalDatabase.DbBase64Id, databaseChangeVector);
+                        Assert.Contains($"A:10-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }
@@ -535,8 +535,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:8-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:11-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:4-{originalDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:12-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -161,8 +161,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                         using (ctx.OpenReadTransaction())
                         {
                             var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                            Assert.Contains($"A:7-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                            Assert.Contains($"A:8-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                            Assert.DoesNotContain(originalDatabase.DbBase64Id, databaseChangeVector);
+                            Assert.Contains($"A:10-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                         }
                     }
                 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -122,8 +122,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:7-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:8-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.DoesNotContain(originalDatabase.DbBase64Id, databaseChangeVector);
+                        Assert.Contains($"A:10-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }
@@ -209,8 +209,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:8-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:11-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:4-{originalDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:12-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -93,8 +93,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:7-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:8-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.DoesNotContain(originalDatabase.DbBase64Id, databaseChangeVector);
+                        Assert.Contains($"A:10-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }
@@ -178,8 +178,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     using (ctx.OpenReadTransaction())
                     {
                         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                        Assert.Contains($"A:8-{originalDatabase.DbBase64Id}", databaseChangeVector);
-                        Assert.Contains($"A:11-{restoredDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:4-{originalDatabase.DbBase64Id}", databaseChangeVector);
+                        Assert.Contains($"A:12-{restoredDatabase.DbBase64Id}", databaseChangeVector);
                     }
                 }
             }

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -781,7 +781,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Smuggler)]
         public async Task CanExportAndImportCountersTwice()
         {
             var file = GetTempFileName();

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -782,6 +782,71 @@ namespace SlowTests.Smuggler
         }
 
         [Fact]
+        public async Task CanExportAndImportCountersTwice()
+        {
+            var file = GetTempFileName();
+            try
+            {
+                using (var store1 = GetDocumentStore())
+                using (var store2 = GetDocumentStore())
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = "Name1" }, "users/1");
+                        await session.StoreAsync(new User { Name = "Name2" }, "users/2");
+
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        session.CountersFor("users/1").Increment("likes", 100);
+                        session.CountersFor("users/1").Increment("dislikes", 200);
+                        session.CountersFor("users/2").Increment("downloads", 500);
+
+                        await session.SaveChangesAsync();
+                    }
+
+                    var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    // first time
+                    operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    // ensure second time doesn't increase the count
+                    operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
+                    Assert.Equal(2, stats.CountOfDocuments);
+                    Assert.Equal(2, stats.CountOfCounterEntries);
+
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        var user1 = await session.LoadAsync<User>("users/1");
+                        var user2 = await session.LoadAsync<User>("users/2");
+
+                        Assert.Equal("Name1", user1.Name);
+                        Assert.Equal("Name2", user2.Name);
+
+                        var dic = await session.CountersFor(user1).GetAllAsync();
+                        Assert.Equal(2, dic.Count);
+                        Assert.Equal(100, dic["likes"]);
+                        Assert.Equal(200, dic["dislikes"]);
+
+                        var val = await session.CountersFor(user2).GetAsync("downloads");
+                        Assert.Equal(500, val);
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [Fact]
         public async Task ShouldAvoidCreatingNewRevisionsDuringImport()
         {
             var file = GetTempFileName();

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -152,8 +152,6 @@ namespace Tests.Infrastructure
                 }
 
                 var r = await Replication.WaitForDocumentToReplicateAsync<object>(dst, id, 15 * 1000);
-                if (r == null)
-                    WaitForUserToContinueTheTest(dst, debug: false);
                 Assert.NotNull(r);
             }
         }
@@ -273,7 +271,10 @@ namespace Tests.Infrastructure
 
         protected static async Task EnsureNoReplicationLoop(RavenServer server, string database)
         {
-            var replication = await ReplicationInstance.GetReplicationInstanceAsync(server, database, new ReplicationManager.ReplicationOptions());
+            var replication = await ReplicationInstance.GetReplicationInstanceAsync(server, database, new ReplicationManager.ReplicationOptions
+            {
+                BreakReplicationOnStart = false
+            });
             await replication.EnsureNoReplicationLoopAsync();
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Replication.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Replication.cs
@@ -74,6 +74,25 @@ public partial class RavenTestBase
             return val == expected;
         }
 
+        public async Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, int timeout)
+            where T : class
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds <= timeout)
+            {
+                using (var session = store.OpenAsyncSession(store.Database))
+                {
+                    var doc = await session.LoadAsync<T>(id);
+                    if (doc != null)
+                        return doc;
+                }
+
+                await Task.Delay(100);
+            }
+
+            return null;
+        }
+
         public Task<string> GetErrorsAsync(IDocumentStore store) => GetErrorsForClusterAsync(new List<RavenServer> { _parent.Server }, store.Database);
 
         public async Task<string> GetErrorsForClusterAsync(IEnumerable<RavenServer> servers, string database)

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -157,6 +157,21 @@ public partial class RavenTestBase
             return record.Sharding;
         }
 
+        public string GetRandomIdForShard(ShardingConfiguration config, int shardNumber)
+        {
+            var tries = 100;
+            using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+            while (tries > 0)
+            {
+                var id = $"foo/{Random.Shared.Next()}";
+                if (ShardHelper.GetShardNumberFor(config, allocator, id) == shardNumber)
+                    return id;
+                tries--;
+            }
+
+            throw new InvalidOperationException($"Have no luck! couldn't randomize an id for shard {shardNumber}");
+        }
+
         public int GetBucket(ShardingConfiguration config, string id)
         {
             using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))

--- a/test/Tests.Infrastructure/ReplicationManager.cs
+++ b/test/Tests.Infrastructure/ReplicationManager.cs
@@ -58,17 +58,24 @@ public partial class RavenTestBase
             }
         }
 
-        internal static async ValueTask<ReplicationManager> GetReplicationManagerAsync(List<RavenServer> servers, string databaseName, bool breakReplication)
+        internal static async ValueTask<ReplicationManager> GetReplicationManagerAsync(List<RavenServer> servers, string databaseName, ReplicationOptions options)
         {
             Dictionary<string, ReplicationInstance> instances = new();
             foreach (var server in servers)
             {
-                var instance = await ReplicationInstance.GetReplicationInstanceAsync(server, databaseName, breakReplication);
+                var instance = await ReplicationInstance.GetReplicationInstanceAsync(server, databaseName, options);
                 if (instance != null)
                     instances[server.ServerStore.NodeTag] = instance;
             }
 
             return new ReplicationManager(databaseName, instances);
+        }
+        
+        public class ReplicationOptions
+        {
+            public bool BreakReplicationOnStart = true;
+            public bool KeepMaxItemsCountOnDispose;
+            public int? MaxItemsCount = 1;
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20574

### Additional description

During import of counters we kept the original change vector of the counter group.

So in a sharded database we might end up in the following situation:
shard 0 might have a change vector of `A:10-fooDbId`
shard 1 might have a change vector of `A:20-fooDbId`

This is a problem if we are replicating from this database, because shard 1 might replicate first, so the destination will have `A:20-fooDbId` as a database change vector, and so we will skip the counter from shard 0.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
