### PR TITLE
RavenDB-20362 Corax- expose document score for projections.

### DIFF
--- a/src/Corax/Queries/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Comparers.cs
@@ -95,7 +95,7 @@ namespace Corax.Queries.SortingMatches;
                 // We get the boosting tree and go to check every document. 
                 BoostDocuments(match, batchResults, readScores);
             }
-                
+            
             // Note! readScores & indexes are aliased and same as batchTermIds
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             for (int i = 0; i < batchTermIds.Length; i++)
@@ -109,6 +109,10 @@ namespace Corax.Queries.SortingMatches;
             for (int i = 0; i < indexes.Length; i++)
             {
                 match._results.Add(batchResults[indexes[i]]);
+                if (match._scoringTable.Length > 0)
+                {
+                    match._scoringTable[i] = (float)batchTerms[indexes[i]].Double;
+                }
             }
         }
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -27,10 +27,9 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     private readonly OrderMetadata _orderMetadata;
     private readonly CancellationToken _cancellationToken;
     private readonly delegate*<ref SortingMatch<TInner>, Span<long>, int> _fillFunc;
-
+    private float[] _scoringTable;
     private readonly int _take;
     private const int NotStarted = -1;
-        
     private ByteStringContext<ByteStringMemoryCache>.InternalScope _entriesBufferScope;
 
     private NativeIntegersList _results;
@@ -45,7 +44,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         _cancellationToken = cancellationToken;
         _take = take;
         _results = new NativeIntegersList(searcher.Allocator);
-
+        _scoringTable =  Array.Empty<float>();
         TotalResults = NotStarted;
 
         if (_orderMetadata.HasBoost)
@@ -515,6 +514,11 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         bufScope.Dispose();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void SetScoreBuffer(float[] scores)
+    {
+        _scoringTable = scores;
+    }
 
     public long Count => _inner.Count;
 

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -124,6 +124,10 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             for (int i = 0; i < indexes.Length; i++)
             {
                 match._results.Add(batchResults[indexes[i]]);
+                if (match._scoringTable.Length > 0)
+                {
+                    match._scoringTable[i] = (float)batchTerms[indexes[i]].Double;
+                }
             }
         }
 

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
@@ -22,6 +22,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     private readonly OrderMetadata[] _orderMetadata;
     private readonly delegate*<ref SortingMultiMatch<TInner>, Span<long>, int> _fillFunc;
     private readonly IEntryComparer[] _nextComparers;
+    private float[] _scoringTable;
 
     private readonly int _take;
     private readonly CancellationToken _token;
@@ -41,7 +42,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         _take = take;
         _token = token;
         _results = new NativeIntegersList(searcher.Allocator);
-
+        _scoringTable = Array.Empty<float>();
         TotalResults = NotStarted;
         AssertNoScoreInnerComparer(orderMetadata);
         _fillFunc = SortBy(orderMetadata);
@@ -79,6 +80,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             return nextComparers;
         }
     }
+
+    public void SetScoreBuffer(float[] scoringTable) => _scoringTable = scoringTable;
 
     private void AssertNoScoreInnerComparer(in OrderMetadata[] orderMetadata)
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -80,7 +80,8 @@ internal static class CoraxQueryBuilder
             DynamicFields = HasDynamics
                 ? new Lazy<List<string>>(() => IndexSearcher.GetFields())
                 : null;
-            HasBoost = index.HasBoostedFields | query.Metadata.HasBoost;
+            HasBoost = index.HasBoostedFields || query.Metadata.HasBoost ||
+                       (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved && query.Metadata.OrderBy is [{OrderingType: OrderByFieldType.Score} _, ..]); // in case when we've implicit boosting we've build primitives with scoring enabled
             Allocator = allocator;
             IndexReadOperation = indexReadOperation;
         }

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -40,6 +40,8 @@ namespace Raven.Server.Documents.Queries.Results
 
         public ScoreDoc Score;
 
+        public float? CoraxScore;
+
         public IndexFieldsPersistence IndexFieldsPersistence;
 
         public Corax.IndexSearcher CoraxIndexSearcher;
@@ -56,14 +58,15 @@ namespace Raven.Server.Documents.Queries.Results
             IndexFieldsPersistence = null;
         }
 
-        public RetrieverInput(Corax.IndexSearcher searcher, IndexFieldsMapping knownFields, IndexEntryReader coraxEntry, string id, IndexFieldsPersistence indexFieldsPersistence)
+        public RetrieverInput(Corax.IndexSearcher searcher, IndexFieldsMapping knownFields, IndexEntryReader coraxEntry, string id, IndexFieldsPersistence indexFieldsPersistence, float? score = null)
         {
             CoraxEntry = coraxEntry;
             KnownFields = knownFields;
             DocumentId = id;
             IndexFieldsPersistence = indexFieldsPersistence;
             CoraxIndexSearcher = searcher;
-
+            CoraxScore = score;
+            
             State = null;
             Score = null;
             LuceneDocument = null;

--- a/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Queries.Results
                 {
                     var doc = DirectGet(ref retrieverInput, id, DocumentFields);
 
-                    FinishDocumentSetup(doc, retrieverInput.Score);
+                    FinishDocumentSetup(doc, ref retrieverInput);
                     return (doc, null);
                 }
             }

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -117,7 +117,7 @@ namespace Raven.Server.Documents.Queries.Results
             {
                 var doc = DirectGet(ref retrieverInput, null, DocumentFields.All);
 
-                FinishDocumentSetup(doc, retrieverInput.Score);
+                FinishDocumentSetup(doc, ref retrieverInput);
 
                 return (doc, null);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20362 

### Additional description

 Corax- expose document scoring for projections.

Exposed only when the query has boosting (explicit or implicit).

### Type of change


- New feature

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
