### PR TITLE
RavenDB-20675 AccessViolationException in DecompressionBuffersPool.Ge…

### DIFF
--- a/src/Voron/Data/Compression/DecompressionBuffersPool.cs
+++ b/src/Voron/Data/Compression/DecompressionBuffersPool.cs
@@ -50,18 +50,18 @@ namespace Voron.Data.Compression
 
                 if (_compressionPager != null)
                 {
-                    _compressionPager._pager.Dispose();
+                    _compressionPager.DisposePager();
 
-                    _scratchSpaceMonitor.Decrease(_compressionPager._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                    _scratchSpaceMonitor.Decrease(_compressionPager.Pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                 }
 
                 foreach (var pager in _oldPagers)
                 {
-                    if (pager._pager.Disposed == false)
+                    if (pager.Pager.Disposed == false)
                     {
-                        pager._pager.Dispose();
+                        pager.DisposePager();
 
-                        _scratchSpaceMonitor.Decrease(pager._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                        _scratchSpaceMonitor.Decrease(pager.Pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                     }
                 }
             });
@@ -126,7 +126,7 @@ namespace Voron.Data.Compression
 
             while (queue.TryDequeue(out buffer))
             {
-                if (buffer._pagerInfo.TryIncreaseNumberOfUsages() == false)
+                if (buffer.PagerInfo.TryUse() == false)
                     continue;
                 try
                 {
@@ -151,12 +151,12 @@ namespace Voron.Data.Compression
 
                     try
                     {
-                        var numberOfPagesBeforeAllocate = _compressionPager._pager.NumberOfAllocatedPages;
+                        var numberOfPagesBeforeAllocate = _compressionPager.Pager.NumberOfAllocatedPages;
 
-                        _compressionPager._pager.EnsureContinuous(_lastUsedPage, allocationInPages);
+                        _compressionPager.Pager.EnsureContinuous(_lastUsedPage, allocationInPages);
 
-                        if (_compressionPager._pager.NumberOfAllocatedPages > numberOfPagesBeforeAllocate)
-                            _scratchSpaceMonitor.Increase((_compressionPager._pager.NumberOfAllocatedPages - numberOfPagesBeforeAllocate) * Constants.Storage.PageSize);
+                        if (_compressionPager.Pager.NumberOfAllocatedPages > numberOfPagesBeforeAllocate)
+                            _scratchSpaceMonitor.Increase((_compressionPager.Pager.NumberOfAllocatedPages - numberOfPagesBeforeAllocate) * Constants.Storage.PageSize);
                     }
                     catch (InsufficientMemoryException)
                     {
@@ -167,7 +167,7 @@ namespace Voron.Data.Compression
                     }
 
                     buffer = new DecompressionBuffer(_compressionPager, _lastUsedPage, pageSize, this, index, tx);
-                    _compressionPager.TryIncreaseNumberOfUsages();
+                    _compressionPager.TryUse();
                     _lastUsedPage += allocationInPages;
 
                     void CreateNewBuffersPager(long size)
@@ -250,7 +250,7 @@ namespace Voron.Data.Compression
 
             var necessaryPages = Interlocked.Read(ref _currentlyUsedBytes) / Constants.Storage.PageSize;
 
-            var availablePages = _compressionPager._pager.NumberOfAllocatedPages;
+            var availablePages = _compressionPager.Pager.NumberOfAllocatedPages;
 
             var pagers = _oldPagers;
 
@@ -258,29 +258,29 @@ namespace Voron.Data.Compression
             {
                 var old = pagers[i];
 
-                if ( old.TryDispose() == false )
+                if (old.TryTakeForDispose() == false)
                     continue;
                 if (availablePages >= necessaryPages)
                 {
-                    old._pager.Dispose();
-                    _scratchSpaceMonitor.Decrease(old._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                    old.DisposePager();
+                    _scratchSpaceMonitor.Decrease(old.Pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                     disposedCount++;
                     continue;
                 }
 
                 // PERF: We dont care about the pager data content anymore. So we can discard the whole context to
                 //       clean up the modified bit.
-                old._pager.DiscardWholeFile();
-                availablePages += old._pager.NumberOfAllocatedPages;
+                old.Pager.DiscardWholeFile();
+                availablePages += old.Pager.NumberOfAllocatedPages;
             }
 
-            _oldPagers = _oldPagers.RemoveWhile(x => x._pager.Disposed);
+            _oldPagers = _oldPagers.RemoveWhile(x => x.Pager.Disposed);
             return disposedCount;
         }
 
         private class DecompressionBuffer : IDisposable
         {
-            internal readonly PagerInfo _pagerInfo;
+            internal readonly PagerInfo PagerInfo;
             private readonly long _position;
             private readonly int _size;
             private readonly DecompressionBuffersPool _pool;
@@ -288,13 +288,13 @@ namespace Voron.Data.Compression
 
             public DecompressionBuffer(PagerInfo pagerInfo, long position, int size, DecompressionBuffersPool pool, int index, LowLevelTransaction tx)
             {
-                _pagerInfo = pagerInfo;
+                PagerInfo = pagerInfo;
                 _position = position;
                 _size = size;
                 _pool = pool;
                 _index = index;
-                _pagerInfo._pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
-                var ptr = _pagerInfo._pager.AcquirePagePointer(tx, position);
+                PagerInfo.Pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
+                var ptr = PagerInfo.Pager.AcquirePagePointer(tx, position);
 
                 TempPage = new TemporaryPage(ptr, size) { ReturnTemporaryPageToPool = this };
             }
@@ -303,46 +303,46 @@ namespace Voron.Data.Compression
 
             public void EnsureValidPointer(LowLevelTransaction tx)
             {
-                _pagerInfo._pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
-                var p = _pagerInfo._pager.AcquirePagePointer(tx, _position);
+                PagerInfo.Pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
+                var p = PagerInfo.Pager.AcquirePagePointer(tx, _position);
 
                 TempPage.SetPointer(p);
             }
 
             public void Dispose()
             {
-                if (_pagerInfo._pager.Options.Encryption.IsEnabled)
+                if (PagerInfo.Pager.Options.Encryption.IsEnabled)
                     Sodium.sodium_memzero(TempPage.TempPagePointer, (UIntPtr)TempPage.PageSize);
 
                 // return it to the pool
                 _pool._pool[_index].Enqueue(this);
 
                 Interlocked.Add(ref _pool._currentlyUsedBytes, -_size);
-                _pagerInfo.DecreaseNumberOfUsages();
+                PagerInfo.Release();
             }
         }
 
         private class PagerInfo
         {
-            internal readonly AbstractPager _pager;
+            internal readonly AbstractPager Pager;
             private long _numberOfUsages;
 
             public PagerInfo(AbstractPager pager)
             {
-                _pager = pager;
+                Pager = pager;
             }
 
-            public bool TryIncreaseNumberOfUsages()
+            public bool TryUse()
             {
                 return Interlocked.Increment(ref _numberOfUsages) > 0;
             }
 
-            public void DecreaseNumberOfUsages()
+            public void Release()
             {
                 Interlocked.Decrement(ref _numberOfUsages);
             }
 
-            public bool TryDispose()
+            public bool TryTakeForDispose()
             {
                 if (Interlocked.Read(ref _numberOfUsages) > 0)
                     return false;
@@ -351,6 +351,11 @@ namespace Voron.Data.Compression
                     return false;
 
                 return true;
+            }
+
+            public void DisposePager()
+            {
+                Pager.Dispose();
             }
         }
     }

--- a/src/Voron/Data/Compression/DecompressionBuffersPool.cs
+++ b/src/Voron/Data/Compression/DecompressionBuffersPool.cs
@@ -25,12 +25,12 @@ namespace Voron.Data.Compression
         private ConcurrentQueue<DecompressionBuffer>[] _pool;
         private long _decompressionPagerCounter;
         private long _lastUsedPage;
-        private AbstractPager _compressionPager;
+        private PagerInfo _compressionPager;
         private bool _initialized;
 
         private long _currentlyUsedBytes;
 
-        private ImmutableAppendOnlyList<AbstractPager> _oldPagers;
+        private ImmutableAppendOnlyList<PagerInfo> _oldPagers;
         private readonly long _maxNumberOfPagesInScratchBufferPool;
 
         internal int NumberOfScratchFiles => 1 + _oldPagers.Count;
@@ -50,18 +50,18 @@ namespace Voron.Data.Compression
 
                 if (_compressionPager != null)
                 {
-                    _compressionPager.Dispose();
+                    _compressionPager._pager.Dispose();
 
-                    _scratchSpaceMonitor.Decrease(_compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                    _scratchSpaceMonitor.Decrease(_compressionPager._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                 }
 
                 foreach (var pager in _oldPagers)
                 {
-                    if (pager.Disposed == false)
+                    if (pager._pager.Disposed == false)
                     {
-                        pager.Dispose();
+                        pager._pager.Dispose();
 
-                        _scratchSpaceMonitor.Decrease(pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                        _scratchSpaceMonitor.Decrease(pager._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
                     }
                 }
             });
@@ -126,18 +126,13 @@ namespace Voron.Data.Compression
 
             while (queue.TryDequeue(out buffer))
             {
-                if (buffer.CanReuse == false)
+                if (buffer._pagerInfo.TryIncreaseNumberOfUsages() == false)
                     continue;
-
                 try
                 {
                     buffer.EnsureValidPointer(tx);
                     tmp = buffer.TempPage;
                     break;
-                }
-                catch (ObjectDisposedException)
-                {
-                    // we could dispose the pager during the cleanup
                 }
                 catch (Exception)
                 {
@@ -156,12 +151,12 @@ namespace Voron.Data.Compression
 
                     try
                     {
-                        var numberOfPagesBeforeAllocate = _compressionPager.NumberOfAllocatedPages;
+                        var numberOfPagesBeforeAllocate = _compressionPager._pager.NumberOfAllocatedPages;
 
-                        _compressionPager.EnsureContinuous(_lastUsedPage, allocationInPages);
+                        _compressionPager._pager.EnsureContinuous(_lastUsedPage, allocationInPages);
 
-                        if (_compressionPager.NumberOfAllocatedPages > numberOfPagesBeforeAllocate)
-                            _scratchSpaceMonitor.Increase((_compressionPager.NumberOfAllocatedPages - numberOfPagesBeforeAllocate) * Constants.Storage.PageSize);
+                        if (_compressionPager._pager.NumberOfAllocatedPages > numberOfPagesBeforeAllocate)
+                            _scratchSpaceMonitor.Increase((_compressionPager._pager.NumberOfAllocatedPages - numberOfPagesBeforeAllocate) * Constants.Storage.PageSize);
                     }
                     catch (InsufficientMemoryException)
                     {
@@ -172,13 +167,13 @@ namespace Voron.Data.Compression
                     }
 
                     buffer = new DecompressionBuffer(_compressionPager, _lastUsedPage, pageSize, this, index, tx);
-
+                    _compressionPager.TryIncreaseNumberOfUsages();
                     _lastUsedPage += allocationInPages;
 
                     void CreateNewBuffersPager(long size)
                     {
                         _oldPagers = _oldPagers.Append(_compressionPager);
-                        _compressionPager = CreateDecompressionPager(size);
+                        _compressionPager = new PagerInfo(CreateDecompressionPager(size));
                         _lastUsedPage = 0;
                     }
                 }
@@ -214,8 +209,8 @@ namespace Voron.Data.Compression
                     return;
 
                 _pool = new[] { new ConcurrentQueue<DecompressionBuffer>() };
-                _compressionPager = CreateDecompressionPager(DecompressedPagesCache.Size * Constants.Compression.MaxPageSize);
-                _oldPagers = ImmutableAppendOnlyList<AbstractPager>.Empty;
+                _compressionPager = new PagerInfo(CreateDecompressionPager(DecompressedPagesCache.Size * Constants.Compression.MaxPageSize));
+                _oldPagers = ImmutableAppendOnlyList<PagerInfo>.Empty;
                 _initialized = true;
             }
         }
@@ -243,17 +238,19 @@ namespace Voron.Data.Compression
             _disposeOnceRunner.Dispose();
         }
 
-        public void Cleanup()
+        public int Cleanup()
         {
+            var disposedCount = 0;
+
             if (_initialized == false)
-                return;
+                return disposedCount;
 
             if (_oldPagers.Count == 0)
-                return;
+                return disposedCount;
 
             var necessaryPages = Interlocked.Read(ref _currentlyUsedBytes) / Constants.Storage.PageSize;
 
-            var availablePages = _compressionPager.NumberOfAllocatedPages;
+            var availablePages = _compressionPager._pager.NumberOfAllocatedPages;
 
             var pagers = _oldPagers;
 
@@ -261,40 +258,43 @@ namespace Voron.Data.Compression
             {
                 var old = pagers[i];
 
+                if ( old.TryDispose() == false )
+                    continue;
                 if (availablePages >= necessaryPages)
                 {
-                    old.Dispose();
-                    _scratchSpaceMonitor.Decrease(old.NumberOfAllocatedPages * Constants.Storage.PageSize);
-
+                    old._pager.Dispose();
+                    _scratchSpaceMonitor.Decrease(old._pager.NumberOfAllocatedPages * Constants.Storage.PageSize);
+                    disposedCount++;
                     continue;
                 }
 
                 // PERF: We dont care about the pager data content anymore. So we can discard the whole context to
                 //       clean up the modified bit.
-                old.DiscardWholeFile();
-                availablePages += old.NumberOfAllocatedPages;
+                old._pager.DiscardWholeFile();
+                availablePages += old._pager.NumberOfAllocatedPages;
             }
 
-            _oldPagers = _oldPagers.RemoveWhile(x => x.Disposed);
+            _oldPagers = _oldPagers.RemoveWhile(x => x._pager.Disposed);
+            return disposedCount;
         }
 
         private class DecompressionBuffer : IDisposable
         {
-            private readonly AbstractPager _pager;
+            internal readonly PagerInfo _pagerInfo;
             private readonly long _position;
             private readonly int _size;
             private readonly DecompressionBuffersPool _pool;
             private readonly int _index;
 
-            public DecompressionBuffer(AbstractPager pager, long position, int size, DecompressionBuffersPool pool, int index, LowLevelTransaction tx)
+            public DecompressionBuffer(PagerInfo pagerInfo, long position, int size, DecompressionBuffersPool pool, int index, LowLevelTransaction tx)
             {
-                _pager = pager;
+                _pagerInfo = pagerInfo;
                 _position = position;
                 _size = size;
                 _pool = pool;
                 _index = index;
-                _pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
-                var ptr = _pager.AcquirePagePointer(tx, position);
+                _pagerInfo._pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
+                var ptr = _pagerInfo._pager.AcquirePagePointer(tx, position);
 
                 TempPage = new TemporaryPage(ptr, size) { ReturnTemporaryPageToPool = this };
             }
@@ -303,23 +303,54 @@ namespace Voron.Data.Compression
 
             public void EnsureValidPointer(LowLevelTransaction tx)
             {
-                _pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
-                var p = _pager.AcquirePagePointer(tx, _position);
+                _pagerInfo._pager.EnsureMapped(tx, _position, _size / Constants.Storage.PageSize);
+                var p = _pagerInfo._pager.AcquirePagePointer(tx, _position);
 
                 TempPage.SetPointer(p);
             }
 
-            public bool CanReuse => _pager.Disposed == false;
-
             public void Dispose()
             {
-                if (_pager.Options.Encryption.IsEnabled)
+                if (_pagerInfo._pager.Options.Encryption.IsEnabled)
                     Sodium.sodium_memzero(TempPage.TempPagePointer, (UIntPtr)TempPage.PageSize);
 
                 // return it to the pool
                 _pool._pool[_index].Enqueue(this);
 
                 Interlocked.Add(ref _pool._currentlyUsedBytes, -_size);
+                _pagerInfo.DecreaseNumberOfUsages();
+            }
+        }
+
+        private class PagerInfo
+        {
+            internal readonly AbstractPager _pager;
+            private long _numberOfUsages;
+
+            public PagerInfo(AbstractPager pager)
+            {
+                _pager = pager;
+            }
+
+            public bool TryIncreaseNumberOfUsages()
+            {
+                return Interlocked.Increment(ref _numberOfUsages) > 0;
+            }
+
+            public void DecreaseNumberOfUsages()
+            {
+                Interlocked.Decrement(ref _numberOfUsages);
+            }
+
+            public bool TryDispose()
+            {
+                if (Interlocked.Read(ref _numberOfUsages) > 0)
+                    return false;
+
+                if (Interlocked.CompareExchange(ref _numberOfUsages, -(1000 * 1000), 0) != 0)
+                    return false;
+
+                return true;
             }
         }
     }

--- a/test/FastTests/Voron/LeafsCompression/RavenDB_5384_DecompressionBuffersPoolTests.cs
+++ b/test/FastTests/Voron/LeafsCompression/RavenDB_5384_DecompressionBuffersPoolTests.cs
@@ -45,7 +45,7 @@ namespace FastTests.Voron.LeafsCompression
                 
                 Env.DecompressionBuffers.Cleanup();
 
-                Assert.Equal(1, Env.DecompressionBuffers.NumberOfScratchFiles);
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
 
                 Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
             }

--- a/test/StressTests/Voron/Issues/RavenDB_20675.cs
+++ b/test/StressTests/Voron/Issues/RavenDB_20675.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using FastTests.Voron;
+using Voron;
+using Voron.Impl.Paging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20675 : StorageTest
+    {
+        private int _64KB = 64 * 1024;
+
+        public RavenDB_20675(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxScratchBufferSize = _64KB * 2;
+        }
+
+        [Fact]
+        public void MustNotReusePagesWhichHaveAlreadyDisposedPager()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+
+                var page1 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out var temp1);
+                var page2 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out var temp2);
+
+                Assert.Equal(1, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                var page3 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out var temp3);
+
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                page1.Dispose();
+                page2.Dispose();
+                page3.Dispose();
+
+                Env.DecompressionBuffers.Cleanup();
+
+                // underlying pager of page1 and page2 was disposed during the cleanup
+                Assert.Equal(1, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                // will try to take it from the pool but since the pager of page1 and page2 is already disposed
+                // it must not take those pagers so it should reuse page3
+                var page4 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out var temp4);
+
+                unsafe
+                {
+                    Assert.Equal(new IntPtr(temp3.TempPagePointer), new IntPtr(temp4.TempPagePointer));
+                }
+            }
+        }
+
+        [Fact]
+        public void CanUsePagerAfterDispose()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+                var page1 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out var temp);
+                var page2 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+                var page3 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                page1.Dispose();
+                Assert.Equal(0, Env.DecompressionBuffers.Cleanup());
+                page2.Dispose();
+                Assert.Equal(1, Env.DecompressionBuffers.Cleanup());
+
+            }
+
+        }
+
+        [Fact]
+        public void CanUsePagerAfterDispose1()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+
+                TemporaryPage temp;
+                var page1 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page2 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page3 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                page1.Dispose();
+                page2.Dispose();
+                page3.Dispose();
+
+                Env.DecompressionBuffers.Cleanup();
+                Assert.Equal(1, Env.DecompressionBuffers.NumberOfScratchFiles);
+            }
+        }
+
+        [Fact]
+        public void CanUsePagerAfterDispose2()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+
+                TemporaryPage temp;
+
+                var page1 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page2 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                var page3 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
+
+                page1.Dispose();
+                page2.Dispose();
+                page3.Dispose();
+
+                // will taken from the pool
+                var page4 = Env.DecompressionBuffers.GetTemporaryPage(llt, _64KB, out temp);
+
+                Env.DecompressionBuffers.Cleanup();
+                Assert.Equal(2, Env.DecompressionBuffers.NumberOfScratchFiles);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
…tPage

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20675

### Additional description

We can have a scenario, in which we dispose a pager while we have a decompression buffer in the queue that still uses it.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 
### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
