### PR TITLE
RavenDB-20753 Sharding - order by random with custom seed.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1061,7 +1061,7 @@ internal static class CoraxQueryBuilder
             if (field.OrderingType == OrderByFieldType.Random)
             {
                 var seed = field.Arguments.Length > 0 ? 
-                    field.Arguments[0].GetString(builderParameters.QueryParameters).GetHashCode() :
+                    (int)Hashing.XXHash32.CalculateRaw(field.Arguments[0].NameOrValue) :
                     Random.Shared.Next(); // use a random seed if none is provided  
                 sortArray[sortIndex++] = new OrderMetadata(seed);
                 continue;

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -10,7 +10,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Comparers;
 
-public class DocumentsComparer : IComparer<BlittableJsonReaderObject>
+public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
 {
     private readonly OrderByField[] _orderByFields;
     private readonly bool _extractFromData;
@@ -25,8 +25,8 @@ public class DocumentsComparer : IComparer<BlittableJsonReaderObject>
     {
         for (var i = 0; i < _orderByFields.Length; i++)
         {
-            var orderByField = _orderByFields[i];
-            var cmp = CompareField(orderByField, i, x, y);
+            ref var orderByField = ref _orderByFields[i];
+            var cmp = CompareField(in orderByField, i, x, y);
             if (cmp != 0)
                 return orderByField.Ascending ? cmp : -cmp;
         }
@@ -34,7 +34,7 @@ public class DocumentsComparer : IComparer<BlittableJsonReaderObject>
         return 0;
     }
 
-    private int CompareField(OrderByField order, int index, BlittableJsonReaderObject x, BlittableJsonReaderObject y)
+    private int CompareField(in OrderByField order, int index, BlittableJsonReaderObject x, BlittableJsonReaderObject y)
     {
         switch (order.OrderingType)
         {

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -35,8 +35,8 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
                 continue;
 
             ref var randomField = ref orderByFields[idX];
-            randoms[randomIdx++] = randomField.Arguments is {Length: > 0} 
-                ? new Random(randomField.Arguments[0].NameOrValue.GetHashCode()) 
+            randoms[randomIdx++] = randomField.Arguments is {Length: > 0}
+                ? new Random((int)Sparrow.Hashing.XXHash32.CalculateRaw(randomField.Arguments[0].NameOrValue)) 
                 :  Random.Shared;
         }
         return randoms;

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -750,7 +750,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             return ConstantComparer.Instance;
 
         if (query.Metadata.OrderBy?.Length > 0)
-            return new DocumentsComparer(query.Metadata.OrderBy, extractFromData: queryType == QueryType.IndexEntries);
+            return new DocumentsComparer(query.Metadata.OrderBy, extractFromData: queryType == QueryType.IndexEntries, query.Metadata.HasOrderByRandom);
 
         if (queryType == QueryType.IndexEntries)
             return ConstantComparer.Instance;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -93,7 +93,7 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
             if (orderByFields?.Length > 0)
             {
                 // apply ordering after the re-reduce of a map-reduce index
-                result.Results.Sort(new DocumentsComparer(orderByFields, extractFromData: true));
+                result.Results.Sort(new DocumentsComparer(orderByFields, extractFromData: true, Query.Metadata.HasOrderByRandom));
             }
         }
     }

--- a/test/SlowTests/MailingList/Random.cs
+++ b/test/SlowTests/MailingList/Random.cs
@@ -6,12 +6,8 @@ using Xunit.Abstractions;
 
 namespace SlowTests.MailingList
 {
-    public class Random : RavenTestBase
+    public class Random(ITestOutputHelper output) : RavenTestBase(output)
     {
-        public Random(ITestOutputHelper output) : base(output)
-        {
-        }
-
         private class User
         {
             public string Id { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20753 

### Additional description

- We've to use a custom seed in sharded comparer in a case when a user pushes it in a query in order to get consistent results.
- Pass `OrderByField` as `read-only reference` instead of copying the whole struct each time.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
