### PR TITLE
RavenDB-20776

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -659,7 +659,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var options = new DatabaseSmugglerOptionsServerSide
             {
                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
-                SkipRevisionCreation = true
+                SkipRevisionCreation = true,
+                DisableSubscriptions = RestoreFromConfiguration.DisableOngoingTasks
             };
 
             options.OperateOnTypes |= DatabaseItemType.LegacyDocumentDeletions;
@@ -921,7 +922,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             {
                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                 OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities | DatabaseItemType.Subscriptions,
-                SkipRevisionCreation = true
+                SkipRevisionCreation = true,
+                DisableSubscriptions = RestoreFromConfiguration.DisableOngoingTasks
             };
 
             var lastPath = GetSmugglerBackupPath(smugglerFile);

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Routing;
@@ -15,6 +14,8 @@ namespace Raven.Server.Smuggler.Documents.Data
         public AuthorizationStatus AuthorizationStatus { get; set; } = AuthorizationStatus.ValidUser;
 
         public bool SkipRevisionCreation { get; set; }
+
+        public bool DisableSubscriptions { get; set; } = true;
 
         public static DatabaseSmugglerOptionsServerSide Create(HttpContext httpContext)
         {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -1119,7 +1119,7 @@ namespace Raven.Server.Smuggler.Documents
         private async Task<SmugglerProgressBase.Counts> ProcessSubscriptionsAsync(SmugglerResult result)
         {
             result.Subscriptions.Start();
-
+            
             await using (var actions = _destination.Subscriptions())
             {
                 await foreach (var subscription in _source.GetSubscriptionsAsync())

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -179,7 +179,8 @@ class exportDatabaseModel {
             MaxStepsForTransformScript: 10 * 1000,
             ReadLegacyEtag: undefined,
             SkipRevisionCreation: undefined,
-            AuthorizationStatus: undefined
+            AuthorizationStatus: undefined,
+            DisableSubscriptions: undefined
         };
     }
     

--- a/test/SlowTests/Issues/RavenDB_20776.cs
+++ b/test/SlowTests/Issues/RavenDB_20776.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Smuggler;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20776 : RavenTestBase
+{
+    public RavenDB_20776(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Import_Should_Disable_Subscriptions()
+    {
+        var path = NewDataPath();
+        var exportPath = Path.Combine(path, "export.ravendbdump");
+        using (var store = GetDocumentStore())
+        {
+            await store.Subscriptions.CreateAsync<Company>();
+
+            var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportPath);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(1, result.Subscriptions.ReadCount);
+        }
+
+        using (var store = GetDocumentStore())
+        {
+            var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportPath);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(1, result.Subscriptions.ReadCount);
+
+            var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, int.MaxValue);
+
+            Assert.NotNull(subscriptions);
+            Assert.Equal(1, subscriptions.Count);
+
+            Assert.True(subscriptions[0].Disabled);
+
+            var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            {
+                BackupType = BackupType.Backup,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = path
+                }
+            }));
+
+            var backupResult = await backupOperation.WaitForCompletionAsync<BackupResult>(TimeSpan.FromSeconds(30));
+
+            using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+            {
+                BackupLocation = Path.Combine(path, backupResult.LocalBackup.BackupDirectory),
+                DatabaseName = $"{store.Database}_restore_1",
+                DisableOngoingTasks = false
+            }))
+            using (var restoreStore = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                ModifyDatabaseName = _ => $"{store.Database}_restore_1"
+            }))
+            {
+                subscriptions = await restoreStore.Subscriptions.GetSubscriptionsAsync(0, int.MaxValue);
+
+                Assert.NotNull(subscriptions);
+                Assert.Equal(1, subscriptions.Count);
+
+                Assert.False(subscriptions[0].Disabled);
+            }
+
+            using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+            {
+                BackupLocation = Path.Combine(path, backupResult.LocalBackup.BackupDirectory),
+                DatabaseName = $"{store.Database}_restore_2",
+                DisableOngoingTasks = true
+            }))
+            using (var restoreStore = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                ModifyDatabaseName = _ => $"{store.Database}_restore_2"
+            }))
+            {
+                subscriptions = await restoreStore.Subscriptions.GetSubscriptionsAsync(0, int.MaxValue);
+
+                Assert.NotNull(subscriptions);
+                Assert.Equal(1, subscriptions.Count);
+
+                Assert.True(subscriptions[0].Disabled);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1210,7 +1210,7 @@ namespace SlowTests.Smuggler
                 store.Subscriptions.Create<User>();
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                Backup.UpdateConfigAndRunBackup(Server, config, store);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
                 await ValidateSubscriptions(store);
 
@@ -1230,7 +1230,7 @@ namespace SlowTests.Smuggler
                     })
                     {
                         restoredStore.Initialize();
-                        var subscriptions = restoredStore.Subscriptions.GetSubscriptions(0, 10);
+                        var subscriptions = await restoredStore.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                         Assert.Equal(2, subscriptions.Count);
 
@@ -1257,9 +1257,9 @@ namespace SlowTests.Smuggler
                 var file = Directory.GetFiles(dir).First();
 
                 var op = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                op.WaitForCompletion(TimeSpan.FromSeconds(30));
+                await op.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                var subscriptions = store.Subscriptions.GetSubscriptions(0, 10);
+                var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                 Assert.Equal(2, subscriptions.Count);
 
@@ -1273,6 +1273,9 @@ namespace SlowTests.Smuggler
                 {
                     Assert.NotNull(subscription.SubscriptionName);
                     Assert.NotNull(subscription.Query);
+                    Assert.True(subscription.Disabled);
+
+                    await store.Subscriptions.EnableAsync(subscription.SubscriptionName);
                 }
 
                 await ValidateSubscriptions(store);
@@ -1474,7 +1477,7 @@ namespace SlowTests.Smuggler
 
         private async Task ValidateSubscriptions(DocumentStore restoredStore)
         {
-            var subscriptions = restoredStore.Subscriptions.GetSubscriptions(0, 10);
+            var subscriptions = await restoredStore.Subscriptions.GetSubscriptionsAsync(0, 10);
 
             int count = 0;
 


### PR DESCRIPTION
- import is disabling all ongoing tasks on import so subscriptions should also be disabled
- respecting disable ongoing tasks option on restore for subscriptions

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20776

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
