### PR TITLE
RavenDB-20029 CGroup fix long mountRoot

### DIFF
--- a/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
+++ b/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
@@ -181,7 +181,7 @@ public abstract class CGroup
     
     protected static string CombinePaths(string mountRoot, string mountPath, string pathForSubsystem)
     {
-        var toAppend = mountRoot.Length == 1 || pathForSubsystem.StartsWith(mountRoot)
+        var toAppend = mountRoot.Length == 1 || pathForSubsystem.StartsWith(mountRoot) == false
             ? pathForSubsystem
             : pathForSubsystem[mountRoot.Length..];
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20029

### Additional description
Should take only the addition of `pathForSubsystem` over `mountRoot`
The check was incorrect. 
https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/unix/cgroup.cpp#L162

### Type of change
- Bug fix

### How risky is the change?
- Low 


### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- Yes. Linux

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
