### PR TITLE
RavenDB-20339 - Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -18,6 +18,8 @@ namespace Raven.Client.Documents.Replication.Messages
 
         public long MigrationIndex { get; set; }
 
+        public string ShardedDatabaseId { get; set; }
+
         public enum ReplicationType
         {
             // External here as the default value to handle older servers, which aren't sending this field.

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -263,12 +263,13 @@ namespace Raven.Server.Documents.Replication
             ThrowInvalidEndOfString(state.ToString(), changeVector);
         }
 
-        public static void MergeChangeVectorDown(string changeVector, List<ChangeVectorEntry> entries)
+        public static bool MergeChangeVectorDown(string changeVector, List<ChangeVectorEntry> entries)
         {
             var start = 0;
             var current = 0;
             var state = State.Tag;
             int tag = -1;
+            bool found = false;
 
             while (current < changeVector.Length)
             {
@@ -296,6 +297,7 @@ namespace Raven.Server.Documents.Replication
                             {
                                 if (entries[i].DbId == dbId)
                                 {
+                                    found = true;
                                     if (entries[i].Etag > etag)
                                     {
                                         entries[i] = new ChangeVectorEntry
@@ -337,9 +339,10 @@ namespace Raven.Server.Documents.Replication
             }
 
             if (state == State.Whitespace)
-                return;
+                return found;
 
             ThrowInvalidEndOfString(state.ToString(), changeVector);
+            return false;
         }
 
         private static void ThrowInvalidEndOfString(string state, string cv)

--- a/src/Raven.Server/Documents/Replication/ExternalReplicationState.cs
+++ b/src/Raven.Server/Documents/Replication/ExternalReplicationState.cs
@@ -15,18 +15,9 @@ namespace Raven.Server.Documents.Replication
 
         public string DestinationChangeVector { get; set; }
 
-        public string SourceDatabaseName { get; set; }
-
-        public string SourceDatabaseId { get; set; }
-
         public static string GenerateItemName(string databaseName, long taskId)
         {
             return $"values/{databaseName}/external-replication/{taskId}";
-        }
-
-        public static string GenerateItemName(string databaseName, string sourceDatabaseName, string sourceDatabaseId)
-        {
-            return $"values/{databaseName}/sharded-incoming-external-replication/{sourceDatabaseName}/{sourceDatabaseId}";
         }
 
         public DynamicJsonValue ToJson()
@@ -37,9 +28,7 @@ namespace Raven.Server.Documents.Replication
                 [nameof(NodeTag)] = NodeTag,
                 [nameof(LastSentEtag)] = LastSentEtag,
                 [nameof(SourceChangeVector)] = SourceChangeVector,
-                [nameof(DestinationChangeVector)] = DestinationChangeVector,
-                [nameof(SourceDatabaseName)] = SourceDatabaseName,
-                [nameof(SourceDatabaseId)] = SourceDatabaseId
+                [nameof(DestinationChangeVector)] = DestinationChangeVector
             };
         }
     }

--- a/src/Raven.Server/Documents/Replication/ExternalReplicationState.cs
+++ b/src/Raven.Server/Documents/Replication/ExternalReplicationState.cs
@@ -15,9 +15,18 @@ namespace Raven.Server.Documents.Replication
 
         public string DestinationChangeVector { get; set; }
 
+        public string SourceDatabaseName { get; set; }
+
+        public string SourceDatabaseId { get; set; }
+
         public static string GenerateItemName(string databaseName, long taskId)
         {
             return $"values/{databaseName}/external-replication/{taskId}";
+        }
+
+        public static string GenerateItemName(string databaseName, string sourceDatabaseName, string sourceDatabaseId)
+        {
+            return $"values/{databaseName}/sharded-incoming-external-replication/{sourceDatabaseName}/{sourceDatabaseId}";
         }
 
         public DynamicJsonValue ToJson()
@@ -28,7 +37,9 @@ namespace Raven.Server.Documents.Replication
                 [nameof(NodeTag)] = NodeTag,
                 [nameof(LastSentEtag)] = LastSentEtag,
                 [nameof(SourceChangeVector)] = SourceChangeVector,
