### PR TITLE
RavenDB-20724: Adding an unrecognized Index configuration option shouldn't trigger the replacement process

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1265,7 +1265,7 @@ namespace Raven.Server.Documents.Indexes
             if ((differences & IndexDefinitionCompareDifferences.DeploymentMode) == IndexDefinitionCompareDifferences.DeploymentMode)
                 return IndexCreationOptions.UpdateWithoutUpdatingCompiledIndex;
 
-            return IndexCreationOptions.Update;
+            return IndexCreationOptions.UpdateWithoutUpdatingCompiledIndex;
         }
 
         public static bool IsValidIndexName(string name, bool isStatic, out string errorMessage)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20724/Adding-an-unrecognized-Index-configuration-option-shouldnt-trigger-the-replacement-process.

### Additional description

We don't want to update compiled Index when trying to add an unrecognized Index configuration option.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed