### PR TITLE
RavenDB-20700 - Using Exists instead of reading the entire page

### DIFF
--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Indexing
                 throw new ArgumentNullException(nameof(s));
 
             var filesTree = state.Transaction.ReadTree(_name);
-            return filesTree.Read(name) != null;
+            return filesTree.Exists(name);
         }
 
         public override string[] ListAll(IState s)
@@ -122,8 +122,7 @@ namespace Raven.Server.Indexing
                 throw new ArgumentNullException(nameof(s));
 
             var filesTree = state.Transaction.ReadTree(_name);
-            var readResult = filesTree.Read(name);
-            if (readResult == null)
+            if (filesTree.Exists(name) == false)
                 throw new FileNotFoundException("Could not find file", name);
 
             using (Slice.From(state.Transaction.Allocator, name, out Slice str))
@@ -168,8 +167,7 @@ namespace Raven.Server.Indexing
                 throw new ArgumentNullException(nameof(s));
 
             var filesTree = state.Transaction.ReadTree(_name);
-            var readResult = filesTree.ReadStream(name);
-            if (readResult == null)
+            if (filesTree.Exists(name) == false)
                 throw new FileNotFoundException("Could not find file", name);
 
             filesTree.DeleteStream(name);

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -98,6 +98,16 @@ namespace Voron.Data.BTrees
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool Exists(string key)
+        {
+            Slice keySlice;
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            {
+                return Exists(keySlice);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, string value)
         {
             Slice keySlice;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1069,6 +1069,12 @@ namespace Voron.Data.BTrees
             return new ReadResult(GetValueReaderFromHeader(node));
         }
 
+        public bool Exists(Slice key)
+        {
+            var p = FindPageFor(key, out _);
+            return p.LastMatch == 0;
+        }
+
         public int GetDataSize(Slice key)
         {
             TreeNodeHeader* node;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20700/Improve-Lucene-memory-utilization

### Additional description

Using exists instead of reading the entire page.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing
