### PR TITLE
RavenDB-20728: Typo in description for `TrafficWatch.CertificateThumbprints` configuration entry

### DIFF
--- a/src/Raven.Server/Config/Categories/TrafficWatchConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/TrafficWatchConfiguration.cs
@@ -57,7 +57,7 @@ public class TrafficWatchConfiguration : ConfigurationCategory
     [ConfigurationEntry("TrafficWatch.ChangeTypes", ConfigurationEntryScope.ServerWideOnly)]
     public List<TrafficWatchChangeType> ChangeTypes { get; set; }
 
-    [Description("Semicolon seperated list of specific client certificate thumbprints by which the Traffic Watch logging entities will be filtered. If not specified, Traffic Watch entities with any certificate thumbprint will be included, including those without any thumbprint. Example list: \"0123456789ABCDEF0123456789ABCDEF01234567;FEDCBA9876543210FEDCBA9876543210FEDCBA98\".")]
+    [Description("A semicolon-separated list of specific client certificate thumbprints by which the Traffic Watch logging entities will be filtered. If not specified, Traffic Watch entities with any certificate thumbprint will be included, including those without any thumbprint. Example list: \"0123456789ABCDEF0123456789ABCDEF01234567;FEDCBA9876543210FEDCBA9876543210FEDCBA98\".")]
     [DefaultValue(null)]
     [ConfigurationEntry("TrafficWatch.CertificateThumbprints", ConfigurationEntryScope.ServerWideOnly)]
     public List<string> CertificateThumbprints { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20728/Typo-in-description-for-TrafficWatch.CertificateThumbprints-configuration-entry

### Additional description

Correction of a typo.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed