### PR TITLE
RavenDB-20433 Introducing `CancellationToken` into Corax's heaviest operation.

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Corax.Queries;
 using Sparrow.Server;
 
@@ -7,7 +8,7 @@ namespace Corax;
 public partial class IndexSearcher
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public BinaryMatch And<TInner, TOuter>(in TInner set1, in TOuter set2)
+    public BinaryMatch And<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
@@ -22,26 +23,26 @@ public partial class IndexSearcher
         // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
         if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldAnd(Allocator, in set1, in set2));
+        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldAnd(Allocator, in set1, in set2, token));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public BinaryMatch Or<TInner, TOuter>( in TInner set1, in TOuter set2)
+    public BinaryMatch Or<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
@@ -53,26 +54,26 @@ public partial class IndexSearcher
         // do all the work to figure out what to emit. The cost is in instantiation not on execution. 
         if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(Allocator, in set1, in set2));
+        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(Allocator, in set1, in set2, token));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public AndNotMatch AndNot<TInner, TOuter>(in TInner set1, in TOuter set2)
+    public AndNotMatch AndNot<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
@@ -81,21 +82,21 @@ public partial class IndexSearcher
         // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
         if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return AndNotMatch.Create(AndNotMatch<TermMatch, TermMatch>.Create(this, (TermMatch)(object)set1, (TermMatch)(object)set2));
+            return AndNotMatch.Create(AndNotMatch<TermMatch, TermMatch>.Create(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return AndNotMatch.Create(AndNotMatch<BinaryMatch, TermMatch>.Create(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2));
+            return AndNotMatch.Create(AndNotMatch<BinaryMatch, TermMatch>.Create(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return AndNotMatch.Create(AndNotMatch<TermMatch, BinaryMatch>.Create(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2));
+            return AndNotMatch.Create(AndNotMatch<TermMatch, BinaryMatch>.Create(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return AndNotMatch.Create(AndNotMatch<BinaryMatch, BinaryMatch>.Create(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2));
+            return AndNotMatch.Create(AndNotMatch<BinaryMatch, BinaryMatch>.Create(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
 
-        return AndNotMatch.Create(AndNotMatch<TInner, TOuter>.Create(this, in set1, in set2));
+        return AndNotMatch.Create(AndNotMatch<TInner, TOuter>.Create(this, in set1, in set2, token));
     }
 }

--- a/src/Corax/IndexSearcher/IndexSearcher.Sorting.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Sorting.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Corax.Queries;
 using Corax.Queries.SortingMatches;
 using Corax.Utils;
@@ -10,19 +11,18 @@ public unsafe partial class IndexSearcher
 {
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SortingMatch OrderBy<TInner>(in TInner set, OrderMetadata metadata,
-        int take = Constants.IndexSearcher.TakeAll)
+    public SortingMatch OrderBy<TInner>(in TInner set, OrderMetadata metadata, int take = Constants.IndexSearcher.TakeAll, in CancellationToken token = default)
         where TInner : IQueryMatch
     {
-        return SortingMatch.Create(new SortingMatch<TInner>(this,  set, metadata, take));
+        return SortingMatch.Create(new SortingMatch<TInner>(this,  set, metadata, token, take));
     }
     
         
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SortingMultiMatch OrderBy<TInner>(in TInner set, OrderMetadata[] metadata,
-        int take = Constants.IndexSearcher.TakeAll)
+        int take = Constants.IndexSearcher.TakeAll, in CancellationToken token = default)
         where TInner : IQueryMatch
     {
-        return SortingMultiMatch.Create(new SortingMultiMatch<TInner>(this,  set, metadata, take));
+        return SortingMultiMatch.Create(new SortingMultiMatch<TInner>(this,  set, metadata, take, token: token));
     }
 }

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Sparrow.Server;
 
 namespace Corax.Queries
@@ -19,8 +20,9 @@ namespace Corax.Queries
         private ByteStringContext _ctx;
         private readonly long _totalResults;
         private readonly QueryCountConfidence _confidence;
-        
-        
+        private readonly CancellationToken _token;
+
+
         private bool _doNotSortResults;
 
         public bool DoNotSortResults()
@@ -43,7 +45,8 @@ namespace Corax.Queries
             delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> andWithFunc,
             delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> inspectionFunc,
             long totalResults,
-            QueryCountConfidence confidence)
+            QueryCountConfidence confidence,
+            in CancellationToken token)
         {
             _totalResults = totalResults;
 
@@ -54,13 +57,13 @@ namespace Corax.Queries
             _inner = inner;
             _outer = outer;
             _confidence = confidence;
+            _token = token;
             _ctx = ctx;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Fill(Span<long> buffer)
         {
-            
             return _fillFunc(ref this, buffer);
         }
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Comparers.cs
@@ -81,6 +81,7 @@ namespace Corax.Queries.SortingMatches;
             bool descending = false)
         {
             var readScores = MemoryMarshal.Cast<long, float>(batchTermIds)[..batchResults.Length];
+            match._cancellationToken.ThrowIfCancellationRequested();
 
             // We have to initialize the score buffer with a positive number to ensure that multiplication (document-boosting) is taken into account when BM25 relevance returns 0 (for example, with AllEntriesMatch).
             readScores.Fill(Bm25Relevance.InitialScoreValue);
@@ -181,6 +182,8 @@ namespace Corax.Queries.SortingMatches;
                 match._results.Add(batchResults);
                 return;
             }
+            
+            match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
             Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
             var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer());
@@ -340,6 +343,7 @@ namespace Corax.Queries.SortingMatches;
                 return;
             }
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            match._cancellationToken.ThrowIfCancellationRequested();
             var indexes = EntryComparerHelper.NumericSortBatch<EntryComparerByLong>(batchTermIds, batchTerms, descending);
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -367,6 +371,7 @@ namespace Corax.Queries.SortingMatches;
                 return;
             }
             _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(double.MinValue));
