### PR TITLE
RavenDB-20530 Throw `NotSupportedInShardingException` during query-building when index has boosting and `Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved` is enabled.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -48,7 +48,7 @@ public class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         Dictionary<string, Dictionary<string, FacetValues>> facetsByName = new();
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
 
-        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1, null);
+        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1);
         var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out _);
         var coraxPageSize = CoraxBufferSize(_indexSearcher, facetQuery.Query.PageSize, query);
         var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -66,8 +66,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         }
 
         public override long EntriesCount() => _indexSearcher.NumberOfEntries;
-
-
+        
         protected interface ISupportsHighlighting
         {
             QueryTimingsScope TimingsScope { get; }
@@ -536,7 +535,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         }
 
                         var builderParameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, serverContext, documentsContext, query, _index,
-                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take);
+                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take, indexReadOperation: this);
 
                         using (closeServerTransaction)
                         {
@@ -1114,7 +1113,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 using (closeServerTransaction)
                 {
                     builderParameters = new(_indexSearcher, _allocator, serverContext, context, query, _index, query.QueryParameters, QueryBuilderFactories,
-                        _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, null);
+                        _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, indexReadOperation: this);
                     moreLikeThisQuery = CoraxQueryBuilder.BuildMoreLikeThisQuery(builderParameters, query.Metadata.Query.Where);
                 }
             }
@@ -1141,7 +1140,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
 
             builderParameters = new(_indexSearcher, _allocator, null, context, query, _index, query.QueryParameters, QueryBuilderFactories,
-                _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, null);
+                _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, indexReadOperation: this);
             using var mlt = new RavenRavenMoreLikeThis(builderParameters, options);
             long? baseDocId = null;
 
@@ -1258,7 +1257,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 take = CoraxConstants.IndexSearcher.TakeAll;
 
             IQueryMatch queryMatch;
-            var builderParameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, null, null, _fieldMappings, null, null, -1, null);
+            var builderParameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, null, null, _fieldMappings, null, null, -1, indexReadOperation: this);
             if ((queryMatch = CoraxQueryBuilder.BuildQuery(builderParameters, out _)) is null)
                 yield break;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -37,6 +37,10 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract long EntriesCount();
 
+        internal virtual void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved()
+        {
+        }
+        
         public abstract IEnumerable<QueryResult> Query(IndexQueryServerSide query, QueryTimingsScope queryTimings, FieldsToFetch fieldsToFetch,
             Reference<long> totalResults, Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext,
             Func<string, SpatialField> getSpatialField, CancellationToken token);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -617,6 +617,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 if (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved == false || query.Metadata.HasBoost == false && index.HasBoostedFields == false)
                     return null;
 
+                AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved();
                 sort = SortByFieldScore;
                 return null;
             }
@@ -727,7 +728,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             sort = new Sort(sortArray);
             return new ReturnSort(sortArray);
         }
-
+        
         private readonly struct ReturnSort : IDisposable
         {
             private readonly ArraySegment<SortField> _sortArray;

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -1,13 +1,12 @@
 ﻿using System.Text;
 using Corax;
 using Corax.Mappings;
-using Corax.Queries;
-using Corax.Queries.SortingMatches;
 using Corax.Queries.SortingMatches.Comparers;
 using Corax.Utils;
 using Corax.Utils.Spatial;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
+using Raven.Server.Config;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -109,4 +108,6 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
 
         return result;
     }
+    
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
@@ -2,6 +2,7 @@
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
+using Raven.Server.Config;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -87,4 +88,6 @@ public sealed class ShardedLuceneIndexReadOperation : LuceneIndexReadOperation
 
         return result;
     }
+    
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Config;
-using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Collections;
 using Raven.Server.ServerWide;
@@ -76,12 +75,6 @@ public class ShardedIndexCreateController : AbstractIndexCreateController
 
         if (string.IsNullOrEmpty(definition.OutputReduceToCollection) == false)
             throw new NotSupportedInShardingException("Index with output reduce to collection is not supported in sharding.");
-        
-        var databaseConfiguration = GetDatabaseConfiguration();
-        var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion); // already compiled in base method
-
-        if (instance.HasBoostedFields)
-            throw new NotSupportedInShardingException("Index with boosted fields is not supported in sharding.");
     }
 
     protected override void ValidateAutoIndex(IndexDefinitionBaseServerSide definition)

--- a/test/SlowTests/Core/Streaming/QueryStreaming.cs
+++ b/test/SlowTests/Core/Streaming/QueryStreaming.cs
@@ -33,11 +33,16 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanStreamQueryResults_Lucene(Options options) => CanStreamQueryResults<Users_ByName>(options);
         
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void CanStreamQueryResults_Lucene_Sharded(Options options) => CanStreamQueryResults<Users_ByName_WithoutBoosting>(options);
+
+        
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
         public void CanStreamQueryResults_Corax(Options options) => CanStreamQueryResults<Users_ByName_WithoutBoosting>(options);
         
         private void CanStreamQueryResults<TIndex>(Options options) where TIndex : AbstractIndexCreationTask, new()
