### PR TITLE
RavenDB-20606 Add context selection in swap side by side index

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/index/forceIndexReplace.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/forceIndexReplace.ts
@@ -4,19 +4,21 @@ import endpoints = require("endpoints");
 
 class forceIndexReplace extends commandBase {
 
-    private indexName: string;
+    private readonly indexName: string;
+    private readonly db: database;
+    private readonly location: databaseLocationSpecifier;
 
-    private db: database;
-
-    constructor(indexName: string, db: database) {
+    constructor(indexName: string, db: database, location: databaseLocationSpecifier) {
         super();
-        this.db = db;
         this.indexName = indexName;
+        this.db = db;
+        this.location = location;
     }
 
     execute(): JQueryPromise<void> {
         const args = {
-            name: this.indexName
+            name: this.indexName,
+            ...this.location
         }
         const url = endpoints.databases.index.indexesReplace + this.urlEncodeArgs(args);
 

--- a/src/Raven.Studio/typescript/components/common/clientConfiguration/useClientConfigurationFormController.tsx
+++ b/src/Raven.Studio/typescript/components/common/clientConfiguration/useClientConfigurationFormController.tsx
@@ -4,11 +4,18 @@ import { ClientConfigurationFormData } from "./ClientConfigurationValidation";
 
 export default function useClientConfigurationFormController(
     control: Control<ClientConfigurationFormData>,
-    setValue: UseFormSetValue<ClientConfigurationFormData>
+    setValue: UseFormSetValue<ClientConfigurationFormData>,
+    shouldOverride: boolean
 ): ClientConfigurationFormData {
     const formValues = useWatch({ control });
 
     useEffect(() => {
+        if (!formValues.overrideConfig && shouldOverride) {
+            setValue("overrideConfig", true, { shouldValidate: true });
+        }
+        if (!formValues.identityPartsSeparatorEnabled && formValues.identityPartsSeparatorValue !== null) {
+            setValue("identityPartsSeparatorValue", null, { shouldValidate: true });
+        }
         if (!formValues.identityPartsSeparatorEnabled && formValues.identityPartsSeparatorValue !== null) {
             setValue("identityPartsSeparatorValue", null, { shouldValidate: true });
         }
@@ -27,7 +34,7 @@ export default function useClientConfigurationFormController(
         if (!formValues.readBalanceBehaviorEnabled && formValues.readBalanceBehaviorValue !== "None") {
             setValue("readBalanceBehaviorValue", "None", { shouldValidate: true });
         }
-    }, [formValues, setValue]);
+    }, [formValues, setValue, shouldOverride]);
 
     return formValues;
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmSwapSideBySideIndex.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmSwapSideBySideIndex.tsx
@@ -1,0 +1,71 @@
+﻿import React, { useState } from "react";
+import { Alert, Button, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { Icon } from "components/common/Icon";
+import {
+    DatabaseActionContexts,
+    MultipleDatabaseLocationSelector,
+} from "components/common/MultipleDatabaseLocationSelector";
+import ActionContextUtils from "components/utils/actionContextUtils";
+
+interface ConfirmSwapSideBySideIndexProps {
+    indexName: string;
+    toggle: () => void;
+    allActionContexts: DatabaseActionContexts[];
+    onConfirm: (contexts: DatabaseActionContexts[]) => void;
+}
+
+export function ConfirmSwapSideBySideIndex(props: ConfirmSwapSideBySideIndexProps) {
+    const { indexName, toggle, onConfirm, allActionContexts } = props;
+
+    const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
+
+    const onSubmit = () => {
+        onConfirm(selectedActionContexts);
+        toggle();
+    };
+
+    return (
+        <Modal isOpen toggle={toggle} wrapClassName="bs5" centered contentClassName="modal-border bulge-warning">
+            <ModalBody className="vstack gap-4 position-relative">
+                <div className="text-center">
+                    <Icon icon="index" color="warning" addon="swap" className="fs-1" margin="m-0" />
+                </div>
+                <div className="position-absolute m-2 end-0 top-0">
+                    <Button close onClick={toggle} />
+                </div>
+                <div className="text-center lead">
+                    You&apos;re about to <span className="text-warning">swap</span> following index
+                </div>
+                <span className="text-center bg-faded-primary py-1 px-3 w-fit-content rounded-pill mx-auto">
+                    <Icon icon="index" />
+                    {indexName}
+                </span>
+                <Alert color="warning">
+                    <small>
+                        Clicking <strong>Swap Now</strong> will immediately replace the current index definition with
+                        the replacement index.
+                    </small>
+                </Alert>
+                {ActionContextUtils.showContextSelector(allActionContexts) && (
+                    <div>
+                        <h4>Select context</h4>
+                        <MultipleDatabaseLocationSelector
+                            allActionContexts={allActionContexts}
+                            selectedActionContexts={selectedActionContexts}
+                            setSelectedActionContexts={setSelectedActionContexts}
+                        />
+                    </div>
+                )}
+            </ModalBody>
+            <ModalFooter>
+                <Button color="link" onClick={toggle} className="text-muted">
+                    Cancel
+                </Button>
+                <Button color="warning" onClick={onSubmit} className="rounded-pill">
+                    <Icon icon="swap" />
+                    Swap Now
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -16,6 +16,9 @@ import { getAllIndexes, useIndexesPage } from "components/pages/database/indexes
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { NoIndexes } from "components/pages/database/indexes/list/partials/NoIndexes";
 import { Icon } from "components/common/Icon";
+import { ConfirmSwapSideBySideIndex } from "./ConfirmSwapSideBySideIndex";
+import ActionContextUtils from "components/utils/actionContextUtils";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 
 interface IndexesPageProps {
     database: database;
@@ -38,6 +41,7 @@ export function IndexesPage(props: IndexesPageProps) {
         setBulkOperationConfirm,
         resetIndexConfirm,
         setResetIndexConfirm,
+        swapSideBySideData,
         stats,
         selectedIndexes,
         toggleSelectAll,
@@ -46,9 +50,7 @@ export function IndexesPage(props: IndexesPageProps) {
         filterByStatusOptions,
         groups,
         replacements,
-        swapNowProgress,
         highlightCallback,
-        confirmSwapSideBySide,
         confirmSetLockModeSelectedIndexes,
         allIndexesCount,
         setIndexPriority,
@@ -161,20 +163,16 @@ export function IndexesPage(props: IndexesPageProps) {
                                                         <div className="title me-4">
                                                             <Icon icon="swap" /> Side by side
                                                         </div>
-                                                        <Button
+                                                        <ButtonWithSpinner
                                                             color="warning"
                                                             size="sm"
-                                                            disabled={swapNowProgress.includes(index.name)}
-                                                            onClick={() => confirmSwapSideBySide(index)}
+                                                            onClick={() => swapSideBySideData.setIndexName(index.name)}
                                                             title="Click to replace the current index definition with the replacement index"
+                                                            isSpinning={swapSideBySideData.inProgress(index.name)}
+                                                            icon="force"
                                                         >
-                                                            {swapNowProgress.includes(index.name) ? (
-                                                                <Spinner size={"sm"} />
-                                                            ) : (
-                                                                <Icon icon="force" />
-                                                            )}{" "}
                                                             Swap now
-                                                        </Button>
+                                                        </ButtonWithSpinner>
                                                     </div>
                                                 </Card>
                                             )}
@@ -211,12 +209,19 @@ export function IndexesPage(props: IndexesPageProps) {
             {bulkOperationConfirm && (
                 <BulkIndexOperationConfirm {...bulkOperationConfirm} toggle={() => setBulkOperationConfirm(null)} />
             )}
-
             {resetIndexConfirm && (
                 <ConfirmResetIndex
                     {...resetIndexConfirm}
                     toggle={() => setResetIndexConfirm(null)}
                     onConfirm={() => onResetIndexConfirm(resetIndexConfirm.index)}
+                />
+            )}
+            {swapSideBySideData.indexName && (
+                <ConfirmSwapSideBySideIndex
+                    indexName={swapSideBySideData.indexName}
+                    toggle={() => swapSideBySideData.setIndexName(null)}
+                    onConfirm={(x) => swapSideBySideData.onConfirm(x)}
+                    allActionContexts={ActionContextUtils.getContexts(database.getLocations())}
                 />
             )}
         </>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -40,14 +40,6 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
             ClientConfigurationUtils.mapToFormData(await asyncGetClientConfiguration.execute(db), false),
     });
 
-    const formValues = useClientConfigurationFormController(control, setValue);
-
-    useEffect(() => {
-        if (formState.isSubmitSuccessful) {
-            reset(formValues);
-        }
-    }, [formState.isSubmitSuccessful, reset, formValues]);
-
     const globalConfig = useMemo(() => {
         const globalConfigResult = asyncGetClientGlobalConfiguration.result;
         if (!globalConfigResult) {
@@ -56,6 +48,19 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
 
         return ClientConfigurationUtils.mapToFormData(globalConfigResult, true);
     }, [asyncGetClientGlobalConfiguration.result]);
+
+    const formValues = useClientConfigurationFormController(
+        control,
+        setValue,
+        (asyncGetClientGlobalConfiguration.status === "success" && !globalConfig) ||
+            asyncGetClientGlobalConfiguration.status === "error"
+    );
+
+    useEffect(() => {
+        if (formState.isSubmitSuccessful) {
+            reset(formValues);
+        }
+    }, [formState.isSubmitSuccessful, reset, formValues]);
 
     const onSave: SubmitHandler<ClientConfigurationFormData> = async (formData) => {
         tryHandleSubmit(async () => {
@@ -124,7 +129,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                         <Row>
                             {globalConfig && (
                                 <Col>
-                                    <RichPanel className={formValues.overrideConfig && "item-disabled"}>
+                                    <RichPanel className={canEditDatabaseConfig && "item-disabled"}>
                                         <RichPanelHeader className="px-4 py-2 gap-2">
                                             <h3 className="mb-0">
                                                 <Icon icon="server" />
@@ -196,7 +201,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                                 </Col>
                             )}
                             <Col>
-                                <RichPanel className={!formValues.overrideConfig && "item-disabled"}>
+                                <RichPanel className={!canEditDatabaseConfig && "item-disabled"}>
                                     <RichPanelHeader className="px-4 py-2">
                                         <h3 className="mb-0">
                                             <Icon icon="database" />
@@ -299,7 +304,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                             {globalConfig && (
                                 <Col>
                                     <RichPanel
-                                        className={classNames("p-4", { "item-disabled": formValues.overrideConfig })}
+                                        className={classNames("p-4", { "item-disabled": canEditDatabaseConfig })}
                                     >
                                         <div className="md-label">
                                             Load Balance Behavior{" "}
@@ -398,9 +403,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                                 </Col>
                             )}
                             <Col>
-                                <RichPanel
-                                    className={classNames("p-4", { "item-disabled": !formValues.overrideConfig })}
-                                >
+                                <RichPanel className={classNames("p-4", { "item-disabled": !canEditDatabaseConfig })}>
                                     <div className="md-label">
                                         Load Balance Behavior <Icon id="SetSessionContext" icon="info" color="info" />
                                     </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
@@ -30,7 +30,7 @@ export default function ClientGlobalConfiguration() {
     });
 
     const popovers = useClientConfigurationPopovers();
-    const formValues = useClientConfigurationFormController(control, setValue);
+    const formValues = useClientConfigurationFormController(control, setValue, true);
 
     useEffect(() => {
         if (formState.isSubmitSuccessful) {

--- a/src/Raven.Studio/typescript/components/services/IndexesService.ts
+++ b/src/Raven.Studio/typescript/components/services/IndexesService.ts
@@ -75,7 +75,7 @@ export default class IndexesService {
         await new openFaultyIndexCommand(index.name, db, location).execute();
     }
 
-    async forceReplace(name: string, database: database) {
-        await new forceIndexReplace(name, database).execute();
+    async forceReplace(indexName: string, database: database, location: databaseLocationSpecifier) {
+        await new forceIndexReplace(indexName, database, location).execute();
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20606/NodeTag-is-mandatory-when-clicking-swap-index-during-Side-By-Side-indexes.

### Additional description

Added context selection in swap side by side index.
Fixed bug in ClientDatabaseConfiguration

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/09d55e28-0d84-4e1b-a06a-fd95e446da04)
