### PR TITLE
RavenDB-20735 Cluster nodes graph cut on /studio/index.html#admin/set…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
+++ b/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
@@ -42,6 +42,7 @@ class clusterGraph {
         this.height = container.innerHeight();
 
         this.initGraph(initialNodesCount);
+        this.addResizeListener();
     }
 
     private initialScale(initialNodesCount: number) {
@@ -70,7 +71,9 @@ class clusterGraph {
         this.svg = container.append("svg")
             .style({
                 width: this.width + "px",
-                height: this.height + "px"
+                height: this.height + "px",
+                display: "block",
+                position: "absolute"
             })
             .attr("viewBox", "0 0 " + this.width + " " + this.height)
             .call(this.zoom);
@@ -284,6 +287,25 @@ class clusterGraph {
         const radius = Math.max(clusterGraph.minDrawRadius, this.estimatedRadius(nodes.length));
         graphHelper.circleLayout(layoutableNodes, radius);
 
+    }
+
+    private updateSize() {
+        this.width = this.$container.innerWidth();
+        this.height = this.$container.innerHeight();
+    
+        this.svg.style("width", this.width + "px")
+          .style("height", this.height + "px")
+          .attr("viewBox", "0 0 " + this.width + " " + this.height);
+          
+        this.svg.select("rect")
+            .attr("width", this.width)
+            .attr("height", this.height);
+      }
+
+    private addResizeListener() {
+        window.addEventListener("resize", () => {
+          this.updateSize();
+        });
     }
 }
 

--- a/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
+++ b/src/Raven.Studio/typescript/models/database/cluster/clusterGraph.ts
@@ -4,6 +4,7 @@ import d3 = require("d3");
 import clusterNode = require("models/database/cluster/clusterNode");
 import graphHelper = require("common/helpers/graph/graphHelper");
 import icomoonHelpers from "common/helpers/view/icomoonHelpers";
+import _ from 'lodash';
 
 interface clusterNodeWithLayout extends clusterNode {
     x: number;
@@ -35,6 +36,7 @@ class clusterGraph {
     private edgesGroup: d3.Selection<void>;
     private nodes: d3.Selection<clusterNode>;
     private edges: d3.Selection<string>;
+    private resizeHandler: _.DebouncedFunc<() => void>;
 
     init(container: JQuery, initialNodesCount: number) {
         this.$container = container;
@@ -42,7 +44,13 @@ class clusterGraph {
         this.height = container.innerHeight();
 
         this.initGraph(initialNodesCount);
-        this.addResizeListener();
+        
+
+        this.resizeHandler = _.throttle(() => {
+            this.updateSize();
+        }, 200);
+        
+        window.addEventListener("resize", this.resizeHandler);
     }
 
     private initialScale(initialNodesCount: number) {
@@ -292,7 +300,7 @@ class clusterGraph {
     private updateSize() {
         this.width = this.$container.innerWidth();
         this.height = this.$container.innerHeight();
-    
+
         this.svg.style("width", this.width + "px")
           .style("height", this.height + "px")
           .attr("viewBox", "0 0 " + this.width + " " + this.height);
@@ -300,12 +308,10 @@ class clusterGraph {
         this.svg.select("rect")
             .attr("width", this.width)
             .attr("height", this.height);
-      }
+    }
 
-    private addResizeListener() {
-        window.addEventListener("resize", () => {
-          this.updateSize();
-        });
+    dispose() {
+        window.removeEventListener("resize", this.resizeHandler);
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/manage/cluster.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/cluster.ts
@@ -81,6 +81,11 @@ class cluster extends viewModelBase {
         this.addNotification(serverWideClient.watchReconnect(() => this.refresh()));
     }
 
+    deactivate():void {
+        super.deactivate();
+        this.graph.dispose();
+    }
+
     private initObservables() {
         this.canDeleteNodes = ko.pureComputed(() => this.topology().leader() && this.topology().nodes().length > 1);
         this.canAddNodes = ko.pureComputed(() => !!this.topology().leader() || this.topology().nodeTag() === "?");


### PR DESCRIPTION
…tings/cluster

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20735/Cluster-nodes-graph-cut-on-studio-index.htmladmin-settings-cluster

### Additional description

Added an event listener for resize

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
