### PR TITLE
RavenDB-20555 - Reduce the memory usage when getting the storage report

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -507,7 +507,7 @@ namespace Voron.Impl.Journal
             return null;
         }
 
-        public Page? ReadPageHeaderForDebug(LowLevelTransaction tx, long pageNumber, Dictionary<int, PagerState> scratchPagerStates)
+        public T? ReadPageHeaderForDebug<T>(LowLevelTransaction tx, long pageNumber, Dictionary<int, PagerState> scratchPagerStates) where T : unmanaged
         {
             // read transactions have to read from journal snapshots
             if (tx.Flags == TransactionFlags.Read)
@@ -517,10 +517,7 @@ namespace Voron.Impl.Journal
                 {
                     if (tx.JournalSnapshots[i].PageTranslationTable.TryGetValue(tx, pageNumber, out PagePosition value))
                     {
-                        var page = _env.ScratchBufferPool.ReadPageHeaderForDebug(tx, value.ScratchNumber, value.ScratchPage, scratchPagerStates[value.ScratchNumber]);
-
-                        Debug.Assert(page.PageNumber == pageNumber);
-
+                        var page = _env.ScratchBufferPool.ReadPageHeaderForDebug<T>(tx, value.ScratchNumber, value.ScratchPage, scratchPagerStates[value.ScratchNumber]);
                         return page;
                     }
                 }
@@ -536,10 +533,7 @@ namespace Voron.Impl.Journal
                 if (files[i].PageTranslationTable.TryGetValue(tx, pageNumber, out value))
                 {
                     // ReSharper disable once RedundantArgumentDefaultValue
-                    var page = _env.ScratchBufferPool.ReadPageHeaderForDebug(tx, value.ScratchNumber, value.ScratchPage, pagerState: null);
-
-                    Debug.Assert(page.PageNumber == pageNumber);
-
+                    var page = _env.ScratchBufferPool.ReadPageHeaderForDebug<T>(tx, value.ScratchNumber, value.ScratchPage, pagerState: null);
                     return page;
                 }
             }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -507,6 +507,46 @@ namespace Voron.Impl.Journal
             return null;
         }
 
+        public Page? ReadPageHeaderForDebug(LowLevelTransaction tx, long pageNumber, Dictionary<int, PagerState> scratchPagerStates)
+        {
+            // read transactions have to read from journal snapshots
+            if (tx.Flags == TransactionFlags.Read)
+            {
+                // read log snapshots from the back to get the most recent version of a page
+                for (var i = tx.JournalSnapshots.Count - 1; i >= 0; i--)
+                {
+                    if (tx.JournalSnapshots[i].PageTranslationTable.TryGetValue(tx, pageNumber, out PagePosition value))
+                    {
+                        var page = _env.ScratchBufferPool.ReadPageHeaderForDebug(tx, value.ScratchNumber, value.ScratchPage, scratchPagerStates[value.ScratchNumber]);
+
+                        Debug.Assert(page.PageNumber == pageNumber);
+
+                        return page;
+                    }
+                }
+
+                return null;
+            }
+
+            // write transactions can read directly from journals that they got when they started up
+            var files = tx.JournalFiles;
+            for (var i = files.Count - 1; i >= 0; i--)
+            {
+                PagePosition value;
+                if (files[i].PageTranslationTable.TryGetValue(tx, pageNumber, out value))
+                {
+                    // ReSharper disable once RedundantArgumentDefaultValue
+                    var page = _env.ScratchBufferPool.ReadPageHeaderForDebug(tx, value.ScratchNumber, value.ScratchPage, pagerState: null);
+
+                    Debug.Assert(page.PageNumber == pageNumber);
+
+                    return page;
+                }
+            }
+
+            return null;
+        }
+
         public bool PageExists(LowLevelTransaction tx, long pageNumber)
         {
             // read transactions have to read from journal snapshots

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -10,7 +10,6 @@ using Sparrow.Binary;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
-using Sparrow.Server;
 using Sparrow.Server.Platform;
 using Sparrow.Threading;
 using Sparrow.Utils;
@@ -353,9 +352,10 @@ namespace Voron.Impl.Paging
             return AcquirePagePointerInternal(tx, pageNumber, pagerState);
         }
 
-        public virtual byte* AcquirePagePointerHeaderForDebug(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        public virtual T AcquirePagePointerHeaderForDebug<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null) where T : unmanaged
         {
-            return AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            var pointer = AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            return *(T*)pointer;
         }
 
         public virtual void BreakLargeAllocationToSeparatePages(IPagerLevelTransactionState tx, long valuePositionInScratchBuffer, long actualNumberOfAllocatedScratchPages)

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -353,6 +353,11 @@ namespace Voron.Impl.Paging
             return AcquirePagePointerInternal(tx, pageNumber, pagerState);
         }
 
