### PR TITLE
RavenDB-20658 Fix attachments & prevent tombstones in Sink -> Hub filtered replication

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -650,20 +650,20 @@ namespace Raven.Server.Documents.Replication
             {
                 if (_allowedPathsValidator != null)
                 {
-                if (_allowedPathsValidator.ShouldAllow(item) == false)
-                {
-                    throw new InvalidOperationException("Attempted to replicate " + _allowedPathsValidator.GetItemInformation(item) +
-                                                        ", which is not allowed, according to the allowed paths policy. Replication aborted");
-                }
+                    if (_allowedPathsValidator.ShouldAllow(item) == false)
+                    {
+                        throw new InvalidOperationException("Attempted to replicate " + _allowedPathsValidator.GetItemInformation(item) +
+                                                            ", which is not allowed, according to the allowed paths policy. Replication aborted");
+                    }
 
-                switch (item)
-                {
-                    case AttachmentReplicationItem a:
-                        expectedAttachmentStreams ??= new HashSet<Slice>(SliceComparer.Instance);
-                        expectedAttachmentStreams.Add(a.Key);
-                        break;
+                    switch (item)
+                    {
+                        case AttachmentReplicationItem a:
+                            expectedAttachmentStreams ??= new HashSet<Slice>(SliceComparer.Instance);
+                            expectedAttachmentStreams.Add(a.Key);
+                            break;
+                    }
                 }
-            }
 
                 if (_preventIncomingSinkDeletions)
                 {
@@ -675,18 +675,6 @@ namespace Raven.Server.Documents.Replication
                                 $"This hub does not allow for tombstone replication via pull replication '{_incomingPullReplicationParams.Name}'." +
                                 $" Replication of item '{infoHelper.GetItemInformation(item)}' has been aborted for sink connection: '{this.ConnectionInfo.ToString()}'.");
                         }
