### PR TITLE
RavenDB-20756 - Go over all place in tests where we do modifyDatabaseRecord(record)

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1121,7 +1121,7 @@ namespace SlowTests.Client.Attachments
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.ConflictSolverConfig = new ConflictSolver
                 {
                     ResolveToLatest = false,
@@ -1211,7 +1211,7 @@ namespace SlowTests.Client.Attachments
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.ConflictSolverConfig = new ConflictSolver
                 {
                     ResolveToLatest = false,
@@ -1963,7 +1963,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -1986,7 +1986,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2096,7 +2096,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2119,7 +2119,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2241,7 +2241,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2264,7 +2264,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2425,7 +2425,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2449,7 +2449,7 @@ namespace SlowTests.Client.Attachments
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -2571,7 +2571,7 @@ namespace SlowTests.Client.Attachments
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
             };
             using (var store1 = GetDocumentStore(options))
@@ -2726,7 +2726,7 @@ namespace SlowTests.Client.Attachments
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
             };
 
@@ -3202,7 +3202,7 @@ namespace SlowTests.Client.Attachments
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
             };
             using (var store1 = GetDocumentStore(options))

--- a/test/SlowTests/Client/TimeSeries/Query/IncrementalTimeSeriesQueries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/IncrementalTimeSeriesQueries.cs
@@ -149,9 +149,7 @@ namespace SlowTests.Client.TimeSeries.Query
 
                     session.SaveChanges();
                 }
-
-                WaitForUserToContinueTheTest(store);
-
+                
                 using (var session = store.OpenSession())
                 {
                     var query = session.Advanced.RawQuery<TimeSeriesAggregationResult>(@"

--- a/test/SlowTests/Client/TimeSeries/TimeSeriesAndDocumentConflicts.cs
+++ b/test/SlowTests/Client/TimeSeries/TimeSeriesAndDocumentConflicts.cs
@@ -154,7 +154,7 @@ namespace SlowTests.Client.TimeSeries
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             options.ModifyDatabaseRecord = record =>
             {
-                modifyDatabaseRecord(record);
+                modifyDatabaseRecord?.Invoke(record);
                 record.ConflictSolverConfig = new ConflictSolver
                 {
                     ResolveToLatest = false,
@@ -253,7 +253,7 @@ namespace SlowTests.Client.TimeSeries
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,
@@ -310,7 +310,7 @@ namespace SlowTests.Client.TimeSeries
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver
                     {
                         ResolveToLatest = false,

--- a/test/SlowTests/Issues/RavenDB-20444.cs
+++ b/test/SlowTests/Issues/RavenDB-20444.cs
@@ -54,7 +54,7 @@ public class RavenDB_20444 : RavenTestBase
         {
             ModifyDatabaseRecord = record =>
             {
-                options.ModifyDatabaseRecord(record);
+                options.ModifyDatabaseRecord?.Invoke(record);
                 record.Settings[RavenConfiguration.GetKey(x => x.Indexing.QueryClauseCacheDisabled)] = queryClauseCacheDisabled;
             }
         });

--- a/test/SlowTests/Issues/RavenDB_14084.cs
+++ b/test/SlowTests/Issues/RavenDB_14084.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    options.ModifyDatabaseRecord(record);
+                    options.ModifyDatabaseRecord?.Invoke(record);
                     record.Settings[RavenConfiguration.GetKey(x => x.Indexing.IndexMissingFieldsAsNull)] = "true";
                 }
             }))

--- a/test/SlowTests/Issues/RavenDB_18357.cs
+++ b/test/SlowTests/Issues/RavenDB_18357.cs
@@ -76,7 +76,7 @@ public class RavenDB_18357 : RavenTestBase
         {
             ModifyDatabaseRecord = record =>
             {
-                options.ModifyDatabaseRecord(record);
+                options.ModifyDatabaseRecord?.Invoke(record);
                 record.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
             }
         };

--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -30,7 +30,7 @@ namespace SlowTests
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver();
                 }
             }))
@@ -38,7 +38,7 @@ namespace SlowTests
             {
                 ModifyDatabaseRecord = record =>
                 {
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                     record.ConflictSolverConfig = new ConflictSolver();
                 }
             }))

--- a/test/SlowTests/Server/Replication/AutomaticConflictResolvingOnPut.cs
+++ b/test/SlowTests/Server/Replication/AutomaticConflictResolvingOnPut.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Server.Replication
                         ResolveToLatest = false,
                         ResolveByCollection = new Dictionary<string, ScriptResolver>()
                     };
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                 }
             }))
             using (var slave = GetDocumentStore(options: new Options(options)
@@ -43,7 +43,7 @@ namespace SlowTests.Server.Replication
                         ResolveToLatest = false,
                         ResolveByCollection = new Dictionary<string, ScriptResolver>()
                     };
-                    modifyDatabaseRecord(record);
+                    modifyDatabaseRecord?.Invoke(record);
                 }
             }))
             {

--- a/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/ExternalReplicationTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Server.Replication
 
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             var record = new DatabaseRecord(database);
-            modifyDatabaseRecord(record);
+            modifyDatabaseRecord?.Invoke(record);
             await CreateDatabaseInCluster(record, 3, cluster.Leader.WebUrl);
 
             using (var store1 = new DocumentStore

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -83,7 +83,7 @@ namespace SlowTests.Server.Replication
 
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             var record = new DatabaseRecord(database);
-            modifyDatabaseRecord(record);
+            modifyDatabaseRecord?.Invoke(record);
 
             await CreateDatabaseInCluster(record, 3, cluster.Leader.WebUrl);
 
@@ -172,7 +172,7 @@ namespace SlowTests.Server.Replication
 
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             var record = new DatabaseRecord(database);
-            modifyDatabaseRecord(record);
+            modifyDatabaseRecord?.Invoke(record);
 
             await CreateDatabaseInCluster(record, 3, cluster.Leader.WebUrl);
 
@@ -242,7 +242,7 @@ namespace SlowTests.Server.Replication
 
             var modifyDatabaseRecord = options.ModifyDatabaseRecord;
             var record = new DatabaseRecord(database);
-            modifyDatabaseRecord(record);
+            modifyDatabaseRecord?.Invoke(record);
 
             await CreateDatabaseInCluster(record, 3, cluster.Leader.WebUrl);
 

--- a/test/SlowTests/Smuggler/SmugglerConflicts.cs
+++ b/test/SlowTests/Smuggler/SmugglerConflicts.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -43,7 +43,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -78,7 +78,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -87,7 +87,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -128,7 +128,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -137,7 +137,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -185,7 +185,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -194,7 +194,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -249,7 +249,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -258,7 +258,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -301,7 +301,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store1",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))
@@ -310,7 +310,7 @@ namespace SlowTests.Smuggler
                     ModifyDatabaseName = s => $"{s}_store2",
                     ModifyDatabaseRecord = record =>
                     {
-                        modifyDatabaseRecord(record);
+                        modifyDatabaseRecord?.Invoke(record);
                         record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
                     }
                 }))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20756

### Additional description

replace all `modifyDatabaseRecord(record)` with `modifyDatabaseRecord?.Invoke(record)` due to NRE

### Type of change

- Bug fix

### How risky is the change?

- Low 