-                [nameof(DestinationChangeVector)] = DestinationChangeVector
+                [nameof(DestinationChangeVector)] = DestinationChangeVector,
+                [nameof(SourceDatabaseName)] = SourceDatabaseName,
+                [nameof(SourceDatabaseId)] = SourceDatabaseId
             };
         }
     }

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -379,7 +379,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             InvokeOnAttachmentStreamsReceived(attachmentStreamCount);
 
-            InvokeOnDocumentsReceived();
+            OnDocumentsReceived();
         }
 
         protected void ReadItemsFromSource(int replicatedDocs, TOperationContext context, ByteStringContext allocator, DataForReplicationCommand data, Reader reader,
@@ -573,7 +573,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         protected abstract void EnsureNotDeleted();
 
-        protected abstract void InvokeOnDocumentsReceived();
+        protected abstract void OnDocumentsReceived();
 
         protected abstract void InvokeOnAttachmentStreamsReceived(int attachmentStreamCount);
 

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -286,7 +286,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             Failed?.Invoke(this, exception);
         }
 
-        protected override void InvokeOnDocumentsReceived() => DocumentsReceived?.Invoke(this);
+        protected override void OnDocumentsReceived() => DocumentsReceived?.Invoke(this);
 
         internal class MergedDocumentReplicationCommand : DocumentMergedTransactionCommand
         {

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -408,7 +408,8 @@ namespace Raven.Server.Documents.Replication.Outgoing
                             $"Received reply for replication batch from {Destination.FromString()}. Destination is reporting missing attachments.");
                     }
 
-                    if (++MissingAttachmentsRetries > 1)
+                    MissingAttachmentsRetries++;
+                    if (MissingAttachmentsRetries > 1)
                     {
                         var msg = $"Failed to send batch successfully to {Destination.FromString()}. " +
                                   $"Destination reported missing attachments {MissingAttachmentsRetries} times.";

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -448,7 +448,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             public Action OnDocumentSenderFetchNewItem;
 
-            public Action<Dictionary<Slice, AttachmentReplicationItem>> OnMissingAttachmentStream;
+            public Action<Dictionary<Slice, AttachmentReplicationItem>, SortedList<long, ReplicationBatchItem>> OnMissingAttachmentStream;
         }
     }
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -1,11 +1,13 @@
 ﻿using System.IO;
 using Raven.Client.Documents.Operations.Replication;
-using Raven.Client.Documents.Replication;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.Util;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Commands;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Outgoing
@@ -19,6 +21,15 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             _taskId = node.TaskId;
             DocumentsSend += (_) => UpdateExternalReplicationInfo();
+        }
+
+        protected override DynamicJsonValue GetInitialHandshakeRequest()
+        {
+            var json = base.GetInitialHandshakeRequest();
+            if (_parent.Database is ShardedDocumentDatabase shardedDatabase)
+                json[nameof(ReplicationLatestEtagRequest.ShardedDatabaseId)] = shardedDatabase.ShardedDatabaseId;
+
+            return json;
         }
 
         public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, Logger logger)

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -588,8 +588,7 @@ namespace Raven.Server.Documents.Replication.Senders
             if (_parent.ForTestingPurposes?.OnMissingAttachmentStream != null &&
                 _parent.MissingAttachmentsRetries > 0)
             {
-                var replicaAttachmentStreams = _replicaAttachmentStreams;
-                _parent.ForTestingPurposes?.OnMissingAttachmentStream?.Invoke(replicaAttachmentStreams);
+                _parent.ForTestingPurposes?.OnMissingAttachmentStream?.Invoke(_replicaAttachmentStreams, _orderedReplicaItems);
             }
 
             var sw = Stopwatch.StartNew();

--- a/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
@@ -171,14 +171,14 @@ public class ShardReplicationLoader : ReplicationLoader
         }
     }
 
