### PR TITLE
RavenDB-20600 Clicking on alerts throws an exception

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -239,7 +239,10 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                 )}
                 {alertsCount > 0 && (
                     <>
-                        <RichPanelDetailItem key="alerts" title="Click to view alerts in Notification Center">
+                        <RichPanelDetailItem
+                            key="alerts"
+                            title={db.currentNode.relevant ? "Click to view alerts in Notification Center" : ""}
+                        >
                             <Badge color="faded-warning" className="d-flex align-items-center lh-base rounded-pill">
                                 <a
                                     href="#"
@@ -274,7 +277,9 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                     <>
                         <RichPanelDetailItem
                             key="performance-hints"
-                            title="Click to view performance hints in Notification Center"
+                            title={
+                                db.currentNode.relevant ? "Click to view performance hints in Notification Center" : ""
+                            }
                         >
                             <Badge color="faded-info" className="d-flex align-items-center lh-base rounded-pill">
                                 <a

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -81,6 +81,9 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
     const localPerformanceHintsCount =
         nonEmptyTopLevelState.find((x) => x.nodeTag === localNodeTag)?.performanceHints ?? 0;
 
+    const hasRemoteAlerts = alertsCount > localAlertsCount;
+    const hasRemotePerformanceHints = performanceHintsCount > localPerformanceHintsCount;
+
     const remoteTopLevelStates = nonEmptyTopLevelState.filter((x) => x.nodeTag !== localNodeTag);
 
     const maxSizes = genUtils.maxByShard(
@@ -251,7 +254,7 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                                     ref={setAlertsPopoverElement}
                                 >
                                     {alertSection}
-                                    {alertsCount !== localAlertsCount && (
+                                    {hasRemoteAlerts && (
                                         <>
                                             <div className="vr bg-warning"></div>
                                             <Icon icon="global" />
@@ -261,16 +264,18 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                                 </a>
                             </Badge>
                         </RichPanelDetailItem>
-                        <PopoverWithHover target={alertsPopoverElement}>
-                            <AlertsPopover
-                                isCurrentNodeRelevant={isCurrentNodeRelevant}
-                                localNodeTag={localNodeTag}
-                                localTotal={localAlertsCount}
-                                getServerNodeUrl={getServerNodeUrl}
-                                openNotificationCenter={() => dispatch(openNotificationCenterForDatabase(db))}
-                                remoteTopLevelStates={remoteTopLevelStates}
-                            />
-                        </PopoverWithHover>
+                        {hasRemoteAlerts && (
+                            <PopoverWithHover target={alertsPopoverElement}>
+                                <AlertsPopover
+                                    isCurrentNodeRelevant={isCurrentNodeRelevant}
+                                    localNodeTag={localNodeTag}
+                                    localTotal={localAlertsCount}
+                                    getServerNodeUrl={getServerNodeUrl}
+                                    openNotificationCenter={() => dispatch(openNotificationCenterForDatabase(db))}
+                                    remoteTopLevelStates={remoteTopLevelStates}
+                                />
+                            </PopoverWithHover>
+                        )}
                     </>
                 )}
                 {performanceHintsCount > 0 && (
@@ -289,7 +294,7 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                                     ref={setPerfHintsPopoverElement}
                                 >
                                     {performanceHintsSection}
-                                    {performanceHintsCount !== localPerformanceHintsCount && (
+                                    {hasRemotePerformanceHints && (
                                         <>
                                             <div className="vr bg-info"></div>
                                             <Icon icon="global" />
@@ -299,16 +304,18 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
                                 </a>
                             </Badge>
                         </RichPanelDetailItem>
-                        <PopoverWithHover target={perfHintsPopoverElement}>
-                            <PerfHintsPopover
-                                isCurrentNodeRelevant={isCurrentNodeRelevant}
-                                localNodeTag={localNodeTag}
-                                localTotal={localPerformanceHintsCount}
-                                getServerNodeUrl={getServerNodeUrl}
-                                openNotificationCenter={() => dispatch(openNotificationCenterForDatabase(db))}
-                                remoteTopLevelStates={remoteTopLevelStates}
-                            />
-                        </PopoverWithHover>
+                        {hasRemotePerformanceHints && (
+                            <PopoverWithHover target={perfHintsPopoverElement}>
+                                <PerfHintsPopover
+                                    isCurrentNodeRelevant={isCurrentNodeRelevant}
+                                    localNodeTag={localNodeTag}
+                                    localTotal={localPerformanceHintsCount}
+                                    getServerNodeUrl={getServerNodeUrl}
+                                    openNotificationCenter={() => dispatch(openNotificationCenterForDatabase(db))}
+                                    remoteTopLevelStates={remoteTopLevelStates}
+                                />
+                            </PopoverWithHover>
+                        )}
                     </>
                 )}
                 {hasAnyLoadError && (

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
@@ -38,6 +38,10 @@ export const toggleIndexing =
 export const openNotificationCenterForDatabase =
     (db: DatabaseSharedInfo): AppThunk =>
     (dispatch, getState) => {
+        if (!db.currentNode.relevant) {
+            return;
+        }
+
         const activeDatabase = databaseSelectors.activeDatabase(getState());
         if (activeDatabase !== db.name) {
             const dbRaw = databasesManager.default.getDatabaseByName(db.name);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20600/Clicking-on-alerts-throws-an-exception

### Additional description

- disable showing notification center if a node is not relevant with a given database
- hide tooltip when only local alerts/hints exists

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
