### PR TITLE
RavenDB-20530 Throw `NotSupportedException` when index has boosted field.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Collections;
 using Raven.Server.ServerWide;
@@ -75,6 +76,12 @@ public class ShardedIndexCreateController : AbstractIndexCreateController
 
         if (string.IsNullOrEmpty(definition.OutputReduceToCollection) == false)
             throw new NotSupportedInShardingException("Index with output reduce to collection is not supported in sharding.");
+        
+        var databaseConfiguration = GetDatabaseConfiguration();
+        var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion); // already compiled in base method
+
+        if (instance.HasBoostedFields)
+            throw new NotSupportedInShardingException("Index with boosted fields is not supported in sharding.");
     }
 
     protected override void ValidateAutoIndex(IndexDefinitionBaseServerSide definition)

--- a/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
+++ b/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
@@ -3,6 +3,8 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq.Indexing;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Sharding;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -135,6 +137,17 @@ namespace SlowTests.Tests.Indexes
                     Assert.Equal("Oren", users[1].FirstName);
                 }
             }
+        }
+
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void IndexingTimeBoostingIsNotSupportedInShardedDatabase(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            var exception = Assert.Throws<NotSupportedInShardingException>(() => new UsersByName().Execute(store));
+
+            Assert.Contains("Index with boosted fields is not supported in sharding.", exception.Message);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20530 

### Additional description

Currently boosting is not supported on a sharded database.

### Type of change

- New feature

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
