### PR TITLE
RavenDB-20684 - Check Raven.Server.Exceptions.MissingAttachmentException

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
@@ -428,11 +427,11 @@ namespace Raven.Server.Documents
 
         public void RevisionAttachments(DocumentsOperationContext context, BlittableJsonReaderObject document, Slice lowerId, Slice changeVector)
         {
-            var currentAttachments = GetAttachmentsFromDocumentMetadata(document)
-                .Select(attachment => JsonDeserializationClient.AttachmentName(attachment));
+            var currentAttachments = GetAttachmentsFromDocumentMetadata(document);
 
-            foreach (var attachment in currentAttachments)
+            foreach (var bjro in currentAttachments)
             {
+                var attachment = JsonDeserializationClient.AttachmentName(bjro);
                 PutRevisionAttachment(context, lowerId.Content.Ptr, lowerId.Size, changeVector, attachment);
             }
         }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -2,14 +2,15 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Binary;
@@ -425,30 +426,14 @@ namespace Raven.Server.Documents
             }
         }
 
-        public void RevisionAttachments(DocumentsOperationContext context, Slice lowerId, Slice changeVector)
+        public void RevisionAttachments(DocumentsOperationContext context, BlittableJsonReaderObject document, Slice lowerId, Slice changeVector)
         {
-            using (GetAttachmentPrefix(context, lowerId.Content.Ptr, lowerId.Size, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
+            var currentAttachments = GetAttachmentsFromDocumentMetadata(document)
+                .Select(attachment => JsonDeserializationClient.AttachmentName(attachment));
+
+            foreach (var attachment in currentAttachments)
             {
-                var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
-                var currentAttachments = new List<(LazyStringValue name, LazyStringValue contentType, Slice base64Hash)>();
-                foreach (var sr in table.SeekByPrimaryKeyPrefix(prefixSlice, Slices.Empty, 0))
-                {
-                    var tableValueHolder = sr.Value;
-                    var name = TableValueToId(context, (int)AttachmentsTable.Name, ref tableValueHolder.Reader);
-                    var contentType = TableValueToId(context, (int)AttachmentsTable.ContentType, ref tableValueHolder.Reader);
-
-                    var ptr = tableValueHolder.Reader.Read((int)AttachmentsTable.Hash, out int size);
-                    Slice.From(context.Allocator, ptr, size, out Slice base64Hash);
-
-                    currentAttachments.Add((name, contentType, base64Hash));
-                }
-                foreach (var attachment in currentAttachments)
-                {
-                    PutRevisionAttachment(context, lowerId.Content.Ptr, lowerId.Size, changeVector, attachment);
-                    attachment.name.Dispose();
-                    attachment.contentType.Dispose();
-                    attachment.base64Hash.Release(context.Allocator);
-                }
+                PutRevisionAttachment(context, lowerId.Content.Ptr, lowerId.Size, changeVector, attachment);
             }
         }
         public void PutAttachmentRevert(DocumentsOperationContext context, LazyStringValue id, BlittableJsonReaderObject document, out bool hasAttachments)
@@ -483,8 +468,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void PutRevisionAttachment(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, Slice changeVector,
-            (LazyStringValue Name, LazyStringValue ContentType, Slice Base64Hash) attachment)
+        private void PutRevisionAttachment(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, Slice changeVector, AttachmentName attachment)
         {
             var attachmentEtag = _documentsStorage.GenerateNextEtag();
 
@@ -492,7 +476,8 @@ namespace Raven.Server.Documents
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.Name, out Slice lowerName, out Slice namePtr))
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.ContentType, out Slice lowerContentType, out Slice contentTypePtr))
-            using (GetAttachmentKey(context, lowerId, lowerIdSize, lowerName.Content.Ptr, lowerName.Size, attachment.Base64Hash,
+            using (Slice.From(context.Allocator, attachment.Hash, out var hashSlice))
+            using (GetAttachmentKey(context, lowerId, lowerIdSize, lowerName.Content.Ptr, lowerName.Size, hashSlice,
                 lowerContentType.Content.Ptr, lowerContentType.Size, AttachmentType.Revision, changeVector, out Slice keySlice))
             using (table.Allocate(out TableValueBuilder tvb))
             {
@@ -500,7 +485,7 @@ namespace Raven.Server.Documents
                 tvb.Add(Bits.SwapBytes(attachmentEtag));
                 tvb.Add(namePtr);
                 tvb.Add(contentTypePtr);
-                tvb.Add(attachment.Base64Hash);
+                tvb.Add(hashSlice);
                 tvb.Add(context.GetTransactionMarker());
                 tvb.Add(changeVector.Content.Ptr, changeVector.Size);
                 table.Set(tvb);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -438,7 +438,7 @@ namespace Raven.Server.Documents.Revisions
                 if (flags.Contain(DocumentFlags.HasAttachments) &&
                     flags.Contain(DocumentFlags.Revision) == false)
                 {
-                    _documentsStorage.AttachmentsStorage.RevisionAttachments(context, lowerId, changeVectorSlice);
+                    _documentsStorage.AttachmentsStorage.RevisionAttachments(context, document, lowerId, changeVectorSlice);
                 }
 
                 document = AddCounterAndTimeSeriesSnapshotsIfNeeded(context, id, document);

--- a/test/SlowTests/Issues/RavenDB_20684.cs
+++ b/test/SlowTests/Issues/RavenDB_20684.cs
@@ -1,0 +1,75 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Attachments;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20684 : RavenTestBase
+    {
+        public RavenDB_20684(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task AttachmentStreamShouldExistInRevisionAfterDeleteAttachment()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string changeVector = null;
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", "profile.png", profileStream, "image/png"));
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    changeVector = session.Advanced.GetChangeVectorFor(user);
+                }
+
+                await RevisionsHelper.SetupRevisions(store, Server.ServerStore);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Attachments.Delete("users/1", "profile.png");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var revision = session.Advanced.Revisions.Get<User>(changeVector);
+                    Assert.NotNull(revision);
+
+                    var readBuffer = new byte[8];
+
+                    using (var attachmentStream = new MemoryStream(readBuffer))
+                    using (var attachment = session.Advanced.Attachments.GetRevision("users/1", "profile.png", changeVector))
+                    {
+                        Assert.NotNull(attachment);
+                        Assert.NotNull(attachment.Stream);
+
+                        await attachment.Stream.CopyToAsync(attachmentStream);
+
+                        Assert.Equal(new byte[] { 1, 2, 3 }, readBuffer.Take(3));
+                        Assert.Equal("image/png", attachment.Details.ContentType);
+                        Assert.Equal(3, attachmentStream.Position);
+                        Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20684

**_Issue explanation:_**
Steps of deleting attachment operation (only one reference exists) of a document (document without revisions, revisions configuration is defined):

1. Deleting the attachment from `AttachmentsSchema` - no reference to this attachment exists.
2. Updating the document:
         2.1. Update document metadata
         2.2. Create revision for the old version:
            2.2.1. Create attachment revision: seeking for the relevant attachment in `AttachmentsSchema` by `documentId` - the entry is already deleted (step 1) -> nothing happens; therefore, because no reference to the stream exists, at the end of the transaction, the stream is removed.

**_Fix:_**
Changed step 2.2.1 - collect attachments from old document metadata.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
