### PR TITLE
RavenDB-20628 - Cluster wide transaction : throw `TaskCanceledException` when fails on timeout

### DIFF
--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -51,7 +51,19 @@ namespace Raven.Client.Http
 
         public string LastServerVersion { get; private set; }
 
-        internal bool SupportsAtomicClusterWrites { get; set; }
+        private bool? _supportsAtomicClusterWrites;
+
+        internal bool SupportsAtomicClusterWrites
+        {
+            get
+            {
+                if (_supportsAtomicClusterWrites.HasValue)
+                    return _supportsAtomicClusterWrites.Value;
+
+                UpdateServerVersion(LastServerVersion);
+                return _supportsAtomicClusterWrites.Value;
+            }
+        }
 
         public bool ShouldUpdateServerVersion()
         {
@@ -69,12 +81,12 @@ namespace Raven.Client.Http
             if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
             {
                 // 5.2 or higher
-                SupportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 ||
-                                              ver.Major > 5;
+                _supportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 ||
+                                               ver.Major > 5;
             }
             else
             {
-                SupportsAtomicClusterWrites = false;
+                _supportsAtomicClusterWrites = false;
             }
         }
 

--- a/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
+++ b/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
@@ -12,6 +12,19 @@ namespace Raven.Client.ServerWide.Operations
 
         public string FullVersion { get; set; }
 
+        public string GetCleanedFullVersion()
+        {
+            if (IsNightlyOrDev(BuildVersion) == false)
+                return FullVersion;
+
+            var index = FullVersion.IndexOf('-');
+            return index == -1 ? FullVersion : FullVersion.Remove(index);
+        }
+        public static bool IsNightlyOrDev(long buildVersion)
+        {
+            return buildVersion >= 50 && buildVersion < 60;
+        }
+
         public override bool Equals(object obj)
         {
             return Equals(obj as BuildNumber);

--- a/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
+++ b/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
@@ -12,7 +12,7 @@ namespace Raven.Client.ServerWide.Operations
 
         public string FullVersion { get; set; }
 
-        public string GetCleanedFullVersion()
+        internal string GetCleanedFullVersion()
         {
             if (IsNightlyOrDev(BuildVersion) == false)
                 return FullVersion;

--- a/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
+++ b/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
@@ -12,18 +12,7 @@ namespace Raven.Client.ServerWide.Operations
 
         public string FullVersion { get; set; }
 
-        internal string GetCleanedFullVersion()
-        {
-            if (IsNightlyOrDev(BuildVersion) == false)
-                return FullVersion;
-
-            var index = FullVersion.IndexOf('-'); // if index is -1, FullVersion looks like that: '5.4.1', else it looks like that: '5.4.1-custom'
-            return index == -1 ? FullVersion : FullVersion.Remove(index); 
-        }
-        internal static bool IsNightlyOrDev(long buildVersion)
-        {
-            return buildVersion >= 50 && buildVersion < 60;
-        }
+        public string AssemblyVersion { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -35,10 +24,11 @@ namespace Raven.Client.ServerWide.Operations
             if (other == null)
                 return false;
 
-            return string.Equals(ProductVersion, other.ProductVersion) && 
-                   BuildVersion == other.BuildVersion && 
-                   string.Equals(CommitHash, other.CommitHash) && 
-                   string.Equals(FullVersion, other.FullVersion);
+            return string.Equals(ProductVersion, other.ProductVersion) &&
+                   BuildVersion == other.BuildVersion &&
+                   string.Equals(CommitHash, other.CommitHash) &&
+                   string.Equals(FullVersion, other.FullVersion) &&
+                   string.Equals(AssemblyVersion, other.AssemblyVersion);
         }
 
         public override int GetHashCode()
@@ -49,6 +39,7 @@ namespace Raven.Client.ServerWide.Operations
                 hashCode = (hashCode * 397) ^ BuildVersion;
                 hashCode = (hashCode * 397) ^ (CommitHash != null ? CommitHash.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (FullVersion != null ? FullVersion.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (AssemblyVersion != null ? AssemblyVersion.GetHashCode() : 0);
                 return hashCode;
             }
         }
@@ -60,7 +51,8 @@ namespace Raven.Client.ServerWide.Operations
                 [nameof(ProductVersion)] = ProductVersion,
                 [nameof(BuildVersion)] = BuildVersion,
                 [nameof(CommitHash)] = CommitHash,
-                [nameof(FullVersion)] = FullVersion
+                [nameof(FullVersion)] = FullVersion,
+                [nameof(AssemblyVersion)] = AssemblyVersion
             };
         }
     }

--- a/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
+++ b/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
@@ -17,10 +17,10 @@ namespace Raven.Client.ServerWide.Operations
             if (IsNightlyOrDev(BuildVersion) == false)
                 return FullVersion;
 
-            var index = FullVersion.IndexOf('-');
-            return index == -1 ? FullVersion : FullVersion.Remove(index);
+            var index = FullVersion.IndexOf('-'); // if index is -1, FullVersion looks like that: '5.4.1', else it looks like that: '5.4.1-custom'
+            return index == -1 ? FullVersion : FullVersion.Remove(index); 
         }
-        public static bool IsNightlyOrDev(long buildVersion)
+        internal static bool IsNightlyOrDev(long buildVersion)
         {
             return buildVersion >= 50 && buildVersion < 60;
         }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -23,6 +23,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
+using Raven.Client.Properties;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
@@ -78,7 +79,8 @@ namespace Raven.Server.Commercial
             BuildVersion = ServerVersion.Build,
             ProductVersion = ServerVersion.Version,
             CommitHash = ServerVersion.CommitHash,
-            FullVersion = ServerVersion.FullVersion
+            FullVersion = ServerVersion.FullVersion,
+            AssemblyVersion = ServerVersion.AssemblyVersion
         };
 
         public LicenseStatus LicenseStatus { get; private set; } = new LicenseStatus();

--- a/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
+++ b/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
@@ -10,13 +10,11 @@ namespace Raven.Server.Documents
     public class ClusterTransactionWaiter
     {
         internal readonly DocumentDatabase Database;
-        internal readonly ServerStore ServerStore;
         private readonly ConcurrentDictionary<string, TaskCompletionSource> _results = new ConcurrentDictionary<string, TaskCompletionSource>();
 
-        public ClusterTransactionWaiter(DocumentDatabase database, ServerStore serverStore)
+        public ClusterTransactionWaiter(DocumentDatabase database)
         {
             Database = database;
-            ServerStore = serverStore;
         }
 
         public RemoveTask CreateTask(string id, long index)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -370,6 +370,11 @@ namespace Raven.Server.Documents
                         _logger);
                     try
                     {
+                        using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                        using (ctx.OpenReadTransaction())
+                        {
+                            LastCompletedClusterTransactionIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(ctx.Transaction.InnerTransaction);
+                        }
                         _hasClusterTransaction.Set();
                         ExecuteClusterTransaction();
                     }
@@ -391,12 +396,6 @@ namespace Raven.Server.Documents
 
                 _serverStore.LicenseManager.LicenseChanged += LoadTimeSeriesPolicyRunnerConfigurations;
                 IoChanges.OnIoChange += CheckWriteRateAndNotifyIfNecessary;
-
-                using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                using (ctx.OpenReadTransaction())
-                {
-                    LastCompletedClusterTransactionIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(ctx.Transaction.InnerTransaction);
-                }
             }
             catch (Exception)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1883,7 +1883,7 @@ namespace Raven.Server.Documents
 
             internal Action<PathSetting> ActionToCallOnGetTempPath;
 
