### PR TITLE
RavenDB-20029 Check controller availability and more information on test failing

### DIFF
--- a/test/FastTests/Sparrow/FileSystemUtilsTest.cs
+++ b/test/FastTests/Sparrow/FileSystemUtilsTest.cs
@@ -1,4 +1,8 @@
-﻿using Sparrow.Platform.Posix;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Sparrow.Platform.Posix;
 using Sparrow.Server.Platform.Posix;
 using Xunit;
 using Xunit.Abstractions;
@@ -34,15 +38,65 @@ namespace FastTests.Sparrow
             var swap = KernelVirtualFileSystemUtils.ReadSwapInformationFromSwapsFile(fileName);
             Assert.All(swap, s => Assert.NotNull(s.DeviceName));
         }
-        
+
         [LinuxFact]
         public void CGroup_WhenTryingToGetData_SuccessToGetValue()
         {
             var cgroup = CGroupHelper.CGroup;
+            if (cgroup.ForTestIsControllerMemoryGroupsAvailable() == false)
+                return;
+            
             //cgroup2 does not always have memory.peak
-            cgroup.GetMaxMemoryUsage();
-            Assert.NotNull(cgroup.GetPhysicalMemoryLimit());
-            Assert.NotNull(cgroup.GetPhysicalMemoryUsage());
+            try
+            {
+                cgroup.GetMaxMemoryUsage();
+                Assert.True(cgroup.GetPhysicalMemoryLimit() != null, $"Failed to {nameof(CGroup.GetPhysicalMemoryLimit)}");
+                Assert.True(cgroup.GetPhysicalMemoryUsage() != null, $"Failed to {nameof(CGroup.GetPhysicalMemoryUsage)}");
+            }
+            catch (Exception e)
+            {
+                var message = new StringBuilder($"Failed to get memory values{Environment.NewLine}");
+                var exceptions = new List<Exception> {e};
+                foreach (var file in new []{CGroup.PROC_CGROUPS_FILENAME, CGroup.PROC_MOUNTINFO_FILENAME, CGroup.PROC_SELF_CGROUP_FILENAME})
+                {
+                    if (TryRead(file, out string content, exceptions) == false) 
+                        continue;
+                    
+                    message.AppendLine($"File name {file}");
+                    message.AppendLine(content);
+                }
+
+                try
+                {
+                    var path = cgroup.ForTestFindCGroupPathForMemory();
+                    if (path != null)
+                    {
+                        message.AppendLine($"{path} cgroup folder content");
+                        message.AppendLine(string.Join(Environment.NewLine, Directory.GetFiles(path)));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    exceptions.Add(exception);
+                }
+                
+                throw new AggregateException(message.ToString(), exceptions);
+                
+                bool TryRead(string fileName, out string content, List<Exception> exceptions)
+                {
+                    try
+                    {
+                        content = File.ReadAllText(fileName);
+                        return true;
+                    }
+                    catch(Exception exception)
+                    {
+                        exceptions.Add(exception);
+                        content = null;
+                        return false;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20029

### Additional description
Some CGroup controllers can be disabled as we have in our Raspberry Pi GitHub test runner.
So I added a check to check if a controller is enabled/disabled.
### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- Yes. Linux

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
