### PR TITLE
RavenDB-20582 Compatibility between sharded and non-sharded unbounded query results for Studio.

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -67,7 +67,9 @@ public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TI
 
     protected static void CombineSingleShardResultProperties(QueryResult<List<TResult>, List<TIncludes>> combinedResult, QueryResult singleShardResult)
     {
-        combinedResult.TotalResults += singleShardResult.TotalResults;
+        // unbounded collection query compatibility to non-sharded (single shard total results is -1 in such case, we set it as -1 only once)
+        if (combinedResult.TotalResults != -1 || singleShardResult.TotalResults != -1)
+            combinedResult.TotalResults += singleShardResult.TotalResults;
         combinedResult.IsStale |= singleShardResult.IsStale;
 
         combinedResult.SkippedResults = 0; // sharded queries start from 0 on all shards and we apply paging on the orchestrator side


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20582
### Additional description

Studio detects unbounded query when `TotalResults` is -1 so this PR ensures sharded query will also return -1 in such case.

![image](https://github.com/ravendb/ravendb/assets/86351904/4e07ef2f-2be2-458f-b3f4-2a5b976d150b)

and after scrolling to the end: 

![image](https://github.com/ravendb/ravendb/assets/86351904/7901ddd1-2528-4643-823e-10960ec6cc3c)


### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