-                    }
-                }
-            }
-
-            if (dataForReplicationCommand.ReplicatedAttachmentStreams != null)
-            {
-                foreach (var kvp in dataForReplicationCommand.ReplicatedAttachmentStreams)
-                {
-                    if (expectedAttachmentStreams == null || expectedAttachmentStreams.Contains(kvp.Key))
-                    {
-                        throw new InvalidOperationException("Attempted to attachment with hash: " + kvp.Key +
-                                                            ", but without a matching attachment key.");
                     }
                 }
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Replication
 
             _shouldSkipSendingTombstones = _parent.Destination is PullReplicationAsSink sink && sink.Mode == PullReplicationMode.SinkToHub &&
                                            parent._outgoingPullReplicationParams?.PreventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == true &&
-                                           _parent._database.ForTestingPurposes?.ForceSendTombstones == false;
+                                           _parent._database.ForTestingPurposes?.ForceSendTombstones != true;
 
             _numberOfAttachmentsTrackedForDeduplication = parent._database.Configuration.Replication.MaxNumberOfAttachmentsTrackedForDeduplication;
             _context = new ByteStringContext(SharedMultipleUseFlag.None);

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -30,6 +30,147 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenFact(RavenTestCategory.Replication)]
+        public async Task PreventDeletionsOnHubForAttachments()
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            var hubDatabase = GetDatabaseName("HUB");
+            var sinkDatabase = GetDatabaseName("SINK");
+
+            using var hubStore = GetDocumentStore(new RavenTestBase.Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = x => hubDatabase
+            });
+
+            using var sinkStore = GetDocumentStore(new RavenTestBase.Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = x => sinkDatabase
+            });
+
+            //setup expiration
+            await SetupExpiration(sinkStore);
+
+            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+                X509KeyStorageFlags.Exportable);
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "pullRepHub",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                PreventDeletionsMode = PreventDeletionsMode.PreventSinkToHubDeletions
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("pullRepHub",
+                new ReplicationHubAccess { Name = "hubAccess", CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)) }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = hubStore.Database + "ConStr",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = hubStore.Database + "ConStr",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = "pullRepHub"
+            }));
+
+            var sinkDatabaseInstance = await Databases.GetDocumentDatabaseInstanceFor(sinkStore);
+            sinkDatabaseInstance.ForTestingPurposes = null;
+
+            using (var s = sinkStore.OpenAsyncSession())
+            {
+                dynamic user1 = new { Source = "Sink" };
+                dynamic user3 = new { Source = "Sink" };
+                using (var attachment = new MemoryStream(new byte[]{1,2,3,4}))
+                using (var attachment2 = new MemoryStream(new byte[]{2,32,3,4}))
+                {
+                    await s.StoreAsync(user1, "users/insink/1");
+                    s.Advanced.Attachments.Store(user1, "foo", attachment);
+                    s.Advanced.GetMetadataFor(user1)[Constants.Documents.Metadata.Expires] = DateTime.UtcNow.AddMinutes(10);
+
+                    dynamic user2 = new { Source = "Sink" };
+                    await s.StoreAsync(user2, "users/insink/2");
+                    s.Advanced.GetMetadataFor(user2)[Constants.Documents.Metadata.Expires] = DateTime.UtcNow.AddMinutes(10);
+
+                    await s.StoreAsync(user3, "users/insink/3");
+                    s.Advanced.Attachments.Store(user3, "bar", attachment2);
+
+                    await s.SaveChangesAsync();
+                }
+            }
+
+            using (var s = hubStore.OpenAsyncSession())
+            {
+                await s.StoreAsync(new { Source = "Hub" }, "users/inhub/1");
+                await s.SaveChangesAsync();
+            }
+
+            Assert.True(WaitForDocument(sinkStore, "users/inhub/1"));
+            
+            await EnsureReplicatingAsync(sinkStore, hubStore);
+
+            using (var s = sinkStore.OpenAsyncSession())
+            {
+                s.Delete("users/insink/3");
+                await s.SaveChangesAsync();
+            }
+
+            //make sure hub got both docs and expires gets deleted
+            using (var h = hubStore.OpenAsyncSession())
+            {
+                //check hub got both docs
+                var doc1 = await h.LoadAsync<dynamic>("users/insink/1");
+                Assert.NotNull(doc1);
+
+                var doc2 = await h.LoadAsync<dynamic>("users/insink/2");
+                Assert.NotNull(doc2);
+
+                //check expired does not exist in users/insink/1
+                IMetadataDictionary metadata = h.Advanced.GetMetadataFor(doc1);
+                Assert.False(metadata?.ContainsKey(Constants.Documents.Metadata.Expires));
+
+                //check expired does not exist in users/insink/2
+                metadata = h.Advanced.GetMetadataFor(doc2);
+                Assert.False(metadata?.ContainsKey(Constants.Documents.Metadata.Expires));
+            }
+
+            //delete doc from sink
+            using (var s = sinkStore.OpenAsyncSession())
+            {
+                s.Delete("users/insink/1");
+                await s.SaveChangesAsync();
+            }
+
+            EnsureReplicating(hubStore, sinkStore);
+            EnsureReplicating(sinkStore, hubStore);
+
+            //make sure doc is deleted from sink
+            Assert.True(WaitForDocumentDeletion(sinkStore, "users/insink/1"));
+
+            //make sure doc not deleted from hub and still doesn't contain expires
+            using (var h = hubStore.OpenAsyncSession())
+            {
+                //check hub got doc
+                var doc1 = await h.LoadAsync<dynamic>("users/insink/1");
+                Assert.NotNull(doc1);
+
+                //check expires does not exist in users/insink/1
+                IMetadataDictionary metadata = h.Advanced.GetMetadataFor(doc1);
+                Assert.False(metadata?.ContainsKey(Constants.Documents.Metadata.Expires));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task PreventDeletionOnHubSinkCompromised()
         {
             var certificates = Certificates.SetupServerAuthentication();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20658 

### Additional description

The PR fix two issues:

1. Attachments might not be replicated due to premature missing attachment stream check.
2.  `_shouldSkipSendingTombstones` on the sink was set incorrectly, which allowed tombstones to be sent and blocked on the hub, which cause a broken replication between the sink and the hub.

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
