### PR TITLE
RavenDB-20746 `Abort query` button do nothing

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -930,13 +930,12 @@ class query extends shardViewModelBase {
     }
 
     killQuery() {
-        const db = this.activeDatabase();
         this.confirmationMessage("Abort the query", "Do you want to abort currently running query?")
             .done(result => {
                 if (result.can) {
                     this.showKillQueryButton(false);
                     if (this.spinners.isLoading()) {
-                        killQueryCommand.byClientQueryId(db, query.clientQueryId)
+                        killQueryCommand.byClientQueryId(this.db, query.clientQueryId)
                             .execute();
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20746/Abort-query-button-do-nothing

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
