### PR TITLE
RavenDB-20566 Identity Property is not removed from json

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
@@ -133,7 +133,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             if (document.Modifications == null)
                 document.Modifications = new DynamicJsonValue(document);
 
-            document.Modifications.Remove(identityProperty.Name);
+            document.Modifications.Remove(conventions.GetConvertedPropertyNameFor(identityProperty));
             return true;
         }
 

--- a/test/FastTests/Issues/RavenDB_20566.cs
+++ b/test/FastTests/Issues/RavenDB_20566.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit.Abstractions;
+using Xunit;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_20566 : RavenTestBase
+    {
+        public RavenDB_20566(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ShouldGetUserResultOnQuery()
+        {
+            using (var store = GetDocumentStore(new Options()
+            {
+                ModifyDocumentStore = documentStore =>
+                {
+                    documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                    {
+                        CustomizeJsonSerializer = (serializer) =>
+                        {
+                            serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                        }
+                    };
+                    documentStore.Conventions.PropertyNameConverter = mi => $"{Char.ToLower(mi.Name[0])}{mi.Name.Substring(1)}";
+                    documentStore.Conventions.ShouldApplyPropertyNameConverter = info => true;
+                    documentStore.Conventions.FindIdentityProperty = ConventionsFindIdentityProperty;
+                    documentStore.Conventions.FindIdentityPropertyNameFromCollectionName = s => "id";
+                }
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var user = new MyUser
+                    {
+                        UserName = "john"
+                    };
+
+                    session.Store(user, "users/1");
+                    session.SaveChanges();
+                }
+
+                WaitForUserToContinueTheTest(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Query<MyUser>().Where(u => u.UserName == "john").FirstOrDefault();
+                    Assert.NotNull(user);
+                    Assert.NotNull(user.Id);
+
+                    var command = new GetDocumentsCommand(store.Conventions, new[] { "users/1" }, null, false);
+                    session.Advanced.RequestExecutor.Execute(command, session.Advanced.Context);
+                    var blittableUser = (BlittableJsonReaderObject)command.Result.Results[0];
+                    Assert.False(blittableUser.GetPropertyNames().Contains("id"));
+                }
+            }
+        }
+
+        private bool ConventionsFindIdentityProperty(MemberInfo info)
+        {
+            var x = $"{Char.ToLower(info.Name[0])}{info.Name.Substring(1)}";
+            return x == "id";
+        }
+
+        public class MyUser : MyUserBaseClass { }
+        public class MyUserBaseClass
+        {
+            public string Id { get; set; }
+            public string UserName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20566

### Additional description

Identity Property is not removed from json when using ContractResolver

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
