### PR TITLE
RavenDB-20542 Add `LongSkip` to LINQ

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1591,6 +1591,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                     DocumentQuery.SuggestUsing(suggestionAsObject as SuggestionBase);
                     break;
+                case nameof(LinqExtensions.Skip):
+                    VisitQueryableMethodCall(expression);
+                    break;
                 default:
                     throw new NotSupportedException("Method not supported: " + expression.Method.Name);
             }
@@ -3782,8 +3785,10 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
         private void VisitSkip(ConstantExpression constantExpression)
         {
-            //Don't have to worry about the cast failing, the Skip() extension method only takes an int
-            DocumentQuery.Skip((int)constantExpression.Value);
+            if (constantExpression.Value.GetType() == typeof(int))
+                DocumentQuery.Skip((int)constantExpression.Value);
+            else
+                DocumentQuery.Skip((long)constantExpression.Value);
         }
 
         private void VisitTake(ConstantExpression constantExpression)

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -1489,6 +1489,17 @@ namespace Raven.Client.Documents
             return ravenQueryInspector.GetAsyncDocumentQuery();
         }
 
+        public static IRavenQueryable<T> Skip<T>(this IQueryable<T> source, long count)
+        {
+            var currentMethod = (MethodInfo)MethodBase.GetCurrentMethod();
+
+            currentMethod = ConvertMethodIfNecessary(currentMethod, typeof(T));
+            var expression = ConvertExpressionIfNecessary(source);
+
+            var queryable = source.Provider.CreateQuery(Expression.Call(null, currentMethod, expression, Expression.Constant(count)));
+            return (IRavenQueryable<T>)queryable;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Expression ConvertExpressionIfNecessary<T>(IQueryable<T> source)
         {

--- a/test/FastTests/Issues/RavenDB_20542.cs
+++ b/test/FastTests/Issues/RavenDB_20542.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_20542 : RavenTestBase
+    {
+        public RavenDB_20542(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void AddLongSkipToLINQ()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "AA" });
+                    session.Store(new User { Name = "BB" });
+                    session.Store(new User { Name = "CC" });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    long x = 1;
+                    List<User> users = session.Query<User>().Skip(x).ToList();
+                    Assert.Equal(2, users.Count);
+                    users = session.Query<User>().Skip(long.MaxValue).ToList();
+                    Assert.Equal(0, users.Count);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20542

### Additional description

Add skip(long) to LINQ

_Please delete below the options that are not relevant_

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
