### PR TITLE
RavenDB-20732 Avoid leaking change vectors between shards

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -335,8 +335,7 @@ namespace Raven.Server.Documents
                 var data = new BlittableJsonReaderObject(copyTvr.Read((int)DocumentsTable.Data, out int size), size, context);
                 var attachments = GetAttachmentsMetadataForDocument(context, lowerDocumentId);
 
-                var flags = TableValueToFlags((int)DocumentsTable.Flags, ref copyTvr);
-                flags = flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
+                var flags = DocumentFlags.None; 
 
                 data.Modifications = new DynamicJsonValue(data);
                 if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -336,10 +336,11 @@ namespace Raven.Server.Documents.ETL
                 foreach (var item in items)
                 {
                     extractedItemsSize++;
+                    var changeVector = context.GetChangeVector(item.ChangeVector);
 
                     if (item.Filtered)
                     {
-                        stats.RecordChangeVector(item.ChangeVector);
+                        stats.RecordChangeVector(context, changeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
 
                         item.Dispose();
@@ -353,7 +354,7 @@ namespace Raven.Server.Documents.ETL
 
                     if (AlreadyLoadedByDifferentNode(item, state))
                     {
-                        stats.RecordChangeVector(item.ChangeVector);
+                        stats.RecordChangeVector(context, changeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
 
                         item.Dispose();
@@ -375,7 +376,7 @@ namespace Raven.Server.Documents.ETL
                         CollectionName.IsHiLoCollection(item.CollectionFromMetadata) &&
                         ShouldFilterOutHiLoDocument())
                     {
-                        stats.RecordChangeVector(item.ChangeVector);
+                        stats.RecordChangeVector(context, changeVector);
                         stats.RecordLastFilteredOutEtag(item.Etag, item.Type);
 
                         item.Dispose();
@@ -393,7 +394,7 @@ namespace Raven.Server.Documents.ETL
 
                             stats.RecordTransformedItem(item.Type, item.IsDelete);
                             stats.RecordLastTransformedEtag(item.Etag, item.Type);
-                            stats.RecordChangeVector(item.ChangeVector);
+                            stats.RecordChangeVector(context, changeVector);
 
                             batchSize++;
 

--- a/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
@@ -173,7 +173,7 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public void RecordChangeVector(IChangeVectorOperationContext context, ChangeVector changeVector)
         {
-            _stats.ChangeVector = changeVector.MergeOrderWith(context.GetChangeVector(_stats.ChangeVector), context);
+            _stats.ChangeVector = changeVector.Order.MergeWith(context.GetChangeVector(_stats.ChangeVector), context);
         }
 
         public void RecordLastLoadedEtag(long etag)

--- a/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlStatsScope.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.ETL.Providers.OLAP;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Stats;
 using Sparrow;
@@ -170,9 +171,9 @@ namespace Raven.Server.Documents.ETL.Stats
                 _stats.LastTransformedEtags[type] = etag;
         }
 
-        public void RecordChangeVector(string changeVector)
+        public void RecordChangeVector(IChangeVectorOperationContext context, ChangeVector changeVector)
         {
-            _stats.ChangeVector = ChangeVectorUtils.MergeVectors(_stats.ChangeVector, changeVector);
+            _stats.ChangeVector = changeVector.MergeOrderWith(context.GetChangeVector(_stats.ChangeVector), context);
         }
 
         public void RecordLastLoadedEtag(long etag)

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
@@ -125,7 +125,7 @@ public class ClusterTransactionMergedCommand : TransactionMergedCommand
                             {
                                 using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
                                 {
-                                    var deleteResult = Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, null, changeVector: changeVector,
+                                    var deleteResult = Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, null, changeVector: context.GetChangeVector(changeVector),
                                         documentFlags: DocumentFlags.FromClusterTransaction);
                                     AddDeleteResult(deleteResult, cmd.Id);
                                 }

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
@@ -126,7 +126,7 @@ public class ClusterTransactionMergedCommand : TransactionMergedCommand
                                 using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
                                 {
                                     var deleteResult = Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, null, changeVector: context.GetChangeVector(changeVector),
-                                        documentFlags: DocumentFlags.FromClusterTransaction);
+                                        newFlags: DocumentFlags.FromClusterTransaction);
                                     AddDeleteResult(deleteResult, cmd.Id);
                                 }
                             }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/DeleteReduceOutputDocumentsCommand.cs
@@ -42,14 +42,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 
             if (_originalPatternForReduceOutputReferences == null)
             {
-                deleteResults = _database.DocumentsStorage.DeleteDocumentsStartingWith(context, _documentsPrefix, _batchSize);
+                deleteResults = _database.DocumentsStorage.DeleteDocumentsStartingWith(context, _documentsPrefix, _batchSize, flags: DocumentFlags.Artificial | DocumentFlags.FromIndex);
             }
             else
             {
                 idsToDeleteByReferenceDocumentId = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
                 deleteResults = _database.DocumentsStorage.DeleteDocumentsStartingWith(context, _documentsPrefix, _batchSize,
-                    doc => RetrieveReferenceDocumentsToCleanup(doc, idsToDeleteByReferenceDocumentId));
+                    doc => RetrieveReferenceDocumentsToCleanup(doc, idsToDeleteByReferenceDocumentId), flags: DocumentFlags.Artificial | DocumentFlags.FromIndex);
             }
 
             DeleteCount = deleteResults.Count;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
