### PR TITLE
RavenDB-20701 - expected exception should cause a failover

### DIFF
--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -29,6 +29,7 @@ using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.TrafficWatch;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
@@ -364,9 +365,8 @@ namespace Raven.Server
                 return;
             }
 
-            if (exception is LowMemoryException ||
+            if (exception.IsOutOfMemory() ||
                 exception is HighDirtyMemoryException ||
-                exception is OutOfMemoryException ||
                 exception is VoronUnrecoverableErrorException ||
                 exception is VoronErrorException ||
                 exception is QuotaException ||


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20701/Error-should-be-detected-as-out-of-memory-error

### Additional description

Out of Memory error should cause a failover.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing