### PR TITLE
RavenDB-7070 - update AspNetCore to 3.1.32

### DIFF
--- a/.github/workflows/FastTests.yml
+++ b/.github/workflows/FastTests.yml
@@ -10,7 +10,7 @@ on:
         - v4.2
 
 env:
-  DOTNET_VERSION: 3.1.423
+  DOTNET_VERSION: 3.1.426
   DOTNET_VERSION_6: 6.0.401
 
 jobs:

--- a/bench/BulkInsert.Benchmark/BulkInsert.Benchmark.csproj
+++ b/bench/BulkInsert.Benchmark/BulkInsert.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>BulkInsert.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BulkInsert.Benchmark</PackageId>

--- a/bench/Indexing.Benchmark/Indexing.Benchmark.csproj
+++ b/bench/Indexing.Benchmark/Indexing.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>Indexing.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Indexing.Benchmark</PackageId>

--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Micro.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/bench/Regression.Benchmark/Regression.Benchmark.csproj
+++ b/bench/Regression.Benchmark/Regression.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Regression.Benchmark</AssemblyName>
     <PackageId>Regression.Benchmark</PackageId>

--- a/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
+++ b/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/bench/Subscriptions.Benchmark/Subscriptions.Benchmark.csproj
+++ b/bench/Subscriptions.Benchmark/Subscriptions.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>Subscriptions.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Subscriptions.Benchmark</PackageId>

--- a/bench/Voron.Benchmark/Voron.Benchmark.csproj
+++ b/bench/Voron.Benchmark/Voron.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -11,7 +11,7 @@ namespace Raven.Embedded
 
         internal static string AltServerDirectory = Path.Combine(AppContext.BaseDirectory, "bin", "RavenDBServer");
 
-        public string FrameworkVersion { get; set; } = "3.1.29+";
+        public string FrameworkVersion { get; set; } = "3.1.32+";
 
         public string LogsPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "RavenDB", "Logs");
 

--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -369,10 +369,12 @@ namespace Raven.Server.Commercial
                 CSR = Jws.Base64UrlEncoded(csr.CreateSigningRequest())
             }, token);
 