-            internal Func<BatchHandler.MergedBatchCommand, TimeSpan?> WaitForDatabaseResultsTimeoutInClusterTransaction;
+            internal Func<Task> AfterCommitInClusterTransaction;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -439,8 +439,11 @@ namespace Raven.Server.Documents
         private long _lastCompletedClusterTransaction;
         public long LastCompletedClusterTransaction => _lastCompletedClusterTransaction;
 
-        private long _lastCompletedClusterTransactionIndex;
-        public long LastCompletedClusterTransactionIndex => _lastCompletedClusterTransactionIndex;
+        public long LastCompletedClusterTransactionIndex { get; private set; }
+
+        public TaskCompletionSource<long> LastCompletedClusterTransactionIndexWaiter { get; private set; } =
+            new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public bool IsEncrypted => MasterKey != null;
 
         private PoolOfThreads.LongRunningWork _clusterTransactionsThread;
@@ -622,6 +625,10 @@ namespace Raven.Server.Documents
             try
             {
                 var index = command.Index;
+                LastCompletedClusterTransactionIndex = index;
+                LastCompletedClusterTransactionIndexWaiter.TrySetResult(index);
+                LastCompletedClusterTransactionIndexWaiter = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+
                 var options = mergedCommands.Options[index];
                 if (exception == null)
                 {
@@ -641,7 +648,6 @@ namespace Raven.Server.Documents
                     ClusterTransactionWaiter.SetResult(options.TaskId, index, result);
                     _nextClusterCommand = command.PreviousCount + command.Commands.Length;
                     _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
-                    _lastCompletedClusterTransactionIndex = command.Index;
                     return;
                 }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -549,7 +549,7 @@ namespace Raven.Server.Documents
                     {
                         _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
                     }
-                    ExecuteClusterTransactionOneByOne(batch, removeTasks);
+                    ExecuteClusterTransactionOneByOne(batch);
                     return batch;
                 }
 
@@ -583,7 +583,7 @@ namespace Raven.Server.Documents
             return batch;
         }
 
-        private void ExecuteClusterTransactionOneByOne(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch, Dictionary<string, RemoveTask> removeTasks)
+        private void ExecuteClusterTransactionOneByOne(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch)
         {
             foreach (var command in batch)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -29,7 +29,6 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Json;
-using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
@@ -529,7 +528,7 @@ namespace Raven.Server.Documents
 
             foreach (var cmd in batch)
             {
-                ClusterTransactionWaiter.CreateTask(cmd.Options.TaskId, out _);
+                ClusterTransactionWaiter.CreateTask(cmd.Options.TaskId);
             }
 
             ForTestingPurposes?.BeforeExecutingClusterTransactions?.Invoke();
@@ -1905,7 +1904,7 @@ namespace Raven.Server.Documents
 
             internal Action<PathSetting> ActionToCallOnGetTempPath;
 
-            internal Func<Task> AfterCommitInClusterTransaction;
+            internal Action AfterCommitInClusterTransaction;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -642,7 +642,19 @@ namespace Raven.Server.Documents
 
                         indexTask.ContinueWith(t =>
                         {
-                            ClusterTransactionWaiter.SetResult(options.TaskId, index);
+                            if (t.IsCompletedSuccessfully)
+                            {
+                                ClusterTransactionWaiter.SetResult(options.TaskId, index);
+                            }
+                            if (t.IsFaulted)
+                            {
+                                Exception e = t.Exception;
+                                if (e is AggregateException ae && ae.InnerExceptions.Count == 1)
+                                {
+                                    e = ae.InnerException;
+                                }
+                                ClusterTransactionWaiter.SetException(options.TaskId, index, e);
+                            }
                         });
                     }
                     else

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1883,6 +1883,8 @@ namespace Raven.Server.Documents
 
             internal Action<PathSetting> ActionToCallOnGetTempPath;
 
+            internal Func<BatchHandler.MergedBatchCommand, TimeSpan?> WaitForDatabaseResultsTimeoutInClusterTransaction;
+
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)
             {
                 ActionToCallDuringDocumentDatabaseInternalDispose = action;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -29,6 +29,7 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Json;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
@@ -437,6 +438,9 @@ namespace Raven.Server.Documents
         private long? _nextClusterCommand;
         private long _lastCompletedClusterTransaction;
         public long LastCompletedClusterTransaction => _lastCompletedClusterTransaction;
+
+        private long _lastCompletedClusterTransactionIndex;
+        public long LastCompletedClusterTransactionIndex => _lastCompletedClusterTransactionIndex;
         public bool IsEncrypted => MasterKey != null;
 
         private PoolOfThreads.LongRunningWork _clusterTransactionsThread;
@@ -637,6 +641,7 @@ namespace Raven.Server.Documents
                     ClusterTransactionWaiter.SetResult(options.TaskId, index, result);
                     _nextClusterCommand = command.PreviousCount + command.Commands.Length;
                     _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
+                    _lastCompletedClusterTransactionIndex = command.Index;
                     return;
                 }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -147,7 +147,7 @@ namespace Raven.Server.Documents
                     }
                 }
 
