### PR TITLE
RavenDB-17745 Send heartbeats from BulkInsertOperation if there is id…

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -382,7 +382,7 @@ namespace Raven.Client.Documents.BulkInsert
 
         private void ThrowNoDatabase()
         {
-            throw new InvalidOperationException(
+            throw new BulkInsertInvalidOperationException(
                 $"Cannot start bulk insert operation without specifying a name of a database to operate on. " +
                 $"Database name can be passed as an argument when bulk insert is being created or default database can be defined using '{nameof(DocumentStore)}.{nameof(IDocumentStore.Database)}' property.");
         } 
@@ -500,8 +500,8 @@ namespace Raven.Client.Documents.BulkInsert
 
         private async Task HandleErrors(string documentId, Exception e)
         {
-            if (e.TargetSite.Name.Equals("ThrowAlreadyRunningTimeSeries"))
-                throw e;
+            if (e is BulkInsertClientException ce)
+                throw ce;
 
             BulkInsertAbortedException errorFromServer = null;
             try
@@ -522,7 +522,7 @@ namespace Raven.Client.Documents.BulkInsert
         private  ValueTask<ReleaseStream> ConcurrencyCheckAsync()
         {
             if (Interlocked.CompareExchange(ref _concurrentCheck, 1, 0) == 1)
-                throw new InvalidOperationException("Bulk Insert store methods cannot be executed concurrently.");
+                throw new BulkInsertInvalidOperationException("Bulk Insert store methods cannot be executed concurrently.");
 
             if (_streamLock.Wait(0))
             {
@@ -625,7 +625,7 @@ namespace Raven.Client.Documents.BulkInsert
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new InvalidOperationException("Document id must have a non empty value");
+                throw new BulkInsertInvalidOperationException("Document id must have a non empty value");
             }
 
             if (id.EndsWith("|"))
@@ -1031,7 +1031,7 @@ namespace Raven.Client.Documents.BulkInsert
 
             internal static void ThrowAlreadyRunningTimeSeries()
             {
-                throw new InvalidOperationException("There is an already running time series operation, did you forget to Dispose it?");
+                throw new BulkInsertInvalidOperationException("There is an already running time series operation, did you forget to Dispose it?");
             }
 
             public void Dispose()

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -319,7 +319,7 @@ namespace Raven.Client.Documents.BulkInsert
             {
                 await ExecuteBeforeStore().ConfigureAwait(false);
                 EndPreviousCommandIfNeeded();
-                _options.ForTestingPurposes?.Store?.Invoke();
+                _options.ForTestingPurposes?.OnSendHeartBeat_DoBulkStore?.Invoke();
                 if (CheckServerVersion(_requestExecutor.LastServerVersion) == false)
                     return;
 
@@ -347,7 +347,7 @@ namespace Raven.Client.Documents.BulkInsert
             if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
             {
                 // 5.4.108 or higher
-                if (ver.Major > 5 || (ver.Major == 5 && ver.Minor >= 4 && ver.Build >= 108))
+                if (ver.Major > 5 || (ver.Major == 5 && ver.Minor >= 4 && ver.Build >= 110))
                     return true;
             }
             return false;

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
@@ -24,7 +24,7 @@ namespace Raven.Client.Documents.BulkInsert
 
         internal class TestingStuff
         {
-            internal Action Store;
+            internal Action OnSendHeartBeat_DoBulkStore;
             internal int OverrideHeartbeatCheckInterval;
         }
     }

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO.Compression;
-using Raven.Client.Documents.Operations;
 
 namespace Raven.Client.Documents.BulkInsert
 {
@@ -12,5 +11,21 @@ namespace Raven.Client.Documents.BulkInsert
         /// Determines whether we should skip overwriting a document when it is updated by exactly the same document (by comparing the content and the metadata)
         /// </summary>
         public bool SkipOverwriteIfUnchanged { get; set; }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal Action Store;
+            internal int OverrideHeartbeatCheckInterval;
+        }
     }
 }

--- a/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
@@ -48,6 +48,7 @@ namespace Raven.Client.Documents.Commands.Batches
 
         JsonPatch,
         ClientAnyCommand,
-        ClientModifyDocumentCommand
+        ClientModifyDocumentCommand,
+        HeartBeat
     }
 }

