### PR TITLE
RavenDB-20678 we need to process all counters from the same counter group in the same indexing batch

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.Documents.Indexes.Workers
                             {
                                 while (true)
                                 {
+                                    var prevEtag = lastEtag;
+
                                     if (itemEnumerator.MoveNext(queryContext.Documents, out IEnumerable mapResults, out var etag) == false)
                                     {
                                         if (etag > lastEtag)
@@ -90,6 +92,26 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     token.ThrowIfCancellationRequested();
 
                                     var current = itemEnumerator.Current;
+
+                                    // we cannot break the indexing batch we are in the same etag batch
+                                    // this can happen for counters, because we are processing counters from counter group separately
+                                    if (prevEtag != current.Etag)
+                                    {
+                                        if (batchContinuationResult == Index.CanContinueBatchResult.False)
+                                        {
+                                            keepRunning = false;
+                                            break;
+                                        }
+
+                                        if (batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction)
+                                            break;
+
+                                        if (totalProcessedCount >= pageSize)
+                                        {
+                                            keepRunning = false;
+                                            break;
+                                        }
+                                    }
 
                                     totalProcessedCount++;
                                     collectionStats.RecordMapAttempt();
@@ -127,17 +149,6 @@ namespace Raven.Server.Documents.Indexes.Workers
                                         lastEtag, lastCollectionEtag, totalProcessedCount, sw);
 
                                     batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
-                                    if (batchContinuationResult != Index.CanContinueBatchResult.True)
-                                    {
-                                        keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;
-                                        break;
-                                    }
-
-                                    if (totalProcessedCount >= pageSize)
-                                    {
-                                        keepRunning = false;
-                                        break;
-                                    }
                                 }
                             }
                         }

--- a/test/SlowTests/Issues/RavenDB_20678.cs
+++ b/test/SlowTests/Issues/RavenDB_20678.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Counters;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Operations;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20678 : RavenTestBase
+{
+    public RavenDB_20678(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Theory]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void CanBreakSingleTxOfCounters(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var company = new Company();
+                session.Store(company, "companies/1");
+                var c = session.CountersFor("companies/1");
+                for (int i = 0; i < 1000; i++)
+                {
+                    c.Increment($"Day{i + 1}", Random.Shared.Next(1, 100));
+                }
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            var result = store.Maintenance.Send(new PutIndexesOperation(new CountersIndexDefinition
+            {
+                Name = "MyCounterIndex",
+                Maps = {
+                    "from counter in counters.Companies " +
+                    "select new { " +
+                    "   HeartBeat = counter.Value, " +
+                    "   Name = counter.Name," +
+                    "   User = counter.DocumentId " +
+                    "}" },
+                Configuration = new IndexConfiguration
+                {
+                    [RavenConfiguration.GetKey(x => x.Indexing.MapBatchSize)] = "128"
+                }
+            }));
+
+            var staleness = store.Maintenance.Send(new GetIndexStalenessOperation("MyCounterIndex"));
+            Assert.True(staleness.IsStale);
+            Assert.Equal(1, staleness.StalenessReasons.Count);
+            Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
+
+            store.Maintenance.Send(new StartIndexingOperation());
+
+            Indexes.WaitForIndexing(store);
+
+            staleness = store.Maintenance.Send(new GetIndexStalenessOperation("MyCounterIndex"));
+            Assert.False(staleness.IsStale);
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            var terms = store.Maintenance.Send(new GetTermsOperation("MyCounterIndex", "Name", null));
+            Assert.Equal(1000, terms.Length);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20678

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
