### PR TITLE
RavenDB-20601 fix an edge case of an attachment conflict on a cluster-wide document

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1457,7 +1457,7 @@ namespace Raven.Server.Documents.Replication
                                 using var newVer = doc.Data.Clone(context);
                                 // now we save it again, and a side effect of that is syncing all the attachments
                                 context.DocumentDatabase.DocumentsStorage.Put(context, docId, null, newVer, lastModifiedTicks,
-                                    flags: doc.Flags);
+                                    flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
                             }
                         }
                     }

--- a/test/SlowTests/Client/Attachments/RavenDB_20601.cs
+++ b/test/SlowTests/Client/Attachments/RavenDB_20601.cs
@@ -1,0 +1,185 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Attachments
+{
+    public class RavenDB_20601 : ReplicationTestBase
+    {
+        public RavenDB_20601(ITestOutputHelper output) : base(output)
+        {
+        }
+        [Fact]
+        public async Task ConflictOfClusterTxDocumentWithAttachment()
+        {
+            var co = new ServerCreationOptions
+            {
+                RunInMemory = false,
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString()
+                },
+                RegisterForDisposal = false
+            };
+            using (var server = GetNewServer(co))
+            using (var store1 = GetDocumentStore(new Options{Server = server}))
+            using (var store2 = GetDocumentStore(new Options{Server = server}))
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var d = await BreakReplication(server.ServerStore, store1.Database);
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+                
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.Attachments.Delete("users/1", "foo/bar");
+                    session.SaveChanges();
+                }
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel2" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                d.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+            }
+        }
+
+        [Fact]
+        public async Task ConflictOfTwoClusterTxAndAttachment()
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+                var d = await BreakReplication(Server.ServerStore, store1.Database);
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+                
+                using (var session = store2.OpenSession())
+                {
+                    session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                    session.Store(new User { Name = "Karmel2" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.Attachments.Delete("users/1", "foo/bar");
+                    session.SaveChanges();
+                }
+
+                d.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+            }
+        }
+
+        [Fact]
+        public async Task ConflictOfClusterTxDocumentWithAttachment2()
+        {
+            var co = new ServerCreationOptions
+            {
+                RunInMemory = false,
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString()
+                },
+                RegisterForDisposal = false
+            };
+            using (var server = GetNewServer(co))
+            using (var store1 = GetDocumentStore(new Options{Server = server}))
+            using (var store2 = GetDocumentStore(new Options{Server = server}))
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+
+                await EnsureReplicatingAsync(store1, store2);
+                var d = await BreakReplication(server.ServerStore, store1.Database);
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+                
+                using (var profileStream = new MemoryStream(new byte[] { 3, 4, 5 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar/2", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 11, 22, 33 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+                
+                using (var profileStream = new MemoryStream(new byte[] { 33, 44, 55 }))
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Advanced.Attachments.Store("users/1", "foo/bar/2", profileStream, "image/png");
+                        session.SaveChanges();
+                    }
+                }
+
+                d.Mend();
+
+                await EnsureReplicatingAsync(store1, store2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20601

### Additional description

When we get an attachment tombstone without the document itself, we check if the existing document have this change by comparing the change vector of the document to the attachment tombstone, it if doesn't, we modify the document.

The problem here is that the document has the flag `FromClusterTransaction` which assumes we are getting the change vector from caller, which in this case results in NRE because we pass `null`.


### Type of change

- Bug fix
- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
