### PR TITLE
RavenDB-20339 - Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/test/SlowTests/Server/Replication/AutomaticConflictResolvingOnPut.cs
+++ b/test/SlowTests/Server/Replication/AutomaticConflictResolvingOnPut.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
@@ -18,10 +17,12 @@ namespace SlowTests.Server.Replication
         {
         }
 
-        [Fact]
-        public async Task CanAutomaticlyResolveConflict()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanAutomaticlyResolveConflict(Options options)
         {
-            using (var master = GetDocumentStore(options: new Options
+            var modifyDatabaseRecord = options.ModifyDatabaseRecord;
+            using (var master = GetDocumentStore(options: new Options(options)
             {
                 ModifyDatabaseRecord = record =>
                 {
@@ -30,9 +31,10 @@ namespace SlowTests.Server.Replication
                         ResolveToLatest = false,
                         ResolveByCollection = new Dictionary<string, ScriptResolver>()
                     };
+                    modifyDatabaseRecord(record);
                 }
             }))
-            using (var slave = GetDocumentStore(options: new Options
+            using (var slave = GetDocumentStore(options: new Options(options)
             {
                 ModifyDatabaseRecord = record =>
                 {
@@ -41,6 +43,7 @@ namespace SlowTests.Server.Replication
                         ResolveToLatest = false,
                         ResolveByCollection = new Dictionary<string, ScriptResolver>()
                     };
+                    modifyDatabaseRecord(record);
                 }
             }))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:

- `SlowTests/Server/Replication/AutomaticConflictResolvingOnPut.cs`
- `SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs`
- `SlowTests/Server/Replication/ReplicationCleanTombstones.cs`
- `SlowTests/Server/Replication/ReplicationConflictsTests.cs`

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
