### PR TITLE
RavenDB-20736: Improve `/admin/debug/memory/gc` Endpoint Information with Heap Generation Names

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -55,17 +55,27 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     [nameof(info.FragmentedBytes)] = info.FragmentedBytes,
                     ["FragmentedHumane"] = Size.Humane(info.FragmentedBytes),
                     [nameof(info.Generation)] = info.Generation,
-                    [nameof(info.GenerationInfo)] = new DynamicJsonArray(info.GenerationInfo.ToArray().Select(x => new DynamicJsonValue
-                    {
-                        [nameof(x.FragmentationAfterBytes)] = x.FragmentationAfterBytes,
-                        ["FragmentationAfterHumane"] = Size.Humane(x.FragmentationAfterBytes),
-                        [nameof(x.FragmentationBeforeBytes)] = x.FragmentationBeforeBytes,
-                        ["FragmentationBeforeHumane"] = Size.Humane(x.FragmentationBeforeBytes),
-                        [nameof(x.SizeAfterBytes)] = x.SizeAfterBytes,
-                        ["SizeAfterHumane"] = Size.Humane(x.SizeAfterBytes),
-                        [nameof(x.SizeBeforeBytes)] = x.SizeBeforeBytes,
-                        ["SizeBeforeHumane"] = Size.Humane(x.SizeBeforeBytes)
-                    })),
+                    [nameof(info.GenerationInfo)] = new DynamicJsonArray(
+                        info.GenerationInfo.ToArray().Select((x, index) => new DynamicJsonValue
+                        {
+                            ["GenerationName"] = index switch
+                                {
+                                    0 => "Heap Generation 0",
+                                    1 => "Heap Generation 1",
+                                    2 => "Heap Generation 2",
+                                    3 => "Large Object Heap",
+                                    4 => "Finalization Queue",
+                                    _ => "Unknown Generation"
+                                },
+                            [nameof(x.FragmentationAfterBytes)] = x.FragmentationAfterBytes,
+                            ["FragmentationAfterHumane"] = Size.Humane(x.FragmentationAfterBytes),
+                            [nameof(x.FragmentationBeforeBytes)] = x.FragmentationBeforeBytes,
+                            ["FragmentationBeforeHumane"] = Size.Humane(x.FragmentationBeforeBytes),
+                            [nameof(x.SizeAfterBytes)] = x.SizeAfterBytes,
+                            ["SizeAfterHumane"] = Size.Humane(x.SizeAfterBytes),
+                            [nameof(x.SizeBeforeBytes)] = x.SizeBeforeBytes,
+                            ["SizeBeforeHumane"] = Size.Humane(x.SizeBeforeBytes)
+                        })),
                     [nameof(info.HeapSizeBytes)] = info.HeapSizeBytes,
                     ["HeapSizeHumane"] = Size.Humane(info.HeapSizeBytes),
                     [nameof(info.HighMemoryLoadThresholdBytes)] = info.HighMemoryLoadThresholdBytes,

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                                     1 => "Heap Generation 1",
                                     2 => "Heap Generation 2",
                                     3 => "Large Object Heap",
-                                    4 => "Finalization Queue",
+                                    4 => "Pinned Object Heap",
                                     _ => "Unknown Generation"
                                 },
                             [nameof(x.FragmentationAfterBytes)] = x.FragmentationAfterBytes,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20736/Improve-admin-debug-memory-gc-Endpoint-Information-with-Heap-Generation-Names

### Additional description

To increase our system's readability and informational value, we need to incorporate `Heap Generation Identifiers` into the `/admin/debug/memory/gc` endpoint. 

This will provide more detailed and easily understood data for debugging and memory management purposes.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed