### PR TITLE
RavenDB-20564 Sharding paging: Include Start and PageSize when `Limit` and `Offset` are null.

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -320,9 +320,8 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             {
                 modifications[nameof(IndexQuery.QueryParameters)] = modifiedArgs = new DynamicJsonValue();
             }
-            
-            var limit = ((Query.Limit ?? 0) + (Query.Offset ?? 0)) * (long)RequestHandler.DatabaseContext.ShardCount;
 
+            var limit = ((Query.Limit ?? 0) + (Query.Offset ?? 0));
             if (limit == 0)
                 limit = Query.Start + Query.PageSize;
             

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -320,9 +320,12 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             {
                 modifications[nameof(IndexQuery.QueryParameters)] = modifiedArgs = new DynamicJsonValue();
             }
-
+            
             var limit = ((Query.Limit ?? 0) + (Query.Offset ?? 0)) * (long)RequestHandler.DatabaseContext.ShardCount;
 
+            if (limit == 0)
+                limit = Query.Start + Query.PageSize;
+            
             if (limit > int.MaxValue) // overflow
                 limit = int.MaxValue;
 
@@ -412,7 +415,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
     {
         var queryChanges = QueryChanges.None;
 
-        if (Query.Offset is > 0)
+        if (Query.Offset is > 0 || Query.Start > 0)
             queryChanges |= QueryChanges.RewriteForPaging;
 
         

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -39,7 +39,11 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
     protected void ApplyPaging(ref TCombinedResult result, QueryTimingsScope scope)
     {
         QueryTimingsScope pagingScope = null;
-
+        Query.Offset ??= Query.Start;
+        Query.Limit ??= Query.PageSize;
+        
+        
+        
         if (Query.Offset is > 0)
         {
             using (GetPagingScope())

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -39,21 +39,22 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
     protected void ApplyPaging(ref TCombinedResult result, QueryTimingsScope scope)
     {
         QueryTimingsScope pagingScope = null;
-        Query.Offset ??= Query.Start;
-        Query.Limit ??= Query.PageSize;
+        
+        var queryOffset = Query.Offset is null && Query.Limit is null ? Query.Start : Query.Offset ?? 0;
+        var queryLimit = Query.Offset is null && Query.Limit is null ? Query.PageSize : Query.Limit ?? long.MaxValue;
         
         
         
-        if (Query.Offset is > 0)
+        if (queryOffset > 0)
         {
             using (GetPagingScope())
             {
-                var count = Math.Min(result.Results.Count, Math.Min(Query.Offset ?? 0, int.MaxValue));
+                var count = Math.Min(result.Results.Count, Math.Min(queryOffset, int.MaxValue));
                 result.Results.RemoveRange(0, (int)count);
             }
         }
 
-        var limit = Math.Min(Query.Limit ?? long.MaxValue, Query.FilterLimit ?? long.MaxValue);
+        var limit = Math.Min(queryLimit, Query.FilterLimit ?? long.MaxValue);
         if (result.Results.Count > limit)
         {
             using (GetPagingScope())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20564 

### Additional description

Studio do paging via `Start` and `PageSize` properties so we've to include them when `Limit` and `Offset` (from RQL) are nulls.

### Type of change

- Bug fix

### How risky is the change?

 
- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
