### PR TITLE
RavenDB-20523 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Smuggler/SmugglerConflicts.cs
+++ b/test/SlowTests/Smuggler/SmugglerConflicts.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
@@ -209,9 +210,14 @@ namespace SlowTests.Smuggler
                     }))
                     {
                         await SetupReplicationAsync(store2, store3);
-                        WaitForDocument(store3, "people/1-A");
 
-                        var stats = await GetDatabaseStatisticsAsync(store3);
+                        DatabaseStatistics stats = null;
+                        await WaitForValueAsync(async () =>
+                        {
+                            stats = await GetDatabaseStatisticsAsync(store3);
+                            return stats.CountOfDocuments;
+                        }, expectedVal: 7);
+
                         Assert.Equal(7, stats.CountOfDocuments);
                         Assert.Equal(0, stats.CountOfDocumentsConflicts);
                         Assert.Equal(0, stats.CountOfConflicts);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20523

### Additional description

use `WaitForValue` (on docs count) instead of `WaitForDocument` (in sharded mode we need to wait for all shards to finish replicating)

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 