-                ClusterTransactionWaiter = new ClusterTransactionWaiter(this, serverStore);
+                ClusterTransactionWaiter = new ClusterTransactionWaiter(this);
                 QueryMetadataCache = new QueryMetadataCache();
                 IoChanges = new IoChangesNotifications
                 {
@@ -392,7 +392,7 @@ namespace Raven.Server.Documents
                 _serverStore.LicenseManager.LicenseChanged += LoadTimeSeriesPolicyRunnerConfigurations;
                 IoChanges.OnIoChange += CheckWriteRateAndNotifyIfNecessary;
 
-                using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
                 using (ctx.OpenReadTransaction())
                 {
                     LastCompletedClusterTransactionIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(ctx.Transaction.InnerTransaction);
@@ -631,8 +631,6 @@ namespace Raven.Server.Documents
             {
                 var index = command.Index;
 
-                LastCompletedClusterTransactionIndex = index;
-
                 var options = mergedCommands.Options[index];
                 if (exception == null)
                 {
@@ -666,6 +664,7 @@ namespace Raven.Server.Documents
                     
                     _nextClusterCommand = command.PreviousCount + command.Commands.Length;
                     _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
+                    LastCompletedClusterTransactionIndex = index;
                     return;
                 }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -45,6 +45,7 @@ namespace Raven.Server.Documents
         public static readonly Slice CollectionsSlice;
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
+        private static readonly Slice LastCompletedClusterTransactionIndexSlice;
         private static readonly Slice LastEtagSlice;
         private static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
@@ -107,6 +108,7 @@ namespace Raven.Server.Documents
             {
                 Slice.From(ctx, "AllTombstonesEtags", ByteStringType.Immutable, out AllTombstonesEtagsSlice);
                 Slice.From(ctx, "Etags", ByteStringType.Immutable, out EtagsSlice);
+                Slice.From(ctx, "LastCompletedClusterTransactionIndex", ByteStringType.Immutable, out LastCompletedClusterTransactionIndexSlice);
                 Slice.From(ctx, "LastEtag", ByteStringType.Immutable, out LastEtagSlice);
                 Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
                 Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
@@ -690,6 +692,31 @@ namespace Raven.Server.Documents
             }
 
             return 0;
+        }
+
+        public static long ReadLastCompletedClusterTransactionIndex(Transaction tx)
+        {
+            if (tx == null)
+                throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
+            var tree = tx.ReadTree(GlobalTreeSlice);
+            if (tree == null)
+            {
+                return 0;
+            }
+            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
+            if (readResult == null)
+            {
+                return 0;
+            }
+
+            return readResult.Reader.ReadLittleEndianInt64();
+        }
+
+        public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
+        {
+            var tree = context.Transaction.InnerTransaction.CreateTree(GlobalTreeSlice);
+            using (Slice.External(context.Allocator, (byte*)&index, sizeof(long), out Slice indexSlice))
+                tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
         }
 
         public static long ReadLastEtag(Transaction tx)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -20,6 +20,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
@@ -39,6 +40,8 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+using static Raven.Server.ServerWide.Commands.ClusterTransactionCommand;
 using Constants = Raven.Client.Constants;
 using Index = Raven.Server.Documents.Indexes.Index;
 
@@ -238,46 +241,54 @@ namespace Raven.Server.Documents.Handlers
                 throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
 
             var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId);
-            var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
-
-            if (result.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
-            {
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
-                throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
-                {
-                    ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
-                };
-            }
-
-            // wait for the command to be applied on this node
-            await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
-
             var array = new DynamicJsonArray();
-            if (clusterTransactionCommand.DatabaseCommandsCount > 0)
+            long index;
+
+            if (ServerStore.CommandAlreadyInLog(clusterTransactionCommand, out _) && clusterTransactionCommand.RaftCommandIndex.HasValue)
             {
-                var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke(ServerStore, Database, clusterTransactionCommand);
-                if (forTestingTask != null)
+                index = clusterTransactionCommand.RaftCommandIndex.Value;
+                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index); // wait for the command to be applied on this node
+                while (Database.LastCompletedClusterTransactionIndex < index)
                 {
-                    await forTestingTask;
+                    await Task.Delay(200);
                 }
 
-                var reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
-                if (reply.IndexTask != null)
-                {
-                    await reply.IndexTask;
-                }
+                var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand); // get results from leader
+                var count = ValidateClusterTransactionResult(result.Result);
 
-                array = reply.Array;
+                var lastModified = Database.Time.GetUtcNow();
+                GenerateDatabaseCommandsEvaluatedResults(clusterTransactionCommand.DatabaseCommands, index, count, lastModified, options.DisableAtomicDocumentWrites, array);
+            }
+            else
+            {
+                var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+                index = result.Index;
+                ValidateClusterTransactionResult(result.Result);
+
+                // wait for the command to be applied on this node
+                await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
+
+                if (clusterTransactionCommand.DatabaseCommandsCount > 0)
+                {
+                    var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
+                    if (forTestingTask != null)
+                    {
+                        await forTestingTask;
+                    }
+
+                    var reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
+                    if (reply.IndexTask != null)
+                    {
+                        await reply.IndexTask;
+                    }
+
+                    array = reply.Array;
+                }
             }
 
             foreach (var clusterCommands in clusterTransactionCommand.ClusterCommands)
             {
-                array.Add(new DynamicJsonValue
-                {
-                    ["Type"] = clusterCommands.Type,
-                    ["Key"] = clusterCommands.Id,
-                    ["Index"] = result.Index
-                });
+                array.Add(new DynamicJsonValue { ["Type"] = clusterCommands.Type, ["Key"] = clusterCommands.Id, ["Index"] = index });
             }
 
             HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
@@ -286,7 +297,7 @@ namespace Raven.Server.Documents.Handlers
                 context.Write(writer, new DynamicJsonValue
                 {
                     [nameof(BatchCommandResult.Results)] = array,
-                    [nameof(BatchCommandResult.TransactionIndex)] = result.Index
+                    [nameof(BatchCommandResult.TransactionIndex)] = index
                 });
             }
         }
