### PR TITLE
RavenDB-20666 setting orchestator replication factor follow same logic as normal database

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -508,7 +508,7 @@ namespace Raven.Client.ServerWide
                 return Topology.ClusterTransactionIdBase64;
 
             Debug.Assert(Sharding.Shards.All(s => s.Value.ClusterTransactionIdBase64.Equals(Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64)));
-            return Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64;
+            return Sharding.Orchestrator.Topology.ClusterTransactionIdBase64;
         }
 
         internal static string GetKeyForDeletionInProgress(string node, int? shardNumber)

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -344,7 +344,7 @@ namespace Raven.Server.ServerWide
                 return Topology.ClusterTransactionIdBase64;
 
             Debug.Assert(Sharding.Shards.All(s => s.Value.ClusterTransactionIdBase64.Equals(Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64)));
-            return Sharding.Shards.ElementAt(0).Value.ClusterTransactionIdBase64;
+            return Sharding.Orchestrator.Topology.ClusterTransactionIdBase64;
         }
 
         private DatabaseStateStatus? _databaseState;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -451,7 +451,7 @@ namespace Raven.Server.Web.System
             {
                 databaseRecord.Sharding.Orchestrator ??= new OrchestratorConfiguration();
                 databaseRecord.Sharding.Orchestrator.Topology ??= new OrchestratorTopology();
-                SetReplicationFactor(databaseRecord.Sharding.Orchestrator.Topology, clusterTopology, replicationFactor);
+                UpdateDatabaseTopology(databaseRecord.Sharding.Orchestrator.Topology, clusterTopology, replicationFactor, clusterTransactionId);
 
                 foreach (var (shardNumber, databaseTopology) in databaseRecord.Sharding.Shards)
                     UpdateDatabaseTopology(databaseTopology, clusterTopology, replicationFactor, clusterTransactionId);

--- a/src/Raven.Server/Web/System/DatabaseHelper.cs
+++ b/src/Raven.Server/Web/System/DatabaseHelper.cs
@@ -104,6 +104,11 @@ namespace Raven.Server.Web.System
                         topology.ValidateTopology(ShardHelper.ToShardName(record.DatabaseName, shardNumber));
                     }
                 }
+
+                if (record.Sharding?.Orchestrator?.Topology?.Count > 0)
+                {
+                    record.Sharding.Orchestrator.Topology.ValidateTopology(record.DatabaseName);
+                }
             }
             else
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20666 

### Additional description

Upon creation, ensure there is no mismatch between the replication factor and number of nodes in the database.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