@@ -292,7 +292,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
                         continue;
                     }
 
-                    _database.DocumentsStorage.Delete(context, id, null);
+                    _database.DocumentsStorage.Delete(context, id, flags: DocumentFlags.Artificial | DocumentFlags.FromIndex);
                     _outputToCollectionReferences?.Delete(id);
                 }
                 else

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
@@ -315,7 +315,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
                         }
                     }
 
-                    _database.DocumentsStorage.DeleteDocumentsStartingWith(context, prefix);
+                    _database.DocumentsStorage.DeleteDocumentsStartingWith(context, prefix, flags: DocumentFlags.Artificial | DocumentFlags.FromIndex);
                 }
             }
 

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -14,6 +14,7 @@ namespace Raven.Server.Documents.Replication
         public static readonly int RaftInt = RaftTag.ParseNodeTag();
         public static readonly int TrxnInt = TrxnTag.ParseNodeTag();
         public static readonly int SinkInt = SinkTag.ParseNodeTag();
+        public static readonly int MoveInt = MoveTag.ParseNodeTag();
         public static readonly int DbBase64IdSize = 23;
 
         private enum State

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.Replication
@@ -176,6 +177,9 @@ namespace Raven.Server.Documents.Replication
         {
             if (string.IsNullOrEmpty(changeVector))
                 return;
+
+            if (changeVector.Contains('|'))
+                Debug.Assert(false, $"Cannot contain pipe {changeVector}");
 
             var start = 0;
             var current = 0;

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         internal CancellationToken CancellationToken => _cts.Token;
         public bool IsConnectionDisposed => _connectionDisposed.IsSet;
         public ReplicationNode Destination { get; }
-        public string LastSentChangeVectorDuringHeartbeat;
+        public string LastSentChangeVector;
         public string LastAcceptedChangeVector { get; set; }
         public long LastHeartbeatTicks;
         public ReplicationNode Node => Destination;
@@ -555,7 +555,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     };
                     if (changeVector != null)
                     {
-                        LastSentChangeVectorDuringHeartbeat = changeVector;
+                        LastSentChangeVector = changeVector;
                         heartbeat[nameof(ReplicationMessageHeader.DatabaseChangeVector)] = changeVector;
                     }
                     context.Write(writer, heartbeat);

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     TaskId = _taskId.Value,
                     NodeTag = _parent._server.NodeTag,
                     LastSentEtag = _lastSentDocumentEtag,
-                    SourceChangeVector = LastSentChangeVectorDuringHeartbeat,
+                    SourceChangeVector = LastSentChangeVector,
                     DestinationChangeVector = LastAcceptedChangeVector
                 }
             };

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -128,7 +128,7 @@ namespace Raven.Server.Documents.Replication
                     foreach (var external in externals)
                     {
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
-                        var myEtag = ChangeVectorUtils.GetEtagById(state.DestinationChangeVector, Database.DbBase64Id);
+                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
                     }
                 }

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -311,7 +311,7 @@ namespace Raven.Server.Documents.Replication
                 using (Slice.From(context.Allocator, resolved.LowerId, out var lowerId))
                 {
                     _database.DocumentsStorage.Delete(context, lowerId, resolved.Id, null, null, changeVector, new CollectionName(resolved.Collection),
-                        documentFlags: resolved.Flags | DocumentFlags.Resolved | DocumentFlags.HasRevisions, nonPersistentFlags: NonPersistentDocumentFlags.FromResolver | NonPersistentDocumentFlags.Resolved);
+                        newFlags: resolved.Flags | DocumentFlags.Resolved | DocumentFlags.HasRevisions, nonPersistentFlags: NonPersistentDocumentFlags.FromResolver | NonPersistentDocumentFlags.Resolved);
                     return;
                 }
             }