@@ -294,6 +305,70 @@ namespace Raven.Server.Documents.Handlers
         private static void ThrowNotSupportedType(string contentType)
         {
             throw new InvalidOperationException($"The requested Content type '{contentType}' is not supported. Use 'application/json' or 'multipart/mixed'.");
+        }
+
+        private long ValidateClusterTransactionResult(object result)
+        {
+            if (result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
+            {
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
+                throw new ClusterTransactionConcurrencyException(
+                    $"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
+                {
+                    ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
+                };
+            }
+
+            if (result is long count)
+            {
+                return count;
+            }
+            
+            throw new InvalidOperationException($"Cluster Transaction result type ({result.GetType()}) isn't valid");
+        }
+
+        private void GenerateDatabaseCommandsEvaluatedResults(List<ClusterTransactionDataCommand> databaseCommands, 
+            long index, long count, DateTime lastModified, bool? disableAtomicDocumentWrites,
+            DynamicJsonArray commandsResults)
+        {
+            foreach (var dataCmd in databaseCommands)
+            {
+                count++;
+                var cv = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
+                if (disableAtomicDocumentWrites == false)
+                {
+                    cv += $",{ChangeVectorParser.TrxnTag}:{index}-{Database.ClusterTransactionId}";
+                }
+
+                switch (dataCmd.Type)
+                {
+                    case CommandType.PUT:
+                        if (dataCmd.Document.GetMetadata().TryGet("@collection", out string collection) == false)
+                            throw new InvalidOperationException(); // TODO: change it to relevant exception
+
+                        commandsResults.Add(new DynamicJsonValue
+                        {
+                            ["Type"] = dataCmd.Type,
+                            [Constants.Documents.Metadata.Id] = dataCmd.Id,
+                            [Constants.Documents.Metadata.Collection] = collection,
+                            [Constants.Documents.Metadata.ChangeVector] = cv,
+                            [Constants.Documents.Metadata.LastModified] = lastModified,
+                            ["@flags"] = "FromClusterTransaction"
+                        });
+                        break;
+                    case CommandType.DELETE:
+                        commandsResults.Add(new DynamicJsonValue
+                        {
+                            [nameof(BatchRequestParser.CommandData.Id)] = dataCmd.Id,
+                            [nameof(BatchRequestParser.CommandData.Type)] = nameof(CommandType.DELETE),
+                            ["Deleted"] = true,
+                            ["ChangeVector"] = cv
+                        });
+                        break;
+                    default:
+                        throw new InvalidOperationException(); // TODO: change it to relevant exception
+                }
+            }
         }
 
         private async Task ParseMultipart(DocumentsOperationContext context, MergedBatchCommand command)

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -291,7 +291,11 @@ namespace Raven.Server.Documents.Handlers
 
             foreach (var clusterCommands in clusterTransactionCommand.ClusterCommands)
             {
-                array.Add(new DynamicJsonValue { ["Type"] = clusterCommands.Type, ["Key"] = clusterCommands.Id, ["Index"] = index });
+                array.Add(new DynamicJsonValue { 
+                    ["Type"] = clusterCommands.Type, 
+                    ["Key"] = clusterCommands.Id, 
+                    ["Index"] = index
+                });
             }
 
             HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -20,7 +20,6 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
-using Raven.Client.Extensions;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
@@ -253,18 +252,16 @@ namespace Raven.Server.Documents.Handlers
             // wait for the command to be applied on this node
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
 
+            var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
+            if (forTestingTask != null)
+            {
+                await forTestingTask;
+            }
+
             var array = new DynamicJsonArray();
             if (clusterTransactionCommand.DatabaseCommandsCount > 0)
             {
-                var timeout = Database.ForTestingPurposes?.WaitForDatabaseResultsTimeoutInClusterTransaction?.Invoke(command) ??
-                              ServerStore.Engine.OperationTimeout;
-                var waitTask = Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
-                if (await waitTask.WaitWithTimeout(timeout) == false)
-                {
-                    throw new System.TimeoutException($"Waited for {timeout} but the command was not applied in this time.");
-                }
-
-                var reply = (ClusterTransactionCompletionResult)await waitTask;
+                var reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
                 if (reply.IndexTask != null)
                 {
                     await reply.IndexTask;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -252,15 +252,15 @@ namespace Raven.Server.Documents.Handlers
             // wait for the command to be applied on this node
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
 
-            var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
-            if (forTestingTask != null)
-            {
-                await forTestingTask;
-            }
-
             var array = new DynamicJsonArray();
             if (clusterTransactionCommand.DatabaseCommandsCount > 0)
             {
+                var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke(ServerStore, Database, clusterTransactionCommand);
+                if (forTestingTask != null)
+                {
+                    await forTestingTask;
+                }
+
                 var reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
                 if (reply.IndexTask != null)
                 {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
-using Nest;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.Batches;
@@ -41,7 +40,6 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using static Raven.Server.ServerWide.Commands.ClusterTransactionCommand;
 using Constants = Raven.Client.Constants;
 using Index = Raven.Server.Documents.Indexes.Index;
@@ -97,7 +95,7 @@ namespace Raven.Server.Documents.Handlers
                     ValidateCommandForClusterWideTransaction(command, disableAtomicDocumentWrites);
                     var raftRequestId = GetRaftRequestIdFromQuery();
 
-                    using (Database.ClusterTransactionWaiter.CreateTask(id: raftRequestId, out _))
+                    using (Database.ClusterTransactionWaiter.CreateTask(id: raftRequestId))
                     {
                         // Since this is a cluster transaction we are not going to wait for the write assurance of the replication.
                         // Because in any case the user will get a raft index to wait upon on his next request.
@@ -246,11 +244,7 @@ namespace Raven.Server.Documents.Handlers
 
             if (count.HasValue)
             {
-                var forTestingTask = Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
-                if (forTestingTask != null)
-                {
-                    await forTestingTask;
-                }
+                Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
 
                 await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
                 var lastModified = Database.Time.GetUtcNow();
@@ -298,10 +292,10 @@ namespace Raven.Server.Documents.Handlers
                 case null:
                     if (databaseCommandsCount == 0) // there isn't any databaseCommands
                         return null;
-                    goto default;
+                    throw new InvalidOperationException($"Cluster Transaction result is null, but has more then 0 database commands ({databaseCommandsCount})");
 
                 default:
-                    throw new InvalidOperationException("Cluster Transaction result type isn't valid");
+                    throw new InvalidOperationException($"Cluster Transaction result type ({result.GetType()}) isn't valid");
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -20,6 +20,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
@@ -255,12 +256,15 @@ namespace Raven.Server.Documents.Handlers
             var array = new DynamicJsonArray();
             if (clusterTransactionCommand.DatabaseCommandsCount > 0)
             {
-                ClusterTransactionCompletionResult reply;
-                using (var timeout = new CancellationTokenSource(ServerStore.Engine.OperationTimeout))
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, HttpContext.RequestAborted))
+                var timeout = Database.ForTestingPurposes?.WaitForDatabaseResultsTimeoutInClusterTransaction?.Invoke(command) ??
+                              ServerStore.Engine.OperationTimeout;
+                var waitTask = Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
+                if (await waitTask.WaitWithTimeout(timeout) == false)
                 {
-                    reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, cts.Token);
+                    throw new System.TimeoutException($"Waited for {timeout} but the command was not applied in this time.");
                 }
+
+                var reply = (ClusterTransactionCompletionResult)await waitTask;
                 if (reply.IndexTask != null)
                 {
                     await reply.IndexTask;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -311,6 +311,7 @@ namespace Raven.Server.Documents.Handlers
         {
             foreach (var dataCmd in databaseCommands)
             {
+
                 count++;
                 var cv = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
                 if (disableAtomicDocumentWrites == false)
@@ -321,14 +322,11 @@ namespace Raven.Server.Documents.Handlers
                 switch (dataCmd.Type)
                 {
                     case CommandType.PUT:
-                        if (dataCmd.Document.GetMetadata().TryGet(Constants.Documents.Metadata.Collection, out string collection) == false)
-                            throw new InvalidOperationException($"Cannot get doc '{dataCmd.Id}' collection");
-
                         commandsResults.Add(new DynamicJsonValue
                         {
                             ["Type"] = dataCmd.Type,
                             [Constants.Documents.Metadata.Id] = dataCmd.Id,
-                            [Constants.Documents.Metadata.Collection] = collection,
+                            [Constants.Documents.Metadata.Collection] = CollectionName.GetCollectionName(dataCmd.Document),
                             [Constants.Documents.Metadata.ChangeVector] = cv,
                             [Constants.Documents.Metadata.LastModified] = lastModified,
                             [Constants.Documents.Metadata.Flags] = DocumentFlags.FromClusterTransaction.ToString()

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -374,7 +374,7 @@ namespace Raven.Server.Documents.Handlers
                         });
                         break;
                     default:
-                        throw new InvalidOperationException("Database command type isn't valid");
+                        throw new InvalidOperationException($"Database command type ({dataCmd.Type}) isn't valid");
                 }
             }
         }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -23,6 +23,7 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Extensions;
 using Raven.Client.Json;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
@@ -95,18 +96,17 @@ namespace Raven.Server.Documents.Handlers
                     ValidateCommandForClusterWideTransaction(command, disableAtomicDocumentWrites);
                     var raftRequestId = GetRaftRequestIdFromQuery();
 
-                    using (Database.ClusterTransactionWaiter.CreateTask(id: raftRequestId))
-                    {
-                        // Since this is a cluster transaction we are not going to wait for the write assurance of the replication.
-                        // Because in any case the user will get a raft index to wait upon on his next request.
-                        var options = new ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites, ClusterCommandsVersionManager.CurrentClusterMinimalVersion)
+                    // Since this is a cluster transaction we are not going to wait for the write assurance of the replication.
+                    // Because in any case the user will get a raft index to wait upon on his next request.
+                    var options =
+                        new ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites, ClusterCommandsVersionManager.CurrentClusterMinimalVersion)
                         {
                             WaitForIndexesTimeout = waitForIndexesTimeout,
                             WaitForIndexThrow = waitForIndexThrow,
                             SpecifiedIndexesQueryString = specifiedIndexesQueryString.Count > 0 ? specifiedIndexesQueryString.ToList() : null,
                         };
-                        await HandleClusterTransaction(context, command, options, raftRequestId);
-                    }
+                    await HandleClusterTransaction(context, command, options, raftRequestId);
+
                     return;
                 }
 
@@ -246,7 +246,9 @@ namespace Raven.Server.Documents.Handlers
             {
                 Database.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
 
-                await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
+                using (Database.ClusterTransactionWaiter.CreateTask(id: options.TaskId, index))
+                    await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, HttpContext.RequestAborted);
+
                 var lastModified = Database.Time.GetUtcNow();
                 GenerateDatabaseCommandsEvaluatedResults(clusterTransactionCommand.DatabaseCommands, index, count.Value, lastModified, options.DisableAtomicDocumentWrites, array);
             }
@@ -658,6 +660,8 @@ namespace Raven.Server.Documents.Handlers
                 Replies.Clear();
                 Options.Clear();
 
+                long lastIndexInBatch = 0L;
+
                 foreach (var command in _batch)
                 {
                     Replies.Add(command.Index, new DynamicJsonArray());
@@ -805,7 +809,14 @@ namespace Raven.Server.Documents.Handlers
                     {
                         context.LastDatabaseChangeVector = updatedChangeVector.ChangeVector;
                     }
+
+                    lastIndexInBatch = long.Max(lastIndexInBatch, command.Index);
                 }
+
+                // set last cluster transaction index (persistent)
+                var lastClusterTxIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(context.Transaction.InnerTransaction);
+                if(lastIndexInBatch > lastClusterTxIndex)
+                    Database.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, lastIndexInBatch);
 
                 return Reply.Count;
             }

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -490,18 +490,5 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public unsafe long? GetIndexByRaftId(ClusterOperationContext context, string guid)
-        {
-            var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
-            using (Slice.From(context.Allocator, guid, out var guidSlice))
-            {
-                if (table.ReadByKey(guidSlice, out var reader) == false)
-                    return null;
-
-                var index = Bits.SwapBytes(*(long*)reader.Read((int)LogHistoryColumn.Index, out _));
-                return index;
-            }
-
-        }
     }
 }

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -489,5 +489,19 @@ namespace Raven.Server.Rachis
                 return true;
             }
         }
