### PR TITLE
RavenDB-20734 Cluster Dashboard view vs Server Dashboard: lack of online/total dbs count

### DIFF
--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -215,7 +215,7 @@ namespace Raven.Server.Dashboard
                 var databaseOnline = serverStore.DatabasesLandlord.TryGetDatabaseIfLoaded(databaseName, out var database);
                 if (databaseOnline == false)
                 {
-                    SetOfflineDatabaseInfo(serverStore, context, databaseName, databasesInfo, drivesUsage, disabled: false);
+                    SetOfflineDatabaseInfo(serverStore, context, databaseName, databasesInfo, drivesUsage, rawRecord.IsDisabled);
                     return;
                 }
 

--- a/src/Raven.Studio/typescript/models/resources/widgets/databaseOverviewItem.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/databaseOverviewItem.ts
@@ -165,7 +165,7 @@ class databaseOverviewItem implements databaseAndNodeAwareStats {
                 return [{
                     text: "Offline",
                     iconClass: "icon-database-cutout icon-addon-clock",
-                    textClass: "text-warning"
+                    textClass: null
                 }];
            } else {
                 return [{

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/databaseOverviewWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/databaseOverviewWidget.html
@@ -1,6 +1,6 @@
 <div>
     <div class="cluster-dashboard-item-header">
-        <h3><i class="icon-database"></i><span>Database Overview</span></h3>
+        <h3><i class="icon-database"></i><span>Databases Overview</span></h3>
         <button class="btn btn-warning btn-sm" data-bind="click: remove" title="Remove widget from board">
             <i class="icon-trash"></i>
         </button>
@@ -8,6 +8,13 @@
             <i data-bind="css: { 'icon-fullscreen': !fullscreen(), 'icon-exit-fullscreen': fullscreen },
                           attr: { title: fullscreen() ? 'Minimize widget' : 'Maximize widget' }"></i>
         </button>
+    </div>
+    <div class="d-flex gap-3 margin-left-xxs margin-right-xxs padding-xs panel-bg-1 border-radius-xxs">
+        <div class="small-label">Total <span>{number}</span><i class="icon-database margin-left-xxs"></i></div>
+        <div class="flex-grow"></div>
+        <div class="small-label">Online <span>{number}</span><i class="icon-database-cutout icon-addon-check text-success margin-left-xxs"></i></div>
+        <div class="small-label">Offline <span>{number}</span><i class="icon-database-cutout icon-addon-clock margin-left-xxs"></i></div>
+        <div class="small-label">Disabled <span>{number}</span><i class="icon-database-cutout icon-addon-cancel text-warning margin-left-xxs"></i></div>
     </div>
     <div class="databases-list" style="position: relative;">
         <div class="list-container">

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/databaseOverviewWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/databaseOverviewWidget.html
@@ -10,11 +10,11 @@
         </button>
     </div>
     <div class="d-flex gap-3 margin-left-xxs margin-right-xxs padding-xs panel-bg-1 border-radius-xxs">
-        <div class="small-label">Total <span>{number}</span><i class="icon-database margin-left-xxs"></i></div>
+        <div class="small-label">Total <span data-bind="text: statusSummary()?.total"></span><i class="icon-database margin-left-xxs"></i></div>
         <div class="flex-grow"></div>
-        <div class="small-label">Online <span>{number}</span><i class="icon-database-cutout icon-addon-check text-success margin-left-xxs"></i></div>
-        <div class="small-label">Offline <span>{number}</span><i class="icon-database-cutout icon-addon-clock margin-left-xxs"></i></div>
-        <div class="small-label">Disabled <span>{number}</span><i class="icon-database-cutout icon-addon-cancel text-warning margin-left-xxs"></i></div>
+        <div class="small-label">Online <span data-bind="text: statusSummary()?.online"></span><i class="icon-database-cutout icon-addon-check text-success margin-left-xxs"></i></div>
+        <div class="small-label">Offline <span data-bind="text: statusSummary()?.offline"></span><i class="icon-database-cutout icon-addon-clock margin-left-xxs"></i></div>
+        <div class="small-label">Disabled <span data-bind="text: statusSummary()?.disabled"></span><i class="icon-database-cutout icon-addon-cancel text-warning margin-left-xxs"></i></div>
     </div>
     <div class="databases-list" style="position: relative;">
         <div class="list-container">

--- a/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
@@ -2198,6 +2198,10 @@ ul.properties {
     border-radius: @gutter-xs;
 }
 
+.border-radius-xxs {
+    border-radius: @gutter-xxs;
+}
+
 .resize-none {
     resize: none;
 }
@@ -2257,7 +2261,11 @@ ul.properties {
 }
 
 .text-shard {
-    color: @color-4-1;
+    color: @sharding-color;
+}
+
+.panel-bg-1 {
+    background-color: var(--panel-bg-1);
 }
 
 @import "prism.less";
@@ -2322,7 +2330,3 @@ ul.properties {
 @import "pages/database-settings.less";
 @import "pages/databaseIDs.less";
 @import "pages/sharding.less";
-
-.text-shard {
-    color: @sharding-color;
-}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20734/Cluster-Dashboard-view-vs-Server-Dashboard-lack-of-online-total-dbs-count

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/0eeb76cf-084d-40dd-9550-6d8d6de6dd96)
