### PR TITLE
RavenDB-20544 :  fix race between UpdateLicenseLimits and PutLicense that results in having wrong limits

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Commercial
                 _serverStore.Engine.CommandsVersionManager.OnClusterVersionChange += PutMyNodeInfoClusterVersionChange;
 
                 if (_serverStore.Engine.CommandsVersionManager.CurrentClusterMinimalVersion > 0)
-                    Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
+                    Task.Run(() => PutMyNodeInfoAsync()).IgnoreUnobservedExceptions();
             }
             catch (Exception e)
             {
@@ -161,15 +161,15 @@ namespace Raven.Server.Commercial
             if (args.PreviousClusterVersion != 0)
                 return;
 
-            Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
+            Task.Run(() => PutMyNodeInfoAsync()).IgnoreUnobservedExceptions();
         }
 
-        public async Task PutMyNodeInfoAsync()
+        public async Task PutMyNodeInfoAsync(int timeout = 0)
         {
             if (_serverStore.IsPassive())
                 return;
 
-            if (await _licenseLimitsSemaphore.WaitAsync(0) == false)
+            if (await _licenseLimitsSemaphore.WaitAsync(timeout) == false)
                 return;
 
             try

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1258,7 +1258,7 @@ namespace Raven.Server.ServerWide
                     ConcurrentBackupsCounter.ModifyMaxConcurrentBackups();
 
                     // we are not waiting here on purpose
-                    var t = LicenseManager.PutMyNodeInfoAsync().IgnoreUnobservedExceptions();
+                    _ = LicenseManager.PutMyNodeInfoAsync(timeout: (int)Engine.OperationTimeout.TotalMilliseconds).IgnoreUnobservedExceptions();
                     break;
 
                 case nameof(PutLicenseLimitsCommand):


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20544

### Additional description

Ensure that an `UpdateLicenseLimits` command will be executed after `PutLicense` command has completed, 
by waiting (with timeout) to enter the `_licenseLimitsSemaphore` in `PutMyNodeInfoAsync` (only when called after `PutLicense`, in all other paths we still don't wait to enter the semaphore)

These changes fix flaky sharded backup tests that failed on exceeding max number of concurrent backups (1)

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
