### PR TITLE
RavenDB-20700: Improve Lucene memory utilization (new configuration property)

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -469,7 +469,13 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool OrderByTicksAutomaticallyWhenDatesAreInvolved { get; set; }
-        
+
+        [Description("EXPERT: Controls how many terms we'll keep in the cache for each term. Higher values reduce memory usage at the expense of increased term data access time.")]
+        [DefaultValue(1)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Lucene.ReaderTermsIndexDivisor", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public int ReaderTermsIndexDivisor { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -470,7 +470,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool OrderByTicksAutomaticallyWhenDatesAreInvolved { get; set; }
 
-        [Description("EXPERT: Controls how many terms we'll keep in the cache for each term. Higher values reduce memory usage at the expense of increased term data access time.")]
+        [Description("EXPERT: Controls how many terms we'll keep in the cache for each field. Higher values reduce the memory usage at the expense of increased search time for each term.")]
         [DefaultValue(1)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Lucene.ReaderTermsIndexDivisor", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -186,7 +186,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         }
                     }
 
-                    reader ??= _lastReader = IndexReader.Open(_directory, readOnly: true, state);
+                    reader ??= _lastReader = IndexReader.Open(_directory, deletionPolicy: null, readOnly: true, termInfosIndexDivisor: _index.Configuration.ReaderTermsIndexDivisor, state);
 
                     reader.IncRef();
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
@@ -175,6 +175,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             // RavenDB already manages the memory for those, no need for Lucene to do this as well
             _indexWriter.SetMaxBufferedDocs(IndexWriter.DISABLE_AUTO_FLUSH);
             _indexWriter.SetRAMBufferSizeMB(1024);
+
+            _indexWriter.ReaderTermsIndexDivisor = _index.Configuration.ReaderTermsIndexDivisor;
         }
 
         private void DisposeIndexWriter()

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -37,7 +37,8 @@ class configurationItem {
         "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
         "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
         "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
-        "Query.RegexTimeoutInMs"
+        "Query.RegexTimeoutInMs",
+        "Indexing.Lucene.ReaderTermsIndexDivisor"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -32,7 +32,7 @@ namespace FastTests.Issues
             var propertiesDeclaredInStudio = new List<string>
             {
                 /*
-                 *  __        ___    ____  _   _ ___ _   _  ____ 
+                 * __        ___    ____  _   _ ___ _   _  ____ 
                  * \ \      / / \  |  _ \| \ | |_ _| \ | |/ ___|
                  *  \ \ /\ / / _ \ | |_) |  \| || ||  \| | |  _ 
                  *   \ V  V / ___ \|  _ <| |\  || || |\  | |_| |
@@ -80,7 +80,7 @@ namespace FastTests.Issues
                 "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
                 "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
                 "Query.RegexTimeoutInMs",
-                
+                "Indexing.Lucene.ReaderTermsIndexDivisor",
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20700/Implementing-Cache-Size-Configuration-for-EachTerm-in-the-Index

### Additional description

We need the ability to configure how many terms we'll keep in the cache for each term in the Index.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed