### PR TITLE
RavenDB-20613 Cut index names

### DIFF
--- a/src/Raven.Studio/typescript/components/common/RichPanel.scss
+++ b/src/Raven.Studio/typescript/components/common/RichPanel.scss
@@ -58,7 +58,7 @@
     }
 
     .rich-panel-header {
-        padding: 0;
+        padding: bs5variables.$gutter-xs bs5variables.$gutter-sm;
         display: flex;
         flex-wrap: wrap;
         align-items: center;
@@ -70,15 +70,35 @@
             min-height: auto;
         }
 
-        .rich-panel-info {
-            .max-width-heading {
-                max-width: 640px;
+        .rich-panel-name {
+            margin: 0;
+            flex-grow: 1;
+            word-break: break-all;
+
+            @media (min-width: map-get(bs5variables.$grid-breakpoints, "sm")) {
+                width: 350px;
+                min-width: 350px;
+                a {
+                    white-space: nowrap;
+                    max-width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    display: inline-block;
+                }
             }
         }
 
-        .rich-panel-info,
+        .rich-panel-info {
+            flex-grow: 1;
+        }
+        .rich-panel-info {
+            // padding: bs5variables.$gutter-xs bs5variables.$gutter-sm;
+            display: flex;
+            align-items: self-start;
+        }
+
         .rich-panel-actions {
-            padding: bs5variables.$gutter-xs bs5variables.$gutter-sm;
+            margin-left: auto;
             display: flex;
             flex-wrap: wrap;
             align-items: center;
@@ -86,8 +106,7 @@
 
         .rich-panel-actions {
             justify-content: end;
-            flex-grow: 1;
-            gap: sizes.$gutter-sm;
+            gap: sizes.$gutter-xs;
         }
     }
 

--- a/src/Raven.Studio/typescript/components/common/RichPanel.tsx
+++ b/src/Raven.Studio/typescript/components/common/RichPanel.tsx
@@ -44,7 +44,7 @@ interface RichPanelHeaderProps extends HTMLAttributes<HTMLDivElement> {
 export function RichPanelHeader(props: RichPanelHeaderProps) {
     const { children, className, ...rest } = props;
     return (
-        <CardHeader className={classNames("rich-panel-header", className)} {...rest}>
+        <CardHeader className={classNames("rich-panel-header gap-2", className)} {...rest}>
             {children}
         </CardHeader>
     );
@@ -95,7 +95,7 @@ interface RichPanelNameProps {
 export function RichPanelName(props: RichPanelNameProps) {
     const { children, className, ...rest } = props;
     return (
-        <h3 className={classNames("m-0 me-4 flex-grow-1", className)} {...rest}>
+        <h3 className={classNames("rich-panel-name", className)} {...rest}>
             {children}
         </h3>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -198,8 +198,8 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                             )}
                         </RichPanelSelect>
 
-                        <RichPanelName className="max-width-heading">
-                            <a href={editUrl} title={index.name} className="d-block text-truncate">
+                        <RichPanelName>
+                            <a href={editUrl} title={index.name}>
                                 {index.name}
                             </a>
                         </RichPanelName>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -245,12 +245,11 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                 </RichPanelSelect>
                             )}
 
-                            <RichPanelName className="max-width-heading">
+                            <RichPanelName>
                                 {canNavigateToDatabase ? (
                                     <a
                                         href={documentsUrl}
                                         className={classNames(
-                                            "d-block text-truncate",
                                             { "link-disabled": db.currentNode.isBeingDeleted },
                                             { "link-shard": db.sharded }
                                         )}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20613/Cut-index-names

### Additional description

replaced a fixed max-width on database/indexes/etl... names with a responsive max-width with elipsis.

_Please delete below the options that are not relevant_

### Type of change

- Optimization

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