@@ -154,19 +159,25 @@ namespace SlowTests.Core.Streaming
 
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanStreamQueryResultsWithQueryStatistic_Corax(Options options) => CanStreamQueryResultsWithQueryStatistics<Users_ByName_WithoutBoosting>(options, "Users/ByName/WithoutBoosting");
+        public void CanStreamQueryResultsWithQueryStatistic_Corax(Options options) => CanStreamQueryResultsWithQueryStatistics<Users_ByName_WithoutBoosting>(options);
 
         
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void CanStreamQueryResultsWithQueryStatistic_Lucene(Options options) => CanStreamQueryResultsWithQueryStatistics<Users_ByName>(options, "Users/ByName");
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanStreamQueryResultsWithQueryStatistic_Lucene(Options options) => CanStreamQueryResultsWithQueryStatistics<Users_ByName>(options);
         
-        private void CanStreamQueryResultsWithQueryStatistics<TIndex>(Options options, string indexName) where TIndex : AbstractIndexCreationTask, new()
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void CanStreamQueryResultsWithQueryStatistic_Lucene_Sharded(Options options) => CanStreamQueryResultsWithQueryStatistics<Users_ByName_WithoutBoosting>(options);
+        
+        private void CanStreamQueryResultsWithQueryStatistics<TIndex>(Options options) where TIndex : AbstractIndexCreationTask, new()
         {
             using (var store = GetDocumentStore(options))
             {
-                new TIndex().Execute(store);
-
+                var index = new TIndex();
+                index.Execute(store);
+                var indexName = index.IndexName;
+                
                 using (var session = store.OpenSession())
                 {
                     for (int i = 0; i < 100; i++)
@@ -214,20 +225,27 @@ namespace SlowTests.Core.Streaming
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanStreamQueryResultsWithQueryStatisticsAsync_Lucene(Options options) =>
-            await CanStreamQueryResultsWithQueryStatisticsAsync<Users_ByName>(options, "Users/ByName");
+            await CanStreamQueryResultsWithQueryStatisticsAsync<Users_ByName>(options);
+        
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task CanStreamQueryResultsWithQueryStatisticsAsync_Lucene_Sharded(Options options) =>
+            await CanStreamQueryResultsWithQueryStatisticsAsync<Users_ByName_WithoutBoosting>(options);
         
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanStreamQueryResultsWithQueryStatisticsAsync_Corax(Options options) =>
-            await CanStreamQueryResultsWithQueryStatisticsAsync<Users_ByName_WithoutBoosting>(options, "Users/ByName/WithoutBoosting");
+            await CanStreamQueryResultsWithQueryStatisticsAsync<Users_ByName_WithoutBoosting>(options);
 
-        private async Task CanStreamQueryResultsWithQueryStatisticsAsync<TIndex>(Options options, string indexName) where TIndex : AbstractIndexCreationTask, new()
+        private async Task CanStreamQueryResultsWithQueryStatisticsAsync<TIndex>(Options options) where TIndex : AbstractIndexCreationTask, new()
         {
             using (var store = GetDocumentStore(options))
             {
-                new TIndex().Execute(store);
+                var index = new TIndex();
+                await index.ExecuteAsync(store);
+                var indexName = index.IndexName;
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-17420.cs
+++ b/test/SlowTests/Issues/RavenDB-17420.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Linq.Indexing;
+using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,6 +25,13 @@ namespace SlowTests.Issues
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public void Can_use_boost_on_in_query(Options options)
         {
+            if (options.DatabaseMode is RavenDatabaseMode.Sharded)
+            {
+                options.ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)] = false.ToString();
+                };
+            }
             using var store = GetDocumentStore(options);
 
             using (var s = store.OpenSession())

--- a/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
+++ b/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
@@ -3,8 +3,6 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq.Indexing;
-using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Sharding;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -137,17 +135,6 @@ namespace SlowTests.Tests.Indexes
                     Assert.Equal("Oren", users[1].FirstName);
                 }
             }
-        }
-
-        [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
-        public void IndexingTimeBoostingIsNotSupportedInShardedDatabase(Options options)
-        {
-            using var store = GetDocumentStore(options);
-
-            var exception = Assert.Throws<NotSupportedInShardingException>(() => new UsersByName().Execute(store));
-
-            Assert.Contains("Index with boosted fields is not supported in sharding.", exception.Message);
         }
     }
 }

--- a/test/SlowTests/Voron/PostingListTests.cs
+++ b/test/SlowTests/Voron/PostingListTests.cs
@@ -129,7 +129,6 @@ public class PostingListTests : StorageTest
             var tree = rtx.OpenPostingList("test");
             var it = tree.Iterate();
             Assert.True(it.Seek(0));
-            bool movedNext = true;
             Span<long> buffer = stackalloc long[256];
             var bufIdx = 0;
             Assert.True(it.Fill(buffer, out var read));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20530 

### Additional description

Currently boosting is not supported on a sharded database.

### Type of change

- New feature

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
