### PR TITLE
RavenDB-20760 streaming query throws InvalidJson when doing MoveNext(…

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -305,6 +305,7 @@ namespace Raven.Client.Documents.Session.Operations
             private UnmanagedJsonParser _parser;
             private JsonOperationContext.MemoryBuffer _buffer;
             private bool _initialized;
+            private bool _done;
             private JsonOperationContext.MemoryBuffer.ReturnBuffer _returnBuffer;
             private readonly bool _isQueryStream;
             private readonly bool _isAsync;
@@ -355,6 +356,9 @@ namespace Raven.Client.Documents.Session.Operations
             {
                 AssertInitialized();
 
+                if (_done)
+                    return false;
+
                 CheckIfContextOrCacheNeedToBeRenewed();
 
                 _timeSeriesIt?.Dispose();
@@ -370,6 +374,7 @@ namespace Raven.Client.Documents.Session.Operations
                     if (_state.CurrentTokenType != JsonParserToken.EndObject)
                         UnmanagedJsonParserHelper.ThrowInvalidJson(_peepingTomStream);
 
+                    _done = true;
                     return false;
                 }
 
@@ -397,6 +402,9 @@ namespace Raven.Client.Documents.Session.Operations
             {
                 AssertInitialized();
 
+                if (_done)
+                    return false;
+
                 CheckIfContextOrCacheNeedToBeRenewed();
 
                 if (_timeSeriesIt != null)
@@ -413,6 +421,7 @@ namespace Raven.Client.Documents.Session.Operations
                     if (_state.CurrentTokenType != JsonParserToken.EndObject)
                         UnmanagedJsonParserHelper.ThrowInvalidJson(_peepingTomStream);
 
+                    _done = true;
                     return false;
                 }
 
@@ -449,6 +458,7 @@ namespace Raven.Client.Documents.Session.Operations
                 try
                 {
                     _initialized = true;
+                    _done = false;
 
                     _state = new JsonParserState();
                     _parser = new UnmanagedJsonParser(_session.Context, _state, "stream contents");
@@ -490,6 +500,7 @@ namespace Raven.Client.Documents.Session.Operations
                 try
                 {
                     _initialized = true;
+                    _done = false;
 
                     _state = new JsonParserState();
                     _parser = new UnmanagedJsonParser(_session.Context, _state, "stream contents");

--- a/test/SlowTests/Issues/RavenDB_20760.cs
+++ b/test/SlowTests/Issues/RavenDB_20760.cs
@@ -1,0 +1,57 @@
+﻿
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20760 : RavenTestBase
+{
+    public RavenDB_20760(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task StreamingQueryMoveNextBeyondDocAmount(Options options)
+    {
+        using (var documentStore = GetDocumentStore(options))
+        {
+            using (var session = documentStore.OpenSession())
+            {
+                for (int i = 0; i < 5; i++)
+                    session.Store(new User());
+
+                session.SaveChanges();
+            }
+
+            using (var session = documentStore.OpenSession())
+            {
+                var q = session.Query<User>().OrderBy(x => x.Name);
+                var enumerator = session.Advanced.Stream(q);
+
+                while (enumerator.MoveNext())
+                {
+                }
+
+                Assert.False(enumerator.MoveNext());
+            }
+
+            using (var session = documentStore.OpenAsyncSession())
+            {
+                var q = session.Query<User>().OrderBy(x => x.Name);
+                var enumerator = await session.Advanced.StreamAsync(q);
+
+                while (await enumerator.MoveNextAsync())
+                {
+                }
+
+                Assert.False(await enumerator.MoveNextAsync());
+            }
+        }
+    }
+}


### PR DESCRIPTION
…) beyond docs amount

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20760

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
