### PR TITLE
RavenDB-20706 fix Icon padding for disabled db

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -312,7 +312,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                         <Icon
                                             icon="database"
                                             addon={db.currentNode.relevant ? "home" : null}
-                                            margin="m-0"
+                                            margin="me-2"
                                         />
                                         {db.name}
                                     </span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20706/fix-Icon-padding-for-disabled-db

### Additional description

Fix icon padding for disabled database on database list

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