+            var finalizeLocation = response.Location;
+
             while (true)
             {
                 // post-as-get (https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380)
-                (response, responseText) = await SendAsync<Order>(HttpMethod.Post, response.Location, string.Empty, token);
+                (response, responseText) = await SendAsync<Order>(HttpMethod.Post, finalizeLocation, string.Empty, token);
 
                 if (response.Status == "valid")
                 {

--- a/src/Raven.Server/Platform/Posix/MemInfoReader.cs
+++ b/src/Raven.Server/Platform/Posix/MemInfoReader.cs
@@ -280,6 +280,12 @@ namespace Raven.Server.Platform.Posix
         [SnmpIndex(54)]
         public Size CmaFree { get; set; }
 
+        [SnmpIndex(55)]
+        public Size Zswap { get; set; }
+
+        [SnmpIndex(56)]
+        public Size Zswapped { get; set; }
+
         public Dictionary<string, Size> Other { get; set; }
 
         public void Set(string name, long value, SizeUnit unit)

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -98,7 +98,7 @@
     <PackageReference Include="Lucene.Net" Version="3.0.45" />
     <PackageReference Include="Lucene.Net.Contrib.Spatial.NTS" Version="3.0.45" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.32" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.25" />

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -3,7 +3,7 @@
     <Description>Raven.Server is the database server for RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Raven.Server</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Raven.Studio/Raven.Studio.csproj
+++ b/src/Raven.Studio/Raven.Studio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Raven.Studio</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/test/BenchmarkTests/BenchmarkTests.csproj
+++ b/test/BenchmarkTests/BenchmarkTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkTests</AssemblyName>
     <PackageId>BenchmarkTests</PackageId>

--- a/test/EmbeddedTests/EmbeddedTests.csproj
+++ b/test/EmbeddedTests/EmbeddedTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>EmbeddedTests</AssemblyName>
     <PackageId>EmbeddedTests</PackageId>

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FastTests</AssemblyName>
     <PackageId>FastTests</PackageId>

--- a/test/InterversionTests/InterversionTests.csproj
+++ b/test/InterversionTests/InterversionTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>InterversionTests</AssemblyName>
     <PackageId>InterversionTests</PackageId>

--- a/test/LicenseTests/LicenseTests.csproj
+++ b/test/LicenseTests/LicenseTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>LicenseTests</AssemblyName>
     <PackageId>LicenseTests</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>

--- a/test/RachisTests/RachisTests.csproj
+++ b/test/RachisTests/RachisTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>RachisTests</AssemblyName>
     <PackageId>RachisTests</PackageId>

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -20,6 +20,7 @@ using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Sparrow.Json;
 using Tests.Infrastructure;
+using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,7 +32,7 @@ namespace SlowTests.Authentication
         {
         }
 
-        [Fact]
+        [RetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanGetLetsEncryptCertificateAndRenewIt()
         {
             var settingPath = Path.Combine(NewDataPath(forceCreateDir: true), "settings.json");

--- a/test/SlowTests/Client/BulkInserts.cs
+++ b/test/SlowTests/Client/BulkInserts.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Tests.Infrastructure;
-using Xunit;
+using xRetry;
 using Xunit.Abstractions;
 
 namespace SlowTests.Client
@@ -11,7 +11,7 @@ namespace SlowTests.Client
         {
         }
 
-        [Fact]
+        [RetryFact]
         public async Task Simple_Bulk_Insert_With_Ssl()
         {
             using (var x = new FastTests.Client.BulkInserts(Output))

--- a/test/SlowTests/Server/Documents/Migration/OracleSQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/OracleSQLSchemaTest.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Server.Documents.Migration
                 var orderTable = tables.First(x => x.TableName == "Order");
 
                 Assert.Equal(4, orderTable.Columns.Count);
-                Assert.Equal(new[] { "ID", "ORDERDATE", "CUSTOMERID", "TOTALAMOUNT" }, orderTable.Columns.Select(x => x.Name).ToList());
+                Assert.Equal(new[] { "ID", "ORDERDATE", "CUSTOMERID", "TOTALAMOUNT" }.ToHashSet(), orderTable.Columns.Select(x => x.Name).ToHashSet());
                 Assert.Equal(new[] { "ID" }, orderTable.PrimaryKeyColumns);
 
                 var orderReferences = orderTable.References;
@@ -53,11 +53,11 @@ namespace SlowTests.Server.Documents.Migration
                 // validate OrderItem (2 columns in PK)
 
                 var orderItemTable = tables.First(x => x.TableName == "ORDERITEM");
-                Assert.Equal(new[] { "ORDERID", "PRODUCTID" }, orderItemTable.PrimaryKeyColumns);
+                Assert.Equal(new[] { "ORDERID", "PRODUCTID" }.ToHashSet(), orderItemTable.PrimaryKeyColumns.ToHashSet());
 
                 Assert.Equal(1, orderItemTable.References.Count);
                 Assert.Equal("DETAILS", orderItemTable.References[0].Table);
-                Assert.Equal(new[] { "ORDERID", "PRODUCTID" }, orderItemTable.References[0].Columns);
+                Assert.Equal(new[] { "ORDERID", "PRODUCTID" }.ToHashSet(), orderItemTable.References[0].Columns.ToHashSet());
 
                 // all types are supported (except UnsupportedTable)
                 Assert.True(tables.Where(x => x.TableName != "UNSUPPORTEDTABLE")

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>SlowTests</AssemblyName>
     <PackageId>SlowTests</PackageId>

--- a/test/StressTests/StressTests.csproj
+++ b/test/StressTests/StressTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>StressTests</AssemblyName>
     <PackageId>StressTests</PackageId>

--- a/test/Tests.Infrastructure/Tests.Infrastructure.csproj
+++ b/test/Tests.Infrastructure/Tests.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>Tests.Infrastructure</AssemblyName>
     <PackageId>Tests.Infrastructure</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>

--- a/test/Tryouts/Tryouts.csproj
+++ b/test/Tryouts/Tryouts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Tryouts</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/tools/Raven.Debug/Raven.Debug.csproj
+++ b/tools/Raven.Debug/Raven.Debug.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tools/Raven.Migrator/Raven.Migrator.csproj
+++ b/tools/Raven.Migrator/Raven.Migrator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/tools/TypingsGenerator/TypingsGenerator.csproj
+++ b/tools/TypingsGenerator/TypingsGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AssemblyName>TypingsGenerator</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TypingsGenerator</PackageId>

--- a/tools/Voron.Recovery/Voron.Recovery.csproj
+++ b/tools/Voron.Recovery/Voron.Recovery.csproj
@@ -3,7 +3,7 @@
     <Description>Voron Recovery Tool</Description>
     <Authors>Hibernating Rhinos</Authors>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Recovery</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -4,7 +4,7 @@
     <Authors>Hibernating Rhinos</Authors>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.29</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <PackageTags>database;nosql;doc db</PackageTags>
     <PackageProjectUrl>https://ravendb.net</PackageProjectUrl>
     <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>


### PR DESCRIPTION
### Additional description

Update AspNetCore to 3.1.32

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing