### PR TITLE
RavenDB-20689 - Improve the performance of a new index when it includes filtering

### DIFF
--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -45,6 +45,8 @@ namespace Raven.Server.Documents.Indexes
         public bool Consumed;
         private static readonly long _consumed = -1L;
 
+        public long CurrentFilterCount => _currentFilter.Count;
+
         private CollectionOfBloomFilters(Mode mode, long version, Tree tree, TransactionOperationContext context)
         {
             _mode = mode;

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -124,11 +124,14 @@ namespace Raven.Server.Documents.Indexes
         {
             if (indexItem.SkipLuceneDelete == false)
             {
+                bool mustDelete;
                 using (_stats.BloomStats.Start())
                 {
-                    if (_filters.Add(indexItem.LowerId) == false)
-                        writer.Value.Delete(indexItem.LowerId, stats);
+                    mustDelete = _filters.Add(indexItem.LowerId) == false;
                 }
+
+                if (mustDelete)
+                    writer.Value.Delete(indexItem.LowerId, stats);
             }
 
             var numberOfOutputs = 0;

--- a/test/SlowTests/Core/Indexing/BloomFilters.cs
+++ b/test/SlowTests/Core/Indexing/BloomFilters.cs
@@ -1,0 +1,110 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="CustomAnalyzers.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Core.Indexing
+{
+    public class BloomFilters : RavenTestBase
+    {
+        public BloomFilters(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Skip_Storing_In_Bloom_Filter_If_No_Document_Was_Stored_In_Lucene()
+        {
+            using (var store = GetDocumentStore())
+            {
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        await session.StoreAsync(new User
+                        {
+                            Age = 37
+                        }, i.ToString());
+                    }
+                    
+                    await session.SaveChangesAsync();
+                }
+
+                await new Index().ExecuteAsync(store);
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var resultsCount = await session.Query<User, Index>().CountAsync();
+                    Assert.Equal(0, resultsCount);
+                }
+
+                var database = await GetDatabase(store.Database);
+                var index = database.IndexStore.GetIndex("Index");
+
+                using (var context = new TransactionOperationContext(index._environment, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
+                {
+                    using (context.OpenWriteTransaction())
+                    {
+                        using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
+                        {
+                            Assert.Equal(1, collection.Count);
+                            Assert.Equal(0, collection.CurrentFilterCount);
+                        }
+                    }
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        await session.StoreAsync(new User
+                        {
+                            Age = 38
+                        }, i.ToString());
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var context = new TransactionOperationContext(index._environment, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
+                {
+                    using (context.OpenWriteTransaction())
+                    {
+                        using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
+                        {
+                            Assert.Equal(1, collection.Count);
+                            Assert.Equal(10, collection.CurrentFilterCount);
+                        }
+                    }
+                }
+            }
+        }
+
+        private class Index : AbstractIndexCreationTask<User>
+        {
+            public Index()
+            {
+                Map = users => from user in users
+                               where user.Age != 37
+                                select new
+                                {
+                                    user.Age
+                                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20689/Slow-performance-of-the-Bloom-Filters

### Additional description

Improve the performance of a new index when it includes filtering.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
