### PR TITLE
RavenDB-20544 : fix failing test - fix race between PutLicense and UpdateLicenseLimits

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -167,7 +167,7 @@ namespace Raven.Server.Commercial
 
         public async Task PutMyNodeInfoAsync()
         {
-            if (_serverStore.IsPassive())
+            if (_serverStore.IsPassive() || LicenseStatus.Type == LicenseType.None)
                 return;
 
             if (await _licenseLimitsSemaphore.WaitAsync(0) == false)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-20544.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-20544.cs
@@ -1,0 +1,54 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Smuggler;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    public class RavenDB_20544 : RavenTestBase
+    {
+        public RavenDB_20544(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanRunTwoBackupsConcurrently()
+        {
+            DoNotReuseServer();
+            await Server.ServerStore.EnsureNotPassiveAsync();
+
+            using var store = GetDocumentStore();
+            await using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < 10_000; i++)
+                {
+                    await bulk.StoreAsync(new User(), "users/" + i);
+                }
+            }
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var config1 = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
+            var config2 = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+
+            var task1 = Backup.UpdateConfigAndRunBackupAsync(Server, config1, store);
+            var task2 = Backup.UpdateConfigAndRunBackupAsync(Server, config2, store);
+
+            await Task.WhenAll(task1, task2);
+
+            var backupDirectories = Directory.GetDirectories(backupPath);
+            Assert.Equal(2, backupDirectories.Length);
+
+            string[] files = Directory.GetFiles(backupPath, "*.*", SearchOption.AllDirectories);
+            Assert.Equal(2, files.Length);
+
+            Assert.Single(files.Where(BackupUtils.IsBackupFile));
+            Assert.Single(files.Where(x => BackupUtils.IsSnapshot(Path.GetExtension(x))));
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20544/SlowTests.Sharding.Backup.ShardedRestoreBackupTests.EncryptedBackupAndRestoreShardedDatabaseUsingDatabaseKey
### Additional description

the race condition occurs when `PutMyNodeInfoClusterVersionChange` is called and triggers an `UpdateLicenseLimits` command, while `PutLicenseCommand` is not yet applied
this can result in having wrong license limits, including `MaxNumberOfConcurrentBackups` - which caused the test
to fail on exceeding maximum number of concurrent backups (1)
e.g. :
- `PutMyNodeInfoClusterVersionChange` is called first and triggers an `UpdateLicenseLimitsCommand` (with default limits)
- `PutLicenseCommand` updates MaxConcurrentBackups to 8 and then calls `LicenseManager.PutMyNodeInfoAsync()` (without awaiting)
- `UpdateLicenseLimitsCommand` updates MaxConcurrentBackups back to 1 (default limit)
- `PutMyNodeInfoAsync` fails to enter the `_licenseLimitsSemaphore` , so it doesn't send another `UpdateLicenseLimitsCommand` and MaxConcurrentBackups stays with value 1 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
