### PR TITLE
RavenDB-20527 Skip locked indexes on delete

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -390,11 +390,11 @@ export function useIndexesPage(database: database, stale: boolean) {
         if (indexes.length > 0) {
             const deleteIndexesVm = new deleteIndexesConfirm(indexes, db);
             app.showBootstrapDialog(deleteIndexesVm);
-            deleteIndexesVm.deleteTask.done((deleted: boolean) => {
-                if (deleted) {
+            deleteIndexesVm.deleteTask.done((succeed: boolean, deletedIndexNames: string[]) => {
+                if (succeed) {
                     dispatch({
                         type: "DeleteIndexes",
-                        indexNames: indexes.map((x) => x.name),
+                        indexNames: deletedIndexNames,
                     });
                 }
             });

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/deleteIndexesConfirm.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/deleteIndexesConfirm.html
@@ -7,7 +7,7 @@
             </button>
         </div>
         <div class="modal-body force-text-wrap">
-            <p data-bind="html: subTitleHtml"></p>
+            <p data-bind="visible: indexesInfoForDelete?.length > 0, html: subTitleHtml"></p>
             <ul data-bind="foreach: indexesInfoForDelete" style="max-height: 200px; overflow-y: auto;">
                 <li class="padding padding-xs">
                     <strong data-bind="text: indexName"></strong>
@@ -15,6 +15,12 @@
                         <span data-bind="visible: referenceCollection, text: '(Reduce Results Collections: ' + reduceOutputCollection + ', ' + referenceCollection + ')'" class="margin-left margin-left-sm"></span>
                         <span data-bind="visible: !referenceCollection, text: '(Reduce Results Collection: ' + reduceOutputCollection + ')'" class="margin-left margin-left-sm"></span>
                     </small>
+                </li>
+            </ul>
+            <p data-bind="visible: lockedIndexNames?.length > 0">Skipping locked indexes:</p>
+            <ul data-bind="foreach: lockedIndexNames" style="max-height: 200px; overflow-y: auto;">
+                <li class="padding padding-xs">
+                    <strong data-bind="text: $data"></strong>
                 </li>
             </ul>
             <hr data-bind="visible: showWarning">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20527/Refreshing-list-of-indexes-when-deleting-index-with-IndexLockMode.LockedIgnore-in-the-studio

### Additional description

Instead of refreshing I just skip indexes in locked state

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/a3b3a161-cd55-423c-8e88-72f1174ceb9d)
