### PR TITLE
RavenDB-20717 - use AcquirePagePointer (overloaded for 32-bit pagers)

### DIFF
--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -351,10 +351,10 @@ namespace Voron.Impl.Paging
         {
             return AcquirePagePointerInternal(tx, pageNumber, pagerState);
         }
-
+        
         public virtual T AcquirePagePointerHeaderForDebug<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null) where T : unmanaged
         {
-            var pointer = AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            var pointer = AcquirePagePointer(tx, pageNumber, pagerState);
             return *(T*)pointer;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20717/NRE-in-AcquirePagePointerHeaderForDebug

### Additional description

Use `AcquirePagePointer` (overloaded for 32-bit pagers).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Yes. 32-bit pagers

### Testing by Contributor

- Fixes existing tests in 32-bit mode.,