@@ -433,7 +433,7 @@ namespace Raven.Server.Documents.Replication
 
                 updatedConflict.Doc = resolved;
                 updatedConflict.Collection = collection;
-                updatedConflict.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
+                updatedConflict.ChangeVector = ChangeVectorUtils.MergeVectors(context, conflicts.Select(c => context.GetChangeVector(c.ChangeVector)));
                 resolvedConflict = updatedConflict;
 
                 return true;
@@ -475,7 +475,7 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            latestDoc.ChangeVector = ChangeVectorUtils.MergeVectors(conflicts.Select(c => c.ChangeVector).ToList());
+            latestDoc.ChangeVector = ChangeVectorUtils.MergeVectors(context, conflicts.Select(c => context.GetChangeVector(c.ChangeVector)));
 
             return latestDoc;
         }

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -148,7 +148,7 @@ namespace Raven.Server.Documents.Replication
 
                             if (solver?.ResolveToLatest == true)
                             {
-                                resolved = ResolveToLatest(conflicts);
+                                resolved = ResolveToLatest(context, conflicts);
                                 resolved.Flags = resolved.Flags.Strip(DocumentFlags.FromReplication);
                                 resolvedConflicts.Add((resolved, maxConflictEtag, ResolvedToLatest: true));
 
@@ -457,11 +457,11 @@ namespace Raven.Server.Documents.Replication
             return false;
         }
 
-        public DocumentConflict ResolveToLatest(List<DocumentConflict> conflicts)
+        public DocumentConflict ResolveToLatest(DocumentsOperationContext context, List<DocumentConflict> conflicts)
         {
             // we have to sort this here because we need to ensure that all the nodes are always
             // arrive to the same conclusion, regardless of what time they go it
-            conflicts.Sort((x, y) => string.Compare(x.ChangeVector, y.ChangeVector, StringComparison.Ordinal));
+            conflicts.Sort((x, y) => ConflictManager.Compare(x, y, context));
 
             var latestDoc = conflicts[0];
             var latestTime = latestDoc.LastModified.Ticks;

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -114,6 +114,8 @@ namespace Raven.Server.Documents.Replication.Senders
                     // filtering a lot of documents, because we need to let the other side know about this, and 
                     // at the same time, we need to send a heartbeat to keep the tcp connection alive
                     _lastEtag = _parent._lastSentDocumentEtag;
+                    ChangeVector _mergedChangeVector = documentsContext.GetChangeVector(null);
+                    ChangeVector _itemChangeVector = documentsContext.GetChangeVector(null);
 
                     var lastEtagFromDestinationChangeVector = ChangeVectorUtils.GetEtagById(_parent.LastAcceptedChangeVector, _parent._database.DbBase64Id);
                     if (lastEtagFromDestinationChangeVector > _lastEtag)
@@ -193,6 +195,8 @@ namespace Raven.Server.Documents.Replication.Senders
                             }
 
                             _lastEtag = item.Etag;
+                            _itemChangeVector.Renew(item.ChangeVector, throwOnRecursion: false, documentsContext);
+                            _mergedChangeVector = _mergedChangeVector.MergeOrderWith(_itemChangeVector, documentsContext);
 
                             if (AddReplicationItemToBatch(documentsContext, item, _stats.Storage, state, skippedReplicationItemsInfo) == false)
                             {
@@ -227,6 +231,8 @@ namespace Raven.Server.Documents.Replication.Senders
 
                         Log.Info(msg);
                     }
