### PR TITLE
RavenDB-20488 Unable to select backup type for sharded database

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideBackupEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/serverWide/serverWideBackupEditModel.ts
@@ -17,7 +17,7 @@ class serverWideBackupEditModel extends periodicBackupConfiguration {
 
         super(databaseName, dto, serverLimits, encryptedDatabase, isServerWide);
 
-        this.excludeInfo(new serverWideExcludeModel(dto.ExcludedDatabases));
+        this.excludeInfo(new serverWideExcludeModel(dto.ExcludedDatabases, this.isSnapshot));
 
         this.initObservablesServerWide();
         this.initValidationServerWide();

--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -1,7 +1,7 @@
 ﻿class tasksCommonContent {
         
     static readonly generalBackupInfo =
-        `<div class="margin-bottom">Differences between Backup and Snapshot:</div> 
+        `<div class="margin-bottom-xs">Differences between Backup and Snapshot:</div> 
         <ul>
             <li>Data
                 <small><ul>
@@ -11,7 +11,7 @@
                 </ul></small>
             </li>
         </ul>
-        <div class="margin-bottom">Differences when Snapshot backs up both index definitions and index data:</div>
+        <div class="margin-bottom-xs">Differences when Snapshot backs up both index definitions and index data:</div>
         <ul>
             <li>Speed
                 <small><ul>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -40,6 +40,9 @@
                         <ul class="dropdown-menu" data-bind="foreach: backupOptions">
                             <li><a href="#" data-bind="text: $data, click: $parent.useBackupType.bind($parent, $data)"></a></li>
                         </ul>
+                        <div class="bg-warning padding-left-xxs" data-bind="visible: $root.db.isSharded()">
+                            <small>Snapshot is not supported in <i class="icon-sharding text-shard"></i> Sharded Databases</small>
+                        </div>
                     </div>
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -41,6 +41,9 @@
                         <ul class="dropdown-menu" data-bind="foreach: backupOptions">
                             <li><a href="#" data-bind="text: $data, click: $parent.useBackupType.bind($parent, $data)"></a></li>
                         </ul>
+                        <div class="bg-warning padding-left-xxs" data-bind="visible: isSnapshot">
+                            <small>Snapshot is not supported in <i class="icon-sharding text-shard"></i> Sharded Databases</small>
+                        </div>
                     </div>
                     <span class="help-block" data-bind="validationMessage: backupType"></span>
                 </div>
@@ -124,38 +127,50 @@
                     </div>
                 </div>
                 <div class="row margin-bottom margin-bottom-xs">
-                    <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="collapse: exclude">
-                        <div class="flex-horizontal">
-                            <div class="flex-grow">
-                                <div class="dropdown btn-block flex-grow" data-bind="validationElement: databasesToExclude">
-                                    <input class="form-control dropdown-toggle" placeholder="Select (or enter) a database to exclude" data-toggle="dropdown" autocomplete="off"
-                                           data-bind="textInput: inputDatabaseToExclude, attr: { id: 'databaseNameInput' }" />
-                                    <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
-                                    <ul class="dropdown-menu" role="menu" style="display: none;"
-                                        data-bind="autoComplete: '#databaseNameInput', foreach: createDatabaseNameAutocompleter()">
-                                        <li role="presentation" data-bind="click: $parent.addWithBlink.bind($parent, $data)">
-                                            <a role="menuitem" tabindex="-1" href="#">
-                                                <span data-bind="text: $data"></span>
-                                            </a>
-                                        </li>
-                                    </ul>
-                                    <span class="help-block" data-bind="validationMessage: databasesToExclude"></span>
+                    <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4">
+                        <div data-bind="collapse: exclude">
+                            <div class="flex-horizontal">
+                                <div class="flex-grow">
+                                    <div class="dropdown btn-block flex-grow" data-bind="validationElement: databasesToExclude">
+                                        <input class="form-control dropdown-toggle" placeholder="Select (or enter) a database to exclude" data-toggle="dropdown" autocomplete="off"
+                                            data-bind="textInput: inputDatabaseToExclude, attr: { id: 'databaseNameInput' }" />
+                                        <span class="caret dropdown-toggle" data-toggle="dropdown"></span>
+                                        <ul class="dropdown-menu" role="menu" style="display: none;"
+                                            data-bind="autoComplete: '#databaseNameInput', foreach: createDatabaseNameAutocompleter()">
+                                            <li role="presentation" data-bind="click: $parent.addWithBlink.bind($parent, $data)">
+                                                <a role="menuitem" tabindex="-1" href="#">
+                                                    <span data-bind="text: $data"></span>
+                                                </a>
+                                            </li>
+                                        </ul>
+                                        <span class="help-block" data-bind="validationMessage: databasesToExclude"></span>
+                                    </div>
+                                </div>
+                                <div>
+                                    <button class="btn btn-info" data-bind="click: addDatabase, enable: inputDatabaseToExclude() && canAddDatabase()">
+                                        <i class="icon-plus"></i><span>Add Database</span>
+                                    </button>
                                 </div>
                             </div>
-                            <div>
-                                <button class="btn btn-info" data-bind="click: addDatabase, enable: inputDatabaseToExclude() && canAddDatabase()">
-                                    <i class="icon-plus"></i><span>Add Database</span>
-                                </button>
+                            <div data-bind="visible: databasesToExclude() && databasesToExclude().length || $parent.isSnapshot" class="margin-top-sm">
+                                <label><strong>Excluded Databases:</strong></label>
+                                <ul class="well collection-list" data-bind="foreach: databasesToExclude, visible: databasesToExclude() && databasesToExclude().length">
+                                    <li>
+                                        <div class="name" data-bind="text: $data"></div>
+                                        <a title="Remove database" href="#" data-bind="click: $parent.removeDatabase.bind($parent, $data)"><i class="icon-trash"></i></a>
+                                    </li>
+                                </ul>
+                                <ul class="well collection-list" data-bind="visible: $parent.isSnapshot">
+                                    <li>
+                                        <div class="bg-warning name">
+                                            <small data-placement="top" data-toggle="tooltip" title="Snapshot is not supported in sharded databases. Existing and new sharded databases will be excluded from this task." data-animation="true" data-bind="visible: isSnapshot"><i class="icon-info"></i><span>All sharded databases listed below are <strong>automatically excluded</strong> as Snapshot is not supported</small>
+                                        </div>
+                                    </li>
+                                    <li>
+                                        <div class="name"><i class="icon-sharding text-shard"></i><span>Sharded #1</span></div>
+                                    </li>
+                                </ul>
                             </div>
-                        </div>
-                        <div data-bind="visible: databasesToExclude() && databasesToExclude().length" class="margin-top">
-                            <label><strong>Excluded Databases:</strong></label>
-                            <ul class="well collection-list" data-bind="foreach: databasesToExclude">
-                                <li>
-                                    <div class="name" data-bind="text: $data"></div>
-                                    <a title="Remove database" href="#" data-bind="click: $parent.removeDatabase.bind($parent, $data)"><i class="icon-trash"></i></a>
-                                </li>
-                            </ul>
                         </div>
                     </div>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -41,7 +41,7 @@
                         <ul class="dropdown-menu" data-bind="foreach: backupOptions">
                             <li><a href="#" data-bind="text: $data, click: $parent.useBackupType.bind($parent, $data)"></a></li>
                         </ul>
-                        <div class="bg-warning padding-left-xxs" data-bind="visible: isSnapshot">
+                        <div class="bg-warning padding-left-xxs" data-bind="visible: isSnapshot() && excludeInfo().shardedDatabaseNames().length > 0">
                             <small>Snapshot is not supported in <i class="icon-sharding text-shard"></i> Sharded Databases</small>
                         </div>
                     </div>
@@ -120,7 +120,7 @@
                     <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4">
                         <div class="toggle">
                             <div data-placement="right" data-toggle="tooltip" title="Select databases to exclude from the server-wide backup" data-animation="true">
-                                <input id="excludeDatabase" type="checkbox" data-bind="checked: exclude">
+                                <input id="excludeDatabase" type="checkbox" data-bind="checked: exclude, disable: isSnapshot() && shardedDatabaseNames().length > 0">
                                 <label for="excludeDatabase">Exclude databases</label>
                             </div>
                         </div>
@@ -147,12 +147,13 @@
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="btn btn-info" data-bind="click: addDatabase, enable: inputDatabaseToExclude() && canAddDatabase()">
+                                    <button class="btn btn-info" data-bind="click: addDatabase, enable: inputDatabaseToExclude() && canAddDatabase() && !(isSnapshot() && shardedDatabaseNames().includes(inputDatabaseToExclude()))">
                                         <i class="icon-plus"></i><span>Add Database</span>
                                     </button>
                                 </div>
                             </div>
-                            <div data-bind="visible: databasesToExclude() && databasesToExclude().length || $parent.isSnapshot" class="margin-top-sm">
+                            
+                            <div data-bind="visible: databasesToExclude() && databasesToExclude().length || ($parent.isSnapshot() && shardedDatabaseNames().length > 0)" class="margin-top-sm">
                                 <label><strong>Excluded Databases:</strong></label>
                                 <ul class="well collection-list" data-bind="foreach: databasesToExclude, visible: databasesToExclude() && databasesToExclude().length">
                                     <li>
@@ -160,15 +161,17 @@
                                         <a title="Remove database" href="#" data-bind="click: $parent.removeDatabase.bind($parent, $data)"><i class="icon-trash"></i></a>
                                     </li>
                                 </ul>
-                                <ul class="well collection-list" data-bind="visible: $parent.isSnapshot">
+                                <ul class="well collection-list" data-bind="visible: $parent.isSnapshot() && shardedDatabaseNames().length > 0">
                                     <li>
                                         <div class="bg-warning name">
-                                            <small data-placement="top" data-toggle="tooltip" title="Snapshot is not supported in sharded databases. Existing and new sharded databases will be excluded from this task." data-animation="true" data-bind="visible: isSnapshot"><i class="icon-info"></i><span>All sharded databases listed below are <strong>automatically excluded</strong> as Snapshot is not supported</small>
+                                            <span data-placement="top" data-toggle="tooltip" title="Snapshot is not supported in sharded databases. Existing and new sharded databases will be excluded from this task." data-animation="true" data-bind="visible: $parent.isSnapshot()"><i class="icon-info"></i><small>All sharded databases listed below are <strong>automatically excluded</strong> as Snapshot is not supported</small></span>
                                         </div>
                                     </li>
+                                    <!-- ko foreach: shardedDatabaseNames()-->
                                     <li>
-                                        <div class="name"><i class="icon-sharding text-shard"></i><span>Sharded #1</span></div>
+                                        <div class="name"><i class="icon-sharding text-shard"></i><span data-bind="text: $data"></span></div>
                                     </li>
+                                    <!-- /ko -->
                                 </ul>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
@@ -2297,3 +2297,7 @@ ul.properties {
 @import "pages/database-settings.less";
 @import "pages/databaseIDs.less";
 @import "pages/sharding.less";
+
+.text-shard {
+    color: @sharding-color;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20488/Unable-to-select-backup-type-for-sharded-database

### Additional description

If a snapshot is selected and someone has a sharded database, then "Exclude database" is activated and additional information is displayed (as in the screenshot).

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/4c93cebb-3714-4c80-b0c1-f701e966f782)