+        public virtual byte* AcquirePagePointerHeaderForDebug(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        {
+            return AcquirePagePointerInternal(tx, pageNumber, pagerState);
+        }
+
         public virtual void BreakLargeAllocationToSeparatePages(IPagerLevelTransactionState tx, long valuePositionInScratchBuffer, long actualNumberOfAllocatedScratchPages)
         {
             // This method is implemented only in Crypto Pager

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -240,13 +240,13 @@ namespace Voron.Impl.Paging
             return buffer.Pointer;
         }
 
-        public override byte* AcquirePagePointerHeaderForDebug(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        public override T AcquirePagePointerHeaderForDebug<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
         {
             var state = GetTransactionState(tx);
             if (state.TryGetValue(pageNumber, out var buffer))
-                return buffer.Pointer;
+                return *(T*)buffer.Pointer;
 
-            return Inner.AcquirePagePointerWithOverflowHandling(tx, pageNumber, pagerState);
+            return Inner.AcquirePagePointerHeaderForDebug<T>(tx, pageNumber, pagerState);
         }
 
         public override void TryReleasePage(IPagerLevelTransactionState tx, long page)

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -240,6 +240,15 @@ namespace Voron.Impl.Paging
             return buffer.Pointer;
         }
 
+        public override byte* AcquirePagePointerHeaderForDebug(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        {
+            var state = GetTransactionState(tx);
+            if (state.TryGetValue(pageNumber, out var buffer))
+                return buffer.Pointer;
+
+            return Inner.AcquirePagePointerWithOverflowHandling(tx, pageNumber, pagerState);
+        }
+
         public override void TryReleasePage(IPagerLevelTransactionState tx, long page)
         {
             if (tx.CryptoPagerTransactionState == null)

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -302,6 +302,12 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Page ReadPageHeaderForDebug(LowLevelTransaction tx, long p, PagerState pagerState = null)
+        {
+            return new Page(_scratchPager.AcquirePagePointerHeaderForDebug(tx, p, pagerState));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte* AcquirePagePointerWithOverflowHandling(IPagerLevelTransactionState tx, long p)
         {
             return _scratchPager.AcquirePagePointerWithOverflowHandling(tx, p);

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -302,9 +302,9 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Page ReadPageHeaderForDebug(LowLevelTransaction tx, long p, PagerState pagerState = null)
+        public T ReadPageHeaderForDebug<T>(LowLevelTransaction tx, long p, PagerState pagerState = null) where T : unmanaged
         {
-            return new Page(_scratchPager.AcquirePagePointerHeaderForDebug(tx, p, pagerState));
+            return _scratchPager.AcquirePagePointerHeaderForDebug<T>(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -6,13 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server;
 using Sparrow.Server.Exceptions;
 using Sparrow.Threading;
-using Voron.Exceptions;
 using Voron.Impl.Paging;
 using Voron.Util;
 using Constants = Voron.Global.Constants;
@@ -389,12 +387,12 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Page ReadPageHeaderForDebug(LowLevelTransaction tx, int scratchNumber, long p, PagerState pagerState = null)
+        public T ReadPageHeaderForDebug<T>(LowLevelTransaction tx, int scratchNumber, long p, PagerState pagerState = null) where T : unmanaged
         {
             var item = GetScratchBufferFile(scratchNumber);
 
             ScratchBufferFile bufferFile = item.File;
-            return bufferFile.ReadPageHeaderForDebug(tx, p, pagerState);
+            return bufferFile.ReadPageHeaderForDebug<T>(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -389,6 +389,15 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Page ReadPageHeaderForDebug(LowLevelTransaction tx, int scratchNumber, long p, PagerState pagerState = null)
+        {
+            var item = GetScratchBufferFile(scratchNumber);
+
+            ScratchBufferFile bufferFile = item.File;
+            return bufferFile.ReadPageHeaderForDebug(tx, p, pagerState);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public PageFromScratchBuffer ShrinkOverflowPage(PageFromScratchBuffer value, int newNumberOfPages)
         {
             var item = GetScratchBufferFile(value.ScratchFileNumber);

--- a/src/Voron/PageHeaderUnion.cs
+++ b/src/Voron/PageHeaderUnion.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+using Voron.Data;
+using Voron.Data.BTrees;
+using Voron.Data.Fixed;
+
+namespace Voron;
+
+[StructLayout(LayoutKind.Explicit, Pack = 1)]
+public struct PageHeaderUnion
+{
+    [FieldOffset(0)]
+    public PageHeader PageHeader;
+
+    [FieldOffset(0)]
+    public FixedSizeTreePageHeader FixedSizeTreePageHeader;
+
+    [FieldOffset(0)]
+    public TreePageHeader TreePageHeader;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20555/High-unmanaged-memory-during-querying-of-an-encrypted-database

### Additional description

When calculating the page density during the storage report generation, we read all pages.
For some operations, it's enough to get the page header.
- For encrypted databases, we don't need to decrypt the entire page.
- For non-encrypted databases, we don't need to calculate the checksum of the page.

Results:
**Non-encrypted**:
Files tree, 13.65GB, 83 entries, response size: 5KB
Before: 12.9 seconds
After: 1.36 seconds

Attachments tree, 3.49GB, 22,695 entries, response size: 1.5MB
Before: 3.4 minutes 
After: 2.2 minutes


**Encrypted**: 
Files tree, 46.37GB, 132 entries, response size: 5.4KB
Before: 5.8 minutes, using 47GB of unmanged memory
After: 2.54 seconds

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
