### PR TITLE
Raven DB-20704 - Support long total results for collection queries

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents
                 isStartsWithOrIdQuery = true;
 
                 return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, new FieldsToFetch(_operationQuery, null, IndexType.None),
-                    collectionName, _operationQuery, null, context, null, null, null, new Reference<int>(), new Reference<int>(), new Reference<long>(), token)
+                    collectionName, _operationQuery, null, context, null, null, null, new Reference<long>(), new Reference<int>(), new Reference<long>(), token)
                 {
                     Fields = fields, StartAfterId = startAfterId, AlreadySeenIdsCount = alreadySeenIdsCount
                 };

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -956,7 +956,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, Reference<int> totalCount)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, Reference<long> totalCount)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -981,7 +981,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, Reference<int> totalCount)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, Reference<long> totalCount)
         {
             var listOfIds = new List<Slice>();
             foreach (var id in ids)
@@ -993,7 +993,7 @@ namespace Raven.Server.Documents
             return GetDocuments(context, listOfIds, start, take, totalCount);
         }
 
-        public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take, Reference<int> totalCount)
+        public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take, Reference<long> totalCount)
         {
             // we'll fetch all documents and do the filtering here since we must check the collection name
             foreach (var doc in GetDocuments(context, ids, start, int.MaxValue, totalCount))

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1064,7 +1064,7 @@ namespace Raven.Server.Documents.Handlers
                     else
                     {
                         var listOfIds = ids.Select(x => x.ToString());
-                        var _ = new Reference<int>
+                        var _ = new Reference<long>
                         {
                             Value = 0
                         };

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -32,7 +32,8 @@ namespace Raven.Server.Documents.Queries
         private readonly IncludeDocumentsCommand _includeDocumentsCommand;
         private readonly IncludeRevisionsCommand _includeRevisionsCommand;
         private readonly IncludeCompareExchangeValuesCommand _includeCompareExchangeValuesCommand;
-        private readonly Reference<int> _totalResults, _scannedResults;
+        private readonly Reference<long> _totalResults;
+        private readonly Reference<int> _scannedResults;
         private readonly Reference<long> _skippedResults;
         private readonly CancellationToken _token;
         private readonly string _collection;
@@ -42,7 +43,7 @@ namespace Raven.Server.Documents.Queries
 
         public CollectionQueryEnumerable(DocumentDatabase database, DocumentsStorage documents, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, string collection,
             IndexQueryServerSide query, QueryTimingsScope queryTimings, DocumentsOperationContext context, IncludeDocumentsCommand includeDocumentsCommand,
-            IncludeRevisionsCommand includeRevisionsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<int> totalResults,
+            IncludeRevisionsCommand includeRevisionsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<long> totalResults,
             Reference<int> scannedResults, Reference<long> skippedResults, CancellationToken token)
         {
             _database = database;
@@ -119,7 +120,7 @@ namespace Raven.Server.Documents.Queries
             private readonly DocumentsStorage _documents;
             private readonly FieldsToFetch _fieldsToFetch;
             private readonly DocumentsOperationContext _context;
-            private readonly Reference<int> _totalResults;
+            private readonly Reference<long> _totalResults;
             private readonly Reference<int> _scannedResults;
             private readonly string _collection;
             private readonly bool _isAllDocsCollection;
@@ -150,7 +151,7 @@ namespace Raven.Server.Documents.Queries
 
             public Enumerator(DocumentDatabase database, DocumentsStorage documents, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, string collection, bool isAllDocsCollection,
                 IndexQueryServerSide query, QueryTimingsScope queryTimings, DocumentsOperationContext context, IncludeDocumentsCommand includeDocumentsCommand,
-                IncludeRevisionsCommand includeRevisionsCommand,IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<int> totalResults, 
+                IncludeRevisionsCommand includeRevisionsCommand,IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, Reference<long> totalResults, 
                 Reference<int> scannedResults, string startAfterId, Reference<long> alreadySeenIdsCount, DocumentFields fields, Reference<long> skippedResults, CancellationToken token)
             {
                 _documents = documents;

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 
                 var includeCompareExchangeValuesCommand = IncludeCompareExchangeValuesCommand.ExternalScope(context, query.Metadata.CompareExchangeValueIncludes);
 
-                var totalResults = new Reference<int>();
+                var totalResults = new Reference<long>();
                 var skippedResults = new Reference<long>();
                 var scannedResults = new Reference<int>();
                 IEnumerator<Document> enumerator;
@@ -254,8 +254,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     resultToFill.AddRevisionIncludes(includeRevisionsCommand);
 
                 resultToFill.RegisterTimeSeriesFields(query, fieldsToFetch);
-                resultToFill.TotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
-                resultToFill.LongTotalResults = resultToFill.TotalResults;
+                resultToFill.LongTotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
+                resultToFill.TotalResults = (int)resultToFill.LongTotalResults;
                 resultToFill.SkippedResults = Convert.ToInt32(skippedResults.Value);
                 resultToFill.ScannedResults = scannedResults.Value;
 

--- a/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
@@ -18,7 +18,7 @@ class queryCommand extends commandBase {
         const selector = (results: Raven.Client.Documents.Queries.QueryResult<Array<any>, any>): pagedResultExtended<document> =>
             ({
                 items: results.Results.map(d => new document(d)), 
-                totalResultCount: results.CappedMaxResults || results.TotalResults, 
+                totalResultCount: results.CappedMaxResults || results.LongTotalResults, 
                 additionalResultInfo: results, 
                 resultEtag: results.ResultEtag.toString(), 
                 highlightings: results.Highlightings,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20704/Collection-query-doesnt-return-the-correct-number-of-results

### Additional description

Support long total results for collection queries.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing

### UI work

- No UI work is needed
