### PR TITLE
RavenDB-15744 Support logging toggling

### DIFF
--- a/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Http
 {
     internal static class ClusterTopologyLocalCache
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger("Client", typeof(ClusterTopologyLocalCache).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Client", typeof(ClusterTopologyLocalCache).FullName);
 
         private static void Clear(string path)
         {
@@ -27,8 +27,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not clear the persisted cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not clear the persisted cluster topology", e);
             }
         }
 
@@ -56,8 +56,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not understand the persisted cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not understand the persisted cluster topology", e);
                 return null;
             }
         }
@@ -94,8 +94,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not persist the cluster topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not persist the cluster topology", e);
             }
         }
     }

--- a/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Http
 {
     internal static class DatabaseTopologyLocalCache
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger("Client", typeof(DatabaseTopologyLocalCache).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DatabaseTopologyLocalCache));
 
         private static void Clear(string path)
         {
@@ -26,8 +26,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not clear the persisted database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not clear the persisted database topology", e);
             }
         }
 
@@ -60,8 +60,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not understand the persisted database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not understand the persisted database topology", e);
                 return null;
             }
         }
@@ -83,8 +83,8 @@ namespace Raven.Client.Http
                 var existingTopology = await TryLoadAsync(path, context).ConfigureAwait(false);
                 if (existingTopology?.Etag >= topology.Etag)
                 {
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Skipping save topology with etag {topology.Etag} to cache " +
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Skipping save topology with etag {topology.Etag} to cache " +
                                      $"as the cache already have a topology with etag: {existingTopology.Etag}");
                     return;
                 }
@@ -118,8 +118,8 @@ namespace Raven.Client.Http
             }
             catch (Exception e)
             {
-                if (_logger.IsInfoEnabled)
-                    _logger.Info("Could not persist the database topology", e);
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Could not persist the database topology", e);
             }
         }
 

--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Http
         public HttpCache(long maxSize)
         {
             _maxSize = maxSize;
-            _unmanagedBuffersPool = new UnmanagedBuffersPool(nameof(HttpCache), "Client");
+            _unmanagedBuffersPool = new UnmanagedBuffersPool(nameof(HttpCache));
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }
 

--- a/src/Raven.Server/Background/BackgroundWorkBase.cs
+++ b/src/Raven.Server/Background/BackgroundWorkBase.cs
@@ -14,10 +14,10 @@ namespace Raven.Server.Background
         private Task _currentTask;
         protected readonly Logger Logger;
 
