### PR TITLE
RavenDB-20588 MySQL import configuration broken

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -50,7 +50,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div data-bind="visible: databaseType() === 'MySQL', with: mySql">
+                            <div data-bind="visible: databaseType() === 'MySQL_MySql_Data' || databaseType() === 'MySQL_MySqlConnector', with: mySql">
                                 <div class="form-group"
                                      data-bind="validationElement: connectionString">
                                     <label class="control-label">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20588/MySQL-import-configuration-broken

### Additional description

The connection menu didn't show up. There was a change in the MySQL naming.


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
