### PR TITLE
RavenDB-20571 : fix flaky test

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.ShardedEtlTestsBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedEtlTestsBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,8 +27,8 @@ public partial class RavenTestBase
                 throw new ArgumentOutOfRangeException(nameof(count));
 
             var mre = new ManualResetEventSlim();
-            var confirmations = new HashSet<int>();
-
+            var confirmations = new ConcurrentDictionary<int, byte>();
+            
             foreach (var task in dbs)
             {
                 var shard = task.Result;
@@ -36,7 +37,7 @@ public partial class RavenTestBase
                 {
                     if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
                     {
-                        confirmations.Add(shard.ShardNumber);
+                        confirmations.TryAdd(shard.ShardNumber, 0);
                         if (confirmations.Count == count)
                             mre.Set();
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20571

### Additional description

- make `ShardedEtlTestsBase.WaitForEtl` thread safe
- add debug info to error message on test failure

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 