-    public static ExternalReplicationState GetShardedExternalReplicationState(ServerStore server, string database, string source, string sourceDbId)
+    public static ShardedExternalReplicationState GetShardedExternalReplicationStates(ServerStore server, string database, string source, string sourceDbId)
     {
         using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         using (context.OpenReadTransaction())
         {
-            var stateBlittable = server.Cluster.Read(context, ExternalReplicationState.GenerateItemName(database, source, sourceDbId));
+            var stateBlittable = server.Cluster.Read(context, ShardedExternalReplicationState.GenerateShardedItemName(database, source, sourceDbId));
 
-            return stateBlittable != null ? JsonDeserializationCluster.ExternalReplicationState(stateBlittable) : null;
+            return stateBlittable != null ? JsonDeserializationCluster.ShardedExternalReplicationState(stateBlittable) : null;
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ShardedExternalReplicationState.cs
+++ b/src/Raven.Server/Documents/Replication/ShardedExternalReplicationState.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using Raven.Client.ServerWide;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Replication
+{
+    public class ShardedExternalReplicationState : IDatabaseTaskStatus
+    {
+        public string NodeTag { get; set; }
+
+        public string SourceShardedDatabaseId { get; set; }
+
+        public string SourceDatabaseName { get; set; }
+
+        public Dictionary<string, ShardedExternalReplicationStateForSingleSource> ReplicationStates { get; set; }
+
+        public static string GenerateShardedItemName(string databaseName, string sourceDatabaseName, string sourceDatabaseId)
+        {
+            return $"values/{databaseName}/sharded-incoming-external-replication/{sourceDatabaseName}/{sourceDatabaseId}";
+        }
+
+        private DynamicJsonValue BuildReplicationStatesJson()
+        {
+            var json = new DynamicJsonValue();
+            foreach (var item in ReplicationStates)
+            {
+                json[item.Key] = item.Value.ToJson();
+            }
+
+            return json;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(NodeTag)] = NodeTag,
+                [nameof(SourceShardedDatabaseId)] = SourceShardedDatabaseId,
+                [nameof(SourceDatabaseName)] = SourceDatabaseName,
+                [nameof(ReplicationStates)] = BuildReplicationStatesJson()
+            };
+        }
+    }
+
+    public class ShardedExternalReplicationStateForSingleSource
+    {
+        public long LastSourceEtag { get; set; }
+
+        public string LastSourceChangeVector { get; set; }
+
+        public Dictionary<string, ExternalReplicationState> DestinationStates { get; set; }
+
+        public DynamicJsonValue BuildDestinationStatesJson()
+        {
+            var json = new DynamicJsonValue();
+            foreach (var item in DestinationStates)
+            {
+                json[item.Key] = item.Value.ToJson();
+            }
+
+            return json;
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(LastSourceEtag)] = LastSourceEtag,
+                [nameof(LastSourceChangeVector)] = LastSourceChangeVector,
+                [nameof(DestinationStates)] = BuildDestinationStatesJson()
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication.Messages;
-using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.Util;
@@ -133,7 +131,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
             long lastAcceptedEtag;
             var handlersChangeVector = new List<string>();
-
             if (ShardHelper.IsShardName(ConnectionInfo.SourceDatabaseName))
             {
                 lastAcceptedEtag = 0;
@@ -222,8 +219,6 @@ namespace Raven.Server.Documents.Sharding.Handlers
                         if (batches[shardNumber].Items.Count == 0)
                             continue;
 
-                        var node = handler.Node as ExternalReplication;
-                        var taskId = node!.TaskId;
                         var command = new UpdateExternalReplicationStateCommand(ShardHelper.ToShardName(_parent.DatabaseName, shardNumber), RaftIdGenerator.NewId())
                         {
                             ExternalReplicationState = new ExternalReplicationState
@@ -236,8 +231,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                             }
                         };
 
-                        _parent._server.SendToLeaderAsync(command)
-                            .IgnoreUnobservedExceptions();
+                        await _parent._server.SendToLeaderAsync(command);
                     }
                 }
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         private string _lastAcceptedChangeVectorFromShard;
         private readonly TaskCompletionSource<(string, long)> _firstChangeVector = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public readonly string DatabaseName;
+        public readonly string DestinationDatabaseName;
         public string MissingAttachmentMessage { get; set; }
 
         public ShardedOutgoingReplicationHandler(ShardedDatabaseContext.ShardedReplicationContext parent, ShardReplicationNode node, TcpConnectionInfo connectionInfo, string sourceDatabaseId) :
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             };
             _sourceDatabaseId = sourceDatabaseId;
 
