### PR TITLE
RavenDB-20557 Fix NRE at `GetDatabaseTopologyCommand`

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseChanges.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseChanges.cs
@@ -252,7 +252,9 @@ internal class ShardedDatabaseChanges : AbstractDatabaseChanges<ShardedDatabaseC
         switch (type)
         {
             case nameof(TopologyChange):
-                var topologyChange = TopologyChange.FromJson(change);
+                change.TryGet("Value", out BlittableJsonReaderObject value);
+                var topologyChange = TopologyChange.FromJson(value);
+
                 var requestExecutor = RequestExecutor;
                 if (requestExecutor != null)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20557

### Additional description

the orchestrator need to unwrap the topology change message

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
