### PR TITLE
RavenDB-20513 : exclude sharded databases from server wide snapshot backups

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
@@ -43,27 +43,6 @@ namespace Raven.Server.Documents.PeriodicBackup
             configuration.LocalSettings.FolderPath = pathResult.FolderPath;
         }
 
-        public static void UpdateExcludedDatabasesIfNeeded(ServerWideBackupConfiguration configuration, ServerStore serverStore)
-        {
-            if (configuration.BackupType != BackupType.Snapshot)
-                return;
-
-            using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
-            {
-                var excludes = new HashSet<string>(configuration.ExcludedDatabases, StringComparer.OrdinalIgnoreCase);
-                var dbs = serverStore.Cluster.GetAllRawDatabases(context);
-
-                foreach (var db in dbs)
-                {
-                    if (db.IsSharded)
-                        excludes.Add(db.DatabaseName);
-                }
-
-                configuration.ExcludedDatabases = excludes.ToArray();
-            }
-        }
-
         public static ActualPathResult GetActualFullPath(ServerStore serverStore, string folderPath)
         {
             var pathResult = new ActualPathResult();

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1994,7 +1994,7 @@ namespace Raven.Server.ServerWide
 
                 if (shouldUpdateServerWideBackups)
                 {
-                    using (serverWideBackups)
+                    using (var old = serverWideBackups)
                     {
                         serverWideBackups = context.ReadObject(serverWideBackups, ServerWideConfigurationKey.Backup);
                     }
@@ -4171,7 +4171,7 @@ namespace Raven.Server.ServerWide
                     [serverWideBackupConfiguration.Name] = serverWideBlittable
                 };
 
-                using (allServerWideBackups)
+                using (var old = allServerWideBackups)
                 {
                     allServerWideBackups = context.ReadObject(allServerWideBackups, ServerWideConfigurationKey.Backup);
                 }

--- a/src/Raven.Server/Web/System/AdminServerWideHandler.cs
+++ b/src/Raven.Server/Web/System/AdminServerWideHandler.cs
@@ -14,7 +14,6 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Server.Documents.PeriodicBackup;
-using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -60,6 +59,7 @@ namespace Raven.Server.Web.System
                 BackupConfigurationHelper.UpdateLocalPathIfNeeded(configuration, ServerStore);
                 BackupConfigurationHelper.AssertBackupConfiguration(configuration);
                 BackupConfigurationHelper.AssertDestinationAndRegionAreAllowed(configuration, ServerStore);
+                BackupConfigurationHelper.UpdateExcludedDatabasesIfNeeded(configuration, ServerStore);
 
                 var (newIndex, _) = await ServerStore.PutServerWideBackupConfigurationAsync(configuration, GetRaftRequestIdFromQuery());
                 await ServerStore.Cluster.WaitForIndexNotification(newIndex);

--- a/src/Raven.Server/Web/System/AdminServerWideHandler.cs
+++ b/src/Raven.Server/Web/System/AdminServerWideHandler.cs
@@ -59,7 +59,6 @@ namespace Raven.Server.Web.System
                 BackupConfigurationHelper.UpdateLocalPathIfNeeded(configuration, ServerStore);
                 BackupConfigurationHelper.AssertBackupConfiguration(configuration);
                 BackupConfigurationHelper.AssertDestinationAndRegionAreAllowed(configuration, ServerStore);
-                BackupConfigurationHelper.UpdateExcludedDatabasesIfNeeded(configuration, ServerStore);
 
                 var (newIndex, _) = await ServerStore.PutServerWideBackupConfigurationAsync(configuration, GetRaftRequestIdFromQuery());
                 await ServerStore.Cluster.WaitForIndexNotification(newIndex);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20513

### Additional description

- when adding a server-wide snapshot backup, add all sharded databases names to `ExcludedDatabases` in server-wide configuration
-  when adding a new sharded database, add its name to the `ExcludedDatabases` list of all server-wide snapshot backups

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