+
+        public unsafe long? GetIndexByRaftId(ClusterOperationContext context, string guid)
+        {
+            var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
+            using (Slice.From(context.Allocator, guid, out var guidSlice))
+            {
+                if (table.ReadByKey(guidSlice, out var reader) == false)
+                    return null;
+
+                var index = Bits.SwapBytes(*(long*)reader.Read((int)LogHistoryColumn.Index, out _));
+                return index;
+            }
+
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -335,17 +335,8 @@ namespace Raven.Server.ServerWide
                 switch (type)
                 {
                     case nameof(ClusterTransactionCommand):
-                        var executeResults = ExecuteClusterTransaction(context, cmd, index);
-                        if (executeResults.Errors != null)
-                        {
-                            result = executeResults.Errors;
-                            leader?.SetStateOf(index, result);
-                        }
-                        else
-                        {
-                            result = executeResults.PreviousCount;
-                            leader?.SetStateOf(index, result);
-                        }
+                        result = ExecuteClusterTransaction(context, cmd, index);
+                        leader?.SetStateOf(index, result);
                         break;
 
                     case nameof(CleanUpClusterStateCommand):
@@ -948,7 +939,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private (long? PreviousCount, List<ClusterTransactionCommand.ClusterTransactionErrorInfo> Errors) ExecuteClusterTransaction(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index)
+        private object ExecuteClusterTransaction(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index)
         {
             ClusterTransactionCommand clusterTransaction = null;
             Exception exception = null;
@@ -974,11 +965,11 @@ namespace Raven.Server.ServerWide
 
                     NotifyDatabaseAboutChanged(context, clusterTransaction.DatabaseName, index, nameof(ClusterTransactionCommand), notify, null);
 
-                    return (count, null);
+                    return count;
                 }
 
                 OnTransactionDispose(context, index);
-                return (null, error);
+                return error;
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Json;
@@ -397,10 +398,10 @@ namespace Raven.Server.ServerWide.Commands
             return Constants.CompareExchange.RvnAtomicPrefix + docId;
         }
 
-        public unsafe void SaveCommandsBatch(ClusterOperationContext context, long index)
+        public unsafe long? SaveCommandsBatch(ClusterOperationContext context, long index)
         {
             if (HasDocumentsInTransaction == false)
-                return;
+                return null;
 
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
             var commandsCountPerDatabase = context.Transaction.InnerTransaction.ReadTree(ClusterStateMachine.TransactionCommandsCountPerDatabase);
@@ -419,6 +420,8 @@ namespace Raven.Server.ServerWide.Commands
                     using (commandsCountPerDatabase.DirectAdd(databaseSlice, sizeof(long), out var ptr))
                         *(long*)ptr = count + DatabaseCommandsCount;
                 }
+
+                return count;
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -86,8 +86,6 @@ using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
 using Voron.Exceptions;
-using static Raven.Server.Documents.Handlers.BatchHandler;
-using static Raven.Server.Rachis.Leader;
 using Constants = Raven.Client.Constants;
 using MemoryCache = Raven.Server.Utils.Imports.Memory.MemoryCache;
 using MemoryCacheOptions = Raven.Server.Utils.Imports.Memory.MemoryCacheOptions;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -13,7 +13,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Lucene.Net.Search;
-using Microsoft.Extensions.Caching.Memory;
 using NCrontab.Advanced;
 using NCrontab.Advanced.Extensions;
 using Raven.Client;
@@ -87,6 +86,8 @@ using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
 using Voron.Exceptions;
+using static Raven.Server.Documents.Handlers.BatchHandler;
+using static Raven.Server.Rachis.Leader;
 using Constants = Raven.Client.Constants;
 using MemoryCache = Raven.Server.Utils.Imports.Memory.MemoryCache;
 using MemoryCacheOptions = Raven.Server.Utils.Imports.Memory.MemoryCacheOptions;
@@ -3260,6 +3261,29 @@ namespace Raven.Server.ServerWide
         {
             await _engine.WaitForCommitIndexChange(modification, value, token);
         }
+
+        public bool CommandAlreadyInLog(CommandBase command,  /*DocumentDatabase database,*/ out Exception exception)
+        {
+            // exception = null;
+            using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                // _engine.GetLastCommitIndex(context, out var lastCommitted, out _);
+                var djv = command.ToJson(context);
+                var cmdJson = context.ReadObject(djv, "raft/command");
+                if (_engine.LogHistory.HasHistoryLog(context, cmdJson, out var index, out var result, out exception))
+                {
+                    command.RaftCommandIndex = index;
+                    // if this command is already committed, we can skip it and notify the caller about it
+                    // if (lastCommitted >= index)
+                    // {
+                        return true;
+                    // }
+                }
+            }
+            return false;
+        }
+
 
         public string LastStateChangeReason()
         {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3262,24 +3262,6 @@ namespace Raven.Server.ServerWide
             await _engine.WaitForCommitIndexChange(modification, value, token);
         }
 