-            DatabaseName = node.Database;
+            DestinationDatabaseName = node.Database;
         }
 
         protected override void Replicate()

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -29,6 +29,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
         private string _lastAcceptedChangeVectorFromShard;
         private readonly TaskCompletionSource<(string, long)> _firstChangeVector = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public readonly string DatabaseName;
         public string MissingAttachmentMessage { get; set; }
 
         public ShardedOutgoingReplicationHandler(ShardedDatabaseContext.ShardedReplicationContext parent, ShardReplicationNode node, TcpConnectionInfo connectionInfo, string sourceDatabaseId) :
@@ -41,6 +42,8 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 Operation = TcpConnectionHeaderMessage.OperationTypes.Replication
             };
             _sourceDatabaseId = sourceDatabaseId;
+
+            DatabaseName = node.Database;
         }
 
         protected override void Replicate()

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -90,7 +90,7 @@ namespace Raven.Server.Documents.Sharding
                     using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var writer = new BlittableJsonTextWriter(context, tcpConnectionOptions.Stream))
                     {
-                        var (databaseChangeVector, lastEtag) = await shardedIncomingHandler.GetInitialHandshakeResponseFromShards();
+                        var (databaseChangeVector, lastEtag) = await shardedIncomingHandler.GetInitialHandshakeResponseFromShardsAsync();
 
                         var request = base.GetInitialRequestMessage(getLatestEtagMessage);
                         request[nameof(ReplicationMessageReply.DatabaseChangeVector)] = databaseChangeVector;

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -70,6 +70,7 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateExternalReplicationCommand)] = Base40CommandsVersion,
             [nameof(UpdatePullReplicationAsSinkCommand)] = Base42CommandsVersion,
             [nameof(UpdateExternalReplicationStateCommand)] = Base40CommandsVersion,
+            [nameof(ShardedUpdateExternalReplicationStateCommand)] = Base40CommandsVersion,
             [nameof(UpdateTopologyCommand)] = Base40CommandsVersion,
             [nameof(AcknowledgeSubscriptionBatchCommand)] = Base40CommandsVersion,
             [nameof(DeleteSubscriptionCommand)] = Base40CommandsVersion,

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -492,6 +492,7 @@ namespace Raven.Server.ServerWide
                     case nameof(RecordBatchSubscriptionDocumentsCommand):
                     case nameof(UpdatePeriodicBackupStatusCommand):
                     case nameof(UpdateExternalReplicationStateCommand):
+                    case nameof(ShardedUpdateExternalReplicationStateCommand):
                     case nameof(PutSubscriptionCommand):
                     case nameof(PutShardedSubscriptionCommand):
                     case nameof(DeleteSubscriptionCommand):