+
+                    _parent.LastSentChangeVector = _mergedChangeVector;
 
                     if (_orderedReplicaItems.Count == 0)
                     {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1625,7 +1625,7 @@ namespace Raven.Server.Documents.Revisions
                         {
                             var etag = documentsStorage.GenerateNextEtag();
                             var changeVector = documentsStorage.ConflictsStorage.GetMergedConflictChangeVectorsAndDeleteConflicts(context, lowerId, etag);
-                            documentsStorage.Delete(context, lowerId, document.Id, null, changeVector: changeVector, documentFlags: DocumentFlags.Reverted);
+                            documentsStorage.Delete(context, lowerId, document.Id, null, changeVector: context.GetChangeVector(changeVector), documentFlags: DocumentFlags.Reverted);
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -474,7 +474,7 @@ namespace Raven.Server.Documents.TimeSeries
                 return;
 
             var data = doc.Data;
-            var flags = doc.Flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
+            var flags = DocumentFlags.None;
 
             BlittableJsonReaderArray tsNames = null;
             if (doc.TryGetMetadata(out var metadata))
@@ -506,10 +506,10 @@ namespace Raven.Server.Documents.TimeSeries
             if (tsNamesList.Count == 0)
             {
                 metadata.Modifications.Remove(Constants.Documents.Metadata.TimeSeries);
-                flags = flags.Strip(DocumentFlags.HasTimeSeries);
             }
             else
             {
+                flags = DocumentFlags.HasTimeSeries;
                 metadata.Modifications[Constants.Documents.Metadata.TimeSeries] = tsNamesList;
             }
 

--- a/src/Raven.Server/ServerWide/Context/IChangeVectorOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/IChangeVectorOperationContext.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Server.Utils;
+﻿using System.Collections.Generic;
+using Raven.Server.Utils;
 
 namespace Raven.Server.ServerWide.Context;
 
@@ -7,4 +8,18 @@ public interface IChangeVectorOperationContext
     ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion = false);
 
     ChangeVector GetChangeVector(string version, string order);
+}
+
+// FOR TESTING ONLY
+public class NoChangeVectorContext : IChangeVectorOperationContext
+{
+    public static NoChangeVectorContext Instance = new NoChangeVectorContext();
+
+    public ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion = false) => new ChangeVector(changeVector, throwOnRecursion, this);
+
+    public ChangeVector GetChangeVector(string version, string order)
+    {
+        return new ChangeVector(new ChangeVector(version, throwOnRecursion: true, this), 
+            new ChangeVector(version, throwOnRecursion: true, this));
+    }
 }

--- a/src/Raven.Server/ServerWide/Context/IChangeVectorOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/IChangeVectorOperationContext.cs
@@ -9,17 +9,3 @@ public interface IChangeVectorOperationContext
 
     ChangeVector GetChangeVector(string version, string order);
 }
-
-// FOR TESTING ONLY
-public class NoChangeVectorContext : IChangeVectorOperationContext
-{
-    public static NoChangeVectorContext Instance = new NoChangeVectorContext();
-
-    public ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion = false) => new ChangeVector(changeVector, throwOnRecursion, this);
-
-    public ChangeVector GetChangeVector(string version, string order)
-    {
-        return new ChangeVector(new ChangeVector(version, throwOnRecursion: true, this), 
-            new ChangeVector(version, throwOnRecursion: true, this));
-    }
-}

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -204,7 +204,9 @@ namespace Raven.Server.ServerWide.Context
             }
         }
 
-        public ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion = false)
+        public ChangeVector GetChangeVector(string changeVector) => GetChangeVector(changeVector, throwOnRecursion: false);
+
+        public ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion)
         {
             ChangeVector allocatedChangeVector;
             if (_numberOfAllocatedChangeVectors < _allocatedChangeVectors.Count)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -601,7 +601,7 @@ namespace Raven.Server.Smuggler.Documents
                             switch (tombstone.Type)
                             {
                                 case Tombstone.TombstoneType.Document:
-                                    _database.DocumentsStorage.Delete(context, key, tombstone.LowerId, null, tombstone.LastModified.Ticks, context.GetChangeVector(tombstone.ChangeVector), new CollectionName(tombstone.Collection), documentFlags: tombstone.Flags);
+                                    _database.DocumentsStorage.Delete(context, key, tombstone.LowerId, null, tombstone.LastModified.Ticks, context.GetChangeVector(tombstone.ChangeVector), new CollectionName(tombstone.Collection), newFlags: tombstone.Flags);
                                     break;
 
                                 case Tombstone.TombstoneType.Attachment:

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -241,6 +241,9 @@ namespace Raven.Server.Utils
             if (string.IsNullOrEmpty(vectorBstring))
                 return vectorAstring;
 
+            if (vectorAstring.Contains('|') || vectorBstring.Contains('|'))
+                Debug.Assert(false, $"A: {vectorAstring}, B: {vectorBstring}");
+
             _mergeVectorBuffer ??= new List<ChangeVectorEntry>();
             _mergeVectorBuffer.Clear();
   
@@ -267,6 +270,17 @@ namespace Raven.Server.Utils
             }
 
             return _mergeVectorBuffer.SerializeVector();
+        }
+
+        public static ChangeVector MergeVectors(IChangeVectorOperationContext context, IEnumerable<ChangeVector> changeVectors)
+        {
+            var merged = context.GetChangeVector(null);
+            foreach (var changeVector in changeVectors)
+            {
+                merged = changeVector.MergeWith(merged, context);
+            }
+
+            return merged;
         }
 
         public static string MergeVectorsDown(List<string> changeVectors)

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -238,7 +238,7 @@ namespace InterversionTests
                     Assert.Equal(0, tombstonesCount);
                 }
 