-        public bool CommandAlreadyInLog(CommandBase command, out long index, out object result, out Exception exception)
-        {
-            result = null;
-            index = -1;
-            using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            using (context.OpenReadTransaction())
-            {
-                var djv = command.ToJson(context);
-                var cmdJson = context.ReadObject(djv, "raft/command");
-                if (_engine.LogHistory.HasHistoryLog(context, cmdJson, out index, out result, out exception))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-
         public string LastStateChangeReason()
         {
             return $"{_engine.CurrentState}, {_engine.LastStateChangeReason} (at {_engine.LastStateChangeTime})";

--- a/src/Raven.Server/ServerWide/ServerVersion.cs
+++ b/src/Raven.Server/ServerWide/ServerVersion.cs
@@ -10,6 +10,7 @@ namespace Raven.Server.ServerWide
         private static string _commitHash;
         private static string _version;
         private static string _fullVersion;
+        private static string _assemblyVersion;
 
         public static string Version => 
             _version ?? (_version = RavenVersionAttribute.Instance.Version);
@@ -22,6 +23,9 @@ namespace Raven.Server.ServerWide
             _commitHash ?? (_commitHash = RavenVersionAttribute.Instance.CommitHash);
         public static string FullVersion => 
             _fullVersion ?? (_fullVersion = RavenVersionAttribute.Instance.FullVersion);
+
+        public static string AssemblyVersion =>
+            _assemblyVersion ?? (_assemblyVersion = RavenVersionAttribute.Instance.AssemblyVersion);
 
         public const int DevBuildNumber = 54;
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -727,7 +727,7 @@ namespace Raven.Server.Smuggler.Documents
                     var parsedCommands = _clusterTransactionCommands.GetArraySegment();
 
                     var raftRequestId = RaftIdGenerator.NewId();
-                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(string.Empty, disableAtomicDocumentWrites: false,
+                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites: false,
                         ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
                     var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -734,7 +734,9 @@ namespace Raven.Server.Smuggler.Documents
                     var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
                     clusterTransactionCommand.FromBackup = true;
 
+
                     var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+
                     for (int i = 0; i < _clusterTransactionCommands.Length; i++)
                     {
                         _clusterTransactionCommands[i].Document.Dispose();

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -226,22 +226,38 @@ namespace Raven.Server.Web.System
                         context.Write(writer, new DynamicJsonValue
                         {
                             [nameof(Topology.Nodes)] = new DynamicJsonArray(
-                                rawRecord.Topology.Members.Select(x => new DynamicJsonValue
-                                {
-                                    [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
-                                    [nameof(ServerNode.ClusterTag)] = x,
-                                    [nameof(ServerNode.ServerRole)] = ServerNode.Role.Member,
-                                    [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
-                                    [nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion()
-                                })
-                                .Concat(rawRecord.Topology.Rehabs.Select(x => new DynamicJsonValue
-                                {
-                                    [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
-                                    [nameof(ServerNode.ClusterTag)] = x,
-                                    [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
-                                    [nameof(ServerNode.ServerRole)] = ServerNode.Role.Rehab,
-                                    [nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion()
-                                })
+                                rawRecord.Topology.Members.Select(x =>
+                                    {
+                                        var json = new DynamicJsonValue
+                                        {
+                                            [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
+                                            [nameof(ServerNode.ClusterTag)] = x,
+                                            [nameof(ServerNode.ServerRole)] = ServerNode.Role.Member,
+                                            [nameof(ServerNode.Database)] = rawRecord.DatabaseName
+                                        };
+
+                                        if (license != null)
+                                        {
+                                            json[nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion();
+                                        }
+                                        return json;
+                                    })
+                                .Concat(rawRecord.Topology.Rehabs.Select(x =>
+                                    {
+                                        var json = new DynamicJsonValue
+                                        {
+                                            [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
+                                            [nameof(ServerNode.ClusterTag)] = x,
+                                            [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
+                                            [nameof(ServerNode.ServerRole)] = ServerNode.Role.Rehab,
+                                        };
+
+                                        if(license != null)
+                                        {
+                                            json[nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion();
+                                        }
+                                        return json;
+                                    })
                                 )
                             ),
                             [nameof(Topology.Etag)] = rawRecord.Topology.Stamp?.Index ?? -1

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -219,6 +219,7 @@ namespace Raven.Server.Web.System
                     }
 
                     clusterTopology.ReplaceCurrentNodeUrlWithClientRequestedNodeUrlIfNecessary(ServerStore, HttpContext);
+                    var license = ServerStore.LoadLicenseLimits();
 
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                     {
@@ -230,14 +231,16 @@ namespace Raven.Server.Web.System
                                     [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
                                     [nameof(ServerNode.ClusterTag)] = x,
                                     [nameof(ServerNode.ServerRole)] = ServerNode.Role.Member,
-                                    [nameof(ServerNode.Database)] = rawRecord.DatabaseName
+                                    [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
+                                    [nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion()
                                 })
                                 .Concat(rawRecord.Topology.Rehabs.Select(x => new DynamicJsonValue
                                 {
                                     [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
                                     [nameof(ServerNode.ClusterTag)] = x,
                                     [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
-                                    [nameof(ServerNode.ServerRole)] = ServerNode.Role.Rehab
+                                    [nameof(ServerNode.ServerRole)] = ServerNode.Role.Rehab,
+                                    [nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion()
                                 })
                                 )
                             ),

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -250,7 +250,8 @@ namespace Raven.Server.Web.System
 
             if (license != null && license.NodeLicenseDetails.TryGetValue(tag, out var nodeDetails))
             {
-                json[nameof(ServerNode.LastServerVersion)] = nodeDetails.BuildInfo.GetCleanedFullVersion();
+                json[nameof(ServerNode.LastServerVersion)] =
+                    nodeDetails.BuildInfo.AssemblyVersion ?? nodeDetails.BuildInfo.ProductVersion;
             }
             return json;
         }

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -17,6 +17,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
@@ -226,38 +227,8 @@ namespace Raven.Server.Web.System
                         context.Write(writer, new DynamicJsonValue
                         {
                             [nameof(Topology.Nodes)] = new DynamicJsonArray(
-                                rawRecord.Topology.Members.Select(x =>
-                                    {
-                                        var json = new DynamicJsonValue
-                                        {
-                                            [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
-                                            [nameof(ServerNode.ClusterTag)] = x,
-                                            [nameof(ServerNode.ServerRole)] = ServerNode.Role.Member,
-                                            [nameof(ServerNode.Database)] = rawRecord.DatabaseName
-                                        };
-
-                                        if (license != null)
-                                        {
-                                            json[nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion();
-                                        }
-                                        return json;
-                                    })
-                                .Concat(rawRecord.Topology.Rehabs.Select(x =>
-                                    {
-                                        var json = new DynamicJsonValue
-                                        {
-                                            [nameof(ServerNode.Url)] = GetUrl(x, clusterTopology),
-                                            [nameof(ServerNode.ClusterTag)] = x,
-                                            [nameof(ServerNode.Database)] = rawRecord.DatabaseName,
-                                            [nameof(ServerNode.ServerRole)] = ServerNode.Role.Rehab,
-                                        };
-
-                                        if(license != null)
-                                        {
-                                            json[nameof(ServerNode.LastServerVersion)] = license.NodeLicenseDetails[x].BuildInfo.GetCleanedFullVersion();
-                                        }
-                                        return json;
-                                    })
+                                rawRecord.Topology.Members.Select(tag => GetNodeJson(tag, ServerNode.Role.Member, license, clusterTopology, rawRecord.DatabaseName))
+                                .Concat(rawRecord.Topology.Rehabs.Select(tag => GetNodeJson(tag, ServerNode.Role.Rehab, license, clusterTopology, rawRecord.DatabaseName))
                                 )
                             ),
                             [nameof(Topology.Etag)] = rawRecord.Topology.Stamp?.Index ?? -1
@@ -265,6 +236,23 @@ namespace Raven.Server.Web.System
                     }
                 }
             }
+        }
+
+        private DynamicJsonValue GetNodeJson(string tag, ServerNode.Role role, LicenseLimits license, ClusterTopology clusterTopology, string database)
+        {
+            var json = new DynamicJsonValue
+            {
+                [nameof(ServerNode.Url)] = GetUrl(tag, clusterTopology),
+                [nameof(ServerNode.ClusterTag)] = tag,
+                [nameof(ServerNode.Database)] = database,
+                [nameof(ServerNode.ServerRole)] = role,
+            };
+
+            if (license != null && license.NodeLicenseDetails.TryGetValue(tag, out var nodeDetails))
+            {
+                json[nameof(ServerNode.LastServerVersion)] = nodeDetails.BuildInfo.GetCleanedFullVersion();
+            }
+            return json;
         }
 
         private void AlertIfDocumentStoreCreationRateIsNotReasonable(string applicationIdentifier, string name)

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -218,9 +218,9 @@ namespace InterversionTests
             }), stores);
         }
 
-        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null)
+        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null, DatabaseRecord record = null)
         {
-            var doc = new DatabaseRecord(dbName)
+            var doc = record ?? new DatabaseRecord(dbName)
             {
                 Settings =
                 {

--- a/test/InterversionTests/RavenDB-20628-Interversion.cs
+++ b/test/InterversionTests/RavenDB-20628-Interversion.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Glacier.Model;
+using Esprima.Ast;
+using FastTests.Graph;
+using FastTests.Issues;
+using InterversionTests;
+using Jint;
+using McMaster.Extensions.CommandLineUtils;
+using Nest;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands.Cluster;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
+using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20628_Interversion : MixedClusterTestBase
+    {
+        public RavenDB_20628_Interversion(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException()
+        {
+            var (leader, peers, local) = await CreateMixedCluster(new[]
+            {
+                "5.4.105",
+                "5.4.105"
+            });
+
+            string databaseName = GetDatabaseName();
+            var urls = new List<string>(){ leader.WebUrl }.Concat(peers.Select(l => l.Url)).ToArray();
+
+            var tags = leader.ServerStore.GetClusterTopology().AllNodes.Keys.Where(x => x != leader.ServerStore.NodeTag).ToList();
+
+
+            using (var store1 = new DocumentStore { Urls = new[]
+                   {
+                       leader.WebUrl
+                   } }.Initialize())
+            {
+                var record = new DatabaseRecord(databaseName)
+                {
+                    Topology = new DatabaseTopology
+                    {
+                        Members = new List<string>
+                        {
+                            leader.ServerStore.NodeTag,
+                        }.Concat(tags).ToList()
+                    },
+                    Settings =
+                    {
+                        [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1",
+                        [RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter)] = "1",
+                        [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = true.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = true.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString()
+                    }
+                };
+                await CreateDatabase(store1, 3, dbName: databaseName, record);
+            }
+
+
+            using var store = new DocumentStore
+            {
+                Urls = new [] { leader.WebUrl },
+                Database = databaseName
+            }.Initialize();
+
+            var killed = false;
+            
+            var disposeNodeTask = Task.Run(async () =>
+            {
+                await Task.Delay(700);
+                var url = store.GetRequestExecutor(databaseName).TopologyNodes.First().Url;
+
+                Assert.Equal(leader.WebUrl, url);
+                await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
+                killed = true;
+            });
+            await ProcessDocument(store, "Docs/1-A");
+
+            await disposeNodeTask;
+            Assert.True(killed);
+
+            foreach (var p in peers)
+            {
+                await KillSlavedServerProcessAsync(p.Process);
+            }
+        }
+
+
+        private async Task ProcessDocument(IDocumentStore store, string id)
+        {
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc = new Doc { Id = id };
+                await session.StoreAsync(doc);
+                await session.SaveChangesAsync();
+            }
+
+            for (int i = 0; i < 8000; i++)
+            {
+                if(i%1000 == 0)
+                    Console.WriteLine($"ProcessDocument {i}");
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var doc = await session.LoadAsync<Doc>(id);
+                    doc.Progress = i;
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        public class Doc
+        {
+            public string Id { get; set; }
+            public int Progress { get; set; }
+        }
+    }
+}
+
+

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -6,22 +6,10 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Glacier.Model;
-using Esprima.Ast;
 using FastTests.Graph;
-using FastTests.Issues;
-using Jint;
-using McMaster.Extensions.CommandLineUtils;
-using Nest;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Commands.Batches;
-using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
-using Raven.Client.Exceptions;
 using Raven.Server;
-using Raven.Server.Config;
-using Raven.Server.Monitoring.Snmp.Objects.Database;
-using Raven.Server.ServerWide.Commands;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -58,7 +46,6 @@ namespace SlowTests.Issues
             db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
             {
                 cts.Cancel();
-                return Task.CompletedTask;
             };
 
             var e = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -253,8 +240,6 @@ namespace SlowTests.Issues
                 {
                     if (Interlocked.CompareExchange(ref failover, 1, 0) == 0)
                         throw new TimeoutException("Shahar"); // for failover in node A
-
-                    return Task.CompletedTask;
                 };
             }
         }

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Graph;
+using Jint;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20628 : ClusterTestBase
+    {
+        public RavenDB_20628(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ClusterWideTransactionShouldThrowTimeoutException()
+        {
+            using var store = GetDocumentStore();
+
+            var user1 = new User()
+            {
+                Id = "Users/1-A", 
+                Name = "Alice"
+            };
+
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+            }
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            db.ForTestingPurposesOnly().WaitForDatabaseResultsTimeoutInClusterTransaction = (command) =>
+            {
+                if (command.ParsedCommands.Any(cmd => cmd.Type == CommandType.PUT))
+                    return TimeSpan.Zero;
+                else
+                    return null;
+            };
+
+            var e = await Assert.ThrowsAsync<RavenException>( async () =>
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user2 = await session.LoadAsync<User>(user1.Id);
+                    user2.Name = "Bob";
+                    await session.SaveChangesAsync();
+                }
+            });
+
+            Assert.NotNull(e);
+            Assert.True(e.InnerException is TimeoutException);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Graph;
 using Jint;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
+using Raven.Server;
 using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
@@ -22,7 +27,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task ClusterWideTransactionShouldThrowTimeoutException()
+        public async Task RequestExecutor_With_CanellationToken_Should_Throw_In_Timeout_When_ClusterWideTransaction_Is_Slow()
         {
             using var store = GetDocumentStore();
 
@@ -40,26 +45,25 @@ namespace SlowTests.Issues
             }
 
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            db.ForTestingPurposesOnly().WaitForDatabaseResultsTimeoutInClusterTransaction = (command) =>
+            db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
             {
-                if (command.ParsedCommands.Any(cmd => cmd.Type == CommandType.PUT))
-                    return TimeSpan.Zero;
-                else
-                    return null;
+                return Task.Delay(15_000);
             };
 
-            var e = await Assert.ThrowsAsync<RavenException>( async () =>
+            var e = await Assert.ThrowsAsync<TaskCanceledException>( async () =>
             {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
                     var user2 = await session.LoadAsync<User>(user1.Id);
                     user2.Name = "Bob";
-                    await session.SaveChangesAsync();
+                    await session.SaveChangesAsync(cts.Token);
                 }
             });
 
             Assert.NotNull(e);
-            Assert.True(e.InnerException is TimeoutException);
+            Assert.Contains("RequestExecutor", e.StackTrace);
+            Assert.Contains("HttpClient", e.StackTrace);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -20,6 +20,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.ServerWide.Commands;
 using Tests.Infrastructure;
 using Xunit;
@@ -77,9 +78,12 @@ namespace SlowTests.Issues
         public async Task ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3);
-            var databaseName = GetDatabaseName();
-            await CreateDatabaseInCluster(databaseName, 3, leader.WebUrl);
-            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
+            var databaseName = store.Database;
 
             var disposeNodeTask = Task.Run(async () =>
             {
@@ -123,10 +127,11 @@ namespace SlowTests.Issues
         public async Task ClusterTransaction_Should_Work_After_Commit_And_Failover()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
-            var databaseName = GetDatabaseName();
-            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
-
-            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
 
             await ApplyFailoverAfterCommit(nodes, store.Database);
 
@@ -149,11 +154,11 @@ namespace SlowTests.Issues
         public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
-            var databaseName = GetDatabaseName();
-            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
-
-            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
-
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
 
             await ApplyFailoverAfterCommit(nodes, store.Database);
 
@@ -193,11 +198,11 @@ namespace SlowTests.Issues
         public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover_UseResults()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
-            var databaseName = GetDatabaseName();
-            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
-
-            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
-
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
 
             await ApplyFailoverAfterCommit(nodes, store.Database);
 

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -57,7 +57,8 @@ namespace SlowTests.Issues
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
             {
-                return Task.Delay(15_000);
+                cts.Cancel();
+                return Task.CompletedTask;
             };
 
             var e = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -71,8 +72,6 @@ namespace SlowTests.Issues
             });
 
             Assert.NotNull(e);
-            Assert.Contains("RequestExecutor", e.StackTrace);
-            Assert.Contains("HttpClient", e.StackTrace);
         }
 
         [Fact]

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -239,7 +239,7 @@ namespace SlowTests.Issues
                 db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
                 {
                     if (Interlocked.CompareExchange(ref failover, 1, 0) == 0)
-                        throw new TimeoutException("Shahar"); // for failover in node A
+                        throw new TimeoutException("Fake server fail that cause failover"); // for failover in node A
                 };
             }
         }

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -52,6 +52,8 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
+            using var cts = new CancellationTokenSource();
+
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
             {
@@ -60,7 +62,6 @@ namespace SlowTests.Issues
 
             var e = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             {
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
                     var user2 = await session.LoadAsync<User>(user1.Id);

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Glacier.Model;
 using FastTests.Graph;
 using Jint;
+using McMaster.Extensions.CommandLineUtils;
+using Nest;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
@@ -14,6 +18,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide.Commands;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,6 +31,7 @@ namespace SlowTests.Issues
         {
         }
 
+
         [Fact]
         public async Task RequestExecutor_With_CanellationToken_Should_Throw_In_Timeout_When_ClusterWideTransaction_Is_Slow()
         {
@@ -33,7 +39,7 @@ namespace SlowTests.Issues
 
             var user1 = new User()
             {
-                Id = "Users/1-A", 
+                Id = "Users/1-A",
                 Name = "Alice"
             };
 
@@ -45,12 +51,12 @@ namespace SlowTests.Issues
             }
 
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
+            db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = (serverStore, database, clusterTransactionCommand) =>
             {
                 return Task.Delay(15_000);
             };
 
-            var e = await Assert.ThrowsAsync<TaskCanceledException>( async () =>
+            var e = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             {
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
@@ -65,5 +71,144 @@ namespace SlowTests.Issues
             Assert.Contains("RequestExecutor", e.StackTrace);
             Assert.Contains("HttpClient", e.StackTrace);
         }
+
+        // Fixed
+        [Fact]
+        public async Task ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3);
+            var databaseName = GetDatabaseName();
+            await CreateDatabaseInCluster(databaseName, 3, leader.WebUrl);
+            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
+
+            var disposeNodeTask = Task.Run(async () =>
+            {
+                await Task.Delay(400);
+                var tag = store.GetRequestExecutor(databaseName).TopologyNodes.First().ClusterTag;
+                var server = nodes.Single(n => n.ServerStore.NodeTag == tag);
+                await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+            });
+            await ProcessDocument(store, "Docs/1-A");
+
+            await disposeNodeTask;
+        }
+
+        private async Task ProcessDocument(IDocumentStore store, string id)
+        {
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc = new Doc { Id = id};
+                await session.StoreAsync(doc);
+                await session.SaveChangesAsync();
+            }
+
+            for (int i = 0; i < 2000; i++)
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var doc = await session.LoadAsync<Doc>(id);
+                    doc.Progress = i;
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        public class Doc
+        {
+            public string Id { get; set; }
+            public int Progress { get; set; }
+        }
+
+
+
+        //---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+        private int _failover1 = 0;
+
+        [Fact]
+        public async Task ClusterTransaction_Should_Work_After_Commit_And_Failover()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            var databaseName = GetDatabaseName();
+            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
+
+            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
+
+
+            foreach (var n in nodes)
+            {
+                var server = n;
+                var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = (serverStore, database, clusterTransactionCommand) =>
+                {
+                    if (Interlocked.CompareExchange(ref _failover1, 1, 0) == 0)
+                    {
+                        throw new TimeoutException("Shahar"); // for failover in node A
+                    }
+
+                    return Task.CompletedTask;
+                };
+            }
+
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+            }
+        }
+
+
+        private int _failover2 = 0;
+
+        [Fact]
+        public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            var databaseName = GetDatabaseName();
+            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
+
+            using var store = new DocumentStore { Database = databaseName, Urls = nodes.Select(n => n.WebUrl).ToArray() }.Initialize();
+
+
+            foreach (var n in nodes)
+            {
+                var server = n;
+                var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = (serverStore, database, clusterTransactionCommand) =>
+                {
+                    if (Interlocked.CompareExchange(ref _failover2, 1, 0) == 0)
+                    {
+                        throw new TimeoutException("Shahar"); // for failover in node A
+                    }
+
+                    return Task.CompletedTask;
+                };
+            }
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            var user2 = new User() { Id = "Users/2-A", Name = "Bob" };
+            var user3 = new User() { Id = "Users/3-A", Name = "Alice" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user3);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                (await session.LoadAsync<User>(user1.Id)).Name = "Bob";
+                await session.StoreAsync(user2);
+                session.Delete(user3.Id);
+                await session.SaveChangesAsync();
+            }
+
+        }
+
     }
 }
+
+

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -282,6 +282,28 @@ namespace Tests.Infrastructure
             }
         }
 
+        protected static async Task KillSlavedServerProcessAsync(Process process)
+        {
+            if (process == null || process.HasExited)
+                return;
+
+            try
+            {
+                process.Kill();
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await process.WaitForExitAsync(cts.Token);
+
+                if (process.HasExited == false)
+                {
+                    throw new TimeoutException("Failed to wait for the process to exit.");
+                }
+            }
+            catch (Exception e)
+            {
+                ReportError(e);
+            }
+        }
+
         private static async Task<string> ReadOutput(StreamReader output, Stopwatch startupDuration, Func<string, StringBuilder, Task<bool>> onLine)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20628/Cluster-wide-transaction-throw-TaskCanceledException-when-fails-on-timeout

### Additional description
Bugs:
- throw `TaskCanceledException` when fails on timeout (instead of throwing `TimeoutException`) in Cluster-wide transaction.
- throw ConcurrencyException or TaskCanceledException or wait forever after a failover on cluster transaction.
- throw ConcurrencyException because we get from client index 0 in cluster transaction.
  It happened because when the client gets the topology for the first time, it doesn't get the servers versions, 
  so when it sends a cluster transaction request right after, it sets the AtomicWrites to false and sends index 0.
 To solve this we send the servers versions with the topology (we get the versions from the license).


### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
