### PR TITLE
RavenDB-16771: Unobserved exception in Subscriptions

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -480,12 +480,13 @@ namespace Raven.Client.Documents.Subscriptions
 
         private async Task ProcessSubscriptionAsync()
         {
+            Task notifiedSubscriber = Task.CompletedTask;
+
             try
             {
                 _processingCts.Token.ThrowIfCancellationRequested();
 
                 var contextPool = _store.GetRequestExecutor(_dbName).ContextPool;
-
                 using (contextPool.AllocateOperationContext(out JsonOperationContext context))
                 using (context.GetMemoryBuffer(out var buffer))
                 using (var tcpStream = await ConnectToServer(_processingCts.Token).ConfigureAwait(false))
@@ -507,8 +508,6 @@ namespace Raven.Client.Documents.Subscriptions
                         return;
 
                     OnEstablishedSubscriptionConnection?.Invoke();
-
-                    Task notifiedSubscriber = Task.CompletedTask;
 
                     var batch = new SubscriptionBatch<T>(_subscriptionLocalRequestExecutor, _store, _dbName, _logger);
 
@@ -609,6 +608,20 @@ namespace Raven.Client.Documents.Subscriptions
 
                 // otherwise this is thrown when shutting down,
                 // it isn't an error, so we don't need to treat it as such
+            }
+            finally
+            {
+                try
+                {
+                    if (notifiedSubscriber is { IsCompleted: false })
+                    {
+                        await notifiedSubscriber.WaitWithTimeout(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16771

### Additional description

try to await subscriber task when worker is errored or disposed


### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Not relevant

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