--- a/src/Raven.Server/ServerWide/Commands/Sharding/ShardedUpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/ShardedUpdateExternalReplicationStateCommand.cs
@@ -1,5 +1,7 @@
-﻿using Raven.Server.Documents.Replication;
+﻿using System;
+using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -25,7 +27,37 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context, BlittableJsonReaderObject existingValue)
         {
-            return context.ReadObject(ReplicationState.ToJson(), GetItemId());
+            if (existingValue == null)
+                return context.ReadObject(ReplicationState.ToJson(), GetItemId());
+
+            var existingState = JsonDeserializationCluster.ShardedExternalReplicationState(existingValue);
+            var existingStates = existingState.ReplicationStates;
+
+            foreach (var (shardedSourceName, shardedSourceState) in ReplicationState.ReplicationStates)
+            {
+                if (existingStates.TryGetValue(shardedSourceName, out var existingShardedSourceState) == false)
+                {
+                    existingStates[shardedSourceName] = shardedSourceState;
+                    continue;
+                }
+
+                existingShardedSourceState.LastSourceEtag = Math.Max(existingShardedSourceState.LastSourceEtag, shardedSourceState.LastSourceEtag);
+                existingShardedSourceState.LastSourceChangeVector = ChangeVectorUtils.MergeVectors(existingShardedSourceState.LastSourceChangeVector, shardedSourceState.LastSourceChangeVector);
+
+                foreach (var (shardedDestinationName, shardedDestinationState) in shardedSourceState.DestinationStates)
+                {
+                    if (existingShardedSourceState.DestinationStates.TryGetValue(shardedDestinationName, out var existingShardedDestinationState) == false)
+                    {
+                        existingShardedSourceState.DestinationStates[shardedDestinationName] = shardedDestinationState;
+                        continue;
+                    }
+
+                    existingShardedDestinationState.LastSentEtag = Math.Max(existingShardedDestinationState.LastSentEtag, shardedDestinationState.LastSentEtag);
+                    existingShardedDestinationState.DestinationChangeVector = ChangeVectorUtils.MergeVectors(existingShardedDestinationState.DestinationChangeVector, shardedDestinationState.DestinationChangeVector);
+                }
+            }
+
+            return context.ReadObject(existingState.ToJson(), GetItemId());
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/Sharding/ShardedUpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/ShardedUpdateExternalReplicationStateCommand.cs
@@ -1,0 +1,36 @@
+﻿using Raven.Server.Documents.Replication;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Sharding
+{
+    public class ShardedUpdateExternalReplicationStateCommand : UpdateValueForDatabaseCommand
+    {
+        public ShardedExternalReplicationState ReplicationState { get; set; }
+
+        private ShardedUpdateExternalReplicationStateCommand()
+        {
+            // for deserialization
+        }
+
+        public ShardedUpdateExternalReplicationStateCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        {
+        }
+
+        public override string GetItemId()
+        {
+            return ShardedExternalReplicationState.GenerateShardedItemName(DatabaseName, ReplicationState.SourceDatabaseName, ReplicationState.SourceShardedDatabaseId);
+        }
+
+        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context, BlittableJsonReaderObject existingValue)
+        {
+            return context.ReadObject(ReplicationState.ToJson(), GetItemId());
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(ReplicationState)] = ReplicationState.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
@@ -20,10 +20,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public override string GetItemId()
         {
-            if (string.IsNullOrEmpty(ExternalReplicationState.SourceDatabaseName))
-                return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.TaskId);
-
-            return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.SourceDatabaseName, ExternalReplicationState.SourceDatabaseId);
+            return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.TaskId);
         }
 
         protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context,

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
@@ -1,5 +1,4 @@
-﻿using Raven.Client.ServerWide;
-using Raven.Server.Documents.Replication;
+﻿using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -21,7 +20,10 @@ namespace Raven.Server.ServerWide.Commands
 
         public override string GetItemId()
         {
-            return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.TaskId);
+            if (string.IsNullOrEmpty(ExternalReplicationState.SourceDatabaseName))
+                return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.TaskId);
+
+            return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.SourceDatabaseName, ExternalReplicationState.SourceDatabaseId);
         }
 
         protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context,

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, ExternalReplicationState> ExternalReplicationState = GenerateJsonDeserializationRoutine<ExternalReplicationState>();
 
+        public static readonly Func<BlittableJsonReaderObject, ShardedExternalReplicationState> ShardedExternalReplicationState = GenerateJsonDeserializationRoutine<ShardedExternalReplicationState>();
+
         public static readonly Func<BlittableJsonReaderObject, RestoreBackupConfiguration> RestoreBackupConfiguration = GenerateJsonDeserializationRoutine<RestoreBackupConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, RestoreFromS3Configuration> RestoreS3BackupConfiguration = GenerateJsonDeserializationRoutine<RestoreFromS3Configuration>();
@@ -229,6 +231,7 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateQueueEtlCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueEtlCommand>(),
             [nameof(UpdateEtlProcessStateCommand)] = GenerateJsonDeserializationRoutine<UpdateEtlProcessStateCommand>(),
             [nameof(UpdateExternalReplicationStateCommand)] = GenerateJsonDeserializationRoutine<UpdateExternalReplicationStateCommand>(),
