### PR TITLE
RavenDB-20031 Add unsaved changes  confirmation on leaving manage database group view

### DIFF
--- a/src/Raven.Studio/typescript/common/extensions.ts
+++ b/src/Raven.Studio/typescript/common/extensions.ts
@@ -4,10 +4,11 @@ import listView = require("widgets/listView/listView");
 import genUtils = require("common/generalUtils");
 import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 import accessManager = require("common/shell/accessManager");
-import React from "react";
+import { createElement } from "react";
 import { createRoot, Root } from "react-dom/client";
 import store from "components/store";
-import { Provider } from "react-redux";
+import { Provider as ReduxProvider, ProviderProps as ReduxProviderProps } from "react-redux";
+import { DirtyFlagProvider } from "components/hooks/useDirtyFlag";
 
 class extensions {
     static install() {
@@ -229,13 +230,12 @@ class extensions {
                 const options = ko.unwrap(valueAccessor());
 
                 if (options && options.component) {
-                    // eslint-disable-next-line
                     const root = createRoot(element);
-                    const inner = React.createElement(options.component, options.props);
-                    // eslint-disable-next-line react/no-children-prop
-                    const wrapper = React.createElement(Provider, { store: store, children: inner });
-                    root.render(wrapper);
-                    
+                    const component = createElement(options.component, options.props);
+                    const dirtyFlagWrapper = createElement(DirtyFlagProvider, options.dirtyFlag, component);
+                    const reduxWrapper = createElement(ReduxProvider, { store: store } as ReduxProviderProps, dirtyFlagWrapper);
+
+                    root.render(reduxWrapper);
                     $(element).data("root", root);
                 }
             }

--- a/src/Raven.Studio/typescript/common/reactViewModelUtils.ts
+++ b/src/Raven.Studio/typescript/common/reactViewModelUtils.ts
@@ -1,7 +1,6 @@
-export function getDirtyFlagForReact(dirtyFlag: () => DirtyFlag): KoToReactDirtyFlag {
+export function getReactDirtyFlag(dirtyFlag: () => DirtyFlag): ReactDirtyFlag {
     return {
-        koIsDirty: dirtyFlag().isDirty,
-        koSetIsDirty: (value: boolean) => value
+        setIsDirty: (value: boolean) => value
             ? dirtyFlag().forceDirty()
             : dirtyFlag().reset(),
     };

--- a/src/Raven.Studio/typescript/common/reactViewModelUtils.ts
+++ b/src/Raven.Studio/typescript/common/reactViewModelUtils.ts
@@ -1,0 +1,8 @@
+export function getDirtyFlagForReact(dirtyFlag: () => DirtyFlag): KoToReactDirtyFlag {
+    return {
+        koIsDirty: dirtyFlag().isDirty,
+        koSetIsDirty: (value: boolean) => value
+            ? dirtyFlag().forceDirty()
+            : dirtyFlag().reset(),
+    };
+}

--- a/src/Raven.Studio/typescript/components/common/ButtonWithSpinner.tsx
+++ b/src/Raven.Studio/typescript/components/common/ButtonWithSpinner.tsx
@@ -22,8 +22,8 @@ export default function ButtonWithSpinner(props: ButtonWithSpinnerProps) {
         <Button
             className={classNames("d-flex", "align-items-center", className)}
             size={size}
-            disabled={isSpinning || disabled}
             {...rest}
+            disabled={disabled || isSpinning}
         >
             {isSpinning ? <Spinner size="sm" className="me-1" /> : IconElement}
             {children}

--- a/src/Raven.Studio/typescript/components/hooks/useDirtyFlag.tsx
+++ b/src/Raven.Studio/typescript/components/hooks/useDirtyFlag.tsx
@@ -1,27 +1,20 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useEffect } from "react";
 
-interface DirtyFlag {
-    isDirty: boolean;
-    setIsDirty: (isDirty: boolean) => void;
+const DirtyFlagContext = createContext<ReactDirtyFlag>(null);
+
+export function DirtyFlagProvider({ setIsDirty, children }: ReactDirtyFlag & { children: React.ReactNode }) {
+    return <DirtyFlagContext.Provider value={{ setIsDirty }}>{children}</DirtyFlagContext.Provider>;
 }
 
-const DirtyFlagContext = createContext<DirtyFlag>(null);
+export const useDirtyFlag = (isDirty: boolean) => {
+    const { setIsDirty } = useContext(DirtyFlagContext);
 
-export function DirtyFlagProvider(props: KoToReactDirtyFlag & { children: React.ReactNode }) {
-    const { koIsDirty, koSetIsDirty, children } = props;
+    useEffect(() => {
+        if (isDirty) {
+            setIsDirty(true);
+            return;
+        }
 
-    const [isDirty, setIsDirty] = useState(koIsDirty());
-
-    const setIsDirtyForKoAndReact = (x: boolean) => {
-        koSetIsDirty(x);
-        setIsDirty(x);
-    };
-
-    return (
-        <DirtyFlagContext.Provider value={{ isDirty, setIsDirty: setIsDirtyForKoAndReact }}>
-            {children}
-        </DirtyFlagContext.Provider>
-    );
-}
-
-export const useDirtyFlag = () => useContext(DirtyFlagContext);
+        setIsDirty(false);
+    }, [isDirty, setIsDirty]);
+};

--- a/src/Raven.Studio/typescript/components/hooks/useDirtyFlag.tsx
+++ b/src/Raven.Studio/typescript/components/hooks/useDirtyFlag.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface DirtyFlag {
+    isDirty: boolean;
+    setIsDirty: (isDirty: boolean) => void;
+}
+
+const DirtyFlagContext = createContext<DirtyFlag>(null);
+
+export function DirtyFlagProvider(props: KoToReactDirtyFlag & { children: React.ReactNode }) {
+    const { koIsDirty, koSetIsDirty, children } = props;
+
+    const [isDirty, setIsDirty] = useState(koIsDirty());
+
+    const setIsDirtyForKoAndReact = (x: boolean) => {
+        koSetIsDirty(x);
+        setIsDirty(x);
+    };
+
+    return (
+        <DirtyFlagContext.Provider value={{ isDirty, setIsDirty: setIsDirtyForKoAndReact }}>
+            {children}
+        </DirtyFlagContext.Provider>
+    );
+}
+
+export const useDirtyFlag = () => useContext(DirtyFlagContext);

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroup.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroup.spec.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { composeStories } from "@storybook/testing-react";
 
 import * as stories from "./ManageDatabaseGroupPage.stories";
+import { mockHooks } from "test/mocks/hooks/MockHooks";
 
 const {
     Cluster,
@@ -91,5 +92,20 @@ describe("ManageDatabaseGroup", function () {
 
         await fireClick(await screen.findByText(selectors.reorderNodes));
         await fireClick(await screen.findByText(selectors.saveReorder));
+    });
+
+    it("can set dirty flag", async () => {
+        const { screen, fireClick } = rtlRender(<Cluster />);
+        const { useDirtyFlag } = mockHooks;
+
+        expect(useDirtyFlag.isDirty).toBeFalse();
+
+        await screen.findByText(selectors.pageReady);
+
+        await fireClick(await screen.findByText(selectors.reorderNodes));
+        expect(useDirtyFlag.isDirty).toBeTrue();
+
+        await fireClick(await screen.findByText(selectors.saveReorder));
+        expect(useDirtyFlag.isDirty).toBeFalse();
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
@@ -19,6 +19,7 @@ import { useAppSelector } from "components/store";
 import { ShardedDatabaseSharedInfo } from "components/models/databases";
 import { Icon } from "components/common/Icon";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { SortableModeCounterProvider } from "./partials/useSortableModeCounter";
 
 interface ManageDatabaseGroupPageProps {
     db: database;
@@ -117,16 +118,18 @@ export function ManageDatabaseGroupPage(props: ManageDatabaseGroupPageProps) {
                 </div>
             </StickyHeader>
             <div className="content-margin">
-                {db.isSharded() ? (
-                    <React.Fragment key="sharded-db">
-                        <OrchestratorsGroup db={dbSharedInfo} />
-                        {(dbSharedInfo as ShardedDatabaseSharedInfo).shards.map((shard) => {
-                            return <ShardsGroup key={shard.name} db={shard} />;
-                        })}
-                    </React.Fragment>
-                ) : (
-                    <NodeGroup key="non-sharded-db" db={dbSharedInfo} />
-                )}
+                <SortableModeCounterProvider>
+                    {db.isSharded() ? (
+                        <React.Fragment key="sharded-db">
+                            <OrchestratorsGroup db={dbSharedInfo} />
+                            {(dbSharedInfo as ShardedDatabaseSharedInfo).shards.map((shard) => {
+                                return <ShardsGroup key={shard.name} db={shard} />;
+                            })}
+                        </React.Fragment>
+                    ) : (
+                        <NodeGroup key="non-sharded-db" db={dbSharedInfo} />
+                    )}
+                </SortableModeCounterProvider>
             </div>
         </>
     );

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
@@ -1,11 +1,12 @@
 ﻿import React, { useCallback, useState } from "react";
-import { Button, Spinner } from "reactstrap";
+import { Button } from "reactstrap";
 import { NodeInfoReorderComponent } from "components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent";
 import { useDrop } from "react-dnd";
 import { NodeInfo } from "components/models/databases";
 import { DatabaseGroup, DatabaseGroupList } from "components/common/DatabaseGroup";
 import { Icon } from "components/common/Icon";
 import { RadioToggleWithIcon, RadioToggleWithIconInputItem } from "components/common/RadioToggle";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 
 interface ReorderNodesControlsProps {
     sortableMode: boolean;
@@ -35,10 +36,9 @@ export function ReorderNodesControls(props: ReorderNodesControlsProps) {
         </Button>
     ) : (
         <>
-            <Button color="success" onClick={onSaveClicked} disabled={saving}>
-                {saving ? <Spinner size="sm" /> : <Icon icon="save" />}
-                <span>Save reorder</span>
-            </Button>
+            <ButtonWithSpinner color="success" onClick={onSaveClicked} isSpinning={saving} icon="save">
+                Save reorder
+            </ButtonWithSpinner>
             <Button onClick={cancelReorder}>
                 <Icon icon="cancel" />
                 <span>Cancel</span>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useGroup.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useGroup.ts
@@ -3,12 +3,14 @@ import { NodeInfo } from "components/models/databases";
 import { useAccessManager } from "hooks/useAccessManager";
 import { useAppSelector } from "components/store";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
+import { useSortableModeCounter } from "./useSortableModeCounter";
 
 export function useGroup(nodes: NodeInfo[], initialFixOrder: boolean) {
     const [fixOrder, setFixOrder] = useState(initialFixOrder);
     const [newOrder, setNewOrder] = useState<NodeInfo[]>([]);
     const [sortableMode, setSortableMode] = useState(false);
     const clusterNodeTags = useAppSelector(clusterSelectors.allNodeTags);
+    const { setCounter: setSortableModeCounter } = useSortableModeCounter();
 
     const { isOperatorOrAbove } = useAccessManager();
     const canSort = nodes.length === 1 || !isOperatorOrAbove();
@@ -16,8 +18,12 @@ export function useGroup(nodes: NodeInfo[], initialFixOrder: boolean) {
     const enableReorder = () => {
         setNewOrder(nodes.slice());
         setSortableMode(true);
+        setSortableModeCounter((counter) => counter + 1);
     };
-    const exitReorder = () => setSortableMode(false);
+    const exitReorder = () => {
+        setSortableMode(false);
+        setSortableModeCounter((counter) => counter - 1);
+    };
 
     const existingTags = nodes ? nodes.map((x) => x.tag) : [];
     const addNodeEnabled = isOperatorOrAbove() && clusterNodeTags.some((x) => !existingTags.includes(x));

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useSortableModeCounter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useSortableModeCounter.tsx
@@ -1,5 +1,5 @@
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useState } from "react";
 
 interface SortableModeCounter {
     counter: number;
@@ -20,16 +20,7 @@ export function SortableModeCounterProvider({ children }: { children: React.Reac
 
 export function useSortableModeCounter(): Pick<SortableModeCounter, "setCounter"> {
     const { counter, setCounter } = useContext(SortableModeCounterContext);
-    const { setIsDirty } = useDirtyFlag();
-
-    useEffect(() => {
-        if (counter === 0) {
-            setIsDirty(false);
-            return;
-        }
-
-        setIsDirty(true);
-    }, [counter, setIsDirty]);
+    useDirtyFlag(counter !== 0);
 
     return {
         setCounter,

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useSortableModeCounter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useSortableModeCounter.tsx
@@ -1,0 +1,37 @@
+import { useDirtyFlag } from "components/hooks/useDirtyFlag";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+interface SortableModeCounter {
+    counter: number;
+    setCounter: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const SortableModeCounterContext = createContext<SortableModeCounter>(null);
+
+export function SortableModeCounterProvider({ children }: { children: React.ReactNode }) {
+    const [counter, setCounter] = useState(0);
+
+    return (
+        <SortableModeCounterContext.Provider value={{ counter, setCounter }}>
+            {children}
+        </SortableModeCounterContext.Provider>
+    );
+}
+
+export function useSortableModeCounter(): Pick<SortableModeCounter, "setCounter"> {
+    const { counter, setCounter } = useContext(SortableModeCounterContext);
+    const { setIsDirty } = useDirtyFlag();
+
+    useEffect(() => {
+        if (counter === 0) {
+            setIsDirty(false);
+            return;
+        }
+
+        setIsDirty(true);
+    }, [counter, setIsDirty]);
+
+    return {
+        setCounter,
+    };
+}

--- a/src/Raven.Studio/typescript/test/mocks/hooks/MockDirtyFlagHook.ts
+++ b/src/Raven.Studio/typescript/test/mocks/hooks/MockDirtyFlagHook.ts
@@ -1,0 +1,19 @@
+export default class MockDirtyFlagHook {
+    private _isDirty: boolean;
+
+    private readonly _mock = (isDirty: boolean) => {
+        this._isDirty = isDirty;
+    };
+
+    constructor() {
+        this._isDirty = false;
+    }
+
+    get isDirty(): boolean {
+        return this._isDirty;
+    }
+
+    get mock() {
+        return this._mock;
+    }
+}

--- a/src/Raven.Studio/typescript/test/mocks/hooks/MockHooks.ts
+++ b/src/Raven.Studio/typescript/test/mocks/hooks/MockHooks.ts
@@ -1,9 +1,11 @@
 ﻿import MockChangesHook from "test/mocks/hooks/MockChangesHook";
 import MockEventsCollector from "test/mocks/hooks/MockEventsCollector";
+import MockDirtyFlagHook from "./MockDirtyFlagHook";
 
 class MockHooksContainer {
     useChanges = new MockChangesHook();
     useEventsCollector = new MockEventsCollector();
+    useDirtyFlag = new MockDirtyFlagHook();
 }
 
 export const mockHooks = new MockHooksContainer();

--- a/src/Raven.Studio/typescript/test/rtlTestUtils.tsx
+++ b/src/Raven.Studio/typescript/test/rtlTestUtils.tsx
@@ -17,8 +17,9 @@ import * as byClassNameQueries from "./byClassNameQueries";
 import { ChangesProvider } from "hooks/useChanges";
 import { mockHooks } from "test/mocks/hooks/MockHooks";
 import { createStoreConfiguration } from "components/store";
-import { Provider } from "react-redux";
+import { Provider as ReduxProvider } from "react-redux";
 import { setEffectiveTestStore } from "components/storeCompat";
+import { DirtyFlagProvider } from "components/hooks/useDirtyFlag";
 
 let needsTestMock = true;
 
@@ -76,11 +77,13 @@ function AllProvidersInner({ children }: any) {
     setEffectiveTestStore(store);
 
     return (
-        <Provider store={store}>
-            <ServiceProvider services={mockServices.context}>
-                <ChangesProvider changes={mockHooks.useChanges.mock}>{children}</ChangesProvider>
-            </ServiceProvider>
-        </Provider>
+        <ReduxProvider store={store}>
+            <DirtyFlagProvider setIsDirty={mockHooks.useDirtyFlag.mock}>
+                <ServiceProvider services={mockServices.context}>
+                    <ChangesProvider changes={mockHooks.useChanges.mock}>{children}</ChangesProvider>
+                </ServiceProvider>
+            </DirtyFlagProvider>
+        </ReduxProvider>
     );
 }
 

--- a/src/Raven.Studio/typescript/test/storybookTestUtils.tsx
+++ b/src/Raven.Studio/typescript/test/storybookTestUtils.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { configureMockServices, ServiceProvider } from "components/hooks/useServices";
 import { ChangesProvider } from "hooks/useChanges";
 import { mockHooks } from "test/mocks/hooks/MockHooks";
+import { DirtyFlagProvider } from "components/hooks/useDirtyFlag";
 
 export function storybookContainerPublicContainer(storyFn: any) {
     return (
@@ -27,9 +28,11 @@ export function forceStoryRerender() {
 
 export function withStorybookContexts(storyFn: any) {
     return (
-        <ServiceProvider services={mockServices.context}>
-            <ChangesProvider changes={mockHooks.useChanges.mock}>{storyFn()}</ChangesProvider>
-        </ServiceProvider>
+        <DirtyFlagProvider setIsDirty={mockHooks.useDirtyFlag.mock}>
+            <ServiceProvider services={mockServices.context}>
+                <ChangesProvider changes={mockHooks.useChanges.mock}>{storyFn()}</ChangesProvider>
+            </ServiceProvider>
+        </DirtyFlagProvider>
     );
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
@@ -1,12 +1,11 @@
 ﻿import React from "react";
 import viewModelBase from "viewmodels/viewModelBase";
-import database from "models/resources/database";
+import { getDirtyFlagForReact } from "common/reactViewModelUtils";
 
 abstract class reactViewModelBase extends viewModelBase {
 
     view = { default: `<div class="react-container" data-bind="react: reactOptions"></div>` };
 
-    private readonly db?: database;
     private readonly reactView: React.FC<any>;
     private readonly bootstrap5: boolean; //TODO: will be removed once we migrate all react views to bs5 (I assume one left)
 
@@ -26,19 +25,22 @@ abstract class reactViewModelBase extends viewModelBase {
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
 
-        this.reactOptions = this.createReactOptions(this.reactView, {
+        const reactDirtyFlag = getDirtyFlagForReact(this.dirtyFlag);
+        const reactProps = {
             ...args,
             db: this.activeDatabase()
-        });
+        }
+
+        this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 
-    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps) {
+    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: KoToReactDirtyFlag) {
         return ko.pureComputed(() => ({
             component,
-            props
+            props,
+            dirtyFlag
         }));
     }
 }
-
 
 export = reactViewModelBase;

--- a/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import viewModelBase from "viewmodels/viewModelBase";
-import { getDirtyFlagForReact } from "common/reactViewModelUtils";
+import { getReactDirtyFlag } from "common/reactViewModelUtils";
 
 abstract class reactViewModelBase extends viewModelBase {
 
@@ -25,7 +25,7 @@ abstract class reactViewModelBase extends viewModelBase {
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
 
-        const reactDirtyFlag = getDirtyFlagForReact(this.dirtyFlag);
+        const reactDirtyFlag = getReactDirtyFlag(this.dirtyFlag);
         const reactProps = {
             ...args,
             db: this.activeDatabase()
@@ -34,7 +34,7 @@ abstract class reactViewModelBase extends viewModelBase {
         this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 
-    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: KoToReactDirtyFlag) {
+    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: ReactDirtyFlag) {
         return ko.pureComputed(() => ({
             component,
             props,

--- a/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
@@ -1,7 +1,7 @@
 ﻿import shardViewModelBase from "viewmodels/shardViewModelBase";
 import React from "react";
 import database from "models/resources/database";
-import { getDirtyFlagForReact } from "common/reactViewModelUtils";
+import { getReactDirtyFlag } from "common/reactViewModelUtils";
 
 abstract class shardedReactViewModelBase extends shardViewModelBase {
 
@@ -26,7 +26,7 @@ abstract class shardedReactViewModelBase extends shardViewModelBase {
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
 
-        const reactDirtyFlag = getDirtyFlagForReact(this.dirtyFlag);
+        const reactDirtyFlag = getReactDirtyFlag(this.dirtyFlag);
         const reactProps = {
             ...args,
             database: this.db,
@@ -36,7 +36,7 @@ abstract class shardedReactViewModelBase extends shardViewModelBase {
         this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 
-    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: KoToReactDirtyFlag) {
+    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: ReactDirtyFlag) {
         return ko.pureComputed(() => ({
             component,
             props,

--- a/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
@@ -1,6 +1,7 @@
 ﻿import shardViewModelBase from "viewmodels/shardViewModelBase";
 import React from "react";
 import database from "models/resources/database";
+import { getDirtyFlagForReact } from "common/reactViewModelUtils";
 
 abstract class shardedReactViewModelBase extends shardViewModelBase {
 
@@ -25,17 +26,21 @@ abstract class shardedReactViewModelBase extends shardViewModelBase {
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
 
-        this.reactOptions = this.createReactOptions(this.reactView, {
+        const reactDirtyFlag = getDirtyFlagForReact(this.dirtyFlag);
+        const reactProps = {
             ...args,
             database: this.db,
             location: this.location,
-        });
+        };
+
+        this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 
-    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps) {
+    createReactOptions<TProps = unknown>(component: (props?: TProps) => JSX.Element, props?: TProps, dirtyFlag?: KoToReactDirtyFlag) {
         return ko.pureComputed(() => ({
             component,
-            props
+            props,
+            dirtyFlag
         }));
     }
 }

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -949,15 +949,14 @@ interface StudioDatabasesResponse {
     Orchestrators: StudioOrchestratorState[];
 }
 
-interface KoToReactDirtyFlag {
-    koIsDirty: () => boolean;
-    koSetIsDirty: (isDirty: boolean) => void;
+interface ReactDirtyFlag {
+    setIsDirty: (isDirty: boolean) => void;
 }
 
 interface ReactInKnockoutOptions<T> {
     component: T;
     props?: Parameters<typeof T>[0];
-    dirtyFlag?: KoToReactDirtyFlag;
+    dirtyFlag?: ReactDirtyFlag;
 }
 
 type ReactInKnockout<T> = KnockoutComputed<ReactInKnockoutOptions<T>>;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -949,9 +949,15 @@ interface StudioDatabasesResponse {
     Orchestrators: StudioOrchestratorState[];
 }
 
+interface KoToReactDirtyFlag {
+    koIsDirty: () => boolean;
+    koSetIsDirty: (isDirty: boolean) => void;
+}
+
 interface ReactInKnockoutOptions<T> {
     component: T;
     props?: Parameters<typeof T>[0];
+    dirtyFlag?: KoToReactDirtyFlag;
 }
 
 type ReactInKnockout<T> = KnockoutComputed<ReactInKnockoutOptions<T>>;

--- a/test/RachisTests/Cluster.cs
+++ b/test/RachisTests/Cluster.cs
@@ -53,6 +53,7 @@ namespace RachisTests
                 };
 
                 var res = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc));
+                WaitForUserToContinueTheTest(store);
                 Assert.NotEqual(res.Topology.Members.First(), leader.ServerStore.NodeTag);
 
                 await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("test", "Karmel", 0));

--- a/test/RachisTests/Cluster.cs
+++ b/test/RachisTests/Cluster.cs
@@ -53,7 +53,6 @@ namespace RachisTests
                 };
 
                 var res = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc));
-                WaitForUserToContinueTheTest(store);
                 Assert.NotEqual(res.Topology.Members.First(), leader.ServerStore.NodeTag);
 
                 await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("test", "Karmel", 0));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20031/Add-unsaved-changes-confirmation-on-leaving-manage-database-group-view

### Additional description

- Bind setting knockout dirty flag to react
- Apply dirty flag to ManageDatabaseGroups
- Change Button to ButtonWithSpinner

### Type of change

- New feature

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
