### PR TITLE
RavenDB-20669 - ObjectDisposedException in RachisMergedCommand killed the server

### DIFF
--- a/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
@@ -115,7 +115,14 @@ namespace Raven.Server.Rachis
 
             private void AfterCommit(LowLevelTransaction tx)
             {
-                _leader._newEntry.Set();
+                try
+                {
+                    _leader._newEntry.Set();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    // _newEntry is disposed because _leader is already disposed
+                }
             }
 
             public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)

--- a/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Rachis
                 {
                     _leader._newEntry.Set();
                 }
-                catch (ObjectDisposedException ex)
+                catch (ObjectDisposedException)
                 {
                     // _newEntry is disposed because _leader is already disposed
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20669/ObjectDisposedException-in-RachisMergedCommand-killed-the-server

### Additional description

ObjectDisposedException in RachisMergedCommand killed the server.
It happened because the leader was disposed before the TxMerger did the commit and then in the 'AfterCommit' we tried to use the 'leader.NewEntry' mre that was already disposed in the 'Leader.Dispose' method.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