+            [nameof(ShardedUpdateExternalReplicationStateCommand)] = GenerateJsonDeserializationRoutine<ShardedUpdateExternalReplicationStateCommand>(),
             [nameof(DeleteOngoingTaskCommand)] = GenerateJsonDeserializationRoutine<DeleteOngoingTaskCommand>(),
             [nameof(PutRavenConnectionStringCommand)] = GenerateJsonDeserializationRoutine<PutRavenConnectionStringCommand>(),
             [nameof(PutSqlConnectionStringCommand)] = GenerateJsonDeserializationRoutine<PutSqlConnectionStringCommand>(),

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -288,7 +288,11 @@ namespace Raven.Server.Utils
                 ChangeVectorParser.MergeChangeVectorDown(changeVectors[i], _mergeVectorBuffer);
             }
 
-            return _mergeVectorBuffer.SerializeVector();
+            var mergedChangeVector = _mergeVectorBuffer.SerializeVector();
+            if (string.Equals(changeVectors[0], mergedChangeVector, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return mergedChangeVector;
         }
 
         public static ChangeVector NewChangeVector(DocumentDatabase database, long etag, IChangeVectorOperationContext context)

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -285,14 +285,11 @@ namespace Raven.Server.Utils
                 if (string.IsNullOrEmpty(changeVectors[i]))
                     return null;
 
-                ChangeVectorParser.MergeChangeVectorDown(changeVectors[i], _mergeVectorBuffer);
+                if (ChangeVectorParser.MergeChangeVectorDown(changeVectors[i], _mergeVectorBuffer) == false)
+                    return null;
             }
 
-            var mergedChangeVector = _mergeVectorBuffer.SerializeVector();
-            if (string.Equals(changeVectors[0], mergedChangeVector, StringComparison.OrdinalIgnoreCase))
-                return null;
-
-            return mergedChangeVector;
+            return _mergeVectorBuffer.SerializeVector();
         }
 
         public static ChangeVector NewChangeVector(DocumentDatabase database, long etag, IChangeVectorOperationContext context)

--- a/test/SlowTests/Server/Replication/ReplicationDocuments.cs
+++ b/test/SlowTests/Server/Replication/ReplicationDocuments.cs
@@ -4,13 +4,11 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Exceptions.Documents;
-using Raven.Client.ServerWide;
 using Raven.Server.Documents.Replication;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -30,7 +28,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanReplicateDocument(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var source = GetDocumentStore(options: options))
             using (var destination = GetDocumentStore(options: options))
             {
@@ -58,7 +56,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanReplicateDocumentDeletion(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var source = GetDocumentStore(options: options))
             using (var destination = GetDocumentStore(options: options))
             {
@@ -91,7 +89,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task GetConflictsResult_command_should_work_properly(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var source = GetDocumentStore(options: options))
             using (var destination = GetDocumentStore(options: options))
             {
@@ -123,7 +121,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ShouldCreateConflictThenResolveIt(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var source = GetDocumentStore(options: options))
             using (var destination = GetDocumentStore(options: options))
             {
@@ -166,22 +164,6 @@ namespace SlowTests.Server.Replication
 
                 Assert.Equal(fetchedVal.ToString(), actualVal.ToString());
             }
-        }
-
-        private Options GetOptionsInternal(Options options)
-        {
-            return new Options(options)
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                    options.ModifyDatabaseRecord(record);
-                }
-            };
         }
     }
 }

--- a/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
+++ b/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Tests.Infrastructure;
@@ -37,14 +36,12 @@ namespace SlowTests.Server.Replication
             }
         }
 
-
         private class UserByNameIndex : AbstractIndexCreationTask<User>
         {
             private readonly string _indexName;
 
             public override string IndexName =>
                 string.IsNullOrEmpty(_indexName) ? base.IndexName : _indexName;
-
 
             public UserByNameIndex(string name = null)
             {
@@ -74,16 +71,16 @@ namespace SlowTests.Server.Replication
                                };
             }
         }