--- a/src/Raven.Client/Exceptions/Documents/BulkInsert/BulkInsertClientException.cs
+++ b/src/Raven.Client/Exceptions/Documents/BulkInsert/BulkInsertClientException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Documents.BulkInsert
+{
+    public abstract class BulkInsertClientException : RavenException
+    {
+        protected BulkInsertClientException(string message) : base(message)
+        {
+        }
+
+        protected BulkInsertClientException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Exceptions/Documents/BulkInsert/BulkInsertInvalidOperationException.cs
+++ b/src/Raven.Client/Exceptions/Documents/BulkInsert/BulkInsertInvalidOperationException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Documents.BulkInsert
+{
+    public class BulkInsertInvalidOperationException : BulkInsertClientException
+    {
+        public BulkInsertInvalidOperationException(string message) : base(message)
+        {
+        }
+
+        public BulkInsertInvalidOperationException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -7,8 +7,8 @@ namespace Raven.Client.Util
 {
     internal class StreamWithTimeout : Stream, IAsyncDisposable
     {
-        private static readonly TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
-        private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
+        internal static TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
+        internal static  TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
 
         private readonly Stream _stream;
         private int _writeTimeout;

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -7,8 +7,8 @@ namespace Raven.Client.Util
 {
     internal class StreamWithTimeout : Stream, IAsyncDisposable
     {
-        internal static TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
-        internal static TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
+        public static TimeSpan DefaultWriteTimeout { get; } = TimeSpan.FromSeconds(120);
+        private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
 
         private readonly Stream _stream;
         private int _writeTimeout;

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -7,7 +7,7 @@ namespace Raven.Client.Util
 {
     internal class StreamWithTimeout : Stream, IAsyncDisposable
     {
-        public static TimeSpan DefaultWriteTimeout { get; } = TimeSpan.FromSeconds(120);
+        internal static TimeSpan DefaultWriteTimeout { get; } = TimeSpan.FromSeconds(120);
         private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
 
         private readonly Stream _stream;

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -8,7 +8,7 @@ namespace Raven.Client.Util
     internal class StreamWithTimeout : Stream, IAsyncDisposable
     {
         internal static TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
-        internal static  TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
+        internal static TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(120);
 
         private readonly Stream _stream;
         private int _writeTimeout;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1914,6 +1914,8 @@ namespace Raven.Server.Documents
 
             internal ManualResetEvent DatabaseRecordLoadHold;
             internal ManualResetEvent HealthCheckHold;
+
+            internal int StreamWriteTimeout;
         }
     }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1915,7 +1915,7 @@ namespace Raven.Server.Documents
             internal ManualResetEvent DatabaseRecordLoadHold;
             internal ManualResetEvent HealthCheckHold;
 
-            internal int StreamWriteTimeout;
+            internal int BulkInsertStreamWriteTimeout;
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchRequestParser.cs
@@ -1164,6 +1164,10 @@ namespace Raven.Server.Documents.Handlers
                     if (*(long*)state.StringBuffer == 7166459905131377482 &&
                         state.StringBuffer[8] == (byte)'h')
                         return CommandType.JsonPatch;
+
+                    if (*(long*)state.StringBuffer == 7018088662229411144 &&
+                        state.StringBuffer[8] == (byte)'t')
+                        return CommandType.HeartBeat;
                     break;
                 case 10:
                     if (*(long*)state.StringBuffer == 7598246930185808212 &&

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -54,10 +54,10 @@ namespace Raven.Server.Documents.Handlers
                         currentCtxReset = ContextPool.AllocateOperationContext(out JsonOperationContext docsCtx);
                         var requestBodyStream = RequestBodyStream();
 
-                        if (Database.ForTestingPurposes?.StreamWriteTimeout > 0)
+                        if (Database.ForTestingPurposes?.BulkInsertStreamWriteTimeout > 0)
                         {
                             var streamWithTimeout = (StreamWithTimeout)requestBodyStream;
-                            streamWithTimeout.WriteTimeout = Database.ForTestingPurposes.StreamWriteTimeout;
+                            streamWithTimeout.WriteTimeout = Database.ForTestingPurposes.BulkInsertStreamWriteTimeout;
                         }
 
                         using (var parser = new BatchRequestParser.ReadMany(context, requestBodyStream, buffer, token))

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -89,7 +89,6 @@ namespace Raven.Server.Documents.Handlers
                                                 SkipOverwriteIfUnchanged = skipOverwriteIfUnchanged
                                             });
                                         }
-
                                         ClearStreamsTempFiles();
 
                                         progress.BatchCount++;
@@ -97,7 +96,6 @@ namespace Raven.Server.Documents.Handlers
                                         progress.LastProcessedId = array[numberOfCommands - 1].Id;
 
                                         onProgress(progress);
-
                                         previousCtxReset?.Dispose();
                                         previousCtxReset = currentCtxReset;
                                         currentCtxReset = ContextPool.AllocateOperationContext(out docsCtx);
@@ -110,6 +108,9 @@ namespace Raven.Server.Documents.Handlers
                                     var commandData = await task;
                                     if (commandData.Type == CommandType.None)
                                         break;
+
+                                    if (commandData.Type == CommandType.HeartBeat)
+                                        continue;
 
                                     if (commandData.Type == CommandType.AttachmentPUT)
                                     {

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Util;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
@@ -52,6 +53,12 @@ namespace Raven.Server.Documents.Handlers
                     {
                         currentCtxReset = ContextPool.AllocateOperationContext(out JsonOperationContext docsCtx);
                         var requestBodyStream = RequestBodyStream();
+
+                        if (Database.ForTestingPurposes?.StreamWriteTimeout > 0)
+                        {
+                            var streamWithTimeout = (StreamWithTimeout)requestBodyStream;
+                            streamWithTimeout.WriteTimeout = Database.ForTestingPurposes.StreamWriteTimeout;
+                        }
 
                         using (var parser = new BatchRequestParser.ReadMany(context, requestBodyStream, buffer, token))
                         {

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Operations.Certificates;
@@ -153,7 +154,7 @@ namespace FastTests.Client
                         };
                     }
 
-                    var e = await Assert.ThrowsAsync<InvalidOperationException>(async () => { await Parallel.ForEachAsync(localList, async (element, _) => { await bulkInsert.StoreAsync(element); }); });
+                    var e = await Assert.ThrowsAsync<BulkInsertInvalidOperationException>(async () => { await Parallel.ForEachAsync(localList, async (element, _) => { await bulkInsert.StoreAsync(element); }); });
 
                     Assert.Contains("Bulk Insert store methods cannot be executed concurrently", e.Message);
                 }

--- a/test/SlowTests/Client/Attachments/BulkInsertAttachments.cs
+++ b/test/SlowTests/Client/Attachments/BulkInsertAttachments.cs
@@ -7,6 +7,7 @@ using FastTests;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
+using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -229,7 +230,7 @@ namespace SlowTests.Client.Attachments
         {
             using (var store = GetDocumentStore())
             {
-                var argumentError = Assert.Throws<InvalidOperationException> (() =>
+                var argumentError = Assert.Throws<BulkInsertInvalidOperationException> (() =>
                 {
                     using (var bulkInsert = store.BulkInsert())
                     {

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
@@ -1183,16 +1184,16 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                     {
                         timeSeriesBulkInsert.Append(baseline.AddMinutes(1), 59d, "watches/fitbit");
 
-                        var error = Assert.Throws<InvalidOperationException>(() => bulkInsert.Store(new { Name = "Oren" }, documentId));
+                        var error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.Store(new { Name = "Oren" }, documentId));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.CountersFor("test").Increment("1", 1));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.CountersFor("test").Increment("1", 1));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Pulse"));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Pulse"));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Heartrate"));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Heartrate"));
                         AssertError();
 
                         void AssertError()

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/TypedBulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/TypedBulkInsert.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Session.TimeSeries;
+using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
@@ -854,16 +855,16 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                     {
                         timeSeriesBulkInsert.Append(baseline.AddMinutes(1), 59d, "watches/fitbit");
 
-                        var error = Assert.Throws<InvalidOperationException>(() => bulkInsert.Store(new { Name = "Oren" }, documentId));
+                        var error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.Store(new { Name = "Oren" }, documentId));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.CountersFor("test").Increment("1", 1));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.CountersFor("test").Increment("1", 1));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Pulse"));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Pulse"));
                         AssertError();
 
-                        error = Assert.Throws<InvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Heartrate"));
+                        error = Assert.Throws<BulkInsertInvalidOperationException>(() => bulkInsert.TimeSeriesFor(documentId, "Heartrate"));
                         AssertError();
 
                         void AssertError()

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-                db.ForTestingPurposesOnly().StreamWriteTimeout = _writeTimeout;
+                db.ForTestingPurposesOnly().BulkInsertStreamWriteTimeout = _writeTimeout;
                 var bulkInsertOptions = new BulkInsertOptions();
                 bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _writeTimeout;
 
@@ -65,14 +65,14 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-                db.ForTestingPurposesOnly().StreamWriteTimeout = _writeTimeout;
+                db.ForTestingPurposesOnly().BulkInsertStreamWriteTimeout = _writeTimeout;
 
                 var bulkInsertOptions = new BulkInsertOptions();
                 bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _writeTimeout;
 
                 var bulk = store.BulkInsert(bulkInsertOptions);
 
-                bulkInsertOptions.ForTestingPurposesOnly().Store = () =>
+                bulkInsertOptions.ForTestingPurposesOnly().OnSendHeartBeat_DoBulkStore = () =>
                 {
                     Task.Run(() => bulk.Store(new User { Name = "Daniel" }, "users/1"));
                 };

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FastTests;
-using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Util;
 using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,62 +15,77 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BulkInsert)]
         public async Task BulkInsertWithDelay()
         {
             using (var store = GetDocumentStore())
             {
-                StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
-                StreamWithTimeout.DefaultReadTimeout = TimeSpan.FromSeconds(20);
-                var bulk = store.BulkInsert();
-
-                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
-                bulk.Store(new User { Name = "Daniel" }, "users/1");
-                bulk.Store(new User { Name = "Yael" }, "users/2");
-
-                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
-                bulk.Store(new User { Name = "Ido" }, "users/3");
-                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
-                bulk.Dispose();
-
-                using (var session = store.OpenSession())
+                try
                 {
-                    var user = session.Load<User>("users/1");
-                    Assert.NotNull(user);
-                    Assert.Equal("Daniel", user.Name);
+                    StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
+                    StreamWithTimeout.DefaultReadTimeout = TimeSpan.FromSeconds(20);
+                    var bulk = store.BulkInsert();
 
-                    user = session.Load<User>("users/2");
-                    Assert.NotNull(user);
-                    Assert.Equal("Yael", user.Name);
+                    await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                    bulk.Store(new User { Name = "Daniel" }, "users/1");
+                    bulk.Store(new User { Name = "Yael" }, "users/2");
 
-                    user = session.Load<User>("users/3");
-                    Assert.NotNull(user);
-                    Assert.Equal("Ido", user.Name);
+                    await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                    bulk.Store(new User { Name = "Ido" }, "users/3");
+                    await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                    bulk.Dispose();
+
+                    using (var session = store.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1");
+                        Assert.NotNull(user);
+                        Assert.Equal("Daniel", user.Name);
+
+                        user = session.Load<User>("users/2");
+                        Assert.NotNull(user);
+                        Assert.Equal("Yael", user.Name);
+
+                        user = session.Load<User>("users/3");
+                        Assert.NotNull(user);
+                        Assert.Equal("Ido", user.Name);
+                    }
+                }
+                finally
+                {
+                    StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(120);
+                    StreamWithTimeout.DefaultReadTimeout = TimeSpan.FromSeconds(120);
                 }
             }
         }
-        [Fact]
+        [RavenFact(RavenTestCategory.BulkInsert)]
         public async Task StartStoreInTheMiddleOfAnHeartbeat()
         {
             using (var store = GetDocumentStore())
             {
-                StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
-                var bulk = store.BulkInsert();
-
-                bulk.ForTestingPurposesOnly().StartStore = () =>
+                try
                 {
-                    Task.Run(() => bulk.Store(new User { Name = "Daniel" }, "users/1"));
-                };
+                    StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
+                    var bulk = store.BulkInsert();
 
-                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                    bulk.ForTestingPurposesOnly().StartStore = () =>
+                    {
+                        Task.Run(() => bulk.Store(new User { Name = "Daniel" }, "users/1"));
+                    };
 
-                bulk.Dispose();
+                    await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
 
-                using (var session = store.OpenSession())
+                    bulk.Dispose();
+
+                    using (var session = store.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1");
+                        Assert.NotNull(user);
+                        Assert.Equal("Daniel", user.Name);
+                    }
+                }
+                finally
                 {
-                    var user = session.Load<User>("users/1");
-                    Assert.NotNull(user);
-                    Assert.Equal("Daniel", user.Name);
+                    StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(120);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.BulkInsert;
+using Raven.Client.Util;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17745 : RavenTestBase
+    {
+        public RavenDB_17745(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task BulkInsertWithDelay()
+        {
+            using (var store = GetDocumentStore())
+            {
+                StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
+                StreamWithTimeout.DefaultReadTimeout = TimeSpan.FromSeconds(20);
+                var bulk = store.BulkInsert();
+
+                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                bulk.Store(new User { Name = "Daniel" }, "users/1");
+                bulk.Store(new User { Name = "Yael" }, "users/2");
+
+                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                bulk.Store(new User { Name = "Ido" }, "users/3");
+                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+                bulk.Dispose();
+
+                //WaitForUserToContinueTheTest(store);
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+        [Fact]
+        public async Task StartStoreInTheMiddleOfAnHeartbeat()
+        {
+            using (var store = GetDocumentStore())
+            {
+                StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
+                var bulk = store.BulkInsert();
+
+                bulk.ForTestingPurposesOnly().startStore = () =>
+                {
+                    bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                };
+
+                await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
+
+                bulk.Dispose();
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -33,7 +33,6 @@ namespace SlowTests.Issues
                 await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));
                 bulk.Dispose();
 
-                //WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenSession())
                 {
                     var user = session.Load<User>("users/1");
@@ -58,9 +57,9 @@ namespace SlowTests.Issues
                 StreamWithTimeout.DefaultWriteTimeout = TimeSpan.FromSeconds(20);
                 var bulk = store.BulkInsert();
 
-                bulk.ForTestingPurposesOnly().startStore = () =>
+                bulk.ForTestingPurposesOnly().StartStore = () =>
                 {
-                    bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    Task.Run(() => bulk.Store(new User { Name = "Daniel" }, "users/1"));
                 };
 
                 await Task.Delay(StreamWithTimeout.DefaultWriteTimeout + TimeSpan.FromSeconds(5));


### PR DESCRIPTION
…le time

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17745

### Additional description

Send heartbeats from BulkInsertOperation if we have a delay at the bulk insert operation.
Added new CommandType , CommandType.HeartBeat. doing nothing for her in BulkInsertHAndler

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
