### PR TITLE
RavenDB-20745 After deleting selected indexes, the number does not refresh

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -395,6 +395,7 @@ export function useIndexesPage(database: database, stale: boolean) {
             app.showBootstrapDialog(deleteIndexesVm);
             deleteIndexesVm.deleteTask.done((succeed: boolean, deletedIndexNames: string[]) => {
                 if (succeed) {
+                    setSelectedIndexes((x) => x.filter((x) => !deletedIndexNames.includes(x)));
                     dispatch({
                         type: "DeleteIndexes",
                         indexNames: deletedIndexNames,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20745/After-deleting-selected-indexes-the-number-does-not-refresh

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
