### PR TITLE
RavenDB-20424 Projection function returns incorrect document id, RQL …

### DIFF
--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -541,6 +541,12 @@ namespace Raven.Server.Documents.Patch
             _doc = doc;
         }
 
+        public bool TryGetOriginalDocumentIfUnchanged(out Document doc)
+        {
+            doc = _doc;
+            return _doc != null && Changed == false;
+        }
+
         public override bool Delete(JsValue property)
         {
             if (property.IsString() == false)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -2065,7 +2065,12 @@ namespace Raven.Server.Documents.Patch
                 {
                     if (val.IsNull())
                         return null;
-                    return JsBlittableBridge.Translate(context, ScriptEngine, val.AsObject(), modifier, usageMode, isNested);
+                    
+                    var instance = val.AsObject();
+                    if (instance is BlittableObjectInstance boi && boi.TryGetOriginalDocumentIfUnchanged(out var doc))
+                        return doc;
+                    
+                    return JsBlittableBridge.Translate(context, ScriptEngine, instance, modifier, usageMode, isNested);
                 }
                 if (val.IsNumber())
                     return val.AsNumber();

--- a/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
@@ -45,6 +45,9 @@ namespace Raven.Server.Smuggler.Documents
                     }
                 }
 
+                if (translatedResult is Document d)
+                    return d.Clone(ctx);
+
                 if (!(translatedResult is BlittableJsonReaderObject bjro))
                     return null;
 

--- a/test/SlowTests/Issues/RavenDB-20424.cs
+++ b/test/SlowTests/Issues/RavenDB-20424.cs
@@ -1,0 +1,43 @@
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20424 : RavenTestBase
+{
+    public RavenDB_20424(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanProjectRelatedDocumentViaJS()
+    {
+        using var store = GetDocumentStore();
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Cat("cats/1", "Origin", null));
+            s.Store(new Cat("cats/2", "Clone", "cats/1"));
+            s.SaveChanges();
+        }
+
+        using (var s = store.OpenSession())
+        {
+            var p = s.Advanced.RawQuery<Cat>("from Cats as c where id() = 'cats/2' load c.Parent as p select p").Single();
+            Assert.Equal("cats/1", p.Id);
+            Assert.Equal("Origin", p.Name);
+        }
+        WaitForUserToContinueTheTest(store);
+        using (var s = store.OpenSession())
+        {
+            var p = s.Advanced.RawQuery<Cat>(
+                "declare function p(c) { return load(c.Parent); } " +
+                "from Cats as c where id() = 'cats/2' select p(c)").Single();
+            Assert.Equal("Origin", p.Name);
+            Assert.Equal("cats/1", p.Id);
+        }
+    }
+
+    private record Cat(string Id, string Name, string Parent);
+}


### PR DESCRIPTION
…cannot project transitive dependencies

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20424 

### Additional description

If we return an unmodified object instance from a JS projection, we'll threat it as the raw document

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

