### PR TITLE
RavenDB-20731 - Fix force created revisions replication

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -29,7 +29,9 @@ namespace Raven.Server.Documents
         FromClusterTransaction = 0x1000,
         Reverted = 0x2000,
 
-        HasTimeSeries = 0x4000
+        HasTimeSeries = 0x4000,
+
+        ForceCreated = 0x10000
 
     }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -786,7 +786,8 @@ namespace Raven.Server.Documents.Replication
                         // we let pass all the conflicted revisions, since we keep them with their original change vector which might be `AlreadyMerged` at the destination.
                         if (doc.Flags.Contain(DocumentFlags.Conflicted) ||
                             doc.Flags.Contain(DocumentFlags.FromClusterTransaction) ||
-                            doc.Flags.Contain(DocumentFlags.FromOldDocumentRevision))
+                            doc.Flags.Contain(DocumentFlags.FromOldDocumentRevision) ||
+                            doc.Flags.Contain(DocumentFlags.ForceCreated))
                         {
                             return false;
                         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -449,6 +449,9 @@ namespace Raven.Server.Documents.Revisions
                     return true;
 
                 flags |= DocumentFlags.Revision;
+                if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation))
+                    flags |= DocumentFlags.ForceCreated;
+
                 var etag = _database.DocumentsStorage.GenerateNextEtag();
                 var newEtagSwapBytes = Bits.SwapBytes(etag);
 

--- a/test/SlowTests/Issues/RavenDB-20731.cs
+++ b/test/SlowTests/Issues/RavenDB-20731.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests.Graph;
+using FastTests.Server.Replication;
 using FastTests.Utils;
 using Microsoft.AspNetCore.Http.HttpResults;
 using NetTopologySuite.Utilities;
