### PR TITLE
RavenDB-20707 Allow reset index on specific shards

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
@@ -1,19 +1,26 @@
-﻿import React from "react";
+﻿import React, { useState } from "react";
 import { Alert, Button, Modal, ModalBody, ModalFooter } from "reactstrap";
-import { IndexSharedInfo } from "components/models/indexes";
 import { Icon } from "components/common/Icon";
+import {
+    DatabaseActionContexts,
+    MultipleDatabaseLocationSelector,
+} from "components/common/MultipleDatabaseLocationSelector";
+import ActionContextUtils from "components/utils/actionContextUtils";
 
 interface ConfirmResetIndexProps {
+    indexName: string;
     toggle: () => void;
-    onConfirm: () => void;
-    index: IndexSharedInfo;
+    allActionContexts: DatabaseActionContexts[];
+    onConfirm: (contexts: DatabaseActionContexts[]) => void;
 }
 
 export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
-    const { toggle, index, onConfirm } = props;
+    const { toggle, indexName, allActionContexts, onConfirm } = props;
+
+    const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
 
     const onSubmit = () => {
-        onConfirm();
+        onConfirm(selectedActionContexts);
         toggle();
     };
 
@@ -31,7 +38,7 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                 </div>
                 <span className="text-center bg-faded-primary py-1 px-3 w-fit-content rounded-pill mx-auto">
                     <Icon icon="index" />
-                    {index.name}
+                    {indexName}
                 </span>
                 <Alert color="warning">
                     <small>
@@ -40,6 +47,16 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                     <br />
                     <small>All items matched by the index definition will be re-indexed.</small>
                 </Alert>
+                {ActionContextUtils.showContextSelector(allActionContexts) && (
+                    <div>
+                        <h4>Select context</h4>
+                        <MultipleDatabaseLocationSelector
+                            allActionContexts={allActionContexts}
+                            selectedActionContexts={selectedActionContexts}
+                            setSelectedActionContexts={setSelectedActionContexts}
+                        />
+                    </div>
+                )}
             </ModalBody>
             <ModalFooter>
                 <Button color="link" onClick={toggle} className="text-muted">

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -51,7 +51,7 @@ interface IndexPanelProps {
     disableIndexing: () => Promise<void>;
     pauseIndexing: () => Promise<void>;
     deleteIndex: () => Promise<void>;
-    resetIndex: () => Promise<void>;
+    resetIndex: () => void;
     openFaulty: (location: databaseLocationSpecifier) => Promise<void>;
     selected: boolean;
     hasReplacement?: boolean;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -7,7 +7,7 @@ import IndexUtils from "../../../../utils/IndexUtils";
 import { useAccessManager } from "hooks/useAccessManager";
 import { useAppUrls } from "hooks/useAppUrls";
 import "./IndexesPage.scss";
-import { Button, Card, Col, Row, Spinner } from "reactstrap";
+import { Button, Card, Col, Row } from "reactstrap";
 import { LoadingView } from "components/common/LoadingView";
 import { StickyHeader } from "components/common/StickyHeader";
 import { BulkIndexOperationConfirm } from "components/pages/database/indexes/list/BulkIndexOperationConfirm";
@@ -39,8 +39,7 @@ export function IndexesPage(props: IndexesPageProps) {
         loading,
         bulkOperationConfirm,
         setBulkOperationConfirm,
-        resetIndexConfirm,
-        setResetIndexConfirm,
+        resetIndexData,
         swapSideBySideData,
         stats,
         selectedIndexes,
@@ -58,9 +57,7 @@ export function IndexesPage(props: IndexesPageProps) {
         disableIndexes,
         pauseIndexes,
         setIndexLockMode,
-        resetIndex,
         toggleSelection,
-        onResetIndexConfirm,
         openFaulty,
         getSelectedIndexes,
         confirmDeleteIndexes,
@@ -77,6 +74,8 @@ export function IndexesPage(props: IndexesPageProps) {
     const pauseSelectedIndexes = () => pauseIndexes(getSelectedIndexes());
 
     const indexNames = getAllIndexes(groups, replacements).map((x) => x.name);
+
+    const allActionContexts = ActionContextUtils.getContexts(database.getLocations());
 
     if (loading) {
         return <LoadingView />;
@@ -141,7 +140,7 @@ export function IndexesPage(props: IndexesPageProps) {
                                                 setPriority={(p) => setIndexPriority(index, p)}
                                                 setLockMode={(l) => setIndexLockMode(index, l)}
                                                 globalIndexingStatus={globalIndexingStatus}
-                                                resetIndex={() => resetIndex(index)}
+                                                resetIndex={() => resetIndexData.setIndexName(index.name)}
                                                 openFaulty={(location: databaseLocationSpecifier) =>
                                                     openFaulty(index, location)
                                                 }
@@ -181,7 +180,7 @@ export function IndexesPage(props: IndexesPageProps) {
                                                     setPriority={(p) => setIndexPriority(replacement, p)}
                                                     setLockMode={(l) => setIndexLockMode(replacement, l)}
                                                     globalIndexingStatus={globalIndexingStatus}
-                                                    resetIndex={() => resetIndex(replacement)}
+                                                    resetIndex={() => resetIndexData.setIndexName(replacement.name)}
                                                     openFaulty={(location: databaseLocationSpecifier) =>
                                                         openFaulty(replacement, location)
                                                     }
@@ -209,11 +208,12 @@ export function IndexesPage(props: IndexesPageProps) {
             {bulkOperationConfirm && (
                 <BulkIndexOperationConfirm {...bulkOperationConfirm} toggle={() => setBulkOperationConfirm(null)} />
             )}
-            {resetIndexConfirm && (
+            {resetIndexData.indexName && (
                 <ConfirmResetIndex
-                    {...resetIndexConfirm}
-                    toggle={() => setResetIndexConfirm(null)}
-                    onConfirm={() => onResetIndexConfirm(resetIndexConfirm.index)}
+                    indexName={resetIndexData.indexName}
+                    toggle={() => resetIndexData.setIndexName(null)}
+                    onConfirm={(x) => resetIndexData.onConfirm(x)}
+                    allActionContexts={allActionContexts}
                 />
             )}
             {swapSideBySideData.indexName && (
@@ -221,7 +221,7 @@ export function IndexesPage(props: IndexesPageProps) {
                     indexName={swapSideBySideData.indexName}
                     toggle={() => swapSideBySideData.setIndexName(null)}
                     onConfirm={(x) => swapSideBySideData.onConfirm(x)}
-                    allActionContexts={ActionContextUtils.getContexts(database.getLocations())}
+                    allActionContexts={allActionContexts}
                 />
             )}
         </>

--- a/src/Raven.Studio/typescript/components/services/IndexesService.ts
+++ b/src/Raven.Studio/typescript/components/services/IndexesService.ts
@@ -35,8 +35,8 @@ export default class IndexesService {
         return new getIndexesStatsCommand(db, location).execute();
     }
 
-    async resetIndex(index: IndexSharedInfo, db: database, location: databaseLocationSpecifier) {
-        await new resetIndexCommand(index.name, db, location).execute();
+    async resetIndex(indexName: string, db: database, location: databaseLocationSpecifier) {
+        await new resetIndexCommand(indexName, db, location).execute();
     }
 
     async pauseAllIndexes(db: DatabaseSharedInfo, location: databaseLocationSpecifier) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20707/Allow-reset-index-on-specific-shards

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/6a93fbfa-253d-4f7b-8a8e-7b2a68c89691)

