### PR TITLE
RavenDB-20627 Indexing progress displays both "100%" and "Up to date" after completion

### DIFF
--- a/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
+++ b/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
@@ -20,18 +20,20 @@ const circumference = 2 * Math.PI * stateIndicatorProgressRadius;
 export function ProgressCircle(props: ProgressCircleProps) {
     const { state, children, inline, icon, progress, onClick } = props;
 
+    const showProgress = progress > 0 && progress < 1;
+
     return (
         <div
             className={classNames("progress-circle", state, { inline }, { "cursor-pointer": onClick })}
             onClick={onClick}
         >
             <div className="state-desc">
-                {progress != null && <strong>{(100 * progress).toFixed(0)}%</strong>}
+                {showProgress && <strong>{(100 * progress).toFixed(0)}%</strong>}
                 {children}
             </div>
             <div className="state-indicator">
                 {icon && <Icon icon={icon} margin="m-0" />}
-                {progress != null && (
+                {showProgress && (
                     <svg className="progress-ring">
                         <circle strokeDashoffset={circumference * (1.0 - progress)} />
                     </svg>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -275,7 +275,7 @@ export function JoinedIndexProgress(props: JoinedIndexProgressProps) {
             inline
             state={getState(index)}
             icon={getIcon(index)}
-            progress={overallProgress !== 0 ? overallProgress : null}
+            progress={overallProgress}
             onClick={onClick}
         >
             {getStateText(index)}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20627/Indexing-progress-displays-both-100-and-Up-to-date-after-completion

### Additional description

displayed when the progress value is between 0 and 1

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
