### PR TITLE
RavenDB-20558 Making sure that we won't leak the subscription connection task while we dispose the connection object. We already cancelled the CTS and diposed TCP connection so it's supposed it will fail but it's better to wait for that so it won't be racy.

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -1075,6 +1075,20 @@ namespace Raven.Server.Documents.Subscriptions
                     // ignored
                 }
 
+                try
+                {
+                    if (SubscriptionConnectionTask is { IsCompleted: false })
+                    {
+                        // precaution - it's supposed this task will fail here since we disposed all resources used by connection
+                        // but we should wait for it before we release _copiedBuffer
+                        SubscriptionConnectionTask.Wait();
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+                
                 RecentSubscriptionStatuses?.Clear();
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20558

### Additional description

Very similar to https://github.com/ravendb/ravendb/pull/16621. During the investigation I did some console writelines during the dispose of connection and saw that sometimes the task was not completed. Fixing it didn't make any difference regarding the original problem with AVE but still I believe it's a good precaution fix.

### Type of change

- Precaution

### How risky is the change?

- Moderate 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