-        
-        [Fact]
-        public async Task Can_replicate_index()
+
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Indexes)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_replicate_index(Options options)
         {
-            var (source, destination) = await CreateDuoCluster();
-            
+            var (source, destination) = await CreateDuoCluster(options: options);
+
             using (source)
             using (destination)
             {
-
                 var userByAge = new UserByAgeIndex();
                 userByAge.Execute(source);
 
@@ -99,10 +96,11 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [Fact]
-        public async Task Can_replicate_multiple_indexes()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Indexes)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_replicate_multiple_indexes(Options options)
         {
-            var (source, destination) = await CreateDuoCluster();
+            var (source, destination) = await CreateDuoCluster(options: options);
 
             using (source)
             using (destination)
@@ -128,10 +126,11 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [Fact]
-        public async Task Can_replicate_multiple_indexes_and_multiple_transformers()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Indexes)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Can_replicate_multiple_indexes_and_multiple_transformers(Options options)
         {
-            var (source, destination) = await CreateDuoCluster();
+            var (source, destination) = await CreateDuoCluster(options: options);
 
             using (source)
             using (destination)
@@ -154,8 +153,6 @@ namespace SlowTests.Server.Replication
                 Assert.Equal(2, destIndexNames.Length);
                 Assert.True(destIndexNames.Contains(userByAge.IndexName));
                 Assert.True(destIndexNames.Contains(userByName.IndexName));
-
-                WaitForUserToContinueTheTest(source);
             }
         }
     }

--- a/test/SlowTests/Server/Replication/ReplicationResolveConflictsOnConfigurationChange.cs
+++ b/test/SlowTests/Server/Replication/ReplicationResolveConflictsOnConfigurationChange.cs
@@ -18,7 +18,6 @@ namespace SlowTests.Server.Replication
         {
         }
 
-
         public async Task<List<ModifyOngoingTaskResult>> GenerateConflictsAndSetupMasterMasterReplication(DocumentStore store1, DocumentStore store2, string id = "foo/bar")
         {
             using (var session = store1.OpenSession())
@@ -49,7 +48,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ResolveWhenScriptAdded(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var store1 = GetDocumentStore(options: options))
             using (var store2 = GetDocumentStore(options: options))
             {
@@ -77,7 +76,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ResolveWhenChangeToLatest(Options options)
         {
-            options = GetOptionsInternal(options);
+            options = UpdateConflictSolverAndGetMergedOptions(options);
             using (var store1 = GetDocumentStore(options: options))
             using (var store2 = GetDocumentStore(options: options))
             {
@@ -97,22 +96,6 @@ namespace SlowTests.Server.Replication
                     Assert.Equal(3, count);
                 }
             }
-        }
-
-        private Options GetOptionsInternal(Options options)
-        {
-            return new Options(options)
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                    options.ModifyDatabaseRecord(record);
-                }
-            };
         }
     }
 }

--- a/test/Tests.Infrastructure/ReplicationTestBase.cs
+++ b/test/Tests.Infrastructure/ReplicationTestBase.cs
@@ -487,6 +487,22 @@ namespace Tests.Infrastructure
             return res.DeletionInProgress.Count;
         }
 
+        protected Options UpdateConflictSolverAndGetMergedOptions(Options options)
+        {
+            return new Options(options)
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.ConflictSolverConfig = new ConflictSolver
+                    {
+                        ResolveToLatest = false,
+                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
+                    };
+                    options.ModifyDatabaseRecord(record);
+                }
+            };
+        }
+
         private class GetConnectionFailuresCommand : RavenCommand<Dictionary<string, string[]>>
         {
             public override bool IsReadRequest => true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

https://issues.hibernatingrhinos.com/issue/RavenDB-20779/Optimize-External-Replication-from-Sharded-to-Sharded

### Additional description

Files:
- `ReplicationDocuments.cs`
- `ReplicationIndexesAndTransformers.cs`
- `ReplicationOfConflicts.cs`
- `ReplicationResolveConflictsOnConfigurationChange.cs`
- `ReplicationSpecialCases.cs`

In addition, a bug was detected and fixed in the `MergeVectorsDown` method (in case none of the vectors is empty and whereas no intersection between the vectors (meaning we should return null) - we accidentally returned the first change vector). 

This PR also contains a fix for https://issues.hibernatingrhinos.com/issue/RavenDB-20779/Optimize-External-Replication-from-Sharded-to-Sharded (please see issue description for more details).


### Type of change

- Bug fix
- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
