### PR TITLE
RavenDB-20742

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -799,7 +799,8 @@ namespace Raven.Server.ServerWide
                     databaseRecordJson = context.ReadObject(databaseRecordJson, dbKey);
                 }
 
-                UpdateValue(index, items, keyLowered, key, databaseRecordJson);
+                using (databaseRecordJson)
+                    UpdateValue(index, items, keyLowered, key, databaseRecordJson);
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -97,5 +97,12 @@ namespace Raven.Server.ServerWide.Commands
 
             return djv;
         }
+
+        public static string GetDatabaseNameFromJson(BlittableJsonReaderObject cmd)
+        {
+            string databaseName = null;
+            cmd?.TryGet(nameof(DatabaseName), out databaseName);
+            return databaseName;
+        }
     }
 }


### PR DESCRIPTION
- AddOrUpdateCompareExchangeBatchCommand should update database etag only once
- removed commands from UpdateEtagForBackup that are not processed by that method ever
- normalized name between SetIndexForBackup and UpdateEtagForBackup, both will use Index now
- IncrementClusterIdentityCommand, IncrementClusterIdentitiesBatchCommand, UpdateClusterIdentityCommand, UpdateClusterIdentityCommand used wrong database property name and set index for backup was not working at all for those commands

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20742

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