+            match._cancellationToken.ThrowIfCancellationRequested();
             var indexes = EntryComparerHelper.NumericSortBatch<EntryComparerByDouble>(batchTermIds, batchTerms, descending);
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -416,13 +421,17 @@ namespace Corax.Queries.SortingMatches;
                 match._results.Add(batchResults);
                 return;
             }
+            
+            match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
             Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
+            
             for (int i = 0; i < batchTermIds.Length; i++)
             {
                 indexes[i] = i;
             }
+
             EntryComparerHelper.IndirectSort(indexes, batchTerms, descending, this);
             for (int i = 0; i < indexes.Length; i++)
             {

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -101,6 +101,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
             // We perform the scoring process. 
             match._inner.Score(batchResults, readScores, 1f);
+            match._token.ThrowIfCancellationRequested();
 
             // If we need to do documents boosting then we need to modify the based on documents stored score. 
             if (match._searcher.DocumentsAreBoosted)
@@ -117,6 +118,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 indexes[i] = i;
             }
 
+            match._token.ThrowIfCancellationRequested();
             EntryComparerHelper.IndirectSort<EntryComparerByScore, TComparer2, TComparer3>(ref match, indexes, batchTerms, new(), comparer2, comparer3);
 
             for (int i = 0; i < indexes.Length; i++)
@@ -210,6 +212,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
             Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            match._token.ThrowIfCancellationRequested();
             var indirectComparer =
                 new IndirectComparer<CompactKeyComparer, TComparer2, TComparer3>(ref match, batchTerms, new CompactKeyComparer(), comparer2, comparer3);
             var indexes = SortByTerms(ref match, batchTermIds, batchTerms, orderMetadata[0].Ascending == false, indirectComparer);
@@ -346,6 +349,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            match._token.ThrowIfCancellationRequested();
             var indexes = EntryComparerHelper.NumericSortBatch(ref match, batchTermIds, batchTerms, new EntryComparerByLong(), comparer2, comparer3);
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -429,6 +433,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(double.MinValue));
+            match._token.ThrowIfCancellationRequested();
             var indexes = EntryComparerHelper.NumericSortBatch(ref match, batchTermIds, batchTerms, new EntryComparerByDouble(), comparer2, comparer3);
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -514,7 +519,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             {
                 indexes[i] = i;
             }
-
+            
+            match._token.ThrowIfCancellationRequested();
             EntryComparerHelper.IndirectSort(ref match, indexes, batchTerms, this, comparer2, comparer3);
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -562,6 +568,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             where TComparer2 : struct, IComparer<UnmanagedSpan>, IComparer<int>, IEntryComparer
             where TComparer3 : struct, IComparer<UnmanagedSpan>, IComparer<int>, IEntryComparer
         {
+            match._token.ThrowIfCancellationRequested();
+
             if (_reader.IsValid == false) // field does not exist, so arbitrary sort order, whatever query said goes
             {
                 match._results.Add(batchResults);
@@ -585,7 +593,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 batchTerms[i] = new UnmanagedSpan(distance);
                 indexes[i] = i;
             }
-
+            
+            
+            match._token.ThrowIfCancellationRequested();
             EntryComparerHelper.IndirectSort<EntryComparerByDouble, TComparer2, TComparer3>(ref match, indexes, batchTerms, new(), comparer2, comparer3);
             for (int i = 0; i < indexes.Length; i++)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -48,7 +48,7 @@ public class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         Dictionary<string, Dictionary<string, FacetValues>> facetsByName = new();
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
 
-        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1);
+        var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1, token: token);
         var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out _);
         var coraxPageSize = CoraxBufferSize(_indexSearcher, facetQuery.Query.PageSize, query);
         var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -67,7 +67,7 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
 
             var orderByFieldMetadata = orderByFields[i];
 
-            IndexEntryReader entryReader = _indexSearcher.GetEntryReaderFor(indexEntryId);
+            IndexEntryReader entryReader = IndexSearcher.GetEntryReaderFor(indexEntryId);
             IndexEntryReader.FieldReader reader = entryReader.GetFieldReaderFor(orderByFieldMetadata.Field);
 
             switch (orderByField.OrderingType)
@@ -82,7 +82,7 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
                     break;
                 case OrderByFieldType.Distance:
                 {
-                        var spatialReader = _indexSearcher.SpatialReader(orderByFieldMetadata.Field.FieldName);
+                        var spatialReader = IndexSearcher.SpatialReader(orderByFieldMetadata.Field.FieldName);
                         double distance;
                         if (spatialReader.TryGetSpatialPoint(indexEntryId, out var coords) == false)
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20433 

### Additional description

Pushing cancelation token for sortings and binary operations.

Already made it for: https://github.com/ravendb/ravendb/pull/16679

### Type of change


- New feature

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor



### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
