### PR TITLE
RDBQA-82 - allow more operations when AllowEncryptedDatabasesOverHttp is set to true

### DIFF
--- a/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
@@ -128,7 +128,7 @@ namespace Raven.Server.Documents.Handlers
                             if (url == null)
                                 throw new InvalidOperationException($"Node {node} is not a part of the cluster, cannot send secret key.");
 
-                            if (url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false)
+                            if (url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false && Server.AllowEncryptedDatabasesOverHttp == false)
                                 throw new InvalidOperationException($"Cannot put secret key for {name} on node {node} with url {url} because it is not using HTTPS");
 
                             await SendKeyToNodeAsync(name, base64, ctx, ServerStore, node, url).ConfigureAwait(false);

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -232,7 +232,9 @@ namespace Raven.Server.Documents.Replication
                     if (rawRecord == null)
                         throw new InvalidOperationException($"The database record for {database.Name} does not exist?!");
 
-                    if (rawRecord.IsEncrypted && Destination.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false)
+                    if (rawRecord.IsEncrypted 
+                        && Destination.Url.StartsWith("https:", StringComparison.OrdinalIgnoreCase) == false 
+                        && _parent._server.Server.AllowEncryptedDatabasesOverHttp == false)
                         throw new InvalidOperationException(
                             $"{database.Name} is encrypted, and require HTTPS for replication, but had endpoint with url {Destination.Url} to database {Destination.Database}");
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBQA-82/Add-option-to-run-encrypted-database-when-authentication-is-off

### Additional description

Allow more operations when AllowEncryptedDatabasesOverHttp is set to true

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change