@@ -18,7 +19,7 @@ using Assert = Xunit.Assert;
 
 namespace SlowTests.Issues
 {
-    internal class RavenDB_20731 : ClusterTestBase
+    internal class RavenDB_20731 : ReplicationTestBase
     {
         public RavenDB_20731(ITestOutputHelper output) : base(output)
         {
@@ -26,6 +27,63 @@ namespace SlowTests.Issues
 
         [Fact]
         public async Task ForceCreatedRevisionsShouldReplicate()
+        {
+            using var store1 = GetDocumentStore();
+            using var store2 = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = null,
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+                {
+                    ["Comments"] = new RevisionsCollectionConfiguration { Disabled = false, PurgeOnDelete = true, },
+                    ["Products"] = new RevisionsCollectionConfiguration { Disabled = false, PurgeOnDelete = true, }
+                }
+            };
+            await RevisionsHelper.SetupRevisions(store1, Server.ServerStore, configuration: configuration);
+            await RevisionsHelper.SetupRevisions(store2, Server.ServerStore, configuration: configuration);
+
+            await SetupReplicationAsync(store1, store2);
+
+            var userId = "Users/1";
+            using (var session = store1.OpenAsyncSession())
+            {
+                var user = new User { Id = userId, Name = "Bob" };
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: userId);
+                await session.SaveChangesAsync(); // replicated because it changes the do and its cv (it adds to the doc "HasRevisions" flag), so it sent with the updated doc (with the flag) in the same batch.
+            }
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(userId);
+                user.Name = "Alice";
+                await session.SaveChangesAsync();
+            }
+
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: userId);
+                await session.SaveChangesAsync(); // revision isn't replicated.
+                                                  // it is in its own batch and its cv equals (equals or lower) to the previous batch (highest) cv - the cv of "Alice" (that has been sent in the previous batch).
+                                                  // so the force-created revision is being skipped and not replicating to the other node.
+            }
+
+            await EnsureReplicatingAsync((DocumentStore)store1, (DocumentStore)store2);
+            
+            using (var session = store2.OpenAsyncSession())
+            {
+                var count = await session.Advanced.Revisions.GetCountForAsync(id: userId);
+                Assert.Equal(2, count);
+            }
+        }
+
+
+        [Fact]
+        public async Task ForceCreatedRevisionsShouldReplicate_InternalReplication()
         {
             var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
             var databaseName = GetDatabaseName();

--- a/test/SlowTests/Issues/RavenDB-20731.cs
+++ b/test/SlowTests/Issues/RavenDB-20731.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Graph;
+using FastTests.Utils;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NetTopologySuite.Utilities;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Assert = Xunit.Assert;
+
+namespace SlowTests.Issues
+{
+    internal class RavenDB_20731 : ClusterTestBase
+    {
+        public RavenDB_20731(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ForceCreatedRevisionsShouldReplicate()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            var databaseName = GetDatabaseName();
+            await CreateDatabaseInCluster(databaseName, 2, leader.WebUrl);
+
+            using var leaderStore = GetStoreForServer(leader, databaseName);
+            var someFollower = nodes.First(n => n.ServerStore.NodeTag != leader.ServerStore.NodeTag);
+            using var followerStore = GetStoreForServer(someFollower, databaseName);
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = null,
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+                {
+                    ["Comments"] = new RevisionsCollectionConfiguration { Disabled = false, PurgeOnDelete = true, },
+                    ["Products"] = new RevisionsCollectionConfiguration { Disabled = false, PurgeOnDelete = true, }
+                }
+            };
+            await RevisionsHelper.SetupRevisions(leaderStore, leader.ServerStore, configuration: configuration);
+
+            var userId = "Users/1";
+            using (var session = leaderStore.OpenAsyncSession())
+            {
+                var user = new User { Id = userId, Name = "Bob" };
+                await session.StoreAsync(user);
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+                await session.SaveChangesAsync();
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: userId);
+                await session.SaveChangesAsync(); // replicated because it changes the do and its cv (it adds to the doc "HasRevisions" flag), so it sent with the updated doc (with the flag) in the same batch.
+            }
+
+            using (var session = followerStore.OpenAsyncSession())
+            {
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+                var user = await session.LoadAsync<User>(userId);
+                user.Name = "Alice";
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = followerStore.OpenAsyncSession())
+            {
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: userId);
+                await session.SaveChangesAsync(); // revision isn't replicated.
+                                                  // it is in its own batch and its cv equals (equals or lower) to the previous batch (highest) cv - the cv of "Alice" (that has been sent in the previous batch).
+                                                  // so the force-created revision is being skipped and not replicating to the other node.
+            }
+
+            await EnsureReplicatingAsync((DocumentStore)followerStore, (DocumentStore)leaderStore);
+
+            using (var session = leaderStore.OpenAsyncSession())
+            {
+                var count = await session.Advanced.Revisions.GetCountForAsync(id: userId);
+                Assert.Equal(2, count);
+            }
+        }
+
+        private IDocumentStore GetStoreForServer(RavenServer server, string database)
+        {
+            return new DocumentStore
+                {
+                    Database = database, 
+                    Urls = new[] { server.WebUrl }, 
+                    Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+                }.Initialize();
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20731

### Additional description

No revisions when the document has `HasRevisions` flag.
when you create a force-created revision in the second time, it isn't sent in the replication to the other node.

The regular revision is created in the document update (automatically), so it is sent with the document in the same batch, and only after we finished with the batch (in the OutgoingReplicationSender),
we update its '_parent.LastAcceptedChangeVector' (the parent is the 'OutgoingReplicationHandler') and move to the next batch.

In case of foce created revision:
We first update the doc.
then it is sent in its own batch, and after that we update the '_parent.LastAcceptedChangeVector' to be the same as the doc cv (or to the cv of the last item in the batch which is higher then the doc cv).
then we create a force-created revision with the same cv as the doc.
the revision should be sent in the next batch, *but* when we get to the revision in the batch, we skip it because its cv is the same (or lower) then the '_parent.LastAcceptedChangeVector'.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