-        protected BackgroundWorkBase(string resourceName, CancellationToken shutdown)
+        protected BackgroundWorkBase(Logger logger, CancellationToken shutdown)
         {
             _shutdown = shutdown;
-            Logger = LoggingSource.Instance.GetLogger(resourceName ?? "Server", GetType().FullName);
+            Logger = logger ?? LoggingSource.Instance.LoggersHolder.Generic.GetLogger(GetType().Name);
             Cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdown);
         }
 

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Commercial.LetsEncrypt;
 
 public class LetsEncryptSimulationHelper
 {
-    internal static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+    internal static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
 
     internal class UniqueResponseResponder : IStartup
     {

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Commercial
 {
     public class LicenseHelper
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseHelper>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseHelper>();
         public static readonly string LicenseStringConfigurationName = RavenConfiguration.GetKey(x => x.Licensing.License);
 
         private readonly ServerStore _serverStore;

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Commercial
 {
     public class LicenseManager : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
         private static readonly RSAParameters _rsaParameters;
         private readonly LicenseStorage _licenseStorage = new LicenseStorage();
         private Timer _leaseLicenseTimer;

--- a/src/Raven.Server/Commercial/OsInfoExtensions.cs
+++ b/src/Raven.Server/Commercial/OsInfoExtensions.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Commercial
 {
     public static class OsInfoExtensions
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("OsInfo");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
 
         public static OsInfo GetOsInfo()
         {

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Commercial
 {
     public static class SetupManager
     {
-        internal static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
+        internal static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<LicenseManager>();
         
         private static string BuildHostName(string nodeTag, string userDomain, string rootDomain)
         {

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Config
 #if !RVN
         internal static readonly RavenConfiguration Default = new RavenConfiguration("__default", ResourceType.Server);
 
-        private readonly Logger _logger;
+        private readonly Logger _logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenConfiguration>();
 
         private readonly string _customConfigPath;
 
@@ -111,8 +111,6 @@ namespace Raven.Server.Config
 
         private RavenConfiguration(string resourceName, ResourceType resourceType, string customConfigPath = null, bool skipEnvironmentVariables = false)
         {
-            _logger = LoggingSource.Instance.GetLogger<RavenConfiguration>(resourceName);
-
             ResourceName = resourceName;
             ResourceType = resourceType;
             _customConfigPath = customConfigPath;

--- a/src/Raven.Server/Dashboard/Cluster/AbstractClusterDashboardNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/AbstractClusterDashboardNotificationSender.cs
@@ -21,7 +21,8 @@ namespace Raven.Server.Dashboard.Cluster
         
         private DateTime _lastSentNotification = DateTime.MinValue;
 
-        protected AbstractClusterDashboardNotificationSender(int widgetId, ConnectedWatcher watcher, CancellationToken shutdown) : base(nameof(AbstractClusterDashboardNotificationSender), shutdown)
+        protected AbstractClusterDashboardNotificationSender(int widgetId, ConnectedWatcher watcher, CancellationToken shutdown) 
+            : base(null, shutdown)
         {
             _widgetId = widgetId;
             _watcher = watcher;

--- a/src/Raven.Server/Dashboard/DatabasesInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoNotificationSender.cs
@@ -17,9 +17,9 @@ namespace Raven.Server.Dashboard
         private readonly TimeSpan _notificationsThrottle;
         private DateTime _lastSentNotification = DateTime.MinValue;
 
-        public DatabasesInfoNotificationSender(string resourceName, ServerStore serverStore,
+        public DatabasesInfoNotificationSender(ServerStore serverStore,
             ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
-            : base(resourceName, shutdown)
+            : base(null, shutdown)
         {
             _serverStore = serverStore;
             _watchers = watchers;

--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Dashboard
         private readonly CanAccessDatabase _canAccessDatabase;
         private const string DatabasesInfoKey = "DatabasesInfo";
 
-        public DatabasesInfoRetriever(ServerStore serverStore, CanAccessDatabase canAccessDatabase)
+        public DatabasesInfoRetriever(ServerStore serverStore, CanAccessDatabase canAccessDatabase) : base(serverStore.Server.Logger)
         {
             _serverStore = serverStore;
             _canAccessDatabase = canAccessDatabase;

--- a/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/MachineResourcesNotificationSender.cs
@@ -24,12 +24,11 @@ namespace Raven.Server.Dashboard
         private DateTime _lastSentNotification = DateTime.MinValue;
 
         public MachineResourcesNotificationSender(
-            string resourceName,
             RavenServer server,
             ConcurrentSet<ConnectedWatcher> watchers,
             TimeSpan notificationsThrottle,
             CancellationToken shutdown)
-            : base(resourceName, shutdown)
+            : base(null, shutdown)
         {
             _server = server;
             _watchers = watchers;

--- a/src/Raven.Server/Dashboard/ServerDashboardNotifications.cs
+++ b/src/Raven.Server/Dashboard/ServerDashboardNotifications.cs
@@ -11,11 +11,11 @@ namespace Raven.Server.Dashboard
             var options = new ServerDashboardOptions();
 
             var machineResourcesNotificationSender = 
-                new MachineResourcesNotificationSender(nameof(ServerStore), serverStore.Server, Watchers, options.MachineResourcesThrottle, shutdown);
+                new MachineResourcesNotificationSender(serverStore.Server, Watchers, options.MachineResourcesThrottle, shutdown);
             BackgroundWorkers.Add(machineResourcesNotificationSender);
 
             var databasesInfoNotificationSender = 
-                new DatabasesInfoNotificationSender(nameof(ServerStore), serverStore, Watchers, options.DatabasesInfoThrottle, shutdown);
+                new DatabasesInfoNotificationSender(serverStore, Watchers, options.DatabasesInfoThrottle, shutdown);
             BackgroundWorkers.Add(databasesInfoNotificationSender);
         }
     }

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
@@ -15,9 +15,8 @@ public class ThreadsInfoNotificationSender : BackgroundWorkBase
     private readonly ThreadsUsage _threadsUsage;
     private DateTime _lastSentNotification = DateTime.MinValue;
 
-    public ThreadsInfoNotificationSender(string resourceName,
-        ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
-        : base(resourceName, shutdown)
+    public ThreadsInfoNotificationSender(ConcurrentSet<ConnectedWatcher> watchers, TimeSpan notificationsThrottle, CancellationToken shutdown)
+        : base(null, shutdown)
     {
         _watchers = watchers;
         _notificationsThrottle = notificationsThrottle;

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotifications.cs
@@ -10,7 +10,7 @@ public class ThreadsInfoNotifications : NotificationsBase
     {
         var options = new ThreadsInfoOptions();
 
-        var threadsInfoNotificationSender = new ThreadsInfoNotificationSender(nameof(ServerStore), Watchers, options.ThreadsInfoThrottle, shutdown);
+        var threadsInfoNotificationSender = new ThreadsInfoNotificationSender(Watchers, options.ThreadsInfoThrottle, shutdown);
         BackgroundWorkers.Add(threadsInfoNotificationSender);
     }
 }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -15,7 +15,6 @@ using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -87,7 +86,6 @@ namespace Raven.Server.Documents
         {
             _documentDatabase = documentDatabase;
             _documentsStorage = documentDatabase.DocumentsStorage;
-            LoggingSource.Instance.GetLogger<AttachmentsStorage>(documentDatabase.Name);
 
             tx.CreateTree(AttachmentsSlice);
             AttachmentsSchema.Create(tx, AttachmentsMetadataSlice, 44);

--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -18,13 +18,12 @@ namespace Raven.Server.Documents
 
         private readonly DatabasesLandlord _databasesLandlord;
         private readonly ServerStore _serverStore;
-        private readonly Logger _logger;
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<CatastrophicFailureHandler>();
         
         public CatastrophicFailureHandler(DatabasesLandlord databasesLandlord, ServerStore serverStore)
         {
             _databasesLandlord = databasesLandlord;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<CatastrophicFailureHandler>("Server");
         }
 
         public bool TryGetStats(Guid environmentId, out FailureStats stats)
@@ -75,8 +74,8 @@ namespace Raven.Server.Documents
                     // exception in raising an alert can't prevent us from unloading a database
                 }
 
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"{title}. {message} (StackTrace='{stacktrace}')", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"{title}. {message} (StackTrace='{stacktrace}')", e);
 
                 // let it propagate the exception to the client first and do
                 // the internal failure handling e.g. Index.HandleIndexCorruption

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -14,10 +14,6 @@ namespace Raven.Server.Documents
 {
     public class ConfigurationStorage : IDisposable
     {
-        private const string ResourceName = nameof(ConfigurationStorage);
-
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ConfigurationStorage>(ResourceName);
-
         public TransactionContextPool ContextPool { get; }
 
         public NotificationsStorage NotificationsStorage { get; }
@@ -36,8 +32,8 @@ namespace Raven.Server.Documents
             }
 
             var options = db.Configuration.Core.RunInMemory
-                ? StorageEnvironmentOptions.CreateMemoryOnly(path.FullPath, tempPath, db.IoChanges, db.CatastrophicFailureNotification)
-                : StorageEnvironmentOptions.ForPath(path.FullPath, tempPath, null, db.IoChanges, db.CatastrophicFailureNotification);
+                ? StorageEnvironmentOptions.CreateMemoryOnly(path.FullPath, tempPath, db.IoChanges, db.CatastrophicFailureNotification, db.Logger)
+                : StorageEnvironmentOptions.ForPath(path.FullPath, tempPath, null, db.IoChanges, db.CatastrophicFailureNotification, db.Logger);
 
             options.OnNonDurableFileSystemError += db.HandleNonDurableFileSystemError;
             options.OnRecoverableFailure += db.HandleRecoverableFailure;
@@ -63,9 +59,9 @@ namespace Raven.Server.Documents
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = db.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.MaxNumberOfRecyclableJournals = db.Configuration.Storage.MaxNumberOfRecyclableJournals;
 
-            DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, db.Configuration.Storage, db.Name, DirectoryExecUtils.EnvironmentType.Configuration, Logger);
+            DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, db.Configuration.Storage, db.Name, DirectoryExecUtils.EnvironmentType.Configuration, db.Logger);
 
-            NotificationsStorage = new NotificationsStorage(db.Name);
+            NotificationsStorage = new NotificationsStorage(db.Logger);
 
             OperationsStorage = new OperationsStorage();
 

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -120,7 +120,7 @@ namespace Raven.Server.Documents
         {
             _documentDatabase = documentDatabase;
             _documentsStorage = documentDatabase.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<ConflictsStorage>(documentDatabase.Name);
+            _logger = documentDatabase.Logger;
 
             ConflictsSchema.Create(tx, ConflictsSlice, 32);
 

--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -12,8 +12,7 @@ namespace Raven.Server.Documents
 {
     public class DatabaseInfoCache
     {
-
-        protected readonly Logger Logger;
+        protected Logger Logger;
 
         private StorageEnvironment _environment;
 
@@ -23,7 +22,6 @@ namespace Raven.Server.Documents
 
         public DatabaseInfoCache()
         {
-            Logger = LoggingSource.Instance.GetLogger<DatabaseInfoCache>("Server");
             _databaseInfoSchema.DefineKey(new TableSchema.SchemaIndexDef
             {
                 StartIndex = 0,
@@ -33,6 +31,8 @@ namespace Raven.Server.Documents
 
         public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)
         {
+            Logger = environment.Logger;
+
             _environment = environment;
             _contextPool = contextPool;
 

--- a/src/Raven.Server/Documents/DatabaseMetricCacher.cs
+++ b/src/Raven.Server/Documents/DatabaseMetricCacher.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents
     {
         private readonly DocumentDatabase _database;
 
-        public DatabaseMetricCacher(DocumentDatabase database)
+        public DatabaseMetricCacher(DocumentDatabase database) : base(database.Logger)
         {
             _database = database;
         }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -25,7 +25,6 @@ namespace Raven.Server.Documents
     {
         protected DocumentsContextPool ContextPool;
         protected DocumentDatabase Database;
-        protected Logger Logger;
 
         public override void Init(RequestHandlerContext context)
         {
@@ -33,7 +32,7 @@ namespace Raven.Server.Documents
 
             Database = context.Database;
             ContextPool = Database.DocumentsStorage.ContextPool;
-            Logger = LoggingSource.Instance.GetLogger(Database.Name, GetType().FullName);
+            Logger = Database.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents
 
             Database = context.Database;
             ContextPool = Database.DocumentsStorage.ContextPool;
-            Logger = Database.Logger.GetLogger(GetType().Name);
+            Logger = Database.Logger;
 
             context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents
             _serverStore = serverStore;
             _databaseSemaphore = new SemaphoreSlim(_serverStore.Configuration.Databases.MaxConcurrentLoads);
             _concurrentDatabaseLoadTimeout = _serverStore.Configuration.Databases.ConcurrentLoadTimeout.AsTimeSpan;
-            _logger = LoggingSource.Instance.GetLogger<DatabasesLandlord>("Server");
+            _logger = serverStore.Server.Logger;
             CatastrophicFailureHandler = new CatastrophicFailureHandler(this, _serverStore);
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -184,7 +184,7 @@ namespace Raven.Server.Documents
         {
             DocumentDatabase = documentDatabase;
             _name = DocumentDatabase.Name;
-            _logger = LoggingSource.Instance.GetLogger<DocumentsStorage>(documentDatabase.Name);
+            _logger = documentDatabase.Logger;
             _addToInitLog = addToInitLog;
         }
 
@@ -242,7 +242,7 @@ namespace Raven.Server.Documents
 
             }
 
-            var options = GetStorageEnvironmentOptionsFromConfiguration(DocumentDatabase.Configuration, DocumentDatabase.IoChanges, DocumentDatabase.CatastrophicFailureNotification);
+            var options = GetStorageEnvironmentOptionsFromConfiguration(DocumentDatabase.Configuration, DocumentDatabase.IoChanges, DocumentDatabase.CatastrophicFailureNotification, _logger);
 
             options.OnNonDurableFileSystemError += DocumentDatabase.HandleNonDurableFileSystemError;
             options.OnRecoveryError += DocumentDatabase.HandleOnDatabaseRecoveryError;
@@ -281,21 +281,23 @@ namespace Raven.Server.Documents
             }
         }
 
-        public static StorageEnvironmentOptions GetStorageEnvironmentOptionsFromConfiguration(RavenConfiguration config, IoChangesNotifications ioChanges, CatastrophicFailureNotification catastrophicFailureNotification)
+        public static StorageEnvironmentOptions GetStorageEnvironmentOptionsFromConfiguration(RavenConfiguration config, IoChangesNotifications ioChanges, CatastrophicFailureNotification catastrophicFailureNotification, Logger logger)
         {
             if (config.Core.RunInMemory)
                 return StorageEnvironmentOptions.CreateMemoryOnly(
                     config.Core.DataDirectory.FullPath,
                     config.Storage.TempPath?.FullPath,
                     ioChanges,
-                    catastrophicFailureNotification);
+                    catastrophicFailureNotification,
+                    logger);
 
             return StorageEnvironmentOptions.ForPath(
                 config.Core.DataDirectory.FullPath,
                 config.Storage.TempPath?.FullPath,
                 null,
                 ioChanges,
-                catastrophicFailureNotification
+                catastrophicFailureNotification, 
+                logger
             );
         }
 

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -55,8 +55,7 @@ namespace Raven.Server.Documents.ETL
 
         public EtlLoader(DocumentDatabase database, ServerStore serverStore)
         {
-            Logger = LoggingSource.Instance.GetLogger(database.Name, GetType().FullName);
-
+            Logger = database.Logger;
             _database = database;
             _serverStore = serverStore;
 

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.ETL
             ConfigurationName = Configuration.Name;
             TransformationName = Transformation.Name;
             Name = $"{Configuration.Name}/{Transformation.Name}";
-            Logger = LoggingSource.Instance.GetLogger(database.Name, GetType().FullName);
+            Logger = database.Logger;
             Database = database;
             _serverStore = serverStore;
             Statistics = new EtlProcessStatistics(Tag, Name, Database.NotificationCenter);

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
         {
             _etl = etl;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger<RelationalDatabaseWriter>(_database.Name);
+            _logger = database.Logger;
             _providerFactory = GetDbProviderFactory(etl.Configuration);
             _providerType = SqlProviderParser.GetSupportedProvider(_etl.Configuration.Connection.FactoryName);
             _commandBuilder = _providerFactory.InitializeCommandBuilder();

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -22,14 +22,10 @@ namespace Raven.Server.Documents.Expiration
         private const string DocumentsByRefresh = "DocumentsByRefresh";
 
         private readonly DocumentDatabase _database;
-        private readonly DocumentsStorage _documentsStorage;
-        private readonly Logger _logger;
 
         public ExpirationStorage(DocumentDatabase database, Transaction tx)
         {
             _database = database;
-            _documentsStorage = _database.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<ExpirationStorage>(database.Name);
 
             tx.CreateTree(DocumentsByExpiration);
             tx.CreateTree(DocumentsByRefresh);

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -34,7 +34,8 @@ namespace Raven.Server.Documents.Expiration
         public ExpirationConfiguration ExpirationConfiguration { get; }
         public RefreshConfiguration RefreshConfiguration { get; }
 
-        private ExpiredDocumentsCleaner(DocumentDatabase database, ExpirationConfiguration expirationConfiguration, RefreshConfiguration refreshConfiguration) : base(database.Name, database.DatabaseShutdown)
+        private ExpiredDocumentsCleaner(DocumentDatabase database, ExpirationConfiguration expirationConfiguration, RefreshConfiguration refreshConfiguration)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             ExpirationConfiguration = expirationConfiguration;
             RefreshConfiguration = refreshConfiguration;
@@ -81,7 +82,7 @@ namespace Raven.Server.Documents.Expiration
                     $"Expiration error in {database.Name}", msg,
                     AlertType.RevisionsConfigurationNotValid, NotificationSeverity.Error, database.Name));
 
-                var logger = LoggingSource.Instance.GetLogger<ExpiredDocumentsCleaner>(database.Name);
+                var logger = database.Logger;
                 if (logger.IsOperationsEnabled)
                     logger.Operations(msg, e);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             });
         }
 
-        [RavenAction("/admin/loggers", "GET", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logging-toggling/loggers", "GET", AuthorizationStatus.Operator)]
         public async Task GetAllLoggers()
         {
             using (AcquireLocksAndGetLoggers(out var generic, out var server))
@@ -280,7 +280,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
         }
         
-        [RavenAction("/admin/loggers/configuration", "GET", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logging-toggling/configuration", "GET", AuthorizationStatus.Operator)]
         public async Task GetLoggingTogglingConfiguration()
         {
             using (AcquireLocksAndGetLoggers(out var generic, out var server))
@@ -298,7 +298,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
         }
         
-        [RavenAction("/admin/loggers", "POST", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logging-toggling/configuration", "POST", AuthorizationStatus.Operator)]
         public async Task SetLoggerMode()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -336,6 +336,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                     }
                 }
             }
+            
+            NoContentStatus();
         }
 
         internal class SwitchLoggerConfiguration

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -313,7 +313,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     generic.ResetRecursively();
                     server.ResetRecursively();
                     
-                    foreach (var (path, mode) in configuration.Loggers)
+                    foreach (var (path, mode) in configuration.Loggers.OrderBy(x => x.Key))
                     {
                         var first = SwitchLoggerConfigurationHelper.IterateSwitches(path).FirstOrDefault();
                         if(first.IsNullOrWhiteSpace())

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             });
         }
 
-        [RavenAction("/admin/logging-toggling/loggers", "GET", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logs/loggers", "GET", AuthorizationStatus.Operator)]
         public async Task GetAllLoggers()
         {
             using (AcquireLocksAndGetLoggers(out var generic, out var server))
@@ -280,7 +280,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
         }
         
-        [RavenAction("/admin/logging-toggling/configuration", "GET", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logs/loggers/configuration", "GET", AuthorizationStatus.Operator)]
         public async Task GetLoggingTogglingConfiguration()
         {
             using (AcquireLocksAndGetLoggers(out var generic, out var server))
@@ -298,16 +298,14 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
         }
         
-        [RavenAction("/admin/logging-toggling/configuration", "POST", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/logs/loggers/configuration", "POST", AuthorizationStatus.Operator)]
         public async Task SetLoggerMode()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             {
                 var input = await ctx.ReadForMemoryAsync(RequestBodyStream(), "SwitchLoggerConfiguration");
-                if (input.TryGet("Configuration", out BlittableJsonReaderObject json) == false)
-                    ThrowRequiredPropertyNameInRequest("Configuration");
             
-                var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(json);
+                var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(input);
                 using (AcquireLocksAndGetLoggers(out var generic, out var server))
                 {
                     generic.ResetRecursively();

--- a/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Sparrow.Logging;
 
@@ -31,19 +32,35 @@ internal static class SwitchLoggerConfigurationHelper
         var end = 0;
         while (end < path.Length)
         {
-            end = path.IndexOf('.', start);
+            end = path.IndexOf('.', end);
             if (end < 0)
+            {
+                end = path.Length;
                 break;
+            }
 
-            if (end != 0 && path[end - 1] == '\\')
+            if (end - start == 0)
+                throw new InvalidOperationException($"Double dot is not meaningful. pos {start} configuration path {path}");
+            
+            if (path[end - 1] == '\\')
+            {
+                end++;
                 continue;
+            }
 
-            string iterateSwitches = path.Substring(start, end - start);
-            yield return iterateSwitches;
-            start = end + 1;
+            yield return GetSwitch();
+            start = end += 1;
         }
 
-        yield return path.Substring(start, path.Length - start);
+        yield return GetSwitch();
+
+        string GetSwitch()
+        {
+            string iterateSwitches = path.Substring(start, end - start);
+            if (iterateSwitches.Contains('\\'))
+                iterateSwitches = iterateSwitches.Replace("\\", "");
+            return iterateSwitches;
+        }
     }
     
     public static void GetConfigurationFromRoot(SwitchLogger root, Dictionary<string, LogMode> configuration)

--- a/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.Handlers.Admin;
+
+internal static class SwitchLoggerConfigurationHelper
+{
+    public static void ApplyConfiguration(SwitchLogger logger, IEnumerable<string> logPath, LogMode mode)
+    {
+        foreach (var switchName in logPath)
+        {
+            if (logger.Loggers.TryGet(switchName, out logger) == false)
+                return;
+        }
+                        
+        SetLoggerModeRecursively(logger, mode);
+    }
+
+    private static void SetLoggerModeRecursively(SwitchLogger root, LogMode mode)
+    {
+        root.SetLoggerMode(mode);
+        foreach (var (_, child) in root.Loggers)
+        {
+            SetLoggerModeRecursively(child, mode);
+        }
+    }
+        
+    public static IEnumerable<string> IterateSwitches(string path)
+    {
+        int start = 0;
+        var end = 0;
+        while (end < path.Length)
+        {
+            end = path.IndexOf('.', start);
+            if (end < 0)
+                break;
+
+            if (end != 0 && path[end - 1] == '\\')
+                continue;
+
+            string iterateSwitches = path.Substring(start, end - start);
+            yield return iterateSwitches;
+            start = end + 1;
+        }
+
+        yield return path.Substring(start, path.Length - start);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/SwitchLoggerConfigurationHelper.cs
@@ -45,4 +45,23 @@ internal static class SwitchLoggerConfigurationHelper
 
         yield return path.Substring(start, path.Length - start);
     }
+    
+    public static void GetConfigurationFromRoot(SwitchLogger root, Dictionary<string, LogMode> configuration)
+    {
+        if (root.IsModeOverrode)
+            configuration.Add(root.Name, root.GetLogMode());
+        GetConfiguration(root, configuration);
+    }
+
+    private static void GetConfiguration(SwitchLogger parent, Dictionary<string, LogMode> configuration)
+    {
+        foreach (var (_, child) in parent.Loggers)
+        {
+            var childMode = child.GetLogMode();
+            if(child.IsModeOverrode && childMode != parent.GetLogMode())
+                configuration.Add($"{child.Source}.{child.Name}", childMode);
+
+            GetConfiguration(child, configuration);
+        }
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Handlers
             var progress = new BulkInsertProgress();
             try
             {
-                var logger = LoggingSource.Instance.GetLogger<MergedInsertBulkCommand>(Database.Name);
+                var logger = Database.Logger;
                 IDisposable currentCtxReset = null, previousCtxReset = null;
 
                 try
@@ -511,7 +511,7 @@ namespace Raven.Server.Documents.Handlers
                 TotalSize = Commands.Sum(c => c.Document.Size),
                 Commands = Commands,
                 Database = database,
-                Logger = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name)
+                Logger = database.Logger
             };
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -59,8 +59,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             nameof(DatabaseRecord.TimeSeries)
         };
 
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<ServerWideDebugInfoPackageHandler>("Server");
-
         [RavenAction("/admin/debug/remote-cluster-info-package", "GET", AuthorizationStatus.Operator)]
         public async Task GetClusterWideInfoPackageForRemote()
         {
@@ -375,8 +373,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var routes = DebugInfoPackageUtils.GetAuthorizedRoutes(Server, HttpContext, databaseName).Where(x => x.TypeOfRoute == routeType);
 
             var id = Guid.NewGuid();
-            if (_logger.IsOperationsEnabled)
-                _logger.Operations($"Creating Debug Package '{id}' for '{databaseName ?? "Server"}'.");
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Creating Debug Package '{id}' for '{databaseName ?? "Server"}'.");
 
             foreach (var route in routes)
             {
@@ -386,8 +384,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 Exception ex = null;
                 var sw = Stopwatch.StartNew();
 
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Started gathering debug info from '{route.Path}' for Debug Package '{id}'.");
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Started gathering debug info from '{route.Path}' for Debug Package '{id}'.");
 
                 try
                 {
@@ -401,8 +399,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 }
                 finally
                 {
-                    if (_logger.IsOperationsEnabled)
-                        _logger.Operations($"Finished gathering debug info from '{route.Path}' for Debug Package '{id}'. Took: {(int)sw.Elapsed.TotalMilliseconds} ms",
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations($"Finished gathering debug info from '{route.Path}' for Debug Package '{id}'. Took: {(int)sw.Elapsed.TotalMilliseconds} ms",
                             ex);
                 }
             }

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1123,7 +1123,7 @@ namespace Raven.Server.Documents.Handlers
                         writer.WriteEndArray();
                         if (indexDefinition.Reduce != null)
                         {
-                            using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("JavaScriptIndexTest", Database.Name))
+                            using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("JavaScriptIndexTest", Database.Logger))
                             {
                                 compiledIndex.SetBufferPoolForTestingPurposes(bufferPool);
                                 compiledIndex.SetAllocatorForTestingPurposes(context.Allocator);

--- a/src/Raven.Server/Documents/HugeDocuments.cs
+++ b/src/Raven.Server/Documents/HugeDocuments.cs
@@ -30,14 +30,14 @@ namespace Raven.Server.Documents
 
         private Timer _timer;
 
-        public HugeDocuments(NotificationCenter.NotificationCenter notificationCenter, NotificationsStorage notificationsStorage, string database, int maxCollectionSize, long maxWarnSize)
+        public HugeDocuments(NotificationCenter.NotificationCenter notificationCenter, NotificationsStorage notificationsStorage, string database, int maxCollectionSize, long maxWarnSize, Logger logger)
         {
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
             _maxWarnSize = maxWarnSize;
             _hugeDocs = new SizeLimitedConcurrentDictionary<Tuple<string, DateTime>, long>(maxCollectionSize);
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = logger;
         }
 
         public void AddIfDocIsHuge(Document doc)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -370,27 +370,26 @@ namespace Raven.Server.Documents.Indexes
             Logger.Dispose();
         }
 
-        public static Index Open(string path, DocumentDatabase documentDatabase, bool generateNewDatabaseId, out SearchEngineType searchEngineType)
+        public static Index Open(string path, DocumentDatabase documentDatabase, bool generateNewDatabaseId, out SearchEngineType searchEngineType, SwitchLogger switchLogger)
         {
 
             StorageEnvironment environment = null;
             searchEngineType = SearchEngineType.None;
 
             var name = new DirectoryInfo(path).Name;
-            var indexLogger = documentDatabase.IndexesLogger.GetSubSwitchLogger(name);
-
+            
             var indexPath = path;
 
             var indexTempPath =
                 documentDatabase.Configuration.Indexing.TempPath?.Combine(name);
 
             var options = StorageEnvironmentOptions.ForPath(indexPath, indexTempPath?.FullPath, null,
-                documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, indexLogger);
+                documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, switchLogger);
             try
             {
                 InitializeOptions(options, documentDatabase, name);
 
-                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, indexLogger);
+                DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, documentDatabase.Configuration.Storage, documentDatabase.Name, DirectoryExecUtils.EnvironmentType.Index, switchLogger);
 
                 environment = StorageLoader.OpenEnvironment(options, StorageEnvironmentWithType.StorageEnvironmentType.Index);
 
@@ -680,7 +679,7 @@ namespace Raven.Server.Documents.Indexes
 
             var indexTempPath = configuration.TempPath?.Combine(name);
 
-            var indexLogger = documentDatabase.IndexesLogger.GetSubSwitchLogger(name);
+            var indexLogger = documentDatabase.IndexesLogger.GetSubSwitchLogger(Name);
             var options = configuration.RunInMemory
                 ? StorageEnvironmentOptions.CreateMemoryOnly(indexPath.FullPath, indexTempPath?.FullPath ?? Path.Combine(indexPath.FullPath, "Temp"),
                     documentDatabase.IoChanges, documentDatabase.CatastrophicFailureNotification, indexLogger)

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Indexes
             _index = index;
             _contextPool = contextPool;
             DocumentDatabase = database;
-            _logger = LoggingSource.Instance.GetLogger<IndexStorage>(DocumentDatabase.Name);
+            _logger = _index.Logger;
 
             var referencedCollections = index.GetReferencedCollections();
             if (referencedCollections != null)

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents.Indexes
         {
             _documentDatabase = documentDatabase;
             _serverStore = serverStore;
-            Logger = LoggingSource.Instance.GetLogger<IndexStore>(_documentDatabase.Name);
+            Logger = documentDatabase.IndexesLogger;
 
             var stoppedConcurrentIndexBatches = _documentDatabase.Configuration.Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory;
             StoppedConcurrentIndexBatches = new SemaphoreSlim(stoppedConcurrentIndexBatches);

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1847,7 +1847,7 @@ namespace Raven.Server.Documents.Indexes
             SearchEngineType searchEngineType = SearchEngineType.None;
             try
             {
-                index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false, out searchEngineType);
+                index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false, out searchEngineType, _documentDatabase.IndexesLogger.GetSubSwitchLogger(name));
 
                 var differences = IndexDefinitionCompareDifferences.None;
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -11,8 +11,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 {
     public class MapReduceIndexingContext : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MapReduceResultsStore>("MapReduceIndexingContext");
-
         internal static Slice LastMapResultIdKey;
 
         public FixedSizeTree DocumentMapEntries;
@@ -53,18 +51,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (MapPhaseTree.Llt.Environment.Options.IsCatastrophicFailureSet)
                 return; // avoid re-throwing it
 
-            try
-            {
-                using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
-                    *(long*)ptr = NextMapResultId;
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info("Failed to store next map result id", e);
-
-                throw;
-            }
+            using (MapPhaseTree.DirectAdd(LastMapResultIdKey, sizeof(long), out byte* ptr))
+                *(long*)ptr = NextMapResultId;
         }
 
         public unsafe void Initialize(Tree mapEntriesTree)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceMapResultsBase.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _indexStorage = indexStorage;
             _metrics = metrics;
             _mapReduceContext = mapReduceContext;
-            _logger = LoggingSource.Instance.GetLogger<ReduceMapResultsBase<T>>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         static ReduceMapResultsBase()
@@ -154,7 +154,17 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
 
             WriteLastEtags(indexContext);
-            _mapReduceContext.StoreNextMapResultId();
+            try
+            {
+                _mapReduceContext.StoreNextMapResultId();
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info("Failed to store next map result id", e);
+                throw;
+            }
+            
 
             return (false, Index.CanContinueBatchResult.None);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
         protected override void OnInitialization()
         {
             base.OnInitialization();
-
+            _compiled.Log = Logger;
             if (string.IsNullOrWhiteSpace(Definition.OutputReduceToCollection) == false)
             {
                 OutputReduceToCollection = new OutputReduceToCollectionActions(this);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -23,7 +23,7 @@ public class CoraxIndexPersistence : IndexPersistenceBase
 
     public CoraxIndexPersistence(Index index) : base(index)
     {
-        _logger = LoggingSource.Instance.GetLogger<CoraxIndexPersistence>(index.DocumentDatabase.Name);
+        _logger = index.Logger;
         bool storeValue = false;
         switch (index.Type)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             QueryBuilderFactories queryBuilderFactories,
             Transaction readTransaction,
             DocumentDatabase documentDatabase)
-            : base(index, queryBuilderFactories, LoggingSource.Instance.GetLogger<LuceneIndexFacetedReadOperation>(documentDatabase.Name))
+            : base(index, queryBuilderFactories, index.Logger)
         {
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         public LuceneIndexPersistence(Index index) : base(index)
         {
-            _logger = LoggingSource.Instance.GetLogger<LuceneIndexPersistence>(index.DocumentDatabase.Name);
+            _logger = index.Logger;
             _suggestionsDirectories = new Dictionary<string, LuceneVoronDirectory>();
             _suggestionsIndexSearcherHolders = new Dictionary<string, LuceneIndexSearcherHolder>();
             _disposeOnce = new DisposeOnce<SingleAttempt>(() =>
@@ -139,7 +139,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
             _fields = fields.ToDictionary(x => x.Name, x => x);
 
-            _luceneIndexSearcherHolder = new LuceneIndexSearcherHolder(CreateIndexSearcher, _index._indexStorage.DocumentDatabase);
+            _luceneIndexSearcherHolder = new LuceneIndexSearcherHolder(CreateIndexSearcher, _index._indexStorage.DocumentDatabase, _index.Logger);
 
             foreach (var field in _fields)
             {
@@ -147,7 +147,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     continue;
 
                 string fieldName = field.Key;
-                _suggestionsIndexSearcherHolders[fieldName] = new LuceneIndexSearcherHolder(state => new IndexSearcher(_suggestionsDirectories[fieldName], true, state), _index._indexStorage.DocumentDatabase);
+                _suggestionsIndexSearcherHolders[fieldName] = new LuceneIndexSearcherHolder(state => new IndexSearcher(_suggestionsDirectories[fieldName], true, state), _index._indexStorage.DocumentDatabase, _index.Logger);
             }
 
             IndexSearcher CreateIndexSearcher(IState state)
@@ -518,7 +518,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     var snapshotter = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
                     var writer = new LuceneSuggestionIndexWriter(field, _suggestionsDirectories[field],
                                         snapshotter, IndexWriter.MaxFieldLength.UNLIMITED,
-                        _index, state);
+                        _index, state, _logger);
 
                     _suggestionsIndexWriters[field] = writer;
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         }
 
         public LuceneIndexReadOperation(Index index, LuceneVoronDirectory directory, LuceneIndexSearcherHolder searcherHolder, QueryBuilderFactories queryBuilderFactories, Transaction readTransaction, IndexQueryServerSide query)
-            : base(index, LoggingSource.Instance.GetLogger<LuceneIndexReadOperation>(index._indexStorage.DocumentDatabase.Name), queryBuilderFactories, query)
+            : base(index, index.Logger, queryBuilderFactories, query)
         {
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexSearcherHolder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexSearcherHolder.cs
@@ -20,16 +20,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly Logger _logger;
         private ImmutableList<IndexSearcherHoldingState> _states = ImmutableList<IndexSearcherHoldingState>.Empty;
 
-        public LuceneIndexSearcherHolder(Func<IState, IndexSearcher> recreateSearcher, DocumentDatabase documentDatabase)
+        public LuceneIndexSearcherHolder(Func<IState, IndexSearcher> recreateSearcher, DocumentDatabase documentDatabase, Logger logger)
         {
             _recreateSearcher = recreateSearcher;
             _documentDatabase = documentDatabase;
-            _logger = LoggingSource.Instance.GetLogger<LuceneIndexSearcherHolder>(documentDatabase.Name);
+            _logger = logger;
         }
 
         public void SetIndexSearcher(Transaction asOfTx)
         {
-            var state = new IndexSearcherHoldingState(asOfTx, _recreateSearcher, _documentDatabase.Name);
+            var state = new IndexSearcherHoldingState(asOfTx, _recreateSearcher, _logger);
 
             _states = _states.Insert(0, state);
 
@@ -135,10 +135,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             public int Usage;
             public readonly long AsOfTxId;
 
-            public IndexSearcherHoldingState(Transaction tx, Func<IState, IndexSearcher> recreateSearcher, string dbName)
+            public IndexSearcherHoldingState(Transaction tx, Func<IState, IndexSearcher> recreateSearcher, Logger logger)
             {
                 _recreateSearcher = recreateSearcher;
-                _logger = LoggingSource.Instance.GetLogger<LuceneIndexSearcherHolder>(dbName);
+                _logger = logger;
                 AsOfTxId = tx.LowLevelTransaction.Id;
                 _lazyIndexSearcher = new Lazy<IndexSearcher>(() =>
                 {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -38,9 +38,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly IState _state;
         private readonly LuceneVoronDirectory _directory;
 
-
+        
         public LuceneIndexWriteOperation(Index index, LuceneVoronDirectory directory, LuceneDocumentConverterBase converter, Transaction writeTransaction, LuceneIndexPersistence persistence)
-            : base(index, LoggingSource.Instance.GetLogger<LuceneIndexWriteOperation>(index._indexStorage.DocumentDatabase.Name))
+            : base(index, index.Logger)
         {
             _converter = converter;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _indexReaderWarmer = indexReaderWarmer;
             _index = index;
 
-            _logger = LoggingSource.Instance.GetLogger<LuceneIndexWriter>(index.DocumentDatabase.Name);
+            _logger = index.Logger;
             RecreateIndexWriter(state);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         private readonly IState _state;
 
         public LuceneSuggestionIndexReader(Index index, LuceneVoronDirectory directory, LuceneIndexSearcherHolder searcherHolder, Transaction readTransaction)
-            : base(index, LoggingSource.Instance.GetLogger<LuceneSuggestionIndexReader>(index._indexStorage.DocumentDatabase.Name))
+            : base(index, index.Logger)
         {
             _releaseReadTransaction = directory.SetTransaction(readTransaction, out _state);
             _releaseSearcher = searcherHolder.GetSearcher(readTransaction, _state, out _searcher);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexWriter.cs
@@ -37,14 +37,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         public Analyzer Analyzer => _indexWriter?.Analyzer;
 
-        public LuceneSuggestionIndexWriter(string field, LuceneVoronDirectory directory, SnapshotDeletionPolicy snapshotter, IndexWriter.MaxFieldLength maxFieldLength, Index index, IState state)
+        public LuceneSuggestionIndexWriter(string field, LuceneVoronDirectory directory, SnapshotDeletionPolicy snapshotter, IndexWriter.MaxFieldLength maxFieldLength, Index index, IState state, Logger logger)
         {
             _directory = directory;
             _indexDeletionPolicy = snapshotter;
             _maxFieldLength = maxFieldLength;
             _index = index;
             _field = field;
-            _logger = LoggingSource.Instance.GetLogger<LuceneSuggestionIndexWriter>(_index.DocumentDatabase.Name);
+            _logger = logger;
 
             RecreateIndexWriter(state);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -55,6 +55,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             return new CountersQueryResultRetriever(DocumentDatabase, query, queryTimings, DocumentDatabase.DocumentsStorage, documentsContext, searchEngineType, fieldsToFetch, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand);
         }
 
+        protected override void OnInitialization()
+        {
+            base.OnInitialization();
+            _compiled.Log = Logger;
+        }
+
         protected override void SubscribeToChanges(DocumentDatabase documentDatabase)
         {
             base.SubscribeToChanges(documentDatabase);

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -124,6 +124,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             }
         }
 
+        protected override void OnInitialization()
+        {
+            base.OnInitialization();
+            _compiled.Log = Logger;
+        }
+
         private void HandleCounterChange(CounterChange change)
         {
             if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false)

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents.Indexes.Static
     [SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalse")]
     public static class IndexCompiler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(IndexCompiler).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(IndexCompiler));
 
         internal static readonly bool EnableDebugging = false; // for debugging purposes (mind https://issues.hibernatingrhinos.com/issue/RavenDB-6960)
 

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -167,6 +167,12 @@ namespace Raven.Server.Documents.Indexes.Static
             return new StaticIndexItemEnumerator<DynamicBlittableJson>(items, filter: null, _compiled.Maps[collection], collection, stats, type);
         }
 
+        protected override void OnInitialization()
+        {
+            base.OnInitialization();
+            _compiled.Log = Logger;
+        }
+
         public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)

--- a/src/Raven.Server/Documents/Indexes/Static/NuGet/ProjectContext.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/NuGet/ProjectContext.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Indexes.Static.NuGet
 {
     public class ProjectContext : INuGetProjectContext
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServer>("NuGet");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenServer>();
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -182,8 +182,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public readonly HashSet<string> CollectionsWithCompareExchangeReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        protected static Logger Log = LoggingSource.Instance.GetLogger<AbstractStaticIndexBase>("Server");
-
+        public Logger Log = LoggingSource.Instance.LoggersHolder.Generic;
         
         public int StackSizeInSelectClause { get; set; }
         

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -147,6 +147,12 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             }
         }
 
+        protected override void OnInitialization()
+        {
+            base.OnInitialization();
+            _compiled.Log = Logger;
+        }
+
         private void HandleTimeSeriesChange(TimeSeriesChange change)
         {
             if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false)

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -226,6 +226,12 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             return null;
         }
 
+        protected override void OnInitialization()
+        {
+            base.OnInitialization();
+            _compiled.Log = Logger;
+        }
+
         public static Index CreateNew(IndexDefinition definition, DocumentDatabase documentDatabase)
         {
             var instance = CreateIndexInstance(definition, documentDatabase.Configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);

--- a/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CleanupDocuments.cs
@@ -30,8 +30,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             _mapReduceContext = mapReduceContext;
             _documentsStorage = documentsStorage;
             _indexStorage = indexStorage;
-            _logger = LoggingSource.Instance
-                .GetLogger<CleanupDocuments>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         public string Name => "Cleanup";

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -28,8 +28,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             _mapReduceContext = mapReduceContext;
             _configuration = configuration;
             _indexStorage = indexStorage;
-            _logger = LoggingSource.Instance
-                .GetLogger<MapDocuments>(indexStorage.DocumentDatabase.Name);
+            _logger = _index.Logger;
         }
 
         public string Name => "Map";

--- a/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
+++ b/src/Raven.Server/Documents/Patch/AdminJsConsole.cs
@@ -10,20 +10,19 @@ namespace Raven.Server.Documents.Patch
     public class AdminJsConsole
     {
         private readonly DocumentDatabase _database;
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<AdminJsConsole>("Server");
+        public readonly Logger Log;
         private readonly RavenServer _server;
 
         public AdminJsConsole(RavenServer server, DocumentDatabase database)
         {
             _server = server;
             _database = database;
+            Log = database != null ? database.Logger : server.Logger;
             if (Log.IsOperationsEnabled)
             {
-                if (database != null)
-                    Log.Operations($"AdminJSConsole : Preparing to execute database script for \"{database.Name}\"");
-                else
-                    Log.Operations("AdminJSConsole : Preparing to execute server script");
-
+                Log.Operations(database != null
+                    ? $"AdminJSConsole : Preparing to execute database script for \"{database.Name}\""
+                    : "AdminJSConsole : Preparing to execute server script");
             }
         }
 

--- a/src/Raven.Server/Documents/Patch/PatchConflict.cs
+++ b/src/Raven.Server/Documents/Patch/PatchConflict.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Patch
 
         public PatchConflict(DocumentDatabase database, IReadOnlyList<DocumentConflict> docs)
         {
-            _logger = LoggingSource.Instance.GetLogger<PatchConflict>(database.Name);
+            _logger = database.Logger;
             _database = database;
 
             foreach (var doc in docs)

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -139,7 +139,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new GlacierRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new GlacierRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new FtpRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new FtpRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -177,7 +177,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }
@@ -198,7 +198,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_retentionPolicyParameters == null)
                     return;
 
-                var runner = new GoogleCloudRetentionPolicyRunner(_retentionPolicyParameters, client);
+                var runner = new GoogleCloudRetentionPolicyRunner(_retentionPolicyParameters, client, _logger);
                 runner.Execute();
             }
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             _database = database;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<PeriodicBackupRunner>(_database.Name);
+            _logger = database.Logger;
             _auditLog = LoggingSource.AuditLog.GetLogger(_database.Name, "Audit");
             _cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
             _tempBackupPath = BackupUtils.GetBackupTempPath(_database.Configuration, "PeriodicBackupTemp", out _);
@@ -382,7 +382,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         Name = periodicBackup.Configuration.Name
                     };
 
-                    var backupTask = new BackupTask(_database, backupParameters, periodicBackup.Configuration, _logger, _forTestingPurposes);
+                    var backupTask = new BackupTask(_database, backupParameters, periodicBackup.Configuration, _forTestingPurposes);
                     periodicBackup.CancelToken = backupTask.TaskCancelToken;
 
                     periodicBackup.RunningTask = new PeriodicBackup.RunningBackupTask

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -477,7 +477,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     Index index = null;
                     try
                     {
-                        index = Index.Open(indexPath, database, generateNewDatabaseId: true, out _);
+                        index = Index.Open(indexPath, database, generateNewDatabaseId: true, searchEngineType: out _, database.IndexesLogger);
                     }
                     catch (Exception e)
                     {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -47,6 +47,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
     public abstract class RestoreBackupTaskBase
     {
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<RestoreBackupTaskBase>();
         private readonly Logger _logger;
 
         private readonly ServerStore _serverStore;
@@ -402,8 +403,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         // we failed to load the database after restore, we don't want to fail the entire restore process since it will delete the database if we throw here
                         result.AddError($"Failed to load the database after restore, {e}");
 
-                        if (Logger.IsOperationsEnabled)
-                            Logger.Operations($"Failed to load the database '{databaseName}' after restore", e);
+                        if (_logger.IsOperationsEnabled)
+                            _logger.Operations($"Failed to load the database '{databaseName}' after restore", e);
                     }
 
                     return result;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             OperationCancelToken operationCancelToken)
         {
             _serverStore = serverStore;
-            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(restoreFromConfiguration.DatabaseName);
+                
             RestoreFromConfiguration = restoreFromConfiguration;
             _nodeTag = nodeTag;
             _operationCancelToken = operationCancelToken;
@@ -75,6 +75,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             if (ResourceNameValidator.IsValidResourceName(RestoreFromConfiguration.DatabaseName, dataDirectoryThatWillBeUsed, out string errorMessage) == false)
                 throw new InvalidOperationException(errorMessage);
 
+            _logger = serverStore.Server.DatabasesLogger.GetSubSwitchLogger(restoreFromConfiguration.DatabaseName);
+            
             _serverStore.EnsureNotPassiveAsync().Wait(_operationCancelToken.Token);
 
             ClusterTopology clusterTopology;

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/AzureRetentionPolicyRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.Documents.PeriodicBackup.Restore;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -16,8 +17,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         private string _continuationToken = null;
 
-        public AzureRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, IRavenAzureClient client)
-            : base(parameters)
+        public AzureRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, IRavenAzureClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
     {
         private readonly RavenFtpClient _client;
 
-        protected override string Name => "Ftp";
+        protected override string Name => "Glacier";
 
         public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client, Logger logger)
             : base(parameters, logger)

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/FtpRetentionPolicyRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -7,10 +8,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
     {
         private readonly RavenFtpClient _client;
 
-        protected override string Name => "Glacier";
+        protected override string Name => "Ftp";
 
-        public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client)
-            : base(parameters)
+        public FtpRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenFtpClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/GlacierRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/GlacierRetentionPolicyRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -10,8 +11,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Glacier";
 
-        public GlacierRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsGlacierClient client)
-            : base(parameters)
+        public GlacierRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsGlacierClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/GoogleCloudRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/GoogleCloudRetentionPolicyRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
 {
@@ -10,8 +11,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Google Cloud";
 
-        public GoogleCloudRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenGoogleCloudClient client)
-            : base(parameters)
+        public GoogleCloudRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenGoogleCloudClient client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/LocalRetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/LocalRetentionPolicyRunner.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Voron.Util.Settings;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
@@ -14,8 +15,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         protected override string Name => "Local";
 
-        public LocalRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, string folderPath)
-            : base(parameters)
+        public LocalRetentionPolicyRunner(RetentionPolicyBaseParameters parameters, string folderPath, Logger logger)
+            : base(parameters, logger)
         {
             _folderPath = PathUtil.ToFullPath(folderPath);
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/S3RetentionPolicyRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/S3RetentionPolicyRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents.PeriodicBackup.Retention
@@ -17,8 +18,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
 
         private string _folderContinuationToken = null;
 
-        public S3RetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsS3Client client)
-            : base(parameters)
+        public S3RetentionPolicyRunner(RetentionPolicyBaseParameters parameters, RavenAwsS3Client client, Logger logger)
+            : base(parameters, logger)
         {
             _client = client;
         }

--- a/src/Raven.Server/Documents/Queries/GraphQueryOrderByFieldComparer.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryOrderByFieldComparer.cs
@@ -12,14 +12,14 @@ namespace Raven.Server.Documents.Queries
         private string _alias;
         private BlittablePath _path;
         private int _order;
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<GraphQueryOrderByFieldComparer>("GraphQueryOrderByFieldComparer");
+        private readonly Logger _logger;
         private readonly string _databaseName;
         private readonly string _query;
         private string _xId = Unknown;
         private string _yId = Unknown;
         private const string Unknown = "Unknown";
 
-        public GraphQueryOrderByFieldComparer(OrderByField field, string databaseName, string query)
+        public GraphQueryOrderByFieldComparer(OrderByField field, string databaseName, string query, Logger logger)
         {
             _databaseName = databaseName;
             _query = query;
@@ -30,6 +30,7 @@ namespace Raven.Server.Documents.Queries
             _alias = fieldName.Substring(0, indexOfDot);
             _path = new BlittablePath(fieldName.Substring(indexOfDot + 1, fieldName.Length - indexOfDot - 1));
             _field = field;
+            _logger = logger;
         }
 
 
@@ -266,9 +267,9 @@ namespace Raven.Server.Documents.Queries
 
         private int LogMissmatchTypesReturnOrder(object xResult, object yResult)
         {
-            if (Log.IsInfoEnabled)
+            if (_logger.IsInfoEnabled)
             {
-                Log.Info($"Database: {_databaseName} Graph Query: {_query} Document Ids:({_xId},{_yId}), Got unexpected types to compare: {xResult} of type {xResult.GetType().Name} and {yResult} of type {yResult.GetType().Name}, this may yield unexpected query ordering.");
+                _logger.Info($"Database: {_databaseName} Graph Query: {_query} Document Ids:({_xId},{_yId}), Got unexpected types to compare: {xResult} of type {xResult.GetType().Name} and {yResult} of type {yResult.GetType().Name}, this may yield unexpected query ordering.");
             }
 
             return _order;
@@ -279,12 +280,12 @@ namespace Raven.Server.Documents.Queries
     {
         private List<GraphQueryOrderByFieldComparer> _comparers;
 
-        public GraphQueryMultipleFieldsComparer(IEnumerable<OrderByField> fields, string databaseName, string query)
+        public GraphQueryMultipleFieldsComparer(IEnumerable<OrderByField> fields, string databaseName, string query, Logger logger)
         {
             _comparers = new List<GraphQueryOrderByFieldComparer>();
             foreach (var field in fields)
             {
-                _comparers.Add(new GraphQueryOrderByFieldComparer(field, databaseName, query));
+                _comparers.Add(new GraphQueryOrderByFieldComparer(field, databaseName, query, logger));
             }
         }
 

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -23,15 +23,18 @@ using Raven.Server.Utils.Features;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Queries
 {
     public partial class GraphQueryRunner : AbstractQueryRunner
     {
         private readonly HashSet<StringSegment> _mapReduceAliases = new HashSet<StringSegment>();
+        private readonly Logger _logger;
 
         public GraphQueryRunner(DocumentDatabase database) : base(database)
         {
+            _logger = database.Logger;
         }
 
         public class EdgeDebugInfo
@@ -217,12 +220,12 @@ namespace Raven.Server.Documents.Queries
         {
             if (orderBy.Length == 1)
             {
-                var orderByFieldSorter = new GraphQueryOrderByFieldComparer(orderBy.First(), databaseName, query);
+                var orderByFieldSorter = new GraphQueryOrderByFieldComparer(orderBy.First(), databaseName, query, _logger);
                 matches.Sort(orderByFieldSorter);
                 return;
             }
 
-            var orderByMltipleFieldsSorter = new GraphQueryMultipleFieldsComparer(orderBy, databaseName, query);
+            var orderByMltipleFieldsSorter = new GraphQueryMultipleFieldsComparer(orderBy, databaseName, query, _logger);
             matches.Sort(orderByMltipleFieldsSorter);
         }
 

--- a/src/Raven.Server/Documents/Queries/LiveRunningQueriesCollector.cs
+++ b/src/Raven.Server/Documents/Queries/LiveRunningQueriesCollector.cs
@@ -14,7 +14,8 @@ namespace Raven.Server.Documents.Queries
         private readonly HashSet<string> _dbNames;
 
         public LiveRunningQueriesCollector(ServerStore serverStore, HashSet<string> dbNames)
-            : base(serverStore.ServerShutdown, "Server")
+            : base(serverStore.ServerShutdown, 
+                serverStore.Server.Logger)
         {
             _dbNames = dbNames;
             _serverStore = serverStore;

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Replication
         {
             _conflictResolver = conflictResolver;
             _database = database;
-            _log = LoggingSource.Instance.GetLogger<ConflictManager>(_database.Name);
+            _log = database.Logger;
         }
 
         public unsafe void HandleConflictForDocument(

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.Documents.Replication
 
             CertificateThumbprint = options.Certificate?.Thumbprint;
 
-            _log = LoggingSource.Instance.GetLogger<IncomingReplicationHandler>(_database.Name);
+            _log = _database.Logger;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
 
             _conflictManager = new ConflictManager(_database, _parent.ConflictResolver);
@@ -1709,7 +1709,7 @@ namespace Raven.Server.Documents.Replication
                 ReplicatedItems = replicationItems,
                 ReplicatedAttachmentStreams = replicatedAttachmentStreams,
                 SupportedFeatures = SupportedFeatures,
-                Logger = LoggingSource.Instance.GetLogger<IncomingReplicationHandler>(database.Name)
+                Logger = database.Logger
             };
 
             return new IncomingReplicationHandler.MergedDocumentReplicationCommand(dataForReplicationCommand, LastEtag, Mode);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents.Replication
 
             Destination = node;
             ReplicationType = external ? ReplicationLatestEtagRequest.ReplicationType.External : ReplicationLatestEtagRequest.ReplicationType.Internal;
-            _log = LoggingSource.Instance.GetLogger<OutgoingReplicationHandler>(_database.Name);
+            _log = _database.Logger;
             _tcpConnectionOptions = tcpConnectionOptions ??
                                     new TcpConnectionOptions { DocumentDatabase = database, Operation = TcpConnectionHeaderMessage.OperationTypes.Replication };
             _connectionInfo = connectionInfo;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Documents.Replication
 
             var config = Database.Configuration.Replication;
             var reconnectTime = config.RetryReplicateAfter.AsTimeSpan;
-            _log = LoggingSource.Instance.GetLogger<ReplicationLoader>(Database.Name);
+            _log = database.Logger;
             _reconnectAttemptTimer = new Timer(state => ForceTryReconnectAll(),
                 null, reconnectTime, reconnectTime);
             MinimalHeartbeatInterval = (int)config.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
@@ -852,7 +852,7 @@ namespace Raven.Server.Documents.Replication
                 return;
 
             ConflictSolverConfig = record.ConflictSolverConfig;
-            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _log);
+            ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this);
             Task.Run(() => ConflictResolver.RunConflictResolversOnce(record.ConflictSolverConfig, index));
             _isInitialized.Raise();
         }

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -32,12 +32,12 @@ namespace Raven.Server.Documents.Replication
 
         internal Dictionary<string, ScriptResolver> ScriptConflictResolversCache = new Dictionary<string, ScriptResolver>();
 
-        public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader, Logger log)
+        public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader)
         {
             _replicationLoader = replicationLoader ??
                 throw new ArgumentNullException($"{nameof(ResolveConflictOnReplicationConfigurationChange)} must have replicationLoader instance");
             _database = _replicationLoader.Database;
-            _log = log;
+            _log = _database.Logger;
         }
 
         public long ConflictsCount => _database.DocumentsStorage?.ConflictsStorage?.ConflictsCount ?? 0;
@@ -547,8 +547,7 @@ namespace Raven.Server.Documents.Replication
         public ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
             var resolver = new ResolveConflictOnReplicationConfigurationChange(
-                database.ReplicationLoader,
-                LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name));
+                database.ReplicationLoader);
 
             return new ResolveConflictOnReplicationConfigurationChange.PutResolvedConflictsCommand(
                 database.DocumentsStorage.ConflictsStorage,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -97,7 +97,7 @@ namespace Raven.Server.Documents.Revisions
         {
             _database = database;
             _documentsStorage = _database.DocumentsStorage;
-            _logger = LoggingSource.Instance.GetLogger<RevisionsStorage>(database.Name);
+            _logger = database.Logger;
             Operations = new RevisionsOperations(_database);
             ConflictConfiguration = new RevisionsConfiguration
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionFetcher.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionFetcher.cs
@@ -8,11 +8,8 @@ namespace Raven.Server.Documents.Subscriptions
 {
     public abstract class SubscriptionFetcher<T> : SubscriptionFetcher
     {
-        protected Logger Logger;
-
         protected SubscriptionFetcher(DocumentDatabase database, SubscriptionConnectionsState subscriptionConnectionsState, string collection) : base(database, subscriptionConnectionsState, collection)
         {
-            Logger = LoggingSource.Instance.GetLogger<SubscriptionFetcher<T>>(Database.Name);
         }
 
         protected abstract IEnumerable<T> FetchByEtag();

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
         protected SubscriptionProcessor(ServerStore server, DocumentDatabase database, SubscriptionConnection connection) :
             base(server, database, connection)
         {
-            Logger = LoggingSource.Instance.GetLogger(Database.Name, connection == null ? $"{nameof(TestDocumentsSubscriptionProcessor)}" : $"{nameof(SubscriptionProcessor)}<{connection.Options.SubscriptionName}>");
+            Logger = database.Logger.GetLogger(connection == null ? $"{nameof(TestDocumentsSubscriptionProcessor)}" : $"{nameof(SubscriptionProcessor)}<{connection.Options.SubscriptionName}>");
         }
 
         protected abstract SubscriptionFetcher<T> CreateFetcher();

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -49,8 +49,7 @@ namespace Raven.Server.Documents.Subscriptions
         {
             _db = db;
             _serverStore = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<SubscriptionStorage>(db.Name);
-
+            _logger = db.Logger;
             _concurrentConnectionsSemiSemaphore = new SemaphoreSlim(db.Configuration.Subscriptions.MaxNumberOfConcurrentConnections);
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.TcpHandlers
                 if (string.IsNullOrEmpty(_options.SubscriptionName))
                     return;
                 
-                _logger = LoggingSource.Instance.GetLogger(TcpConnection.DocumentDatabase.Name, $"{nameof(SubscriptionConnection)}<{_options.SubscriptionName}>");
+                _logger = TcpConnection.DocumentDatabase.Logger.GetLogger($"{nameof(SubscriptionConnection)}<{_options.SubscriptionName}>");
                 context.OpenReadTransaction();
 
                 var subscriptionItemKey = SubscriptionState.GenerateSubscriptionItemKeyName(TcpConnection.DocumentDatabase.Name, _options.SubscriptionName);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
@@ -25,7 +25,8 @@ namespace Raven.Server.Documents.TimeSeries
 
         private readonly TimeSpan _checkFrequency;
 
-        public TimeSeriesPolicyRunner(DocumentDatabase database, TimeSeriesConfiguration configuration) : base(database.Name, database.DatabaseShutdown)
+        public TimeSeriesPolicyRunner(DocumentDatabase database, TimeSeriesConfiguration configuration)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             _database = database;
             Configuration = configuration;
@@ -79,7 +80,7 @@ namespace Raven.Server.Documents.TimeSeries
                         AlertType.RevisionsConfigurationNotValid, NotificationSeverity.Error, database.Name));
                 }
 
-                var logger = LoggingSource.Instance.GetLogger<TimeSeriesPolicyRunner>(database.Name);
+                var logger = database.Logger;
                 if (logger.IsOperationsEnabled)
                     logger.Operations(msg, e);
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -125,8 +125,8 @@ namespace Raven.Server.Documents.TimeSeries
             tx.CreateTree(DeletedRangesKey);
 
             Stats = new TimeSeriesStats(this, tx);
+            _logger = documentDatabase.Logger;
             Rollups = new TimeSeriesRollups(_documentDatabase);
-            _logger = LoggingSource.Instance.GetLogger<TimeSeriesStorage>(documentDatabase.Name);
         }
 
         public long PurgeSegmentsAndDeletedRanges(DocumentsOperationContext context, string collection, long upto, long numberOfEntriesToDelete)

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents
         private readonly HashSet<ITombstoneAware> _subscriptions = new HashSet<ITombstoneAware>();
         private long? _maxTombstoneEtagToDelete;
 
-        public TombstoneCleaner(DocumentDatabase documentDatabase) : base(documentDatabase.Name, documentDatabase.DatabaseShutdown)
+        public TombstoneCleaner(DocumentDatabase documentDatabase) : base(documentDatabase.Logger, documentDatabase.DatabaseShutdown)
         {
             _documentDatabase = documentDatabase;
             _numberOfTombstonesToDeleteInBatch = _documentDatabase.Is32Bits
@@ -420,7 +420,7 @@ namespace Raven.Server.Documents
 
         public TombstoneCleaner.DeleteTombstonesCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var log = LoggingSource.Instance.GetLogger<TombstoneCleaner.DeleteTombstonesCommand>(database.Name);
+            var log = database.Logger;
             var command = new TombstoneCleaner.DeleteTombstonesCommand(Tombstones, MinAllDocsEtag, MinAllTimeSeriesEtag, MinAllCountersEtag, NumberOfTombstonesToDeleteInBatch ?? long.MaxValue, database, log);
             return command;
         }

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents
         public TransactionOperationsMerger(DocumentDatabase parent, CancellationToken shutdown)
         {
             _parent = parent;
-            _log = LoggingSource.Instance.GetLogger<TransactionOperationsMerger>(_parent.Name);
+            _log = parent.Logger;
             _shutdown = shutdown;
 
             _maxTimeToWaitForPreviousTxInMs = _parent.Configuration.TransactionMergerConfiguration.MaxTimeToWaitForPreviousTx.AsTimeSpan.TotalMilliseconds;

--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -202,7 +202,7 @@ namespace Raven.Server.Indexing
             if (state == null)
                 throw new ArgumentNullException(nameof(s));
             
-            return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
+            return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary, _environment.Logger);
         }
 
         public IDisposable SetTransaction(Transaction tx, out IState state)

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Indexing
 {
     public class VoronIndexOutput : BufferedIndexOutput
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<LuceneVoronDirectory>("VoronIndexOutput");
+        private readonly Logger _logger;
 
         private readonly TempFileCache _fileCache;
         private readonly string _name;
@@ -24,13 +24,14 @@ namespace Raven.Server.Indexing
 
         private Stream StreamToUse => _ms ?? _file;
 
-        public VoronIndexOutput(
-            TempFileCache fileCache,
+        public VoronIndexOutput(TempFileCache fileCache,
             string name,
             Transaction tx,
             string tree,
-            IndexOutputFilesSummary indexOutputFilesSummary)
+            IndexOutputFilesSummary indexOutputFilesSummary, 
+            Logger logger)
         {
+            _logger = logger;
             _fileCache = fileCache;
             _name = name;
             _tree = tree;
@@ -151,8 +152,8 @@ namespace Raven.Server.Indexing
             }
             catch (Exception e)
             {
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations($"Failed to copy the file: {_name}", e);
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"Failed to copy the file: {_name}", e);
 
                 _indexOutputFilesSummary.SetWriteError();
 

--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -15,8 +15,6 @@ namespace Raven.Server.Integrations.PostgreSQL
 {
     public abstract class PgQuery : IDisposable
     {
-        private static Logger _log = LoggingSource.Instance.GetLogger<PgQuery>("Postgres Server");
-
         protected readonly string QueryString;
         public readonly int[] ParametersDataTypes;
         protected readonly bool IsEmptyQuery;
@@ -63,8 +61,8 @@ namespace Raven.Server.Integrations.PostgreSQL
             }
             catch (Exception e)
             {
-                if (_log.IsInfoEnabled)
-                    _log.Info($"Failed to create instance of {nameof(PgQuery)}:{Environment.NewLine}{queryText}", e);
+                if (documentDatabase.Logger.IsInfoEnabled)
+                    documentDatabase.Logger.Info($"Failed to create instance of {nameof(PgQuery)}:{Environment.NewLine}{queryText}", e);
 
                 throw;
             }

--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 {
     public class PgServer : IDisposable
     {
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<PgServer>("Postgres Server");
+        private readonly Logger _logger; 
 
         private readonly RavenServer _server;
         private readonly ConcurrentDictionary<TcpClient, Task> _connections = new();
@@ -32,6 +32,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         public PgServer(RavenServer server)
         {
             _server = server;
+            _logger = server.Logger.GetLogger<PgServer>();
             _processId = Process.GetCurrentProcess().Id;
             _port = _server.Configuration.Integrations.PostgreSql.Port;
 
@@ -136,6 +137,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                     identifier,
                     _processId,
                     _server.ServerStore.DatabasesLandlord,
+                    _logger,
                     _cts.Token);
 
                 await session.Run();

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -29,12 +29,12 @@ namespace Raven.Server.Integrations.PostgreSQL
         private List<Document> _result;
         private readonly int? _limit;
         private bool _queryWasRun;
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<PgSession>("Postgres RqlQuery");
+        private readonly Logger _logger;
 
         ~RqlQuery()
         {
-            if(Logger.IsOperationsEnabled)
-                Logger.Operations($"Query '{QueryString}' wasn't disposed properly.{Environment.NewLine}" +
+            if(_logger.IsOperationsEnabled)
+                _logger.Operations($"Query '{QueryString}' wasn't disposed properly.{Environment.NewLine}" +
                                 $"Query was run: {_queryWasRun}{Environment.NewLine}" +
                                 $"Are transactions still opened: {_queryOperationContext.AreTransactionsOpened()}{Environment.NewLine}");
             Dispose();
@@ -43,7 +43,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         public RqlQuery(string queryString, int[] parametersDataTypes, DocumentDatabase documentDatabase, int? limit = null) : base(queryString, parametersDataTypes)
         {
             DocumentDatabase = documentDatabase;
-
+            _logger = documentDatabase.Logger.GetLogger<RqlQuery>();
             _result = null;
             _limit = limit;
         }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -220,6 +220,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, PeriodicBackupConfiguration> GetPeriodicBackupConfiguration = GenerateJsonDeserializationRoutine<PeriodicBackupConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, AdminLogsHandler.SwitchLoggerConfiguration> SwitchLoggerConfiguration = GenerateJsonDeserializationRoutine<AdminLogsHandler.SwitchLoggerConfiguration>();
+
         public class Parameters
         {
             private Parameters()

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
         private Stats _latest;
 
         public DatabaseStatsSender(DocumentDatabase database, NotificationCenter notificationCenter)
-            : base(database.Name, database.DatabaseShutdown)
+            : base(database.Logger, database.DatabaseShutdown)
         {
             _database = database;
             _notificationCenter = notificationCenter;

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/PostponedNotificationsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/PostponedNotificationsSender.cs
@@ -6,6 +6,7 @@ using Raven.Client.Util;
 using Raven.Server.Background;
 using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Collections;
+using Sparrow.Logging;
 using Sparrow.Server;
 
 namespace Raven.Server.NotificationCenter.BackgroundWork
@@ -16,9 +17,9 @@ namespace Raven.Server.NotificationCenter.BackgroundWork
         private readonly ConcurrentSet<ConnectedWatcher> _watchers;
         private AsyncManualResetEvent _event;
 
-        public PostponedNotificationsSender(string resourceName, NotificationsStorage notificationsStorage,
-            ConcurrentSet<ConnectedWatcher> watchers, CancellationToken shutdown)
-            : base(resourceName, shutdown)
+        public PostponedNotificationsSender(NotificationsStorage notificationsStorage,
+            ConcurrentSet<ConnectedWatcher> watchers, Logger logger, CancellationToken shutdown)
+            : base(logger, shutdown)
         {
             _notificationsStorage = notificationsStorage;
             _watchers = watchers;

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardConnection.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.NotificationCenter.Handlers
     {
         private const int WelcomeMessageId = -1;
         
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ClusterDashboardConnection>(nameof(ClusterDashboardConnection));
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ClusterDashboardConnection>();
 
         private readonly CanAccessDatabase _canAccessDatabase;
         private readonly ClusterDashboardNotifications _clusterDashboardNotifications;

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
@@ -25,8 +25,6 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ClusterDashboardHandler : ServerNotificationHandlerBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ClusterDashboardHandler>("Server");
-
         [RavenAction("/cluster-dashboard/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task Watch()
         {

--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ProxyWebSocketConnection : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ProxyWebSocketConnection>(nameof(ProxyWebSocketConnection));
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ProxyWebSocketConnection>();
 
         private readonly CancellationTokenSource _cts;
         private readonly Uri _remoteWebSocketUri;

--- a/src/Raven.Server/NotificationCenter/Handlers/ServerDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ServerDashboardHandler.cs
@@ -11,8 +11,6 @@ namespace Raven.Server.NotificationCenter.Handlers
 {
     public class ServerDashboardHandler : ServerNotificationHandlerBase
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ServerDashboardHandler>("Server");
-
         [RavenAction("/server-dashboard/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task Get()
         {

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void AddWarning(string indexName, WarnIndexOutputsPerDocument.WarningDetails indexOutputsWarning)

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.NotificationCenter
 
         private static readonly Slice ByPostponedUntil;
 
-        protected readonly Logger Logger;
+        private readonly Logger _logger;
 
         private StorageEnvironment _environment;
 
@@ -40,9 +40,9 @@ namespace Raven.Server.NotificationCenter
             }
         }
 
-        public NotificationsStorage(string resourceName)
+        public NotificationsStorage(Logger logger)
         {
-            Logger = LoggingSource.Instance.GetLogger<NotificationsStorage>(resourceName);
+            _logger = logger;
 
             _actionsSchema.DefineKey(new TableSchema.SchemaIndexDef
             {
@@ -101,8 +101,8 @@ namespace Raven.Server.NotificationCenter
                     }
                 }
 
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Saving notification '{notification.Id}'.");
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Saving notification '{notification.Id}'.");
 
                 using (var json = context.ReadObject(notification.ToJson(), "notification", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 using (var tx = context.OpenWriteTransaction())
@@ -242,8 +242,8 @@ namespace Raven.Server.NotificationCenter
                 }
             }
 
-            if (deleteResult && Logger.IsInfoEnabled)
-                Logger.Info($"Deleted notification '{id}'.");
+            if (deleteResult && _logger.IsInfoEnabled)
+                _logger.Info($"Deleted notification '{id}'.");
 
             return deleteResult;
 

--- a/src/Raven.Server/NotificationCenter/Paging.cs
+++ b/src/Raven.Server/NotificationCenter/Paging.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void Add(PagingOperationType operation, string action, string details, long numberOfResults, int pageSize, long duration, long totalDocumentsSizeInBytes)

--- a/src/Raven.Server/NotificationCenter/RequestLatency.cs
+++ b/src/Raven.Server/NotificationCenter/RequestLatency.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter = notificationCenter;
             _notificationsStorage = notificationsStorage;
             _database = database;
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void AddHint(long duration, string action, string query)

--- a/src/Raven.Server/NotificationCenter/SlowWriteNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/SlowWriteNotifications.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.NotificationCenter
             _notificationsStorage = notificationsStorage;
             _database = database;
             _slowWrites = new ConcurrentDictionary<string, SlowIoDetails.SlowWriteInfo>();
-            _logger = LoggingSource.Instance.GetLogger(database, GetType().FullName);
+            _logger = notificationCenter.Logger;
         }
 
         public void Add(IoChange ioChange)

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -33,8 +33,8 @@ namespace Raven.Server
 {
     public class Program
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<Program>("Server");
-        
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<Program>();
+
         public static unsafe int Main(string[] args)
         {
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -158,7 +158,7 @@ namespace Raven.Server.Rachis
 
                         Stopwatch sp;
                         _connection?.Dispose();
-                        _connection = new RemoteConnection(_tag, _engine.Tag, _candidate.ElectionTerm, stream, features, disconnect);
+                        _connection = new RemoteConnection(_tag, _engine.Tag, _candidate.ElectionTerm, stream, features, disconnect, _engine.ClusterLogger);
 
                         using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                         {

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -189,7 +189,7 @@ namespace Raven.Server.Rachis
                                     var connection = connectTask.Result;
                                     var stream = connection.Stream;
                                     var disconnect = connection.Disconnect;
-                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, connection.SupportedFeatures.Cluster, disconnect);
+                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, connection.SupportedFeatures.Cluster, disconnect, _engine.ClusterLogger);
                                     Interlocked.Exchange(ref _connection, con);
                                     
                                     ClusterTopology topology;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -320,6 +320,7 @@ namespace Raven.Server.Rachis
 
         public ClusterContextPool ContextPool { get; private set; }
         private StorageEnvironment _persistentState;
+        internal SwitchLogger ClusterLogger;
         internal Logger Log;
 
         private readonly ConcurrentQueue<Elector> _electors = new ConcurrentQueue<Elector>();
@@ -452,6 +453,7 @@ namespace Raven.Server.Rachis
 
                     RequestSnapshot = GetSnapshotRequest(context);
 
+                    ClusterLogger = clusterLogger;
                     Log = clusterLogger.GetLogger(_tag);
                     LogsTable.Create(tx.InnerTransaction, EntriesSlice, 16);
 
@@ -479,7 +481,7 @@ namespace Raven.Server.Rachis
                     tx.Commit();
                 }
 
-                Timeout = new TimeoutEvent(0, "Consensus");
+                Timeout = new TimeoutEvent(0, "Consensus", Log);
                 RandomizeTimeout();
 
                 // if we don't have a topology id, then we are passive

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -427,7 +427,7 @@ namespace Raven.Server.Rachis
             Timeout.TimeoutPeriod = _rand.Next(timeout / 3 * 2, timeout);
         }
 
-        public unsafe void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, out long clusterTopologyEtag)
+        public unsafe void Initialize(StorageEnvironment env, RavenConfiguration configuration, ClusterChanges changes, string myUrl, out long clusterTopologyEtag, SwitchLogger clusterLogger)
         {
             try
             {
@@ -452,7 +452,7 @@ namespace Raven.Server.Rachis
 
                     RequestSnapshot = GetSnapshotRequest(context);
 
-                    Log = LoggingSource.Instance.GetLogger<RachisConsensus>(_tag);
+                    Log = clusterLogger.GetLogger(_tag);
                     LogsTable.Create(tx.InnerTransaction, EntriesSlice, 16);
 
                     CurrentTerm = ReadTerm(context);

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Rachis.Remote
             _context = JsonOperationContext.ShortTermSingleUse();
             _releaseBuffer = _context.GetMemoryBuffer(out _buffer);
             _disposeOnce = new DisposeOnce<SingleAttempt>(DisposeInternal);
-            _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{src} > {dest}");
+            _log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger($"{src} > {dest}");
             RegisterConnection(dest, term, caller);
         }
 
@@ -433,7 +433,7 @@ namespace Raven.Server.Rachis.Remote
                 var rachisHello = JsonDeserializationRachis<RachisHello>.Deserialize(json);
                 _src = rachisHello.DebugSourceIdentifier ?? "unknown";
                 _destTag = rachisHello.DebugDestinationIdentifier ?? _destTag;
-                _log = LoggingSource.Instance.GetLogger<RemoteConnection>($"{_src} > {_destTag}");
+                _log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger($"{_src} > {_destTag}");
                 _info.Destination = _destTag;
 
                 return rachisHello;

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -36,12 +36,14 @@ namespace Raven.Server.Rachis.Remote
         public string Dest => _destTag;
         public TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures Features => _features;
 
-        public RemoteConnection(string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
-            : this(dest: "?", src, term, stream,features, disconnect, caller)
+        public RemoteConnection(string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect,
+            SwitchLogger clusterLogger, [CallerMemberName] string caller = null)
+            : this(dest: "?", src, term, stream,features, disconnect, clusterLogger, caller)
         {
         }
 
-        public RemoteConnection(string dest, string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
+        public RemoteConnection(string dest, string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features,
+            Action disconnect, SwitchLogger clusterLogger, [CallerMemberName] string caller = null)
         {
             _destTag = dest;
             _src = src;
@@ -51,7 +53,7 @@ namespace Raven.Server.Rachis.Remote
             _context = JsonOperationContext.ShortTermSingleUse();
             _releaseBuffer = _context.GetMemoryBuffer(out _buffer);
             _disposeOnce = new DisposeOnce<SingleAttempt>(DisposeInternal);
-            _log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger($"{src} > {dest}");
+            _log = clusterLogger.GetLogger($"{src} > {dest}");
             RegisterConnection(dest, term, caller);
         }
 

--- a/src/Raven.Server/Rachis/TimeoutEvent.cs
+++ b/src/Raven.Server/Rachis/TimeoutEvent.cs
@@ -29,14 +29,14 @@ namespace Raven.Server.Rachis
             LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
         }
 
-        public TimeoutEvent(int timeoutPeriod, string name, Logger logger = null) :
+        public TimeoutEvent(int timeoutPeriod, string name, Logger logger) :
             this(timeoutPeriod, name, true, logger)
         {
             
         }
 
 
-        public TimeoutEvent(TimeSpan timeoutPeriod, string name, bool singleShot = true, Logger logger = null) :
+        public TimeoutEvent(TimeSpan timeoutPeriod, string name, bool singleShot, Logger logger) :
             this((int)timeoutPeriod.TotalMilliseconds, name, singleShot, logger)
         {
         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -76,10 +76,12 @@ namespace Raven.Server
         static RavenServer()
         {
             DebugStuff.Attach();
-            UnhandledExceptions.Track(Logger);
+            UnhandledExceptions.Track(LoggingSource.Instance.LoggersHolder.Generic);
         }
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServer>("Server");
+        public readonly SwitchLogger Logger = new SwitchLogger(LoggingSource.Instance, "Server");
+        public readonly SwitchLogger DatabasesLogger;
+        public readonly SwitchLogger ClusterLogger;
         private readonly Logger _authAuditLog = LoggingSource.AuditLog.GetLogger("AuthenticateCertificate", "Audit");
         internal TestingStuff _forTestingPurposes;
 
@@ -125,6 +127,9 @@ namespace Raven.Server
 
         public RavenServer(RavenConfiguration configuration)
         {
+            DatabasesLogger = Logger.GetSubSwitchLogger("Databases");
+            ClusterLogger = Logger.GetSubSwitchLogger("Cluster");
+            
             JsonDeserializationValidator.Validate();
 
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -142,7 +147,7 @@ namespace Raven.Server
             Metrics = new MetricCounters();
             MetricCacher = new ServerMetricCacher(this);
 
-            _tcpLogger = LoggingSource.Instance.GetLogger<RavenServer>("Server/TCP");
+            _tcpLogger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger("Server/TCP");
             _externalCertificateValidator = new ExternalCertificateValidator(this, Logger);
             _tcpContextPool = new JsonContextPool(Configuration.Memory.MaxContextSizeToKeep);
         }

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -45,7 +45,7 @@ namespace Raven.Server
         private RequestRouter _router;
         private RavenServer _server;
         private long _requestId;
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenServerStartup>();
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
@@ -221,9 +221,9 @@ namespace Raven.Server
                 }
                 catch (Exception internalException)
                 {
-                    if (_logger.IsOperationsEnabled)
+                    if (Logger.IsOperationsEnabled)
                     {
-                        _logger.Operations($"Error during error handling of a failed request. Original error: {e}", internalException);
+                        Logger.Operations($"Error during error handling of a failed request. Original error: {e}", internalException);
                     }
 
                     throw;
@@ -245,9 +245,9 @@ namespace Raven.Server
                     requestHandlerContext.Database?.Metrics.Requests.UpdateDuration(requestDuration);
                 }
 
-                if (_logger.IsInfoEnabled && SkipHttpLogging == false)
+                if (Logger.IsInfoEnabled && SkipHttpLogging == false)
                 {
-                    _logger.Info($"{context.Request.Method} {context.Request.Path.Value}{context.Request.QueryString.Value} - {context.Response.StatusCode} - {(sp?.ElapsedMilliseconds ?? 0):#,#;;0} ms", exception);
+                    Logger.Info($"{context.Request.Method} {context.Request.Path.Value}{context.Request.QueryString.Value} - {context.Response.StatusCode} - {(sp?.ElapsedMilliseconds ?? 0):#,#;;0} ms", exception);
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
+++ b/src/Raven.Server/ServerWide/BackgroundTasks/LatestVersionCheck.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.ServerWide.BackgroundTasks
     {
         private const string ApiRavenDbNet = "https://api.ravendb.net";
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(LatestVersionCheck).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(typeof(LatestVersionCheck).FullName);
 
         public static LatestVersionCheck Instance = new LatestVersionCheck();
 

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.ServerWide
         public static int CurrentClusterMinimalVersion => _currentClusterMinimalVersion;
         private static int _currentClusterMinimalVersion;
 
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger(typeof(ClusterCommandsVersionManager).FullName, typeof(ClusterCommandsVersionManager).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(ClusterCommandsVersionManager));
 
         public static readonly IReadOnlyDictionary<string, int> ClusterCommandsVersions = new Dictionary<string, int>
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -286,7 +286,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForParsing))
                         using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForBuffer))
                         using (contextForBuffer.GetMemoryBuffer(out var readBuffer))
-                        using (var timeoutEvent = new TimeoutEvent(receiveFromWorkerTimeout, $"Timeout event for: {_name}", singleShot: false))
+                        using (var timeoutEvent = new TimeoutEvent(receiveFromWorkerTimeout, $"Timeout event for: {_name}", false, _log))
                         {
                             timeoutEvent.Start(OnTimeout);
                             var unchangedReports = new List<DatabaseStatusReport>();

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -206,7 +206,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 _token = _cts.Token;
                 _readStatusUpdateDebugString = $"ClusterMaintenanceServer/{ClusterTag}/UpdateState/Read-Response in term {term}";
                 _name = $"Heartbeats supervisor from {_parent._server.NodeTag} to {ClusterTag} in term {term}";
-                _log = LoggingSource.Instance.GetLogger<ClusterNode>(_name);
+                _log = _parent._server.Server.ClusterLogger;
                 _term = term;
             }
 
@@ -230,7 +230,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     {
                         if (_log.IsInfoEnabled)
                         {
-                            _log.Info($"Exception occurred while collecting info from {ClusterTag}. Task is closed.", e);
+                            _log.Info($"{_name}: Exception occurred while collecting info from {ClusterTag}. Task is closed.", e);
                         }
                         // we don't want to crash the process so we don't propagate this exception.
                     }
@@ -249,7 +249,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     if (_log.IsInfoEnabled)
                     {
                         _log.Info(
-                            $"Warning: TCP timeout is lower than the receive from worker timeout ({tcpTimeout} < {receiveFromWorkerTimeout}), " +
+                            $"{_name}: Warning: TCP timeout is lower than the receive from worker timeout ({tcpTimeout} < {receiveFromWorkerTimeout}), " +
                             "this could affect the cluster observer's decisions.");
                     }
                 }
@@ -312,7 +312,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                                     if (_log.IsInfoEnabled)
                                     {
-                                        _log.Info("Exception occurred while reading the report from the connection", e);
+                                        _log.Info($"{_name}: Exception occurred while reading the report from the connection", e);
                                     }
 
                                     ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),
@@ -345,7 +345,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                         if (_log.IsInfoEnabled)
                         {
-                            _log.Info($"Exception was thrown while collecting info from {ClusterTag}", e);
+                            _log.Info($"{_name}: Exception was thrown while collecting info from {ClusterTag}", e);
                         }
 
                         ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),
@@ -404,7 +404,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 // expected timeout
                 if (_log.IsInfoEnabled)
                 {
-                    _log.Info("Timeout occurred while collecting info report.");
+                    _log.Info($"{_name}: Timeout occurred while collecting info report.");
                 }
 
                 ReceivedReport = new ClusterNodeStatusReport(new ServerReport(), new Dictionary<string, DatabaseStatusReport>(),

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.ServerWide.Maintenance
             _cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
             _token = _cts.Token;
             _server = serverStore;
-            _logger = LoggingSource.Instance.GetLogger<ClusterMaintenanceWorker>(serverStore.NodeTag);
+            _logger = serverStore.Server.ClusterLogger;
             _name = $"Heartbeats worker connection to leader {leader} in term {term}";
             _temporaryDirtyMemoryAllowedPercentage = _server.Server.ServerStore.Configuration.Memory.TemporaryDirtyMemoryAllowedPercentage;
             _leader = leader;
@@ -79,7 +79,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 {
                     if (_logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Exception occurred while collecting info from {_server.NodeTag}. Task is closed.", e);
+                        _logger.Info($"{_server.NodeTag}: Exception occurred while collecting info from {_server.NodeTag}. Task is closed.", e);
                     }
                     // we don't want to crash the process so we don't propagate this exception.
                 }
@@ -122,13 +122,13 @@ namespace Raven.Server.ServerWide.Maintenance
                     {
                         if (_logger.IsInfoEnabled)
                         {
-                            _logger.Info("The tcp connection was closed, so we exit the maintenance work.");
+                            _logger.Info($"{_server.NodeTag}: The tcp connection was closed, so we exit the maintenance work.");
                         }
                         return;
                     }
                     if (_logger.IsInfoEnabled)
                     {
-                        _logger.Info($"Exception occurred while collecting info from {_server.NodeTag}", e);
+                        _logger.Info($"{_server.NodeTag}: Exception occurred while collecting info from {_server.NodeTag}", e);
                     }
                 }
                 finally

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.ServerWide.Maintenance
             _engine = engine;
             _term = term;
             _contextPool = contextPool;
-            _logger = LoggingSource.Instance.GetLogger<ClusterObserver>(_nodeTag);
+            _logger = server.Server.ClusterLogger;
             _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
 
             var config = server.Configuration.Cluster;
@@ -175,7 +175,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (_logger.IsInfoEnabled)
             {
-                _logger.Info(message, e);
+                _logger.Info($"{_nodeTag}: {message}", e);
             }
         }
 

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.ServerWide
 {
     public class RavenTransaction : IDisposable
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenTransaction>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenTransaction>();
 
         public Transaction InnerTransaction;
 

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.ServerWide
     {
         public static readonly byte[] EncryptionContext = Encoding.UTF8.GetBytes("Secrets!");
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<SecretProtection>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<SecretProtection>();
         private readonly Lazy<byte[]> _serverMasterKey;
         private readonly SecurityConfiguration _config;
         private const int MaxDeveloperCertificateValidityDurationInMonths = 4;

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.ServerWide
 
         public const int DefaultCpuRefreshRateInMs = 1000;
 
-        public ServerMetricCacher(RavenServer server)
+        public ServerMetricCacher(RavenServer server) : base(server.Logger)
         {
             _server = server;
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3217,7 +3217,7 @@ namespace Raven.Server.ServerWide
                 }
 
                 var features = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Cluster, tcp.ProtocolVersion);
-                var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features.Cluster, disconnect);
+                var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features.Cluster, disconnect, _server.ClusterLogger);
 
                 _engine.AcceptNewConnection(remoteConnection, remoteEndpoint);
             }

--- a/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
+++ b/src/Raven.Server/ServerWide/Tcp/Sync/TcpNegotiationSyncExtensions.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.ServerWide.Tcp.Sync
 {
     internal static class TcpNegotiationSyncExtensions
     {
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger("TCP Negotiation", typeof(TcpNegotiation).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(TcpNegotiation));
 
         internal static TcpConnectionHeaderMessage.SupportedFeatures NegotiateProtocolVersion(this TcpNegotiation.SyncTcpNegotiation syncTcpNegotiation, JsonOperationContext context, Stream stream, TcpNegotiateParameters parameters)
         {

--- a/src/Raven.Server/ServerWide/UnmanagedBuffersPoolWithLowMemoryHandling.cs
+++ b/src/Raven.Server/ServerWide/UnmanagedBuffersPoolWithLowMemoryHandling.cs
@@ -1,11 +1,12 @@
 ﻿using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 
 namespace Raven.Server.ServerWide
 {
     public class UnmanagedBuffersPoolWithLowMemoryHandling : UnmanagedBuffersPool, ILowMemoryHandler
     {
-        public UnmanagedBuffersPoolWithLowMemoryHandling(string debugTag, string databaseName = null) : base(debugTag, databaseName)
+        public UnmanagedBuffersPoolWithLowMemoryHandling(string debugTag, Logger logger = null) : base(debugTag, logger)
         {
             LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
         }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.Smuggler.Documents
         {
             _database = database;
             _token = token;
-            _log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+            _log = database.Logger;
             _duplicateDocsHandler = new DuplicateDocsHandler(_database);
         }
 
@@ -1810,7 +1810,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public MergedBatchPutCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                var log = database.Logger;
                 var command = new MergedBatchPutCommand(database, BuildType, log)
                 {
                     IsRevision = IsRevision
@@ -1962,7 +1962,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 public MergedBatchFixDocumentMetadataCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
                 {
-                    var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                    var log = database.Logger;
                     var command = new MergedBatchFixDocumentMetadataCommand(database, log);
 
                     foreach (var id in Ids)
@@ -2045,7 +2045,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public MergedBatchDeleteRevisionCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                var log = LoggingSource.Instance.GetLogger<DatabaseDestination>(database.Name);
+                var log = database.Logger;
                 var command = new MergedBatchDeleteRevisionCommand(database, log);
 
                 foreach (var id in Ids)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -24,7 +24,6 @@ using Raven.Server.Smuggler.Documents.Iteration;
 using Raven.Server.Utils.Enumerators;
 using Sparrow;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Voron;
 
 namespace Raven.Server.Smuggler.Documents
@@ -37,7 +36,6 @@ namespace Raven.Server.Smuggler.Documents
 
         private readonly long _startDocumentEtag;
         private readonly long _startRaftIndex;
-        private readonly Logger _logger;
         private IDisposable _returnContext;
         private IDisposable _returnServerContext;
         private DocumentsTransaction _disposeTransaction;
@@ -69,12 +67,11 @@ namespace Raven.Server.Smuggler.Documents
 
         private readonly SmugglerSourceType _type;
 
-        public DatabaseSource(DocumentDatabase database, long startDocumentEtag, long startRaftIndex, Logger logger)
+        public DatabaseSource(DocumentDatabase database, long startDocumentEtag, long startRaftIndex)
         {
             _database = database;
             _startDocumentEtag = startDocumentEtag;
             _startRaftIndex = startRaftIndex;
-            _logger = logger;
             _type = _startDocumentEtag == 0 ? SmugglerSourceType.FullExport : SmugglerSourceType.IncrementalExport;
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -197,7 +197,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
         {
             using (token)
             {
-                var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex, Logger);
+                var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex);
                 await using (var outputStream = GetOutputStream(ResponseBodyStream(), options))
                 {
                     var destination = new StreamDestination(outputStream, context, source);

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Smuggler.Documents
             _peepingTomStream = new PeepingTomStream(stream, context);
             _context = context;
             _database = database;
-            _log = LoggingSource.Instance.GetLogger<StreamSource>(database.Name);
+            _log = database.Logger;
         }
 
         public async Task<SmugglerInitializeResult> InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result)

--- a/src/Raven.Server/Storage/StorageSpaceMonitor.cs
+++ b/src/Raven.Server/Storage/StorageSpaceMonitor.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Storage
     {
         private static readonly TimeSpan CheckFrequency = TimeSpan.FromMinutes(10);
 
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<StorageSpaceMonitor>(nameof(StorageSpaceMonitor));
+        private readonly Logger _logger;
         private readonly LinkedList<DocumentDatabase> _databases = new LinkedList<DocumentDatabase>();
 
         private readonly object _runLock = new object();
@@ -31,6 +31,7 @@ namespace Raven.Server.Storage
 
         public StorageSpaceMonitor(NotificationCenter.NotificationCenter notificationCenter)
         {
+            _logger = notificationCenter.Logger;
             _notificationCenter = notificationCenter;
 
             _timer = new Timer(Run, null, CheckFrequency, CheckFrequency);

--- a/src/Raven.Server/TrafficWatch/TrafficWatchConnection.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchConnection.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.TrafficWatch
 
     internal class TrafficWatchConnection
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<TrafficWatchConnection>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<TrafficWatchConnection>();
 
         private readonly WebSocket _webSocket;
         private readonly JsonOperationContext _context;

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -19,8 +19,6 @@ namespace Raven.Server.TrafficWatch
 {
     public class TrafficWatchHandler : RequestHandler
     {
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger<TrafficWatchHandler>("Server");
-
         [RavenAction("/admin/traffic-watch", "GET", AuthorizationStatus.Operator)]
         public async Task TrafficWatchWebsockets()
         {
@@ -41,8 +39,8 @@ namespace Raven.Server.TrafficWatch
                     }
                     catch (Exception ex)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error encountered in TrafficWatch handler", ex);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error encountered in TrafficWatch handler", ex);
 
                         try
                         {
@@ -62,8 +60,8 @@ namespace Raven.Server.TrafficWatch
                         }
                         catch (Exception)
                         {
-                            if (_logger.IsInfoEnabled)
-                                _logger.Info("Failed to send the error in TrafficWatch handler to the client", ex);
+                            if (Logger.IsInfoEnabled)
+                                Logger.Info("Failed to send the error in TrafficWatch handler to the client", ex);
                         }
                     }
                 }

--- a/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.TrafficWatch;
 
 internal class TrafficWatchToLog : IDynamicJson
 {
-    private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("TrafficWatchManager");
+    private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger("TrafficWatchManager");
 
     private TrafficWatchMode _trafficWatchMode;
     private List<string> _databases;

--- a/src/Raven.Server/Utils/AffinityHelper.cs
+++ b/src/Raven.Server/Utils/AffinityHelper.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Utils
     public class AffinityHelper
     {
         private static readonly ConcurrentSet<PoolOfThreads.PooledThread> _customAffinityThreads = new ConcurrentSet<PoolOfThreads.PooledThread>();
-        private static readonly Logger _logger = LoggingSource.Instance.GetLogger<AffinityHelper>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<AffinityHelper>();
 
         public static void SetProcessAffinity(Process process, int cores, long? processAffinityMask, out long currentlyAssignedCores)
         {
@@ -123,8 +123,8 @@ namespace Raven.Server.Utils
                 {
                     if (retries-- == 0)
                     {
-                        if (_logger.IsOperationsEnabled)
-                            _logger.Operations("Failed to set thread affinity", e);
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations("Failed to set thread affinity", e);
                         return false;
                     }
 

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Utils
     {
         private const int BitsPerByte = 8;
 
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(CertificateUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(typeof(CertificateUtils).FullName);
 
         internal static bool CertHasKnownIssuer(X509Certificate2 userCertificate, X509Certificate2 knownCertificate, SecurityConfiguration securityConfiguration)
         {

--- a/src/Raven.Server/Utils/Cpu/CpuHelper.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuHelper.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Utils.Cpu
 {
     public static class CpuHelper
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(CpuHelper));
 
         internal static ICpuUsageCalculator GetOSCpuUsageCalculator()
         {

--- a/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Utils.Cpu
     
     internal abstract class CpuUsageCalculator<T> : ICpuUsageCalculator where T : ProcessInfo
     {
-        protected readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
+        protected readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MachineResources>();
         private readonly object _locker = new object();
 
         protected  CpuUsageStats LastCpuUsage;

--- a/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageExtensionPoint.cs
@@ -12,8 +12,9 @@ namespace Raven.Server.Utils.Cpu
 {
     public class CpuUsageExtensionPoint : IDisposable
     {
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MachineResources>();
+
         private readonly JsonContextPool _contextPool;
-        private readonly Logger _logger = LoggingSource.Instance.GetLogger<MachineResources>("Server");
         private readonly NotificationCenter.NotificationCenter _notificationCenter;
         private readonly ProcessStartInfo _startInfo;
         private readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
@@ -239,9 +240,9 @@ namespace Raven.Server.Utils.Cpu
 
         private void NotifyWarning(string warningMsg, Exception e = null)
         {
-            if (_logger.IsOperationsEnabled)
+            if (Logger.IsOperationsEnabled)
             {
-                _logger.Operations(warningMsg, e);
+                Logger.Operations(warningMsg, e);
             }
 
             try

--- a/src/Raven.Server/Utils/EchoServer.cs
+++ b/src/Raven.Server/Utils/EchoServer.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Utils;
 
 internal static class EchoServer
 {
-    private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServer>("Server");
+    private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(EchoServer));
 
     public static void StartEchoSockets(int? echoSocketPort)
     {

--- a/src/Raven.Server/Utils/Metrics/MetricsScheduler.cs
+++ b/src/Raven.Server/Utils/Metrics/MetricsScheduler.cs
@@ -23,13 +23,12 @@ namespace Raven.Server.Utils.Metrics
 
         private readonly ConcurrentSet<WeakReference<Ewma>> _scheduledEwmaActions = new ConcurrentSet<WeakReference<Ewma>>();
 
-        private readonly Logger _logger;
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MetricsScheduler>();
 
         public static readonly MetricsScheduler Instance = new MetricsScheduler();
 
         private MetricsScheduler()
         {
-            _logger = LoggingSource.Instance.GetLogger<MetricsScheduler>("Server");
             _tickIntervalInNanoseconds = Clock.NanosecondsInSecond;
             _schedulerThread = new Thread(SchedulerTicking)
             {
@@ -64,8 +63,8 @@ namespace Raven.Server.Utils.Metrics
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error occurred during MetricsScheduler ticking of a single Metric action", e);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error occurred during MetricsScheduler ticking of a single Metric action", e);
                     }
                 }
 
@@ -84,8 +83,8 @@ namespace Raven.Server.Utils.Metrics
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info("Error occurred during MetricsScheduler ticking of a single EWMA action", e);
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error occurred during MetricsScheduler ticking of a single EWMA action", e);
                     }
                 }
 

--- a/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
+++ b/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Utils.MicrosoftLogging;
 
 public class MicrosoftLoggingConfiguration : IEnumerable<(string Category, LogLevel LogLevel)>
 {
-    private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", nameof(MicrosoftLoggingConfiguration));
+    private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<MicrosoftLoggingConfiguration>();
     private const string NotificationKey = "microsoft-configuration-logs-error";
     private const AlertType AlertType = NotificationCenter.Notifications.AlertType.MicrosoftLogsConfigurationLoadError;
     

--- a/src/Raven.Server/Utils/Pipes.cs
+++ b/src/Raven.Server/Utils/Pipes.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Utils
     public class Pipes
     {
 #if !RVN
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<Pipes>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<Pipes>();
 #endif
 
         public const string AdminConsolePipePrefix = "raven-control-pipe-";

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Utils
         });
 
         public static PoolOfThreads GlobalRavenThreadPool => _globalRavenThreadPool.Value;
-        private static Logger _log = LoggingSource.Instance.GetLogger<PoolOfThreads>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<PoolOfThreads>();
 
         public int TotalNumberOfThreads;
 
@@ -224,9 +224,9 @@ namespace Raven.Server.Utils
                 }
                 catch (Exception e)
                 {
-                    if (_log.IsOperationsEnabled)
+                    if (Logger.IsOperationsEnabled)
                     {
-                        _log.Operations($"An uncaught exception occurred in '{_threadInfo.FullName}' and killed the process", e);
+                        Logger.Operations($"An uncaught exception occurred in '{_threadInfo.FullName}' and killed the process", e);
                     }
 
                     throw;
@@ -283,12 +283,12 @@ namespace Raven.Server.Utils
                 var currentPriority = ThreadHelper.GetThreadPriority();
                 if (currentPriority != ThreadPriority.Normal)
                 {
-                    if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, _log) == false)
+                    if (ThreadHelper.TrySetThreadPriority(ThreadPriority.Normal, null, Logger) == false)
                     {
                         // if we can't reset it, better just kill it
-                        if (_log.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
-                            _log.Info($"Unable to set this thread priority to normal, since we don't want its priority of {currentPriority}, we'll let it exit");
+                            Logger.Info($"Unable to set this thread priority to normal, since we don't want its priority of {currentPriority}, we'll let it exit");
                         }
 
                         return false;

--- a/src/Raven.Server/Utils/Stats/DatabaseAwareLivePerformanceCollector.cs
+++ b/src/Raven.Server/Utils/Stats/DatabaseAwareLivePerformanceCollector.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Utils.Stats
     {
         protected readonly DocumentDatabase Database;
 
-        protected DatabaseAwareLivePerformanceCollector(DocumentDatabase database): base(database.DatabaseShutdown, database.Name)
+        protected DatabaseAwareLivePerformanceCollector(DocumentDatabase database): base(database.DatabaseShutdown, database.Logger)
         {
             Database = database;
         }

--- a/src/Raven.Server/Utils/Stats/LivePerformanceCollector.cs
+++ b/src/Raven.Server/Utils/Stats/LivePerformanceCollector.cs
@@ -17,11 +17,11 @@ namespace Raven.Server.Utils.Stats
         private readonly CancellationTokenSource _cts;
         private Task _task;
 
-        protected readonly Logger Logger;
+        private readonly Logger _logger;
 
-        protected LivePerformanceCollector(CancellationToken parentCts, string loggingSource)
+        protected LivePerformanceCollector(CancellationToken parentCts, Logger logger)
         {
-            Logger = LoggingSource.Instance.GetLogger(loggingSource, GetType().FullName);
+            _logger = logger;
 
             _cts = CancellationTokenSource.CreateLinkedTokenSource(parentCts);
         }
@@ -100,7 +100,7 @@ namespace Raven.Server.Utils.Stats
 
             _cts.Cancel();
 
-            var exceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {GetType().Name}");
+            var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {GetType().Name}");
 
             exceptionAggregator.Execute(() =>
             {

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Utils
 {
     public class ThreadsUsage
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MachineResources>("ThreadsUsage");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<ThreadsUsage>();
         private (long TotalProcessorTimeTicks, long TimeTicks) _processTimes;
         private Dictionary<int, long> _threadTimesInfo = new Dictionary<int, long>();
 

--- a/src/Raven.Server/Utils/WindowsServiceRunner.cs
+++ b/src/Raven.Server/Utils/WindowsServiceRunner.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Utils
 
     internal class RavenWin32Service : IWin32Service
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenWin32Service>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RavenWin32Service>();
 
         private RavenServer _ravenServer;
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -76,6 +76,7 @@ namespace Raven.Server.Web
         public virtual void Init(RequestHandlerContext context)
         {
             _context = context;
+            Logger = Server.Logger;
         }
 
         protected Stream TryGetRequestFromStream(string itemName)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -31,6 +31,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Web
 {
@@ -41,6 +42,8 @@ namespace Raven.Server.Web
         public const string PageSizeParameter = "pageSize";
 
         private RequestHandlerContext _context;
+
+        protected Logger Logger;
 
         protected HttpContext HttpContext
         {

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -8,7 +8,6 @@ namespace Raven.Server.Web
         public override void Init(RequestHandlerContext context)
         {
             base.Init(context);
-            Logger = Server.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
         }

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -8,6 +8,7 @@ namespace Raven.Server.Web
         public override void Init(RequestHandlerContext context)
         {
             base.Init(context);
+            Logger = Server.Logger.GetLogger(GetType().Name);
 
             context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
         }

--- a/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
+++ b/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Web.Studio
 {
     public class DataDirectoryInfo
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<DataDirectoryInfo>("DataDirectoryInfo");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<DataDirectoryInfo>();
 
         private readonly ServerStore _serverStore;
         private readonly string _path;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1166,13 +1166,7 @@ namespace Raven.Server.Web.System
                         catch (Exception e)
                         {
                             if (Logger.IsOperationsEnabled)
-                            {
-                                Logger.Operations($"Compaction process failed. " +
-                                                  $"{nameof(compactSettings.DatabaseName)}:\"{compactSettings.DatabaseName}\", " +
-                                                  $"{nameof(compactSettings.Documents)}:\"{compactSettings.Documents}\", " +
-                                                  $"{nameof(compactSettings.Indexes)}:\"{(compactSettings.Indexes != null ? string.Join(", ", compactSettings.Indexes) : null)}\""
-                                    , e);
-                            }
+                                Logger.Operations("Compaction process failed", e);
 
                             throw;
                         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -61,8 +61,6 @@ namespace Raven.Server.Web.System
 {
     public class AdminDatabasesHandler : ServerRequestHandler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<AdminDatabasesHandler>("Server");
-
         [RavenAction("/admin/databases", "GET", AuthorizationStatus.Operator)]
         public async Task Get()
         {
@@ -1168,7 +1166,13 @@ namespace Raven.Server.Web.System
                         catch (Exception e)
                         {
                             if (Logger.IsOperationsEnabled)
-                                Logger.Operations("Compaction process failed", e);
+                            {
+                                Logger.Operations($"Compaction process failed. " +
+                                                  $"{nameof(compactSettings.DatabaseName)}:\"{compactSettings.DatabaseName}\", " +
+                                                  $"{nameof(compactSettings.Documents)}:\"{compactSettings.Documents}\", " +
+                                                  $"{nameof(compactSettings.Indexes)}:\"{(compactSettings.Indexes != null ? string.Join(", ", compactSettings.Indexes) : null)}\""
+                                    , e);
+                            }
 
                             throw;
                         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -316,7 +316,7 @@ namespace Raven.Server.Web.System
                         if (documentDatabase.DatabaseShutdown.IsCancellationRequested)
                             return;
 
-                        index = Index.Open(indexPath, documentDatabase, generateNewDatabaseId: false, out var _);
+                        index = Index.Open(indexPath, documentDatabase, generateNewDatabaseId: false, searchEngineType: out var _, documentDatabase.IndexesLogger);
                         if (index == null)
                             continue;
 

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -30,6 +30,7 @@ using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Web.System

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -30,15 +30,12 @@ using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Web.System
 {
     public sealed class DatabasesHandler : RequestHandler
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<DatabasesHandler>("Server");
-
         [RavenAction("/databases", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Databases()
         {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -477,7 +477,7 @@ namespace Raven.Server.Web.System
                         Name = backupName
                     };
 
-                    var backupTask = new BackupTask(Database, backupParameters, backupConfiguration, Logger);
+                    var backupTask = new BackupTask(Database, backupParameters, backupConfiguration);
                     var threadName = $"Backup thread {backupName} for database '{Database.Name}'";
 
                     var t = Database.Operations.AddOperation(

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        public static async Task ConnectToClientNodeAsync(RavenServer server, TcpConnectionInfo tcpConnectionInfo, TimeSpan timeout, Logger log, string database,
+        public static async Task ConnectToClientNodeAsync(RavenServer server, TcpConnectionInfo tcpConnectionInfo, TimeSpan timeout, string database,
             NodeConnectionTestResult result, CancellationToken token = default)
         {
             List<string> negLogs = new();

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
@@ -4,7 +4,7 @@ import endpoints = require("endpoints");
 class getAdminLogsLoggersCommand extends commandBase {
     
     execute(): JQueryPromise<adminLogsLoggersResponse> {
-        const url = endpoints.global.adminLogs.adminLoggingTogglingLoggers;
+        const url = endpoints.global.adminLogs.adminLogsLoggers;
         
         return this.query<adminLogsLoggersResponse>(url, null)
             .fail((response: JQueryXHR) => this.reportError("Failed to get loggers", response.responseText, response.statusText)) 

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
@@ -4,7 +4,7 @@ import endpoints = require("endpoints");
 class getAdminLogsLoggersCommand extends commandBase {
     
     execute(): JQueryPromise<adminLogsLoggersResponse> {
-        const url = endpoints.global.adminLogs.adminLoggers;
+        const url = endpoints.global.adminLogs.adminLoggingTogglingLoggers;
         
         return this.query<adminLogsLoggersResponse>(url, null)
             .fail((response: JQueryXHR) => this.reportError("Failed to get loggers", response.responseText, response.statusText)) 

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersCommand.ts
@@ -1,0 +1,14 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class getAdminLogsLoggersCommand extends commandBase {
+    
+    execute(): JQueryPromise<adminLogsLoggersResponse> {
+        const url = endpoints.global.adminLogs.adminLoggers;
+        
+        return this.query<adminLogsLoggersResponse>(url, null)
+            .fail((response: JQueryXHR) => this.reportError("Failed to get loggers", response.responseText, response.statusText)) 
+    }
+}
+
+export = getAdminLogsLoggersCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
@@ -1,0 +1,14 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class getAdminLogsLoggersConfigurationCommand extends commandBase {
+    
+    execute(): JQueryPromise<adminLogsLoggersConfigurationResponse> {
+        const url = endpoints.global.adminLogs.adminLoggersConfiguration;
+        
+        return this.query<adminLogsLoggersConfigurationResponse>(url, null)
+            .fail((response: JQueryXHR) => this.reportError("Failed to get loggers configuration", response.responseText, response.statusText)) 
+    }
+}
+
+export = getAdminLogsLoggersConfigurationCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
@@ -4,7 +4,7 @@ import endpoints = require("endpoints");
 class getAdminLogsLoggersConfigurationCommand extends commandBase {
     
     execute(): JQueryPromise<adminLogsLoggersConfigurationResponse> {
-        const url = endpoints.global.adminLogs.adminLoggingTogglingConfiguration;
+        const url = endpoints.global.adminLogs.adminLogsLoggersConfiguration
         
         return this.query<adminLogsLoggersConfigurationResponse>(url, null)
             .fail((response: JQueryXHR) => this.reportError("Failed to get loggers configuration", response.responseText, response.statusText)) 

--- a/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/getAdminLogsLoggersConfigurationCommand.ts
@@ -4,7 +4,7 @@ import endpoints = require("endpoints");
 class getAdminLogsLoggersConfigurationCommand extends commandBase {
     
     execute(): JQueryPromise<adminLogsLoggersConfigurationResponse> {
-        const url = endpoints.global.adminLogs.adminLoggersConfiguration;
+        const url = endpoints.global.adminLogs.adminLoggingTogglingConfiguration;
         
         return this.query<adminLogsLoggersConfigurationResponse>(url, null)
             .fail((response: JQueryXHR) => this.reportError("Failed to get loggers configuration", response.responseText, response.statusText)) 

--- a/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
@@ -11,12 +11,10 @@ class saveAdminLogsLoggersConfigurationCommand extends commandBase {
     }
     
     execute(): JQueryPromise<void> {
-        const url = endpoints.global.adminLogs.adminLoggingTogglingConfiguration;
+        const url = endpoints.global.adminLogs.adminLogsLoggersConfiguration;
         
         const args = {
-            Configuration: {
-                Loggers: this.configuration
-            }
+            Loggers: this.configuration
         };
 
         return this.post<void>(url, JSON.stringify(args), null, { dataType: undefined })

--- a/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
@@ -1,0 +1,28 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class saveAdminLogsLoggersConfigurationCommand extends commandBase {
+    
+    private readonly configuration: dictionary<Sparrow.Logging.LogMode>;
+    
+    constructor(configuration: dictionary<Sparrow.Logging.LogMode>) {
+        super();
+        this.configuration = configuration;
+    }
+    
+    execute(): JQueryPromise<void> {
+        const url = endpoints.global.adminLogs.adminLoggers;
+        
+        const args = {
+            Configuration: {
+                Loggers: this.configuration
+            }
+        };
+
+        return this.post<void>(url, JSON.stringify(args), null, { dataType: undefined })
+            .done(() => this.reportSuccess("Loggers configuration was successfully set"))
+            .fail((response: JQueryXHR) => this.reportError("Failed to set Loggers configuration", response.responseText, response.statusText));
+    }
+}
+
+export = saveAdminLogsLoggersConfigurationCommand;

--- a/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/maintenance/saveAdminLogsLoggersConfigurationCommand.ts
@@ -11,7 +11,7 @@ class saveAdminLogsLoggersConfigurationCommand extends commandBase {
     }
     
     execute(): JQueryPromise<void> {
-        const url = endpoints.global.adminLogs.adminLoggers;
+        const url = endpoints.global.adminLogs.adminLoggingTogglingConfiguration;
         
         const args = {
             Configuration: {

--- a/src/Raven.Studio/typescript/viewmodels/manage/configureLoggersDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/configureLoggersDialog.ts
@@ -1,0 +1,109 @@
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import dialog = require("plugins/dialog");
+
+class loggerCategory {
+    source = ko.observable<string>();
+    logLevel = ko.observable<Sparrow.Logging.LogMode>("Operations");
+    
+    
+    static fromDto(source: string, logLevel: Sparrow.Logging.LogMode) {
+        const item = new loggerCategory();
+        item.source(source);
+        item.logLevel(logLevel);
+        return item;
+    }
+}
+
+class configureLoggersDialog extends dialogViewModelBase {
+    view = require("views/manage/configureLoggersDialog.html");
+    
+    private readonly loggers: string[];
+    private readonly configuration = ko.observableArray<loggerCategory>([]);
+    
+    newSourceName = ko.observable<string>();
+    
+    constructor(availableLoggers: adminLogsLoggersResponse, configuration: adminLogsLoggersConfigurationResponse) {
+        super();
+        
+        this.loggers = this.extractLoggerNames(availableLoggers.Loggers ?? {});
+        
+        this.configuration(Object.entries<Sparrow.Logging.LogMode>(configuration.Loggers ?? {}).map(kv => loggerCategory.fromDto(kv[0], kv[1])));
+        
+        _.bindAll(this, "deleteItem", "addLogSourceFromDropdown");
+        
+        this.newSourceName.extend({
+            required: true
+        });
+    }
+
+    addLogSource() {
+        const newItem = loggerCategory.fromDto(this.newSourceName(), "Operations");
+        this.configuration.push(newItem);
+        this.newSourceName("");
+        this.newSourceName.clearError();
+    }
+
+    addLogSourceFromDropdown(source: string): void {
+        this.newSourceName(source);
+        this.addLogSource();
+    }
+
+    createLogSourceAutoCompleter() {
+        return ko.pureComputed(() => {
+            const key = this.newSourceName();
+            
+            const maxAutocompleteItems = 50;
+            
+            const existingSources = this.configuration().map(x => x.source());
+            
+            const completions = this.loggers.filter(x => !existingSources.includes(x));
+            
+            if (key) {
+                return completions.filter(x => x.startsWith(key)).slice(0, maxAutocompleteItems);
+            } else {
+                return completions.slice(0, maxAutocompleteItems);
+            }
+        });
+    }
+    
+    private extractLoggerNames(loggers: dictionary<adminLogsLoggerDto>) {
+        const result: string[] = [];
+
+        const queue: Array<adminLogsLoggerDto> = [...Object.values(loggers)];
+        while (queue.length) {
+            const item = queue.pop();
+            result.push(item.Source ? item.Source + "." + item.Name : item.Name);
+
+            if (item.Loggers) {
+                queue.push(...Object.values(item.Loggers));    
+            }
+        }
+        
+        return result;
+    }
+
+    attached() {
+        // empty by design, so that pressing enter does not call save button click
+    }
+
+    close() {
+        dialog.close(this);
+    }
+
+    deleteItem(item: loggerCategory) {
+        this.configuration.remove(item);
+    }
+    
+    save() {
+        const result: dictionary<Sparrow.Logging.LogMode> = { 
+        };
+        
+        this.configuration().forEach(item => {
+            result[item.source()] = item.logLevel();
+        });
+        
+        dialog.close(this, result);
+    }
+}
+
+export = configureLoggersDialog;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -786,6 +786,23 @@ interface clusterWideStackTraceResponseItem {
     Error: string;
 }
 
+interface adminLogsLoggersConfigurationResponse {
+    Loggers: dictionary<string, string>;
+}
+
+interface adminLogsLoggerDto {
+    Name: string;
+    Source: string;
+    IsModeOverrode: boolean;
+    LogMode: Sparrow.Logging.LogMode;
+    Loggers: dictionary<adminLogsLoggerDto>;
+}
+
+interface adminLogsLoggersResponse {
+    LogMode: Sparrow.Logging.LogMode;
+    Loggers: dictionary<adminLogsLoggerDto>;
+}
+
 interface stackTracesResponseDto {
     Results: Array<rawStackTraceResponseItem>;
     Threads: Array<Raven.Server.Dashboard.ThreadInfo>;

--- a/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
@@ -111,6 +111,19 @@
                                 </div>
                             </div>
                             <div class="row">
+                                <label class="col-md-3 control-label">Loggers:</label>
+                                <div class="col-md-9">
+                                    <div class="form-control-static">
+                                        <button type="button" class="btn btn-default btn-sm close-panel margin-right"
+                                                id="js-loggers-config" 
+                                                data-bind="click: $root.configureLoggers, css: { 'btn-spinner': $root.spinners.loggersLoading }, disable: $root.spinners.loggersLoading">
+                                            <i class="icon-settings"></i>
+                                            <span>Configure</span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
                                 <label class="col-md-3 control-label">Retention Time:</label>
                                 <div class="col-md-9">
                                     <p class="form-control-static" data-bind="text: retentionTimeText"></p>

--- a/src/Raven.Studio/wwwroot/App/views/manage/configureLoggersDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/configureLoggersDialog.html
@@ -1,0 +1,79 @@
+<div class="modal-dialog modal-lg prevent-close" role="document">
+    <div class="modal-content" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <h4 class="modal-title">Configure Loggers</h4>
+
+        </div>
+        <div class="modal-body">
+            <div class="flex-horizontal margin-bottom margin-bottom-sm">
+                <div class="flex-grow"
+                     data-bind="validationOptions: { insertMessages: false }, validationElement: newSourceName">
+                    <div class="dropdown btn-block">
+                        <input type="text" class="form-control dropdown-toggle" data-toggle="dropdown"
+                               id="loggerSourceInput" autocomplete="off"
+                               data-bind="textInput: newSourceName"
+                               placeholder="Select (or enter) a logger source">
+                        <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                        <ul class="dropdown-menu"
+                            data-bind="foreach: $root.createLogSourceAutoCompleter(), autoComplete: '#loggerSourceInput'">
+                            <li data-bind="click: _.partial($root.addLogSourceFromDropdown, $data)">
+                                <a href="#" data-bind="text: $data"></a>
+                            </li>
+                        </ul>
+                    </div>
+                    <span class="help-block" data-bind="validationMessage: newSourceName"></span>
+                </div>
+                <div>
+                    <button data-bind="click: $root.addLogSource, enable: $root.newSourceName"
+                            class="btn btn-default">
+                        <i class="icon-plus"></i>
+                    </button>
+                </div>
+            </div>
+            <ul class="well collection-list"
+                data-bind="visible: configuration().length, foreach: configuration">
+                <li>
+                    <div class="name force-text-wrap" data-bind="text: source">
+                    </div>
+                    <div data-bind="validationOptions: { insertMessages: false }">
+                        <div class="radio radio-default radio-inline">
+                            <input type="radio" value="Operations"
+                                   data-bind="checked: logLevel, attr: { id: 'logLevel_op_' + $index() }"/>
+                            <label data-bind="attr: { for: 'logLevel_op_' + $index() }">Operations</label>
+                        </div>
+                        <div class="radio radio-default radio-inline">
+                            <input type="radio" value="Information"
+                                   data-bind="checked: logLevel, attr: { id: 'logLevel_info_' + $index() }"/>
+                            <label data-bind="attr: { for: 'logLevel_info_' + $index() }">
+                                Information 
+                            </label>
+                        </div>
+                        <div class="radio radio-default radio-inline">
+                            <input type="radio" value="None"
+                                   data-bind="checked: logLevel, attr: { id: 'logLevel_none_' + $index() }"/>
+                            <label data-bind="attr: { for: 'logLevel_none_' + $index() }">
+                                None
+                            </label>
+                        </div>
+                    </div>
+                    <a href="#" data-bind="click: _.partial($root.deleteItem, $data)"
+                       title="Delete this logger configuration">
+                        <i class="icon-trash"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-bind="click: close">
+                Cancel
+            </button>
+            <button type="button" class="btn btn-primary" data-bind="click: save">
+                <i class="icon-save"></i>
+                <span>Save</span>
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
+++ b/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
@@ -19,7 +19,7 @@ namespace Sparrow.Server.LowMemory
 {
     public static class CheckPageFileOnHdd
     {
-        private static readonly Logger Log = LoggingSource.Instance.GetLogger("Server", typeof(CheckPageFileOnHdd).FullName);
+        private static readonly Logger Log = LoggingSource.Instance.LoggersHolder.Memory.GetLogger(nameof(CheckPageFileOnHdd));
 
         private const string PageFileName = "pagefile.sys";
 
@@ -482,7 +482,8 @@ namespace Sparrow.Server.LowMemory
             }
             catch (Exception ex)
             {
-                Log.Info("Error while trying to determine if hdd swaps instead of ssd on linux, ignoring this check and assuming no hddswap", ex);
+                if(Log.IsInfoEnabled)
+                    Log.Info("Error while trying to determine if hdd swaps instead of ssd on linux, ignoring this check and assuming no hddswap", ex);
                 // ignore
                 return null;
             }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -19,7 +19,7 @@ namespace Sparrow.LowMemory
 {
     public static class MemoryInformation
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MemoryInfoResult>("Server");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<MemoryInfoResult>();
 
         private static readonly ConcurrentQueue<Tuple<long, DateTime>> MemByTime = new ConcurrentQueue<Tuple<long, DateTime>>();
         private static DateTime _memoryRecordsSet;

--- a/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
+++ b/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
@@ -13,7 +13,7 @@ namespace Sparrow.Server.Platform.Posix;
 
 public abstract class CGroup
 {
-    protected static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", nameof(CGroup));
+    protected static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(CGroup));
     
     protected const string PROC_CGROUP_FILENAME = "/proc/self/cgroup";
     protected const string PROC_MOUNTINFO_FILENAME = "/proc/self/mountinfo";

--- a/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
+++ b/src/Sparrow.Server/Platform/Posix/KernelVirtualFileSystemUtils.cs
@@ -10,7 +10,7 @@ namespace Sparrow.Platform.Posix
 {
     internal static class KernelVirtualFileSystemUtils
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(KernelVirtualFileSystemUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger(nameof(KernelVirtualFileSystemUtils));
         private static readonly ConcurrentSet<string> IsOldFileAlert = new ConcurrentSet<string>();
         private static readonly ConcurrentSet<string> MissingCgroupFiles = new ConcurrentSet<string>();
 

--- a/src/Sparrow.Server/Utils/DiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter.cs
@@ -18,7 +18,7 @@ namespace Sparrow.Server.Utils
     internal class DiskStatsGetter : IDiskStatsGetter
     {
         private readonly TimeSpan _minInterval;
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(DiskStatsGetter).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DiskStatsGetter));
 
         private readonly ConcurrentDictionary<string, Task<PrevInfo>> _previousInfo = new ConcurrentDictionary<string, Task<PrevInfo>>();
 

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -12,7 +12,7 @@ namespace Sparrow.Server.Utils
 {
     public static class DiskUtils
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(DiskUtils).FullName);
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger(nameof(DiskUtils));
 
         // from https://github.com/dotnet/corefx/blob/9c06da6a34fcefa6fb37776ac57b80730e37387c/src/Common/src/System/IO/PathInternal.Windows.cs#L52
         public const short WindowsMaxPath = short.MaxValue;

--- a/src/Sparrow.Server/Utils/TaskExecutor.cs
+++ b/src/Sparrow.Server/Utils/TaskExecutor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Utils;
 
@@ -104,6 +105,7 @@ namespace Sparrow.Server.Utils
 
         private class RunOnce
         {
+            private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<RunOnce>();
             private WaitCallback _callback;
 
             public RunOnce(WaitCallback callback)
@@ -126,9 +128,8 @@ namespace Sparrow.Server.Utils
                 }
                 catch (Exception e)
                 {
-                    var logger = Logging.LoggingSource.Instance.GetLogger<RunOnce>("TaskExecutor");
-                    if (logger.IsOperationsEnabled)
-                        logger.Operations("Failed to execute task", e);
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Failed to execute task", e);
                 }
             }
         }

--- a/src/Sparrow/Json/JsonContextPoolBase.cs
+++ b/src/Sparrow/Json/JsonContextPoolBase.cs
@@ -13,7 +13,7 @@ namespace Sparrow.Json
         where T : JsonOperationContext
     {
         private readonly object _locker = new object();
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<JsonContextPoolBase<T>>("Memory");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<JsonContextPoolBase<T>>();
 
         private bool _disposed;
 

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -12,20 +12,20 @@ namespace Sparrow.Json
 {
     public unsafe class UnmanagedBuffersPool : IDisposable
     {
-        protected readonly string _debugTag;
+        private static readonly Logger StaticLogger = LoggingSource.Instance.GetLogger<UnmanagedBuffersPool>("Client");
 
-        protected readonly string _databaseName;
+        private readonly string _debugTag;
 
-        private static readonly Logger _log = LoggingSource.Instance.GetLogger<UnmanagedBuffersPool>("Client");
+        private  readonly Logger _log;
 
         private readonly ConcurrentStack<AllocatedMemoryData>[] _freeSegments;
 
         private bool _isDisposed;
 
-        public UnmanagedBuffersPool(string debugTag, string databaseName = null)
+        public UnmanagedBuffersPool(string debugTag, Logger logger = null)
         {
             _debugTag = debugTag;
-            _databaseName = databaseName ?? string.Empty;
+            _log = logger ?? StaticLogger;;
             _freeSegments = new ConcurrentStack<AllocatedMemoryData>[32];
             for (int i = 0; i < _freeSegments.Length; i++)
             {
@@ -40,7 +40,7 @@ namespace Sparrow.Json
 
             var size = FreeAllPooledMemory();
             if (_log.IsInfoEnabled && size > 0)
-                _log.Info($"{_debugTag}: HandleLowMemory freed {new Size(size, SizeUnit.Bytes)} in {_debugTag}");
+                _log.Info($"HandleLowMemory freed {new Size(size, SizeUnit.Bytes)} in {_debugTag}");
         }
 
         private long FreeAllPooledMemory()

--- a/src/Sparrow/Json/UnmanagedBuffersPool.cs
+++ b/src/Sparrow/Json/UnmanagedBuffersPool.cs
@@ -12,7 +12,7 @@ namespace Sparrow.Json
 {
     public unsafe class UnmanagedBuffersPool : IDisposable
     {
-        private static readonly Logger StaticLogger = LoggingSource.Instance.GetLogger<UnmanagedBuffersPool>("Client");
+        private static readonly Logger StaticLogger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<UnmanagedBuffersPool>();
 
         private readonly string _debugTag;
 

--- a/src/Sparrow/Logging/LogAvailability.cs
+++ b/src/Sparrow/Logging/LogAvailability.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Sparrow.Logging;
 
 public class LogAvailability

--- a/src/Sparrow/Logging/LogAvailability.cs
+++ b/src/Sparrow/Logging/LogAvailability.cs
@@ -1,0 +1,41 @@
+namespace Sparrow.Logging;
+
+public class LogAvailability
+{
+    public bool IsInfoEnabled;
+    public bool IsOperationsEnabled;
+
+    public LogAvailability()
+    {
+            
+    }
+        
+    public LogAvailability(LogMode logMode)
+    {
+        InternalSetMode(logMode);
+    }
+        
+    public LogMode GetMode()
+    {
+        return IsInfoEnabled
+            ? LogMode.Information
+            : IsOperationsEnabled
+                ? LogMode.Operations
+                : LogMode.None;
+    }
+
+    protected void InternalSetMode(LogMode logMode)
+    {
+        IsOperationsEnabled = (logMode & LogMode.Operations) == LogMode.Operations;
+        IsInfoEnabled = (logMode & LogMode.Information) == LogMode.Information;
+    }
+}
+
+internal class LoggingSourceLogAvailability : LogAvailability
+{
+    public void SetMode(LogMode logMode)
+    {
+        InternalSetMode(logMode);
+    }
+}
+

--- a/src/Sparrow/Logging/LogEntry.cs
+++ b/src/Sparrow/Logging/LogEntry.cs
@@ -10,5 +10,7 @@ namespace Sparrow.Logging
         public string Logger;
         public string Message;
         public Exception Exception;
+        
+        public LogMode? OverrideWriteMode { get; set; }
     }
 }

--- a/src/Sparrow/Logging/LogMessageEntry.cs
+++ b/src/Sparrow/Logging/LogMessageEntry.cs
@@ -10,6 +10,7 @@ namespace Sparrow.Logging
         public LogMode Type;
         public MemoryStream Data;
         public TaskCompletionSource<object> Task;
+        public LogMode? OverrideWriteMode;
 
         public readonly List<WebSocket> WebSocketsList = new List<WebSocket>();
 

--- a/src/Sparrow/Logging/Logger.cs
+++ b/src/Sparrow/Logging/Logger.cs
@@ -14,7 +14,7 @@ namespace Sparrow.Logging
         [ThreadStatic]
         private static LogEntry _logEntry;
 
-        public Logger(SwitchLogger parent, string source, string name)
+        internal Logger(SwitchLogger parent, string source, string name)
             : this(parent.LoggingSource, source, name)
         {
             Parent = parent;
@@ -136,7 +136,7 @@ namespace Sparrow.Logging
 
         protected virtual LogMode? GetOverrideWriteMode()
         {
-            return Parent != null && Parent.IsReset() ? Parent.GetLogMode() : null;
+            return Parent == null || Parent.IsModeOverrode == false ? null : Parent.GetLogMode();
         }
     }
 }

--- a/src/Sparrow/Logging/LoggersCollection.cs
+++ b/src/Sparrow/Logging/LoggersCollection.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sparrow.Logging
+{
+    public class LoggersCollection : IEnumerable<(string, SwitchLogger)>, IDisposable
+    {
+        private readonly SwitchLogger _parent;
+        private readonly ConcurrentDictionary<string, SwitchLogger> _loggers = new ConcurrentDictionary<string, SwitchLogger>(StringComparer.OrdinalIgnoreCase);
+
+        public int Count => _loggers.Count;
+        
+        public LoggersCollection(LoggingSource collectionOfLoggers, SwitchLogger parent)
+        {
+            _parent = parent;
+        }
+
+        public bool TryGet(string name, out SwitchLogger value) => _loggers.TryGetValue(name, out value);
+        public SwitchLogger GetOrAdd(string name)
+        {
+            return _loggers.GetOrAdd(name, _ =>
+                {
+                    var source = _parent.Source != null ? $"{_parent.Source}.{_parent.Name}" : _parent.Name;
+                    return new SwitchLogger(parent: _parent, source, name);
+                }
+               );
+        }
+
+        public void TryRemove(string name)
+        {
+            if (_loggers.TryRemove(name, out var holder))
+                holder.Dispose();
+        }
+
+        public void TryUpdateMode(string name, LogMode mode)
+        {
+            if(_loggers.TryGetValue(name, out var switchLogger))
+                switchLogger.UpdateMode(mode);
+        }
+
+        public IEnumerator<(string, SwitchLogger)> GetEnumerator()
+        {
+            foreach (var keyValue in _loggers)
+            {
+                yield return (keyValue.Key, keyValue.Value);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Dispose()
+        {
+            foreach (SwitchLogger logger in _loggers.Values.ToArray())
+            {
+                logger.Dispose();
+            }
+        }
+    }
+}

--- a/src/Sparrow/Logging/LoggersHolder.cs
+++ b/src/Sparrow/Logging/LoggersHolder.cs
@@ -1,0 +1,23 @@
+using Sparrow.Json.Parsing;
+
+namespace Sparrow.Logging;
+
+public class LoggersHolder
+{
+    private const string Root = null;
+
+    private readonly SwitchLogger _rootLogger;
+        
+    public LoggersHolder(LoggingSource loggingSource)
+    {
+        _rootLogger = new SwitchLogger(loggingSource, Root);
+        
+        Generic = _rootLogger.GetSubSwitchLogger("Generic");
+        Memory = Generic.GetSubSwitchLogger("Memory");
+    }
+
+    public readonly SwitchLogger Generic;
+    public readonly SwitchLogger Memory;
+    
+    public DynamicJsonValue ToJson() => _rootLogger.ToJson();
+}

--- a/src/Sparrow/Logging/LoggersHolder.cs
+++ b/src/Sparrow/Logging/LoggersHolder.cs
@@ -2,22 +2,14 @@ using Sparrow.Json.Parsing;
 
 namespace Sparrow.Logging;
 
-public class LoggersHolder
+internal class LoggersHolder
 {
-    private const string Root = null;
-
-    private readonly SwitchLogger _rootLogger;
-        
     public LoggersHolder(LoggingSource loggingSource)
     {
-        _rootLogger = new SwitchLogger(loggingSource, Root);
-        
-        Generic = _rootLogger.GetSubSwitchLogger("Generic");
+        Generic = new SwitchLogger(loggingSource, "Generic");
         Memory = Generic.GetSubSwitchLogger("Memory");
     }
 
     public readonly SwitchLogger Generic;
     public readonly SwitchLogger Memory;
-    
-    public DynamicJsonValue ToJson() => _rootLogger.ToJson();
 }

--- a/src/Sparrow/Logging/LoggingSource.cs
+++ b/src/Sparrow/Logging/LoggingSource.cs
@@ -243,7 +243,7 @@ namespace Sparrow.Logging
             _keepLogging.Raise();
             _loggingThread = new Thread(BackgroundLogger) { IsBackground = true, Name = _name + " Thread" };
             _loggingThread.Start();
-            if (compress && LogMode != LogMode.None)
+            if (compress)
             {
                 _compressLoggingThread = new Thread(BackgroundLoggerCompress) { IsBackground = true, Name = _name + " Log Compression Thread" };
                 _compressLoggingThread.Start();

--- a/src/Sparrow/Logging/LoggingSource.cs
+++ b/src/Sparrow/Logging/LoggingSource.cs
@@ -611,7 +611,7 @@ namespace Sparrow.Logging
             return new Logger(this, source, logger);
         }
 
-        public readonly LoggersHolder LoggersHolder;
+        internal readonly LoggersHolder LoggersHolder;
         
         private void BackgroundLogger()
         {

--- a/src/Sparrow/Logging/SwitchLogger.cs
+++ b/src/Sparrow/Logging/SwitchLogger.cs
@@ -9,19 +9,19 @@ public class SwitchLogger : Logger, IDisposable
 {
     private LogAvailability _logAvailability; 
         
-    public readonly LoggersCollection Loggers;
+    internal readonly LoggersCollection Loggers;
 
-    public SwitchLogger(LoggingSource loggingSource, string name) : 
+    internal SwitchLogger(LoggingSource loggingSource, string name) : 
         base(loggingSource, null, name)
     {
-        Loggers = new LoggersCollection(LoggingSource, this);
+        Loggers = new LoggersCollection(this);
         _logAvailability = loggingSource.LogAvailability;
     }
     
-    public SwitchLogger(SwitchLogger parent, string source, string name) : 
+    internal SwitchLogger(SwitchLogger parent, string source, string name) : 
         base(parent, source, name)
     {
-        Loggers = new LoggersCollection(LoggingSource, this);
+        Loggers = new LoggersCollection(this);
         _logAvailability = parent._logAvailability;
     }
 
@@ -37,10 +37,10 @@ public class SwitchLogger : Logger, IDisposable
         get { return _logAvailability.IsOperationsEnabled; }
     }
 
-    public Logger GetLogger<T>() => GetLogger(typeof(T).Name);
-    public Logger GetLogger(string name) => new Logger(this, $"{Source}.{name}", name);
+    internal Logger GetLogger<T>() => GetLogger(typeof(T).Name);
+    internal Logger GetLogger(string name) => new Logger(this, $"{Source}.{name}", name);
     
-    public SwitchLogger GetSubSwitchLogger(string name)
+    internal SwitchLogger GetSubSwitchLogger(string name)
     {
         if (string.IsNullOrEmpty(name))
             throw new InvalidOperationException($"{nameof(name)} {nameof(string.IsNullOrEmpty)}");
@@ -48,41 +48,37 @@ public class SwitchLogger : Logger, IDisposable
         return Loggers.GetOrAdd(name);
     }
 
-    public bool IsReset() => _logAvailability == LoggingSource.LogAvailability;
+    internal bool IsModeOverrode => _logAvailability != LoggingSource.LogAvailability;
 
-    public LogMode GetLogMode() => _logAvailability.GetMode();
+    internal LogMode GetLogMode() => _logAvailability.GetMode();
 
-    public void SetLoggerMode(LogMode mode) => _logAvailability = new LogAvailability(mode);
+    public void SetLoggerMode(LogMode mode)
+    {
+        _logAvailability = new LogAvailability(mode);
+    }
+    private void SetModeRecursively(LogAvailability logAvailability)
+    {
+        _logAvailability = logAvailability;
+        foreach (var (_, child) in Loggers)
+        {
+            child.SetModeRecursively(logAvailability);
+        }
+    }
 
     public void Dispose()
     {
         Loggers.Dispose();
-        Parent.Loggers.TryRemove(Name);
+        Parent?.Loggers.TryRemove(Name);
     }
 
-    public void UpdateMode(LogMode mode)
+    public void ResetRecursively()
     {
-        _logAvailability = new LogAvailability
-        {
-            IsInfoEnabled = (mode & LogMode.Operations) == LogMode.Operations,
-            IsOperationsEnabled = (mode & LogMode.Information) == LogMode.Information
-        };
-    }
-    public void Reset(bool recursively)
-    {
-        _logAvailability = LoggingSource.LogAvailability;
-        if (recursively)
-        {
-            foreach ((_, SwitchLogger switchLogger) in Loggers.ToArray())
-            {
-                switchLogger.Reset(true);
-            }
-        }
+        SetModeRecursively(LoggingSource.LogAvailability);
     }
 
     protected override LogMode? GetOverrideWriteMode()
     {
-        return IsReset() == false ? GetLogMode() : null;
+        return IsModeOverrode == false ? null : GetLogMode();
     }
     
     public DynamicJsonValue ToJson()
@@ -92,15 +88,15 @@ public class SwitchLogger : Logger, IDisposable
             [nameof(Name)] = Name,
             [nameof(Source)] = Source,
             
-            [nameof(IsReset)] = IsReset(),
-            [nameof(IsInfoEnabled)] = IsInfoEnabled,
-            [nameof(IsOperationsEnabled)] = IsOperationsEnabled,
+            [nameof(IsModeOverrode)] = IsModeOverrode,
+            [nameof(LogMode)] = _logAvailability.GetMode(),
         };
+        
         var loggers = Loggers.ToArray();
         if (loggers.Any())
         {
             var json = new DynamicJsonValue();
-            foreach ((var name, var logger) in loggers)
+            foreach (var ( name, logger) in loggers)
             {
                 json[name] = logger.ToJson();
             }
@@ -108,5 +104,4 @@ public class SwitchLogger : Logger, IDisposable
         }
         
         return ret;
-    }
-}
+    }}

--- a/src/Sparrow/Logging/SwitchLogger.cs
+++ b/src/Sparrow/Logging/SwitchLogger.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Sparrow.Json.Parsing;
+
+namespace Sparrow.Logging;
+
+public class SwitchLogger : Logger, IDisposable
+{
+    private LogAvailability _logAvailability; 
+        
+    public readonly LoggersCollection Loggers;
+
+    public SwitchLogger(LoggingSource loggingSource, string name) : 
+        base(loggingSource, null, name)
+    {
+        Loggers = new LoggersCollection(LoggingSource, this);
+        _logAvailability = loggingSource.LogAvailability;
+    }
+    
+    public SwitchLogger(SwitchLogger parent, string source, string name) : 
+        base(parent, source, name)
+    {
+        Loggers = new LoggersCollection(LoggingSource, this);
+        _logAvailability = parent._logAvailability;
+    }
+
+    public override bool IsInfoEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get { return _logAvailability.IsInfoEnabled; }
+    }
+
+    public override bool IsOperationsEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get { return _logAvailability.IsOperationsEnabled; }
+    }
+
+    public Logger GetLogger<T>() => GetLogger(typeof(T).Name);
+    public Logger GetLogger(string name) => new Logger(this, $"{Source}.{name}", name);
+    
+    public SwitchLogger GetSubSwitchLogger(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new InvalidOperationException($"{nameof(name)} {nameof(string.IsNullOrEmpty)}");
+
+        return Loggers.GetOrAdd(name);
+    }
+
+    public bool IsReset() => _logAvailability == LoggingSource.LogAvailability;
+
+    public LogMode GetLogMode() => _logAvailability.GetMode();
+
+    public void SetLoggerMode(LogMode mode) => _logAvailability = new LogAvailability(mode);
+
+    public void Dispose()
+    {
+        Loggers.Dispose();
+        Parent.Loggers.TryRemove(Name);
+    }
+
+    public void UpdateMode(LogMode mode)
+    {
+        _logAvailability = new LogAvailability
+        {
+            IsInfoEnabled = (mode & LogMode.Operations) == LogMode.Operations,
+            IsOperationsEnabled = (mode & LogMode.Information) == LogMode.Information
+        };
+    }
+    public void Reset(bool recursively)
+    {
+        _logAvailability = LoggingSource.LogAvailability;
+        if (recursively)
+        {
+            foreach ((_, SwitchLogger switchLogger) in Loggers.ToArray())
+            {
+                switchLogger.Reset(true);
+            }
+        }
+    }
+
+    protected override LogMode? GetOverrideWriteMode()
+    {
+        return IsReset() == false ? GetLogMode() : null;
+    }
+    
+    public DynamicJsonValue ToJson()
+    {
+        var ret = new DynamicJsonValue
+        {
+            [nameof(Name)] = Name,
+            [nameof(Source)] = Source,
+            
+            [nameof(IsReset)] = IsReset(),
+            [nameof(IsInfoEnabled)] = IsInfoEnabled,
+            [nameof(IsOperationsEnabled)] = IsOperationsEnabled,
+        };
+        var loggers = Loggers.ToArray();
+        if (loggers.Any())
+        {
+            var json = new DynamicJsonValue();
+            foreach ((var name, var logger) in loggers)
+            {
+                json[name] = logger.ToJson();
+            }
+            ret[nameof(Loggers)] = json;
+        }
+        
+        return ret;
+    }
+}

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -245,7 +245,7 @@ namespace Sparrow.LowMemory
 
         internal LowMemoryNotification()
         {
-            _logger = LoggingSource.Instance.GetLogger<LowMemoryNotification>("Server");
+            _logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<LowMemoryNotification>();
         }
 
         private void MonitorMemoryUsage()

--- a/src/Sparrow/Utils/NativeMemoryCleaner.cs
+++ b/src/Sparrow/Utils/NativeMemoryCleaner.cs
@@ -9,8 +9,7 @@ namespace Sparrow.Utils
 {
     public class NativeMemoryCleaner<TStack, TPooledItem> : IDisposable where TPooledItem : PooledItem where TStack : StackHeader<TPooledItem>
     {
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<NativeMemoryCleaner<TStack, TPooledItem>>("Memory");
-
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<NativeMemoryCleaner<TStack, TPooledItem>>();
         private readonly object _lock = new object();
         private readonly Func<object, ICollection<TStack>> _getContextsFromCleanupTarget;
         private readonly SharedMultipleUseFlag _lowMemoryFlag;

--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -46,7 +46,7 @@ namespace Voron
 
         private readonly ConcurrentDictionary<uint, MountPointInfo> _mountPoints = new ConcurrentDictionary<uint, MountPointInfo>();
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<GlobalFlushingBehavior>("Global Flusher");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<GlobalFlushingBehavior>();
 
         private class MountPointInfo
         {
@@ -74,9 +74,9 @@ namespace Voron
                         if (_envsToSync.Count == 0)
                             continue;
 
-                        if (_log.IsInfoEnabled)
+                        if (Logger.IsInfoEnabled)
                         {
-                            _log.Info($"Starting force sync with {_envsToSync.Count:#,#} items to sync after a period of no activity");
+                            Logger.Info($"Starting force sync with {_envsToSync.Count:#,#} items to sync after a period of no activity");
                         }
 
                         // sync after 5 seconds if no flushing occurred
@@ -92,9 +92,9 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
+                if (Logger.IsOperationsEnabled)
                 {
-                    _log.Operations("Catastrophic failure in Voron environment flushing", e);
+                    Logger.Operations("Catastrophic failure in Voron environment flushing", e);
                 }
 
                 // wait for the message to be flushed to the logs
@@ -172,8 +172,8 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
-                    _log.Operations($"Failed to sync data file for {storageEnvironment.Options.BasePath}", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Failed to sync data file for {storageEnvironment.Options.BasePath}", e);
                 storageEnvironment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
             }
         }
@@ -240,8 +240,8 @@ namespace Voron
                     }
                     catch (Exception e)
                     {
-                        if (_log.IsOperationsEnabled)
-                            _log.Operations($"Failed to flush {storageEnvironment.Options.BasePath}", e);
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations($"Failed to flush {storageEnvironment.Options.BasePath}", e);
 
                         storageEnvironment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
                     }

--- a/src/Voron/GlobalPrefetchingBehavior.cs
+++ b/src/Voron/GlobalPrefetchingBehavior.cs
@@ -30,8 +30,8 @@ namespace Voron.Impl
             return prefetcher;
         });
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<GlobalPrefetchingBehavior>("Global Prefetcher");
-         
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Generic.GetLogger<GlobalPrefetchingBehavior>();
+
         public readonly BlockingCollection<PrefetchRanges> CommandQueue = new BlockingCollection<PrefetchRanges>(128);
 
         private unsafe void VoronPrefetcher()
@@ -81,9 +81,9 @@ namespace Voron.Impl
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled)
+                if (Logger.IsOperationsEnabled)
                 {
-                    _log.Operations("Catastrophic failure in Voron prefetcher ", e);
+                    Logger.Operations("Catastrophic failure in Voron prefetcher ", e);
                 }
 
                 // Note that we intentionally don't have error handling here.

--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -23,7 +23,7 @@ namespace Voron.Impl
         private readonly object _locker = new object();
 
         public static EncryptionBuffersPool Instance = new EncryptionBuffersPool();
-        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<EncryptionBuffersPool>("Memory");
+        private static readonly Logger Logger = LoggingSource.Instance.LoggersHolder.Memory.GetLogger<EncryptionBuffersPool>();
         private const int MaxNumberOfPagesToCache = 128; // 128 * 8K = 1 MB, beyond that, we'll not both
         private readonly MultipleUseFlag _isLowMemory = new MultipleUseFlag();
         private readonly MultipleUseFlag _isExtremelyLowMemory = new MultipleUseFlag();

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -33,7 +33,7 @@ namespace Voron.Impl.Journal
 
         private readonly FastList<PagePosition> _unusedPages;
         private readonly ContentionLoggingLocker _locker2;
-        private Logger _logger;
+        private readonly Logger _logger;
 
         public JournalFile(StorageEnvironment env, IJournalWriter journalWriter, long journalNumber)
         {
@@ -43,7 +43,7 @@ namespace Voron.Impl.Journal
             _journalWriter = journalWriter;
             _writePosIn4Kb = 0;
             _unusedPages = new FastList<PagePosition>();
-            _logger = LoggingSource.Instance.GetLogger<JournalFile>(JournalWriter.FileName.FullPath);
+            _logger = env.Logger;
             _locker2 = new ContentionLoggingLocker(_logger, JournalWriter.FileName.FullPath);
         }
 

--- a/src/Voron/Impl/Journal/JournalWriter.cs
+++ b/src/Voron/Impl/Journal/JournalWriter.cs
@@ -38,7 +38,7 @@ namespace Voron.Impl.Journal
         {
             _options = options;
             FileName = filename;
-            _log = LoggingSource.Instance.GetLogger<JournalWriter>(options.BasePath.FullPath);
+            _log = options.Logger;
 
             var result = Pal.rvn_open_journal_for_writes(filename.FullPath, mode, size, options.SupportDurabilityFlags, out _writeHandle, out var actualSize, out var error);
             if (result != PalFlags.FailCodes.Success)
@@ -60,7 +60,7 @@ namespace Voron.Impl.Journal
                 if (error == ERROR_WORKING_SET_QUOTA && _log.IsOperationsEnabled && _workingSetQuotaLogged == false)
                 {
                     _log.Operations(
-                        $"We managed to accomplish journal write although we got {nameof(ERROR_WORKING_SET_QUOTA)} under the covers and wrote data in 4KB chunks");
+                        $"We managed to accomplish journal write although we got {nameof(ERROR_WORKING_SET_QUOTA)} under the covers and wrote data in 4KB chunks. FileName {FileName}");
 
                     _workingSetQuotaLogged = true;
                 }

--- a/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
+++ b/src/Voron/Impl/Journal/LazyTransactionBuffer.cs
@@ -27,7 +27,7 @@ namespace Voron.Impl.Journal
             _options = options;
             _lazyTransactionPager = CreateBufferPager();
             _transactionPersistentContext = new TransactionPersistentContext(true);
-            _log = LoggingSource.Instance.GetLogger<LazyTransactionBuffer>(options.BasePath.FullPath);
+            _log = options.Logger;
         }
 
         private AbstractPager CreateBufferPager()
@@ -95,7 +95,7 @@ namespace Voron.Impl.Journal
                     journalFile.Write(_firstPositionInJournalFile.Value, src, _lastUsed4Kbs);
                     if (_log.IsInfoEnabled)
                     {
-                        _log.Info($"Writing lazy transaction buffer with {_lastUsed4Kbs / 4:#,#0} kb took {sp.Elapsed}");
+                        _log.Info($"Writing lazy transaction buffer with {_lastUsed4Kbs / 4:#,#0} kb took {sp.Elapsed}. {nameof(_options)} {_options}");
                     }
                     ZeroLazyTransactionBufferIfNeeded(tempTx);
                 }

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -23,7 +23,7 @@ namespace Voron.Impl.Paging
 {
     public abstract unsafe class AbstractPager : IDisposable, ILowMemoryHandler
     {
-        public readonly Logger Log = LoggingSource.Instance.GetLogger<AbstractPager>("AbstractPager");
+        protected readonly Logger Logger;
         private readonly StorageEnvironmentOptions _options;
 
         public static ConcurrentDictionary<string, uint> PhysicalDrivePerMountCache = new ConcurrentDictionary<string, uint>();
@@ -236,6 +236,7 @@ namespace Voron.Impl.Paging
 
         protected AbstractPager(StorageEnvironmentOptions options, bool canPrefetchAhead, bool usePageProtection = false) : this()
         {
+            Logger = options.Logger;
             DisposeOnceRunner = new DisposeOnce<SingleAttempt>(() =>
             {
                 if (FileName?.FullPath != null)
@@ -431,8 +432,8 @@ namespace Voron.Impl.Paging
             {
                 try
                 {
-                    if (Log.IsInfoEnabled)
-                        Log.Info("AbstractPager finalizer was called (leak?), and 'DisposeOnceRunner.Dispose' threw exception", e);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info("AbstractPager finalizer was called (leak?), and 'DisposeOnceRunner.Dispose' threw exception", e);
                 }
                 catch
                 {
@@ -443,8 +444,8 @@ namespace Voron.Impl.Paging
             {
                 try
                 {
-                    if (Log.IsInfoEnabled)
-                        Log.Info("AbstractPager finalizer was called although GC.SuppressFinalize should have been called", new InvalidOperationException("Leak in "));
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info("AbstractPager finalizer was called although GC.SuppressFinalize should have been called", new InvalidOperationException("Leak in "));
                 }
                 catch
                 {

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -25,7 +25,6 @@ namespace Voron.Impl.Paging
         public override string ToString() => FileName?.FullPath ?? "";
         protected override string GetSourceName() => $"mmf64: {FileName?.FullPath}";
         private long _totalAllocationSize;
-        private readonly Logger _logger;
         private readonly SafeMmapHandle _handle;
 
         public RvnMemoryMapPager(StorageEnvironmentOptions options, VoronPathSetting file, long? initialFileSize = null, bool canPrefetchAhead = true, bool usePageProtection = false, bool deleteOnClose = false)
@@ -34,7 +33,6 @@ namespace Voron.Impl.Paging
             DeleteOnClose = deleteOnClose;
             FileName = file;
             var copyOnWriteMode = options.CopyOnWriteMode && FileName.FullPath.EndsWith(Constants.DatabaseFilename);
-            _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
 
             if (initialFileSize.HasValue == false || initialFileSize.Value == 0) 
                 initialFileSize = Math.Max(SysInfo.PageSize * 16, 64 * 1024);
@@ -166,10 +164,10 @@ namespace Voron.Impl.Paging
             if (_handle.FailCode == FailCodes.Success)
                 return;
 
-            if (_logger.IsInfoEnabled)
+            if (Logger.IsInfoEnabled)
             {
-                _logger.Info($"Unable to dispose handle for {FileName.FullPath} (ignoring). rc={_handle.FailCode}. DeleteOnClose={DeleteOnClose}, "
-                             + $"errorCode={PalHelper.GetNativeErrorString(_handle.ErrorNo, "Unable to dispose handle for {FileName.FullPath} (ignoring).", out _)}",
+                Logger.Info($"Unable to dispose handle for {FileName.FullPath} (ignoring). rc={_handle.FailCode}. DeleteOnClose={DeleteOnClose}, "
+                             + $"errorCode={PalHelper.GetNativeErrorString(_handle.ErrorNo, $"Unable to dispose handle for {FileName.FullPath} (ignoring).", out _)}",
                     new IOException($"Unable to dispose handle for {FileName.FullPath} (ignoring)."));
             }
         }
@@ -235,8 +233,8 @@ namespace Voron.Impl.Paging
             if (rvn_protect_range(start, (long)size, ProtectRange.Protect, out var errorCode) == 0)
                 return;
 
-            if (_logger.IsInfoEnabled)
-                _logger.Info($"Unable to protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Protect, errorCode={errorCode}");
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Unable to protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Protect, errorCode={errorCode}");
         }
 
         internal override void UnprotectPageRange(byte* start, ulong size, bool force = false)
@@ -248,8 +246,8 @@ namespace Voron.Impl.Paging
             if (rvn_protect_range(start, (long)size, ProtectRange.Unprotect, out var errorCode) == 0)
                 return;
 
-            if (_logger.IsInfoEnabled)
-                _logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
         }
     }
 }

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -59,7 +59,7 @@ namespace Voron.Impl.Scratch
 
         public ScratchBufferPool(StorageEnvironment env)
         {
-            _logger = LoggingSource.Instance.GetLogger<ScratchBufferPool>(Path.GetFileName(env.ToString()));
+            _logger = env.Logger;
 
             _disposeOnceRunner = new DisposeOnce<ExceptionRetry>(() =>
             {
@@ -575,7 +575,7 @@ namespace Voron.Impl.Scratch
                             if (_logger.IsInfoEnabled)
                             {
                                 _logger.Info(
-                                    $"Cleanup of {nameof(ScratchBufferPool)} removed: {removedInactive} inactive scratches and {removedInactiveRecycled} inactive from the recycle area");
+                                    $"Cleanup of {nameof(ScratchBufferPool)} removed: {removedInactive} inactive scratches and {removedInactiveRecycled} inactive from the recycle area. env {_env}");
                             }
 
                             _forTestingPurposes?.ActionToCallDuringCleanupRightAfterRemovingInactiveScratches?.Invoke();

--- a/src/Voron/Platform/Posix/PosixAbstractPager.cs
+++ b/src/Voron/Platform/Posix/PosixAbstractPager.cs
@@ -17,7 +17,7 @@ namespace Voron.Platform.Posix
 
         private readonly bool _supportsUnmapping;
 
-        private readonly Logger _log = LoggingSource.Instance.GetLogger<PosixAbstractPager>("PosixAbstractPager");
+        private readonly Logger _log;
 
         public override int CopyPage(I4KbBatchWrites destwI4KbBatchWrites, long p, PagerState pagerState)
         {
@@ -45,6 +45,7 @@ namespace Voron.Platform.Posix
             : base(options, canPrefetchAhead, usePageProtection: usePageProtection)
         {
             _supportsUnmapping = supportsUnmapping;
+            _log = options.Logger;
         }
 
         public override unsafe void ReleaseAllocationInfo(byte* baseAddress, long size)

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -32,7 +32,6 @@ namespace Voron.Platform.Win32
         private readonly Win32NativeFileAccess _access;
         private readonly MemoryMappedFileAccess _memoryMappedFileAccess;
         private readonly bool _copyOnWriteMode;
-        private readonly Logger _logger;
         public override long TotalAllocationSize => _totalAllocationSize;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -58,7 +57,6 @@ namespace Voron.Platform.Win32
             SYSTEM_INFO systemInfo;
             GetSystemInfo(out systemInfo);
             FileName = file;
-            _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
 
             _access = access;
             _copyOnWriteMode = Options.CopyOnWriteMode && FileName.FullPath.EndsWith(Constants.DatabaseFilename);
@@ -96,14 +94,14 @@ namespace Voron.Platform.Win32
                     if (PhysicalDrivePerMountCache.TryGetValue(drive, out UniquePhysicalDriveId) == false)
                         UniquePhysicalDriveId = GetPhysicalDriveId(drive);
 
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Physical drive '{drive}' unique id = '{UniquePhysicalDriveId}' for file '{file}'");
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Physical drive '{drive}' unique id = '{UniquePhysicalDriveId}' for file '{file}'");
                 }
                 catch (Exception ex)
                 {
                     UniquePhysicalDriveId = 0;
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Failed to determine physical drive Id for drive letter '{drive}', file='{file}'", ex);
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Failed to determine physical drive Id for drive letter '{drive}', file='{file}'", ex);
                 }
 
                 var streamAccessType = _access == Win32NativeFileAccess.GenericRead

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -118,7 +118,7 @@ namespace Voron
 
         private readonly ConcurrentQueue<TemporaryPage> _tempPagesPool = new ConcurrentQueue<TemporaryPage>();
         public bool Disposed;
-        private readonly Logger _log;
+        public readonly Logger Logger;
         public static int MaxConcurrentFlushes = 10; // RavenDB-5221
         public int TimeToSyncAfterFlushInSec;
 
@@ -138,7 +138,7 @@ namespace Voron
             {
                 SelfReference.Owner = this;
                 SelfReference.WeekReference = new WeakReference<StorageEnvironment>(this);
-                _log = LoggingSource.Instance.GetLogger<StorageEnvironment>(options.BasePath.FullPath);
+                Logger = options.Logger;
                 _options = options;
                 _dataPager = options.DataPager;
                 _freeSpaceHandling = new FreeSpaceHandling();
@@ -189,8 +189,8 @@ namespace Voron
 
         ~StorageEnvironment()
         {
-            if (_log.IsOperationsEnabled)
-                _log.Operations($"Finalizer of storage environment was called. Env: {this}");
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations($"Finalizer of storage environment was called. Env: {this}");
 
             try
             {
@@ -198,8 +198,8 @@ namespace Voron
             }
             catch (Exception e)
             {
-                if (_log.IsOperationsEnabled) 
-                    _log.Operations($"Failed to dispose storage environment via finalizer. Env: {this}", e);
+                if (Logger.IsOperationsEnabled) 
+                    Logger.Operations($"Failed to dispose storage environment via finalizer. Env: {this}", e);
             }
         }
 
@@ -262,9 +262,9 @@ namespace Voron
 
                 string message = $"{nameof(IdleFlushTimer)} failed (numberOfFailures: {numberOfFailures}), unable to schedule flush / syncs of data file. Will be restarted on new write transaction";
 
-                if (env._log.IsOperationsEnabled)
+                if (env.Logger.IsOperationsEnabled)
                 {
-                    env._log.Operations(message, e);
+                    env.Logger.Operations($"{message}. Env {env}", e);
                 }
 
                 try
@@ -1437,8 +1437,8 @@ namespace Voron
             {
                 var oldMode = Options.TransactionsMode;
 
-                if (_log.IsOperationsEnabled)
-                    _log.Operations($"Setting transaction mode to {mode}. Old mode is {oldMode}");
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Setting transaction mode to {mode}. Old mode is {oldMode}. Env {this}");
 
                 if (oldMode == mode)
                     return TransactionsModeResult.ModeAlreadySet;

--- a/test/SlowTests/SparrowTests/LogTestsHelper.cs
+++ b/test/SlowTests/SparrowTests/LogTestsHelper.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow;
+
+namespace SlowTests.SparrowTests;
+
+public class LogTestsHelper
+{
+    public class DummyWebSocket : WebSocket
+    {
+        private bool _close;
+        TaskCompletionSource<WebSocketReceiveResult> _tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        public string LogsReceived { get; private set; } = "";
+
+        public void Close() => _close = true;
+
+        public Func<Task<WebSocketReceiveResult>> ReceiveAsyncFunc { get; set; }
+
+        public override void Abort()
+        {
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override void Dispose()
+        {
+            _tcs.TrySetResult(new WebSocketReceiveResult(1, WebSocketMessageType.Text, true, WebSocketCloseStatus.NormalClosure, string.Empty));
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) => ReceiveAsyncFunc != null ? ReceiveAsyncFunc() : _tcs.Task;
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            if (_close)
+                throw new Exception("Closed");
+            LogsReceived += Encodings.Utf8.GetString(buffer.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public override WebSocketCloseStatus? CloseStatus { get; }
+        public override string CloseStatusDescription { get; }
+        public override WebSocketState State { get; }
+        public override string SubProtocol { get; }
+    }
+
+}

--- a/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
+++ b/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
@@ -117,33 +117,40 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            var bLogger = aLogger.GetSubSwitchLogger("B");
-            var cLogger = bLogger.GetSubSwitchLogger("C");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                var bLogger = aLogger.GetSubSwitchLogger("B");
+                var cLogger = bLogger.GetSubSwitchLogger("C");
 
-            var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
-            var contest = JsonOperationContext.ShortTermSingleUse();
-            var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
-            var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
+                var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
+                var contest = JsonOperationContext.ShortTermSingleUse();
+                var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
+                var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
 
 
-            Assert.True(aLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
-            Assert.True(cLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(aLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(cLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            Assert.True(bLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(bLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            configuration.Apply(aLogger);
+                configuration.Apply(aLogger);
 
-            Assert.True(aLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
-            Assert.True(cLogger.IsReset());
-            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(aLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+                Assert.True(cLogger.IsReset());
+                Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
 
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
         }
 
         [Fact]
@@ -162,12 +169,19 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            aLogger.SetLoggerMode(LogMode.Information);
-            var bLogger = aLogger.GetSubSwitchLogger("B");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                aLogger.SetLoggerMode(LogMode.Information);
+                var bLogger = aLogger.GetSubSwitchLogger("B");
 
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
         }
 
         [Fact]
@@ -186,26 +200,33 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var aLogger = new SwitchLogger(loggingSource, "A");
-            aLogger.SetLoggerMode(LogMode.Information);
-            var bLogger = aLogger.GetSubSwitchLogger("B");
-            var cLogger = bLogger.GetSubSwitchLogger("C");
+            try
+            {
+                var aLogger = new SwitchLogger(loggingSource, "A");
+                aLogger.SetLoggerMode(LogMode.Information);
+                var bLogger = aLogger.GetSubSwitchLogger("B");
+                var cLogger = bLogger.GetSubSwitchLogger("C");
 
-            Assert.False(aLogger.IsReset());
-            Assert.True(aLogger.IsInfoEnabled);
-            Assert.False(bLogger.IsReset());
-            Assert.True(bLogger.IsInfoEnabled);
-            Assert.False(cLogger.IsReset());
-            Assert.True(cLogger.IsInfoEnabled);
+                Assert.False(aLogger.IsReset());
+                Assert.True(aLogger.IsInfoEnabled);
+                Assert.False(bLogger.IsReset());
+                Assert.True(bLogger.IsInfoEnabled);
+                Assert.False(cLogger.IsReset());
+                Assert.True(cLogger.IsInfoEnabled);
 
-            aLogger.Reset(true);
+                aLogger.Reset(true);
 
-            Assert.True(aLogger.IsReset());
-            Assert.Equal(LogMode.None, aLogger.GetLogMode());
-            Assert.True(bLogger.IsReset());
-            Assert.Equal(LogMode.None, bLogger.GetLogMode());
-            Assert.True(cLogger.IsReset());
-            Assert.Equal(LogMode.None, cLogger.GetLogMode());
+                Assert.True(aLogger.IsReset());
+                Assert.Equal(LogMode.None, aLogger.GetLogMode());
+                Assert.True(bLogger.IsReset());
+                Assert.Equal(LogMode.None, bLogger.GetLogMode());
+                Assert.True(cLogger.IsReset());
+                Assert.Equal(LogMode.None, cLogger.GetLogMode());
+            }
+            finally
+            {
+                loggingSource.EndLogging();
+            }
 
         }
 
@@ -223,76 +244,84 @@ namespace SlowTests.SparrowTests
                 long.MaxValue,
                 false);
 
-            var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
-
-            var logger = new SwitchLogger(loggingSource, "A");
-
-            var shouldContainList = new List<string>();
-            var shouldNotContainList = new List<string>();
-
-            //Without listeners
+            try
             {
-                await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
 
-                logger.SetLoggerMode(LogMode.None);
-                await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-            
-                logger.SetLoggerMode(LogMode.Operations);
-                await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+                var logger = new SwitchLogger(loggingSource, "A");
 
-                logger.SetLoggerMode(LogMode.Information);
-                await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                var shouldContainList = new List<string>();
+                var shouldNotContainList = new List<string>();
+
+                //Without listeners
+                {
+                    await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                    logger.SetLoggerMode(LogMode.None);
+                    await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Operations);
+                    await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Information);
+                    await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                }
+
+                //With listeners
+                using (var socket = new LogTestsHelper.DummyWebSocket())
+                {
+                    var context = new LoggingSource.WebSocketContext();
+                    _ = loggingSource.Register(socket, context, CancellationToken.None);
+
+                    loggingSource.SetupLogMode(LogMode.Information);
+                    await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                    logger.SetLoggerMode(LogMode.None);
+                    await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Operations);
+                    await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                    logger.SetLoggerMode(LogMode.Information);
+                    await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+                }
+
+                //To be sure all logs where written to file
+                var lastLineLogger = loggingSource.GetLogger("Test", "Test");
+                await lastLineLogger.InfoWithWait("");
+
+                var actualLogContent = await File.ReadAllTextAsync(logFile);
+                foreach (var msg in shouldContainList)
+                {
+                    Assert.Contains(msg, actualLogContent);
+                }
+
+                foreach (var msg in shouldNotContainList)
+                {
+                    Assert.DoesNotContain(msg, actualLogContent);
+                }
+
+                async Task AddLog(string msg, bool shouldContain)
+                {
+                    var list = shouldContain ? shouldContainList : shouldNotContainList;
+
+                    var subLogger = logger.GetLogger("test");
+                    list.Add(msg);
+                    if (logger.IsInfoEnabled)
+                        logger.Info(msg);
+
+                    var subLoggerMsg = $"subLogger {msg}";
+                    list.Add(subLoggerMsg);
+                    if (subLogger.IsInfoEnabled)
+                        subLogger.Info(subLoggerMsg);
+
+                    var waitLogger = loggingSource.GetLogger("", "");
+                    await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+                }
             }
-            
-            //With listeners
-            using(var socket = new LogTestsHelper.DummyWebSocket())
+            finally
             {
-                var context = new LoggingSource.WebSocketContext();
-                _ = loggingSource.Register(socket, context, CancellationToken.None);
-                
-                loggingSource.SetupLogMode(LogMode.Information);
-                await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
-
-                logger.SetLoggerMode(LogMode.None);
-                await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-            
-                logger.SetLoggerMode(LogMode.Operations);
-                await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
-
-                logger.SetLoggerMode(LogMode.Information);
-                await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
-            }
-
-            //To be sure all logs where written to file
-            var lastLineLogger = loggingSource.GetLogger("Test", "Test");
-            await lastLineLogger.InfoWithWait("");
-            
-            var actualLogContent = await File.ReadAllTextAsync(logFile);
-            foreach (var msg in shouldContainList)
-            {            
-                Assert.Contains(msg, actualLogContent);
-            }
-            foreach (var msg in shouldNotContainList)
-            {            
-                Assert.DoesNotContain(msg, actualLogContent);
-            }
-
-            async Task AddLog(string msg, bool shouldContain)
-            {
-                var list = shouldContain ? shouldContainList : shouldNotContainList;
-
-                var subLogger = logger.GetLogger("test");
-                list.Add(msg);
-                if (logger.IsInfoEnabled)
-                    logger.Info(msg);
-                
-                var subLoggerMsg = $"subLogger {msg}";
-                list.Add(subLoggerMsg);
-                if(subLogger.IsInfoEnabled)
-                    subLogger.Info(subLoggerMsg);
-
-                var waitLogger = loggingSource.GetLogger("", "");
-                await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+                loggingSource.EndLogging();
             }
         }
 

--- a/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
+++ b/test/SlowTests/SparrowTests/LoggersTogglingTests.cs
@@ -1,0 +1,301 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Json;
+using SlowTests.Issues;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SparrowTests
+{
+    public class LoggersTogglingTests : RavenTestBase
+    {
+        public LoggersTogglingTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenRequestAllLogger_ShouldGetLoggersWithCurrentState()
+        {
+            using var server = GetNewServer();
+            server.Logger.SetLoggerMode(LogMode.Information);
+            using var store = new DocumentStore {Urls = new[] {server.WebUrl}, Database = "Random"}.Initialize();
+            var client = store.GetRequestExecutor().HttpClient;
+            var response = await client.GetAsync(store.Urls.First() + "/admin/loggers");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = await response.Content.ReadAsStringAsync();
+            var loggers = JsonConvert.DeserializeObject<JObject>(result);
+            Assert.NotNull(loggers);
+            Assert.True(loggers["Loggers"]["Server"][nameof(Logger.IsInfoEnabled)].Value<bool>());
+
+            //We want the client to be able to get the result of "/admin/loggers" configure it and send it back to "/admin/loggers/set"
+            //We don't want to change generic loggers while they are common to all test
+            loggers["Loggers"].Value<JObject>().Property("Generic").Remove();
+            var data = new StringContent(JsonConvert.SerializeObject(new {Configuration = loggers}), Encoding.UTF8, "application/json");
+            var setResponse = await client.PostAsync(store.Urls.First() + "/admin/loggers/set", data);
+            Assert.Equal(HttpStatusCode.OK, setResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenRequestSetServerLoggerToInfo_ShouldServerLoggerBeSetToInfo()
+        {
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options {Server = server});
+
+            var client = store.GetRequestExecutor().HttpClient;
+
+            var configuration = new {Loggers = new {Server = new {LogMode = LogMode.Information}}};
+
+            var data = new StringContent(JsonConvert.SerializeObject(new {Configuration = configuration}), Encoding.UTF8, "application/json");
+            var setResponse = await client.PostAsync(store.Urls.First() + "/admin/loggers/set", data);
+
+            Assert.Equal(HttpStatusCode.OK, setResponse.StatusCode);
+            Assert.Equal(LogMode.Information, server.Logger.GetLogMode());
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenAddAndRemoveDatabaseAndIndex_ShouldContainsEquivalentSwitches()
+        {
+            using var server = GetNewServer();
+            Assert.True(server.Logger.IsReset());
+
+            Assert.True(server.Logger.Loggers.TryGet("Databases", out var databasesSwitchLogger));
+            Assert.True(databasesSwitchLogger.IsReset());
+
+            string databaseName;
+            using (var store = GetDocumentStore(new Options {Server = server}))
+            {
+                databaseName = store.Database;
+                var index = new SampleIndex();
+                await index.ExecuteAsync(store);
+
+                Assert.True(databasesSwitchLogger.Loggers.TryGet(store.Database, out var databaseSwitchLogger));
+                Assert.True(databaseSwitchLogger.IsReset());
+
+                Assert.True(databaseSwitchLogger.Loggers.TryGet("Indexes", out var indexesSwitchLogger));
+                Assert.True(indexesSwitchLogger.IsReset());
+
+                Assert.True(indexesSwitchLogger.Loggers.TryGet(index.IndexName, out var indexSwitchLogger));
+                Assert.True(indexSwitchLogger.IsReset());
+
+                await store.Maintenance.SendAsync(new DeleteIndexOperation(index.IndexName));
+                Assert.False(indexesSwitchLogger.Loggers.TryGet(index.IndexName, out _));
+            }
+
+            Assert.False(databasesSwitchLogger.Loggers.TryGet(databaseName, out _));
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenApplyConfiguration_ShouldSetOnlyConfiguredSwitch()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+            var cLogger = bLogger.GetSubSwitchLogger("C");
+
+            var configuration1 = new DynamicJsonValue {["Loggers"] = new DynamicJsonValue {["B"] = new DynamicJsonValue {["LogMode"] = LogMode.Information}}};
+            var contest = JsonOperationContext.ShortTermSingleUse();
+            var blittable = contest.ReadObject(configuration1, "JsonDeserializationServer");
+            var configuration = JsonDeserializationServer.SwitchLoggerConfiguration(blittable);
+
+
+            Assert.True(aLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+            Assert.True(cLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            Assert.True(bLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            configuration.Apply(aLogger);
+
+            Assert.True(aLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+            Assert.True(cLogger.IsReset());
+            Assert.False(aLogger.IsOperationsEnabled || aLogger.IsInfoEnabled);
+
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenCreateNewFromSetLogger_ShouldSetTheNew()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            aLogger.SetLoggerMode(LogMode.Information);
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+        }
+
+        [Fact]
+        public void LoggerToggling_WhenReset_ShouldResetSwitches()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(forceCreateDir: true);
+            path = Path.Combine(path, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(path);
+
+            var loggingSource = new LoggingSource(
+                LogMode.None,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var aLogger = new SwitchLogger(loggingSource, "A");
+            aLogger.SetLoggerMode(LogMode.Information);
+            var bLogger = aLogger.GetSubSwitchLogger("B");
+            var cLogger = bLogger.GetSubSwitchLogger("C");
+
+            Assert.False(aLogger.IsReset());
+            Assert.True(aLogger.IsInfoEnabled);
+            Assert.False(bLogger.IsReset());
+            Assert.True(bLogger.IsInfoEnabled);
+            Assert.False(cLogger.IsReset());
+            Assert.True(cLogger.IsInfoEnabled);
+
+            aLogger.Reset(true);
+
+            Assert.True(aLogger.IsReset());
+            Assert.Equal(LogMode.None, aLogger.GetLogMode());
+            Assert.True(bLogger.IsReset());
+            Assert.Equal(LogMode.None, bLogger.GetLogMode());
+            Assert.True(cLogger.IsReset());
+            Assert.Equal(LogMode.None, cLogger.GetLogMode());
+
+        }
+
+        [Fact]
+        public async Task LoggerToggling_WhenSwitchLoggerIsDifferentFromLoggingSource_ShouldUseSwitchLoggerConfiguration()
+        {
+            var name = GetTestName();
+            var path = NewDataPath(suffix: "Logs", forceCreateDir: true);
+
+            var loggingSource = new LoggingSource(
+                LogMode.Information,
+                path,
+                "LoggingSource" + name,
+                TimeSpan.MaxValue,
+                long.MaxValue,
+                false);
+
+            var logFile = await AssertWaitForNotNullAsync(async () => Directory.GetFiles(path, "*.log").FirstOrDefault());
+
+            var logger = new SwitchLogger(loggingSource, "A");
+
+            var shouldContainList = new List<string>();
+            var shouldNotContainList = new List<string>();
+
+            //Without listeners
+            {
+                await AddLog($"Without listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                logger.SetLoggerMode(LogMode.None);
+                await AddLog($"Without listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+            
+                logger.SetLoggerMode(LogMode.Operations);
+                await AddLog($"Without listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                logger.SetLoggerMode(LogMode.Information);
+                await AddLog($"Without listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+            }
+            
+            //With listeners
+            using(var socket = new LogTestsHelper.DummyWebSocket())
+            {
+                var context = new LoggingSource.WebSocketContext();
+                _ = loggingSource.Register(socket, context, CancellationToken.None);
+                
+                loggingSource.SetupLogMode(LogMode.Information);
+                await AddLog($"With listeners 1 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+
+                logger.SetLoggerMode(LogMode.None);
+                await AddLog($"With listeners 2 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+            
+                logger.SetLoggerMode(LogMode.Operations);
+                await AddLog($"With listeners 3 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", false);
+
+                logger.SetLoggerMode(LogMode.Information);
+                await AddLog($"With listeners 4 - loggingSource.LogMode:{loggingSource.LogMode} logger.GetLogMode:{logger.GetLogMode()}", true);
+            }
+
+            //To be sure all logs where written to file
+            var lastLineLogger = loggingSource.GetLogger("Test", "Test");
+            await lastLineLogger.InfoWithWait("");
+            
+            var actualLogContent = await File.ReadAllTextAsync(logFile);
+            foreach (var msg in shouldContainList)
+            {            
+                Assert.Contains(msg, actualLogContent);
+            }
+            foreach (var msg in shouldNotContainList)
+            {            
+                Assert.DoesNotContain(msg, actualLogContent);
+            }
+
+            async Task AddLog(string msg, bool shouldContain)
+            {
+                var list = shouldContain ? shouldContainList : shouldNotContainList;
+
+                var subLogger = logger.GetLogger("test");
+                list.Add(msg);
+                if (logger.IsInfoEnabled)
+                    logger.Info(msg);
+                
+                var subLoggerMsg = $"subLogger {msg}";
+                list.Add(subLoggerMsg);
+                if(subLogger.IsInfoEnabled)
+                    subLogger.Info(subLoggerMsg);
+
+                var waitLogger = loggingSource.GetLogger("", "");
+                await waitLogger.OperationsWithWait("").WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        private static string GetTestName([CallerMemberName] string memberName = "") => memberName;
+    }
+}

--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -577,7 +577,7 @@ namespace SlowTests.SparrowTests
 
             var logger = new Logger(loggingSource, "Source" + name, "Logger" + name);
             var tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var socket = new MyDummyWebSocket();
+            var socket = new LogTestsHelper.DummyWebSocket();
             socket.ReceiveAsyncFunc = () => tcs.Task;
             var context = new LoggingSource.WebSocketContext();
 
@@ -721,7 +721,7 @@ namespace SlowTests.SparrowTests
 
             var logger = new Logger(loggingSource, "Source" + name, "Logger" + name);
             var tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var socket = new MyDummyWebSocket();
+            var socket = new LogTestsHelper.DummyWebSocket();
             socket.ReceiveAsyncFunc = () => tcs.Task;
             var context = new LoggingSource.WebSocketContext();
 
@@ -745,45 +745,6 @@ namespace SlowTests.SparrowTests
             var logContent = await File.ReadAllTextAsync(logFile);
             Assert.DoesNotContain(uniqForOperation, logContent);
             Assert.DoesNotContain(uniqForInformation, logContent);
-        }
-
-        private class MyDummyWebSocket : WebSocket
-        {
-            private bool _close;
-            public string LogsReceived { get; private set; } = "";
-
-            public void Close() => _close = true;
-
-            public Func<Task<WebSocketReceiveResult>> ReceiveAsyncFunc { get; set; } = () => Task.FromResult(new WebSocketReceiveResult(1, WebSocketMessageType.Text, true));
-
-            public override void Abort()
-            {
-            }
-
-            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
-            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
-            public override void Dispose()
-            {
-            }
-
-            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) => ReceiveAsyncFunc();
-
-            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
-            {
-                if (_close)
-                    throw new Exception("Closed");
-                LogsReceived += Encodings.Utf8.GetString(buffer.ToArray());
-                return Task.CompletedTask;
-            }
-
-            public override WebSocketCloseStatus? CloseStatus { get; }
-            public override string CloseStatusDescription { get; }
-            public override WebSocketState State { get; }
-            public override string SubProtocol { get; }
         }
 
         private static string GetTestName([CallerMemberName] string memberName = "") => memberName;

--- a/test/SlowTests/Tests/TempFileCacheTests.cs
+++ b/test/SlowTests/Tests/TempFileCacheTests.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Indexing;
+using Sparrow.Logging;
 using Sparrow.Server;
 using Voron;
 using Voron.Exceptions;
@@ -27,7 +28,9 @@ namespace SlowTests.Tests
         public void Can_reuse_files_for_cache()
         {
             var path = new VoronPathSetting(NewDataPath());
-            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+
+            var logger = LoggingSource.Instance.GetLogger<TempFileCacheTests>("Test");
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null, logger);
 
             using (File.Create(TempFileCache.GetTempFileName(environment)))
             {
@@ -43,7 +46,8 @@ namespace SlowTests.Tests
         public void Skip_files_that_are_in_use()
         {
             var path = new VoronPathSetting(NewDataPath());
-            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var environment = new StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions(path, path, path, null, null, logger);
 
             for (var i = 0; i < TempFileCache.MaxFilesToKeepInCache; i++)
             {

--- a/test/SlowTests/Voron/Storage/Files.cs
+++ b/test/SlowTests/Voron/Storage/Files.cs
@@ -6,6 +6,7 @@
 
 using System.IO;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,7 +32,8 @@ namespace SlowTests.Voron.Storage
         [Fact]
         public void TemporaryPathTest()
         {
-            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null, logger);
 
             Assert.Equal(DataDir, options.BasePath.FullPath);
             Assert.Equal(DataDir + "Temp", options.TempPath.FullPath);
@@ -51,7 +53,8 @@ namespace SlowTests.Voron.Storage
         [Fact]
         public void ScratchLocationWithTemporaryPathSpecified()
         {
-            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);
+            var logger = LoggingSource.Instance.GetLogger("Test","Test");
+            var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null, logger);
             using (var env = new StorageEnvironment(options))
             {
                 var scratchFile = Path.Combine(DataDir, StorageEnvironmentOptions.ScratchBufferName(0));

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -256,7 +256,7 @@ namespace Tests.Infrastructure
                         features: new TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures
                         {
                             MultiTree = true
-                        }, () => tcpClient.Client?.Disconnect(false));
+                        }, () => tcpClient.Client?.Disconnect(false), rachis.ClusterLogger);
 
                     rachis.AcceptNewConnection(remoteConnection, tcpClient.Client.RemoteEndPoint, hello =>
                     {

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -206,7 +206,7 @@ namespace Tests.Infrastructure
             serverStore.Initialize();
             var rachis = new RachisConsensus<CountingStateMachine>(serverStore, seed);
             var storageEnvironment = new StorageEnvironment(server);
-            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], out _);
+            rachis.Initialize(storageEnvironment, configuration, new ClusterChanges(), configuration.Core.ServerUrls[0], out _, serverStore.Server.ClusterLogger);
             rachis.OnDispose += (sender, args) =>
             {
                 serverStore.Dispose();

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -80,7 +80,7 @@ namespace FastTests
         {
             LicenseManager.IgnoreProcessorAffinityChanges = ignore;
         }
-
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<TestBase>(nameof(TestBase));
         static unsafe TestBase()
         {
             IgnoreProcessorAffinityChanges(ignore: true);
@@ -606,7 +606,7 @@ namespace FastTests
 
             base.Dispose();
 
-            var exceptionAggregator = new ExceptionAggregator("Could not dispose test");
+            var exceptionAggregator = new ExceptionAggregator(Logger, "Could not dispose test");
 
             var testOutcomeAnalyzer = new TestOutcomeAnalyzer(Context);
             var shouldSaveDebugPackage = testOutcomeAnalyzer.ShouldSaveDebugPackage();
@@ -645,7 +645,6 @@ namespace FastTests
             ServersForDisposal = null;
 
             RavenTestHelper.DeletePaths(_localPathsToDelete, exceptionAggregator);
-
             exceptionAggregator.ThrowIfNeeded();
         }
 

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Cpu;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
@@ -12,7 +13,7 @@ namespace Tests.Infrastructure.TestMetrics
         private readonly SmapsReader _smapsReader;
         private readonly TimeSpan _cacheRefreshRate = TimeSpan.FromMilliseconds(25);
 
-        public TestResourcesAnalyzerMetricCacher(ICpuUsageCalculator cpuUsageCalculator)
+        public TestResourcesAnalyzerMetricCacher(ICpuUsageCalculator cpuUsageCalculator) : base(LoggingSource.Instance.GetLogger<TestResourcesAnalyzerMetricCacher>("Test"))
         {
             if (PlatformDetails.RunningOnLinux)
                 _smapsReader = new SmapsReader(new[] { new byte[SmapsReader.BufferSize], new byte[SmapsReader.BufferSize] });

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -68,7 +68,7 @@ namespace Voron.Recovery
 
         private StorageEnvironmentOptions CreateOptions()
         {
-            var result = StorageEnvironmentOptions.ForPath(_config.DataFileDirectory, null, null, null, null);
+            var result = StorageEnvironmentOptions.ForPath(_config.DataFileDirectory);
             result.CopyOnWriteMode = _copyOnWrite;
             result.ManualFlushing = true;
             result.ManualSyncing = true;


### PR DESCRIPTION
Closed PR to v5.2
https://github.com/ravendb/ravendb/pull/14790

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-15744/Support-logging-toggling

### Additional description
* The switch loggers have a hierarchy, parent - children. (the current structure is present in "Switch loggers structure")
* Setting switch logger will not affect its already existing children
* A new child will be set as its parent 
* Setup the Logging source will affect only "reset" loggers.


Switch loggers structure:
```
 Generic: 
  Name: "Generic"
  Loggers" 
   - Name: "Memory"
 Server: 
  - Name: "Server"
   Loggers: 
   - Name: "Databases"
    Loggers: 
     - Name: "DB1"
      Loggers: 
       - Name: "Indexes"
         Loggers": 
          - Name: "Index1"
          - Name: "Index2"
     - Name: "DB2"
   - Name: "Cluster"
```
### Type of change
- New feature

### How risky is the change?
- High

### Backward compatibility
- Non-breaking change

### Is it a platform-specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing 
- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- UI work can be added