### PR TITLE
RavenDB-20673 Added missing quotes in RQL + test

### DIFF
--- a/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Raven.Client.Documents.Queries;
 
 namespace Raven.Client.Documents.Session.Tokens
 {
@@ -13,14 +14,14 @@ namespace Raven.Client.Documents.Session.Tokens
         private SuggestToken(string fieldName, string alias, string termParameterName, string optionsParameterName)
         {
             FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
-            _alias = alias?.Contains(" ") == true ? $"\"{alias}\"" : alias;
+            _alias = alias;
             _termParameterName = termParameterName ?? throw new ArgumentNullException(nameof(termParameterName));
             _optionsParameterName = optionsParameterName;
         }
 
         public static SuggestToken Create(string fieldName, string alias, string termParameterName, string optionsParameterName)
         {
-            return new SuggestToken(fieldName, alias, termParameterName, optionsParameterName);
+            return new SuggestToken(fieldName, QueryFieldUtil.EscapeIfNecessary(alias), termParameterName, optionsParameterName);
         }
 
         public override void WriteTo(StringBuilder writer)

--- a/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Session.Tokens
         private SuggestToken(string fieldName, string alias, string termParameterName, string optionsParameterName)
         {
             FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
-            _alias = alias.Contains(" ") ? $"\"{alias}\"" : alias;
+            _alias = alias?.Contains(" ") == true ? $"\"{alias}\"" : alias;
             _termParameterName = termParameterName ?? throw new ArgumentNullException(nameof(termParameterName));
             _optionsParameterName = optionsParameterName;
         }

--- a/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/SuggestToken.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Session.Tokens
         private SuggestToken(string fieldName, string alias, string termParameterName, string optionsParameterName)
         {
             FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
-            _alias = alias;
+            _alias = alias.Contains(" ") ? $"\"{alias}\"" : alias;
             _termParameterName = termParameterName ?? throw new ArgumentNullException(nameof(termParameterName));
             _optionsParameterName = optionsParameterName;
         }

--- a/test/SlowTests/Issues/RavenDB_20673.cs
+++ b/test/SlowTests/Issues/RavenDB_20673.cs
@@ -21,9 +21,9 @@ namespace SlowTests.Issues
         {
             using (var s = store.OpenSession())
             {
-                s.Store(new User {Name = "dan"});
-                s.Store(new User {Name = "daniel"});
-                s.Store(new User {Name = "danielle"});
+                s.Store(new User { Name = "dan" });
+                s.Store(new User { Name = "daniel" });
+                s.Store(new User { Name = "danielle" });
                 s.SaveChanges();
             }
         }

--- a/test/SlowTests/Issues/RavenDB_20673.cs
+++ b/test/SlowTests/Issues/RavenDB_20673.cs
@@ -1,0 +1,79 @@
+﻿using FastTests;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20673 : RavenTestBase
+    {
+        public RavenDB_20673(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private void Setup(IDocumentStore store)
+        {
+            using (var s = store.OpenSession())
+            {
+                s.Store(new User {Name = "dan"});
+                s.Store(new User {Name = "daniel"});
+                s.Store(new User {Name = "danielle"});
+                s.SaveChanges();
+            }
+        }
+
+        [Fact]
+        public void CustomizeDisplayNameWithSpaces()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Setup(store);
+
+                using (var s = store.OpenSession())
+                {
+                    var suggestionQuery = s.Query<User>()
+                        .SuggestUsing(builder => builder
+                            .ByField(x => x.Name, "daniele")
+                            .WithDisplayName("Customized name with spaces"));
+
+                    var rql = suggestionQuery.ToString();
+                    Assert.Contains("Customized name with spaces", rql);
+
+                    var results = suggestionQuery.Execute();
+                    Assert.Equal(2, results["Customized name with spaces"].Suggestions.Count);
+                    Assert.Equal("danielle", results["Customized name with spaces"].Suggestions[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public void CustomizeDisplayNameWithOutSpaces()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Setup(store);
+
+                using (var s = store.OpenSession())
+                {
+                    var suggestionQuery = s.Query<User>()
+                        .SuggestUsing(builder => builder
+                            .ByField(x => x.Name, "daniele")
+                            .WithDisplayName("CustomizedName"));
+
+                    var rql = suggestionQuery.ToString();
+                    Assert.Contains("CustomizedName", rql);
+
+                    var results = suggestionQuery.Execute();
+                    Assert.Equal(2, results["CustomizedName"].Suggestions.Count);
+                    Assert.Equal("danielle", results["CustomizedName"].Suggestions[0]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20673

### Additional description
Added missing quotes in RQL when making a Suggestion Query that uses a **display name** (alias) with **spaces**

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
