### PR TITLE
RavenDB-20421 Now extracting AutoSpatialOptions from blittable in AutoMapIndexDefinition.LoadFromJson()

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Server.Extensions;
+using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using Voron;
@@ -137,6 +139,12 @@ namespace Raven.Server.Documents.Indexes.Auto
                 json.TryGet(nameof(AutoIndexField.Indexing), out string indexing);
                 json.TryGet(nameof(AutoIndexField.HasSuggestions), out bool hasSuggestions);
                 json.TryGet(nameof(AutoIndexField.HasQuotedName), out bool hasQuotedName);
+                json.TryGet(nameof(AutoIndexField.Spatial), out BlittableJsonReaderObject spatialBlittable);
+
+                AutoSpatialOptions spatial = null;
+                
+                if (spatialBlittable != null)
+                    spatial = JsonDeserializationServer.AutoSpatialOptions(spatialBlittable);
 
                 var field = new AutoIndexField
                 {
@@ -145,6 +153,7 @@ namespace Raven.Server.Documents.Indexes.Auto
                     Indexing = (AutoFieldIndexing)Enum.Parse(typeof(AutoFieldIndexing), indexing),
                     HasSuggestions = hasSuggestions,
                     HasQuotedName = hasQuotedName,
+                    Spatial = spatial
                 };
 
                 fields[i] = field;

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
+using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
@@ -219,6 +220,8 @@ namespace Raven.Server.Json
         public static readonly Func<BlittableJsonReaderObject, BackupConfiguration> BackupConfiguration = GenerateJsonDeserializationRoutine<BackupConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, PeriodicBackupConfiguration> GetPeriodicBackupConfiguration = GenerateJsonDeserializationRoutine<PeriodicBackupConfiguration>();
+        
+        internal static readonly Func<BlittableJsonReaderObject, AutoSpatialOptions> AutoSpatialOptions = GenerateJsonDeserializationRoutine<AutoSpatialOptions>();
 
         public class Parameters
         {

--- a/test/SlowTests/Issues/RavenDB-20421.cs
+++ b/test/SlowTests/Issues/RavenDB-20421.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20421 : RavenTestBase
+{
+    public RavenDB_20421(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestAutoSpatialIndexAfterDatabaseRestart()
+    {
+        var path = NewDataPath();
+        using var store = GetDocumentStore(new Options()
+        {
+            RunInMemory = false,
+            Path = path
+        });
+        
+        using (var session = store.OpenSession())
+        {
+            var e1 = new Employee() { Name = "Name1", Latitude = 47.623473, Longitude = -122.306009 };
+            var e2 = new Employee() { Name = "Name2", Latitude = 0.0, Longitude = 0.0 };
+
+            session.Store(e1);
+            session.Store(e2);
+
+            session.SaveChanges();
+
+            var query = session.Query<Employee>().Customize(x => x.WaitForNonStaleResults())
+                .Spatial(factory => factory.Point(x => x.Latitude, x => x.Longitude),
+                    criteria => criteria.WithinRadius(1000, 47.56, -122.31));
+            
+            var res = query.ToList();
+
+            Assert.Equal(1, res.Count);
+        }
+        
+        store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
+        store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, false));
+        
+        using (var session = store.OpenSession())
+        {
+            var query = session.Advanced.RawQuery<Employee>(
+                @"from index 'Auto/Employees/BySpatial.point(Latitude|Longitude)' where spatial.within('spatial.point(Latitude, Longitude)', spatial.circle(1000, 47.56,-122.31))").WaitForNonStaleResults();
+
+            var e3 = new Employee() { Name = "Name3", Latitude = 47.561, Longitude = -122.311 };
+
+            session.Store(e3);
+
+            session.SaveChanges();
+
+            var resAfterRestart = query.ToList();
+            
+            Assert.Equal(2, resAfterRestart.Count);
+        }
+    }
+
+    private class Employee
+    {
+        public string Name { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20421/Auto-Spatial-indexes-does-not-index-spatial-fields-after-restart

### Additional description

We want to load `Spatial` field for `AutoIndexField` when loading index definition.
It's already being loaded on v5.4, but it happens in `IndexStore.OpenIndexesFromRecord()`. On v6.0 we don't load it at all.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
