### PR TITLE
RavenDB-20589 Free up space on Databases view

### DIFF
--- a/src/Raven.Studio/typescript/components/common/StickyHeader.scss
+++ b/src/Raven.Studio/typescript/components/common/StickyHeader.scss
@@ -3,7 +3,7 @@
 .sticky-header {
     position: sticky;
     top: 0;
-    padding: bs5variables.$gutter bs5variables.$gutter bs5variables.$gutter-sm;
+    padding: bs5variables.$gutter-sm bs5variables.$gutter bs5variables.$gutter-xs bs5variables.$gutter-sm;
     background-color: rgba(bs5variables.$body-bg-var, 0.96);
     z-index: 1000;
     backdrop-filter: blur(2px);

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -93,7 +93,7 @@ export function DatabasesPage(props: DatabasesPageProps) {
     return (
         <>
             <StickyHeader>
-                <div className="d-flex flex-wrap gap-3 align-items-center">
+                <div className="d-flex flex-wrap gap-3 align-items-end">
                     {canCreateNewDatabase && (
                         <UncontrolledDropdown>
                             <ButtonGroup className="rounded-group">

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesFilter.tsx
@@ -37,7 +37,7 @@ export function DatabasesFilter(props: DatabasesFilterProps) {
     };
 
     return (
-        <div className="d-flex flex-wrap flex-grow gap-3 mb-3">
+        <>
             <div className="d-flex flex-column flex-grow">
                 <div className="small-label ms-1 mb-1">Filter by name</div>
                 <Input
@@ -61,6 +61,6 @@ export function DatabasesFilter(props: DatabasesFilterProps) {
                     selectAllCount={allDatabasesCount}
                 />
             </div>
-        </div>
+        </>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
@@ -114,7 +114,7 @@ export function DatabasesSelectActions({
     };
 
     return (
-        <div className="position-relative">
+        <div className="position-relative mt-3">
             <Checkbox
                 selected={selectionState === "AllSelected"}
                 indeterminate={selectionState === "SomeSelected"}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20589/Add-possibility-to-toggle-filtering-bar

### Additional description
Temporary solution that adds a bit more space to the screen. Toggling possibility should be added in the second phase - as the Filter by state for Indexing gets done.

### Type of change
- Optimization

### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
