### PR TITLE
RavenDB-20585 - SlowTests.Client.TimeSeries.Replication.TimeSeriesRep…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -927,10 +927,10 @@ namespace SlowTests.Client.TimeSeries.Replication
                 }
 
                 await SetupReplicationAsync(storeA, storeB);
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 await SetupReplicationAsync(storeB, storeA);
-                EnsureReplicating(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
 
                 AssertValues(storeA);
                 AssertValues(storeB);


### PR DESCRIPTION
…licationTests.PreferDeletedValues2(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20585/SlowTests.Client.TimeSeries.Replication.TimeSeriesReplicationTests.PreferDeletedValues2options-DatabaseMode-Sharded

### Additional description

`EnsureReplicating` method only sends one document marker but for sharding we want to ensure we reached all shards. 

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