-                await EnsureNoReplicationLoop(Server, ShardHelper.ToShardName(store.Database, newLocation));
+                await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store.Database);
             }
         }
 
@@ -304,7 +304,8 @@ namespace InterversionTests
                     Assert.Equal(4, revisionTombsCount); 
                     Assert.Equal(1, documentTombsCount);
                 }
-          
+
+                await Task.Delay(3000);
                 await ShardingCluster.EnsureNoReplicationLoopForSharding(Server, store.Database);
             }
         }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -3360,8 +3360,21 @@ namespace SlowTests.Client.Attachments
                         Assert.NotNull(attachment3);
 
                         var user = await session.LoadAsync<User>("users/1");
-                        Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
-                                    ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0), $"age: {user.Age}, hash: {attachment.Details.Hash}");
+                        switch (options.DatabaseMode)
+                        {
+                            case RavenDatabaseMode.Single:
+                                Assert.True(("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=" == attachment.Details.Hash && user.Age == 30) ||
+                                            ("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 0), $"age: {user.Age}, hash: {attachment.Details.Hash}");
+
+                                break;
+                            case RavenDatabaseMode.Sharded:
+                                //Assert.True("7hoAZadly0e2TKk4NC6+MrtVuqZblV3+UDW7/Iz9H5U=" == attachment.Details.Hash && user.Age == 30, $"age: {user.Age}, hash: {attachment.Details.Hash}");
+
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+
                         Assert.Equal("foo/bar", attachment.Details.Name);
 
                         var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();

--- a/test/SlowTests/Issues/RavenDB_12601.cs
+++ b/test/SlowTests/Issues/RavenDB_12601.cs
@@ -83,10 +83,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Change_vector_of_cluster_tx_updated_correctly_in_cluster()
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task Change_vector_of_cluster_tx_updated_correctly_in_cluster(Options options)
         {
-            var (source, destination) = await CreateDuoCluster();
+            var (source, destination) = await CreateDuoCluster(options);
 
             using (source)
             using (destination)

--- a/test/SlowTests/MailingList/Random.cs
+++ b/test/SlowTests/MailingList/Random.cs
@@ -6,8 +6,12 @@ using Xunit.Abstractions;
 
 namespace SlowTests.MailingList
 {
-    public class Random(ITestOutputHelper output) : RavenTestBase(output)
+    public class Random : RavenTestBase
     {
+        public Random(ITestOutputHelper output) : base(output)
+        {
+        }
+
         private class User
         {
             public string Id { get; set; }

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -270,7 +270,7 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenTheory(RavenTestCategory.Replication)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public async Task DatabaseChangeVectorShouldBeIdentical(Options options)
         {
             var modifyRecord = options.ModifyDatabaseRecord;

--- a/test/SlowTests/Server/Replication/ReplicationDocuments.cs
+++ b/test/SlowTests/Server/Replication/ReplicationDocuments.cs
@@ -107,8 +107,9 @@ namespace SlowTests.Server.Replication
 
                     var conflicts = destination.Commands().GetConflictsFor("docs/1");
                     Assert.Equal(2, conflicts.Length);
-                    var cv1 = conflicts[0].ChangeVector.ToChangeVector();
-                    var cv2 = conflicts[1].ChangeVector.ToChangeVector();
+
+                    var cv1 = conflicts[0].ChangeVector.ToVersion().AsString().ToChangeVector();
+                    var cv2 = conflicts[1].ChangeVector.ToVersion().AsString().ToChangeVector();
                     Assert.NotEqual(cv1[0].DbId, cv2[0].DbId);
                     Assert.Equal(1, cv1[0].Etag);
                     Assert.Equal(1, cv2[0].Etag);
@@ -140,8 +141,8 @@ namespace SlowTests.Server.Replication
 
                     conflicts = destination.Commands().GetConflictsFor("docs/1");
                     Assert.Equal(2, conflicts.Length);
-                    var cv1 = conflicts[0].ChangeVector.ToChangeVector();
-                    var cv2 = conflicts[1].ChangeVector.ToChangeVector();
+                    var cv1 = conflicts[0].ChangeVector.ToVersion().AsString().ToChangeVector();
+                    var cv2 = conflicts[1].ChangeVector.ToVersion().AsString().ToChangeVector();
                     Assert.NotEqual(cv1[0].DbId, cv2[0].DbId);
                     Assert.Equal(1, cv1[0].Etag);
                     Assert.Equal(1, cv2[0].Etag);

--- a/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
+++ b/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task Can_replicate_index(Options options)
         {
-            var (source, destination) = await CreateDuoCluster(options: options);
+            var (source, destination) = await CreateDuoCluster(options);
 
             using (source)
             using (destination)
@@ -100,7 +100,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task Can_replicate_multiple_indexes(Options options)
         {
-            var (source, destination) = await CreateDuoCluster(options: options);
+            var (source, destination) = await CreateDuoCluster(options);
 
             using (source)
             using (destination)
@@ -110,8 +110,6 @@ namespace SlowTests.Server.Replication
 
                 var userByName = new UserByNameIndex();
                 userByName.Execute(source);
-
-                await SetupReplicationAsync(source, destination);
 
                 var sw = Stopwatch.StartNew();
                 var destIndexNames = new string[0];
@@ -130,7 +128,7 @@ namespace SlowTests.Server.Replication
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task Can_replicate_multiple_indexes_and_multiple_transformers(Options options)
         {
-            var (source, destination) = await CreateDuoCluster(options: options);
+            var (source, destination) = await CreateDuoCluster(options);
 
             using (source)
             using (destination)

--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -378,7 +378,7 @@ namespace SlowTests.Sharding.Replication
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Sharding)]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
         public async Task ExternalReplicationWithRevisionTombstones_NonShardedToNonSharded()
         {
             using (var store1 = GetDocumentStore())

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -32,6 +32,7 @@ using Xunit;
 using Raven.Server.Documents;
 using System.Text;
 using Newtonsoft.Json;
+using Raven.Client.Util;
 using Tests.Infrastructure;
 
 namespace FastTests
@@ -139,7 +140,7 @@ namespace FastTests
                 predicate ??= (n, statistics) => statistics.LoadSuccesses > 0;
                 var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
                 return record.IsSharded
-                    ? _parent.Sharding.Etl.WaitForEtl(store, predicate, numOfProcessesToWaitFor)
+                    ? AsyncHelpers.RunSync(() => _parent.Sharding.Etl.WaitForEtlAsync(store, predicate, numOfProcessesToWaitFor))
                     : WaitForEtl(store, predicate);
             }
 
@@ -170,7 +171,7 @@ namespace FastTests
 
             public async Task<(string, string, EtlProcessStatistics)> WaitForEtlAsync(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate, TimeSpan timeout)
             {
-                var database = _parent.GetDatabase(store.Database).Result;
+                var database = await _parent.GetDatabase(store.Database);
 
                 var taskCompletionSource = new TaskCompletionSource<(string, string, EtlProcessStatistics)>();
 

--- a/test/Tests.Infrastructure/RavenTestBase.ReshardingTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ReshardingTestBase.cs
@@ -46,7 +46,7 @@ public partial class RavenTestBase
 
             using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, shardNumber)))
             {
-                Assert.True(await session.Advanced.ExistsAsync(id));
+                Assert.True(await session.Advanced.ExistsAsync(id), "The document doesn't exists on the source");
             }
 
             foreach (var server in servers)

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -236,7 +236,7 @@ public partial class RavenTestBase
         public async IAsyncEnumerable<ShardedDocumentDatabase> GetShardsDocumentDatabaseInstancesFor(string database, List<RavenServer> servers = null)
         {
             servers ??= _parent.GetServers();
-            foreach (var server in servers)
+            foreach (var server in servers.Where(s => s.Disposed == false))
             {
                 foreach (var task in server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(database))
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -287,12 +287,19 @@ namespace FastTests
                             if (CreatedStores.TryRemove(store) == false)
                                 return; // can happen if we are wrapping the store inside sharded one
 
+                            if (sharded && options.CreateDatabase)
+                            {
+                                if (Servers.Contains(serverToUse) || IsGlobalOrLocalServer(serverToUse))
+                                {
+                                    AsyncHelpers.RunSync(() => Sharding.EnsureNoDatabaseChangeVectorLeakAsync(store.Database));
+                                }
+                            }
+
                             DeleteDatabaseResult result = null;
-                            if (options.DeleteDatabaseOnDispose)
+                            if (options.DeleteDatabaseOnDispose && options.CreateDatabase)
                             {
                                 result = DeleteDatabase(options, serverToUse, name, hardDelete, store);
                             }
-
                             if (Servers.Contains(serverToUse) && result != null)
                             {
                                 var timeout = options.DeleteTimeout ?? TimeSpan.FromSeconds(Debugger.IsAttached ? 150 : 15);

--- a/test/Tests.Infrastructure/ReplicationTestBase.cs
+++ b/test/Tests.Infrastructure/ReplicationTestBase.cs
@@ -585,5 +585,18 @@ namespace Tests.Infrastructure
                 Result = result;
             }
         }
+
+        public class NoChangeVectorContext : IChangeVectorOperationContext
+        {
+            public static NoChangeVectorContext Instance = new NoChangeVectorContext();
+
+            public ChangeVector GetChangeVector(string changeVector, bool throwOnRecursion = false) => new ChangeVector(changeVector, throwOnRecursion, this);
+
+            public ChangeVector GetChangeVector(string version, string order)
+            {
+                return new ChangeVector(new ChangeVector(version, throwOnRecursion: true, this), 
+                    new ChangeVector(version, throwOnRecursion: true, this));
+            }
+        }
     }
 }

--- a/test/Tests.Infrastructure/ReplicationTestBase.cs
+++ b/test/Tests.Infrastructure/ReplicationTestBase.cs
@@ -41,6 +41,18 @@ namespace Tests.Infrastructure
         {
         }
 
+        public async Task EnsureNoReplicationLoopAsync(IDocumentStore store, RavenDatabaseMode mode)
+        {
+            using (var manager = await GetReplicationManagerAsync(store, store.Database, mode, new ReplicationManager.ReplicationOptions
+                   {
+                       BreakReplicationOnStart = false,
+                       MaxItemsCount = null
+                   }))
+            {
+                await manager.EnsureNoReplicationLoopAsync();
+            }
+        }
+
         public ValueTask<IReplicationManager> GetReplicationManagerAsync(IDocumentStore store, string databaseName, RavenDatabaseMode mode, bool breakReplication = false, List<RavenServer> servers = null)
         {
             var options = new ReplicationManager.ReplicationOptions

--- a/test/Tests.Infrastructure/ReplicationTestBase.cs
+++ b/test/Tests.Infrastructure/ReplicationTestBase.cs
@@ -24,6 +24,8 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Raven.Server.Web.System;
 using Sparrow.Json;
@@ -87,7 +89,10 @@ namespace Tests.Infrastructure
             {
                 var conflicts = store.Commands().GetConflictsFor(docId);
                 if (conflicts.Length >= count)
-                    return conflicts;
+                {
+                    // we need a stable order for testing purposes, should be good enough 
+                    return conflicts.OrderBy(x => x.LastModified).ToArray();
+                }
 
                 if (sw.ElapsedMilliseconds > timeout)
                 {

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -250,7 +250,7 @@ namespace FastTests
                 return Servers;
             }
 
-            return new List<RavenServer> { Server };
+            return new List<RavenServer> { _localServer ?? _globalServer ?? throw new ArgumentNullException(nameof(Server))};
         }
 
         private static void CheckServerLeak()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20732 

### Additional description

- For conflicts, attachment, revisions and deletion we had a code path that leaked change vectors
We must avoid this, so features like subscriptions/replication/ETL will not skip documents after resharding and failover

-  external replication rely on the source change vector for the tombstone cleansing

- Unify the code of change vector creation for Put & Delete of a document 

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change
- 
Checked interversion tests and they passed.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- No UI work is needed
