### PR TITLE
RavenDB-20268: Support of streaming primitives.

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -20,6 +20,7 @@ using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Data.Lookups;
 using InvalidOperationException = System.InvalidOperationException;
+using static Voron.Data.CompactTrees.CompactTree;
 
 namespace Corax;
 
@@ -260,7 +261,13 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         return terms?.NumberOfEntries ?? 0;
     }
 
-    public bool TryGetTermsOfField(FieldMetadata field, out ExistsTermProvider existsTermProvider)
+    public bool TryGetTermsOfField(FieldMetadata field, out ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator> existsTermProvider)
+    {
+        return TryGetTermsOfField<Lookup<CompactKeyLookup>.ForwardIterator>(field, out existsTermProvider);
+    }
+
+    public bool TryGetTermsOfField<TLookupIterator>(FieldMetadata field, out ExistsTermProvider<TLookupIterator> existsTermProvider)
+        where TLookupIterator : struct, ILookupIterator
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
 
@@ -270,7 +277,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             return false;
         }
 
-        existsTermProvider = new ExistsTermProvider(this, terms, field);
+        existsTermProvider = new ExistsTermProvider<TLookupIterator>(this, terms, field);
         return true;
     }
 

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -244,14 +244,14 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         return disposable;
     }
     
-    public AllEntriesMatch AllEntries() => new AllEntriesMatch(this, _transaction);
-   public TermMatch EmptyMatch() => TermMatch.CreateEmpty(this, Allocator);
+    public AllEntriesMatch AllEntries() => new(this, _transaction);
+    public TermMatch EmptyMatch() => TermMatch.CreateEmpty(this, Allocator);
 
-   public long GetDictionaryIdFor(Slice field)
-   {
+    public long GetDictionaryIdFor(Slice field)
+    {
        var terms = _fieldsTree?.CompactTreeFor(field);
        return terms?.DictionaryId ?? -1;
-   }
+    }
    
     public long GetTermAmountInField(FieldMetadata field)
     {

--- a/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -1,8 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Corax.Mappings;
 using Corax.Queries;
 using Voron;
+using Voron.Data.CompactTrees;
 
 namespace Corax;
 
@@ -16,12 +17,12 @@ public partial class IndexSearcher
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch StartWithQuery(FieldMetadata field, string startWith, bool isNegated = false)
     {
-        return MultiTermMatchBuilder<StartWithTermProvider>(field, startWith, isNegated);
+        return MultiTermMatchBuilder<StartsWithTermProvider>(field, startWith, isNegated);
     }
     
     public MultiTermMatch StartWithQuery(FieldMetadata field, Slice startWith, bool isNegated = false)
     {
-        return MultiTermMatchBuilder<StartWithTermProvider>(field, startWith, isNegated);
+        return MultiTermMatchBuilder<StartsWithTermProvider>(field, startWith, isNegated);
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -4,6 +4,8 @@ using Corax.Mappings;
 using Corax.Queries;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
+using static Voron.Data.CompactTrees.CompactTree;
 
 namespace Corax;
 
@@ -12,52 +14,108 @@ public partial class IndexSearcher
     /// <summary>
     /// Test API only
     /// </summary>
-    public MultiTermMatch StartWithQuery(string field, string startWith, bool isNegated = false, bool hasBoost = false) => StartWithQuery(FieldMetadataBuilder(field, hasBoost: hasBoost), EncodeAndApplyAnalyzer(default, startWith));
+    public MultiTermMatch StartWithQuery(string field, string startWith, bool isNegated = false, bool hasBoost = false, bool forward = true) => StartWithQuery(FieldMetadataBuilder(field, hasBoost: hasBoost), EncodeAndApplyAnalyzer(default, startWith), isNegated, forward);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MultiTermMatch StartWithQuery(FieldMetadata field, string startWith, bool isNegated = false)
+    public MultiTermMatch StartWithQuery(FieldMetadata field, string startWith, bool isNegated = false, bool forward = true)
     {
-        return MultiTermMatchBuilder<StartsWithTermProvider>(field, startWith, isNegated);
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<StartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, isNegated);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, isNegated);
+        }
     }
     
-    public MultiTermMatch StartWithQuery(FieldMetadata field, Slice startWith, bool isNegated = false)
+    public MultiTermMatch StartWithQuery(FieldMetadata field, Slice startWith, bool isNegated = false, bool forward = true)
     {
-        return MultiTermMatchBuilder<StartsWithTermProvider>(field, startWith, isNegated);
-    }
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MultiTermMatch EndsWithQuery(FieldMetadata field, string endsWith, bool isNegated = false)
-    {
-        return MultiTermMatchBuilder<EndsWithTermProvider>(field, endsWith, isNegated);
-    }
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MultiTermMatch EndsWithQuery(FieldMetadata field, Slice endsWith, bool isNegated = false)
-    {
-        return MultiTermMatchBuilder<EndsWithTermProvider>(field, endsWith, isNegated);
-    }
-    
-    public MultiTermMatch ContainsQuery(FieldMetadata field, string containsTerm, bool isNegated = false) => ContainsQuery(field, EncodeAndApplyAnalyzer(field, containsTerm), isNegated);
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MultiTermMatch ContainsQuery(FieldMetadata field, Slice containsTerm, bool isNegated = false)
-    {
-        return MultiTermMatchBuilder<ContainsTermProvider>(field, containsTerm, isNegated);
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<StartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, startWith, isNegated);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, startWith, isNegated);
+        }
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MultiTermMatch ExistsQuery(FieldMetadata field)
+    public MultiTermMatch EndsWithQuery(FieldMetadata field, string endsWith, bool isNegated = false, bool forward = true)
     {
-        return MultiTermMatchBuilder<ExistsTermProvider>(field, default(Slice), false);
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<EndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, isNegated);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<EndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, isNegated);
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch EndsWithQuery(FieldMetadata field, Slice endsWith, bool isNegated = false, bool forward = true)
+    {
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<EndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, endsWith, isNegated);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<EndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, endsWith, isNegated);
+        }
+    }
+    
+    public MultiTermMatch ContainsQuery(FieldMetadata field, string containsTerm, bool isNegated = false, bool forward = true) => ContainsQuery(field, EncodeAndApplyAnalyzer(field, containsTerm), isNegated, forward);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ContainsQuery(FieldMetadata field, Slice containsTerm, bool isNegated = false, bool forward = true)
+    {
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<ContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, containsTerm, isNegated);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, containsTerm, isNegated);
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch ExistsQuery(FieldMetadata field, bool forward = true)
+    {
+        if (forward == true)
+        {
+            return MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, default(Slice), false);
+        }
+        else
+        {
+            return MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), false);
+        }
     }
 
-    public MultiTermMatch RegexQuery(FieldMetadata field, Regex regex)
+    public MultiTermMatch RegexQuery(FieldMetadata field, Regex regex, bool forward = true)
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
         if (terms == null)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
 
-        return MultiTermMatch.Create(new MultiTermMatch<RegexTermProvider>(field, _transaction.Allocator,
-            new RegexTermProvider(this, terms, field, regex)));
+        if (forward == true)
+        {
+            return MultiTermMatch.Create(
+                    new MultiTermMatch<RegexTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(
+                        field, _transaction.Allocator, 
+                        new RegexTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, terms, field, regex)
+                    ));
+        }
+        else
+        {
+            return MultiTermMatch.Create(
+                    new MultiTermMatch<RegexTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(
+                        field, _transaction.Allocator,
+                    new RegexTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, terms, field, regex)
+                    ));
+        }
     }
 }

--- a/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -45,15 +45,15 @@ public partial class IndexSearcher
     private MultiTermMatch MultiTermMatchBuilderBase<TTermProvider>(FieldMetadata field, CompactTree termTree, CompactKey term, bool isNegated)
         where TTermProvider : ITermProvider
     {
-        if (typeof(TTermProvider) == typeof(StartWithTermProvider))
+        if (typeof(TTermProvider) == typeof(StartsWithTermProvider))
         {
             return (isNegated) switch
             {
-                (false) => MultiTermMatch.Create(new MultiTermMatch<StartWithTermProvider>(field, _transaction.Allocator,
-                    new StartWithTermProvider(this, termTree, field, term))),
+                (false) => MultiTermMatch.Create(new MultiTermMatch<StartsWithTermProvider>(field, _transaction.Allocator,
+                    new StartsWithTermProvider(this, termTree, field, term))),
 
-                (true) => MultiTermMatch.Create(new MultiTermMatch<NotStartWithTermProvider>(field, _transaction.Allocator,
-                    new NotStartWithTermProvider(this, _transaction.Allocator, termTree, field, term))),
+                (true) => MultiTermMatch.Create(new MultiTermMatch<NotStartsWithTermProvider>(field, _transaction.Allocator,
+                    new NotStartsWithTermProvider(this, _transaction.Allocator, termTree, field, term))),
             };
         }
 

--- a/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/IndexSearcher/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -2,6 +2,8 @@ using Corax.Mappings;
 using Corax.Queries;
 using Voron;
 using Voron.Data.CompactTrees;
+using static Voron.Data.CompactTrees.CompactTree;
+using Voron.Data.Lookups;
 
 namespace Corax;
 
@@ -45,45 +47,100 @@ public partial class IndexSearcher
     private MultiTermMatch MultiTermMatchBuilderBase<TTermProvider>(FieldMetadata field, CompactTree termTree, CompactKey term, bool isNegated)
         where TTermProvider : ITermProvider
     {
-        if (typeof(TTermProvider) == typeof(StartsWithTermProvider))
+        if (typeof(TTermProvider) == typeof(StartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
         {
             return (isNegated) switch
             {
-                (false) => MultiTermMatch.Create(new MultiTermMatch<StartsWithTermProvider>(field, _transaction.Allocator,
-                    new StartsWithTermProvider(this, termTree, field, term))),
+                (false) => MultiTermMatch.Create(
+                    new MultiTermMatch<StartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(
+                        field, _transaction.Allocator,
+                        new StartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term))),
 
-                (true) => MultiTermMatch.Create(new MultiTermMatch<NotStartsWithTermProvider>(field, _transaction.Allocator,
-                    new NotStartsWithTermProvider(this, _transaction.Allocator, termTree, field, term))),
+                (true) => MultiTermMatch.Create(
+                    new MultiTermMatch<NotStartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(
+                        field, _transaction.Allocator,
+                        new NotStartsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term))),
             };
         }
 
-        if (typeof(TTermProvider) == typeof(EndsWithTermProvider))
+        if (typeof(TTermProvider) == typeof(StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
         {
             return (isNegated) switch
             {
-                (false) => MultiTermMatch.Create(new MultiTermMatch<EndsWithTermProvider>(field, _transaction.Allocator,
-                    new EndsWithTermProvider(this, termTree, field, term))),
+                (false) => MultiTermMatch.Create(
+                    new MultiTermMatch<StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(
+                        field, _transaction.Allocator,
+                        new StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term))),
 
-                (true) => MultiTermMatch.Create(new MultiTermMatch<NotEndsWithTermProvider>(field, _transaction.Allocator,
-                    new NotEndsWithTermProvider(this, termTree, field, term)))
+                (true) => MultiTermMatch.Create(
+                    new MultiTermMatch<NotStartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(
+                        field, _transaction.Allocator,
+                        new NotStartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term))),
             };
         }
 
-        if (typeof(TTermProvider) == typeof(ContainsTermProvider))
+        if (typeof(TTermProvider) == typeof(EndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
         {
             return (isNegated) switch
             {
-                (false) => MultiTermMatch.Create(new MultiTermMatch<ContainsTermProvider>(field, _transaction.Allocator,
-                    new ContainsTermProvider(this, termTree, field, term))),
+                (false) => MultiTermMatch.Create(new MultiTermMatch<EndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, _transaction.Allocator,
+                    new EndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term))),
 
-                (true) => MultiTermMatch.Create(new MultiTermMatch<NotContainsTermProvider>(field, _transaction.Allocator,
-                    new NotContainsTermProvider(this, termTree, field, term))),
+                (true) => MultiTermMatch.Create(new MultiTermMatch<NotEndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, _transaction.Allocator,
+                    new NotEndsWithTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term)))
             };
         }
 
-        if (typeof(TTermProvider) == typeof(ExistsTermProvider))
+        if (typeof(TTermProvider) == typeof(EndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
         {
-            return MultiTermMatch.Create(new MultiTermMatch<ExistsTermProvider>(field, _transaction.Allocator, new ExistsTermProvider(this, termTree, field)));
+            return (isNegated) switch
+            {
+                (false) => MultiTermMatch.Create(new MultiTermMatch<EndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, _transaction.Allocator,
+                    new EndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term))),
+
+                (true) => MultiTermMatch.Create(new MultiTermMatch<NotEndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, _transaction.Allocator,
+                    new NotEndsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term)))
+            };
+        }
+
+        if (typeof(TTermProvider) == typeof(ContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
+        {
+            return (isNegated) switch
+            {
+                (false) => MultiTermMatch.Create(new MultiTermMatch<ContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, _transaction.Allocator,
+                    new ContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term))),
+
+                (true) => MultiTermMatch.Create(new MultiTermMatch<NotContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, _transaction.Allocator,
+                    new NotContainsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term))),
+            };
+        }
+
+        if (typeof(TTermProvider) == typeof(ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
+        {
+            return (isNegated) switch
+            {
+                (false) => MultiTermMatch.Create(new MultiTermMatch<ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, _transaction.Allocator,
+                    new ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term))),
+
+                (true) => MultiTermMatch.Create(new MultiTermMatch<NotContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, _transaction.Allocator,
+                    new NotContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term))),
+            };
+        }
+
+        if (typeof(TTermProvider) == typeof(ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
+        {
+            return MultiTermMatch.Create(
+                new MultiTermMatch<ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(
+                    field, _transaction.Allocator, 
+                    new ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field)));
+        }
+
+        if (typeof(TTermProvider) == typeof(ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
+        {
+            return MultiTermMatch.Create(
+                new MultiTermMatch<ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(
+                    field, _transaction.Allocator, 
+                    new ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field)));
         }
 
         return MultiTermMatch.CreateEmpty(_transaction.Allocator);

--- a/src/Corax/Queries/AllEntriesMatch.cs
+++ b/src/Corax/Queries/AllEntriesMatch.cs
@@ -36,6 +36,7 @@ namespace Corax.Queries
         }
 
         public bool IsBoosting => false;
+        public bool IsOrdered => false;
         public long Count => _count;
         public QueryCountConfidence Confidence => QueryCountConfidence.High;
 

--- a/src/Corax/Queries/AndNotMatch.Erasure.cs
+++ b/src/Corax/Queries/AndNotMatch.Erasure.cs
@@ -18,6 +18,7 @@ namespace Corax.Queries
 
         public bool DoNotSortResults() => _inner.DoNotSortResults();
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
 
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -23,6 +23,8 @@ namespace Corax.Queries
         private readonly CancellationToken _token;
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
+
         public long Count => _totalResults;
 
         private readonly ByteStringContext _context;

--- a/src/Corax/Queries/BinaryMatch.Erasure.cs
+++ b/src/Corax/Queries/BinaryMatch.Erasure.cs
@@ -19,6 +19,7 @@ namespace Corax.Queries
 
         public bool DoNotSortResults() => _inner.DoNotSortResults();
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
 
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -21,9 +21,10 @@ namespace Corax.Queries
         private readonly long _totalResults;
         private readonly QueryCountConfidence _confidence;
         private readonly CancellationToken _token;
-
-
+        private readonly bool _isNotOr;
+        
         private bool _doNotSortResults;
+
 
         public bool DoNotSortResults()
         {
@@ -33,6 +34,8 @@ namespace Corax.Queries
 
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
+
+        public bool IsOrdered => _inner.IsOrdered && _isNotOr;
 
         public long Count => _totalResults;
 
@@ -46,7 +49,8 @@ namespace Corax.Queries
             delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> inspectionFunc,
             long totalResults,
             QueryCountConfidence confidence,
-            in CancellationToken token)
+            in CancellationToken token,
+            bool isOr = false)
         {
             _totalResults = totalResults;
 
@@ -59,6 +63,7 @@ namespace Corax.Queries
             _confidence = confidence;
             _token = token;
             _ctx = ctx;
+            _isNotOr = !isOr;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Queries/BoostingMatch.cs
+++ b/src/Corax/Queries/BoostingMatch.cs
@@ -50,6 +50,7 @@ namespace Corax.Queries
         public QueryCountConfidence Confidence => _inner.Confidence;
 
         public bool IsBoosting => true;
+        public bool IsOrdered => _inner.IsOrdered;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int AndWith(Span<long> buffer, int matches) => _inner.AndWith(buffer, matches);

--- a/src/Corax/Queries/MemoizationMatch.Erasure.cs
+++ b/src/Corax/Queries/MemoizationMatch.Erasure.cs
@@ -20,6 +20,7 @@ namespace Corax.Queries
         }
 
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
 
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Queries/MemoizationMatch.Provider.cs
+++ b/src/Corax/Queries/MemoizationMatch.Provider.cs
@@ -20,6 +20,8 @@ namespace Corax.Queries
         private TInner _inner;
 
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
+
         public long Count => _inner.Count;
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Queries/MemoizationMatch.cs
+++ b/src/Corax/Queries/MemoizationMatch.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace Corax.Queries
 {    
     [DebuggerDisplay("{DebugView,nq}")]
-    public unsafe struct MemoizationMatch<TInner> : IQueryMatch
+    public struct MemoizationMatch<TInner> : IQueryMatch
         where TInner : IQueryMatch
     {
         private MemoizationMatchProvider<TInner> _inner;
@@ -13,6 +13,8 @@ namespace Corax.Queries
         public bool IsAllEntries = typeof(TInner) == typeof(AllEntriesMatch);
 
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
+
         public long Count => _inner.Count;
         public bool DoNotSortResults()
         {

--- a/src/Corax/Queries/Meta/IMemoizationMatchSource.cs
+++ b/src/Corax/Queries/Meta/IMemoizationMatchSource.cs
@@ -4,6 +4,8 @@ namespace Corax.Queries
 {
     public interface IMemoizationMatchSource : IDisposable
     {
+        bool IsOrdered { get; }
+
         MemoizationMatch Replay();
     }
 }

--- a/src/Corax/Queries/Meta/IQueryMatch.cs
+++ b/src/Corax/Queries/Meta/IQueryMatch.cs
@@ -47,6 +47,8 @@ namespace Corax.Queries
 
         bool IsBoosting { get; }
 
+        bool IsOrdered { get; }
+
         // Guarantees: The output of Fill will be sorted and deduplicated for the call.
         //             Different calls to Fill may return identical values are not guaranteed to be sorted between calls.
         //             0 return means no more matches. 

--- a/src/Corax/Queries/Meta/ITermProvider.cs
+++ b/src/Corax/Queries/Meta/ITermProvider.cs
@@ -1,7 +1,8 @@
 ﻿namespace Corax.Queries
 {
     public interface ITermProvider
-    { 
+    {
+        bool IsOrdered { get; }
         void Reset();
         bool Next(out TermMatch term);
         QueryInspectionNode Inspect();

--- a/src/Corax/Queries/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Queries/MultiTermMatch.Erasure.cs
@@ -21,6 +21,8 @@ namespace Corax.Queries
         public bool DoNotSortResults() => _inner.DoNotSortResults();
         
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
+
         public long Count => _functionTable.CountFunc(ref this);
 
         public QueryCountConfidence Confidence => _inner.Confidence;
@@ -136,6 +138,8 @@ namespace Corax.Queries
         private struct EmptyTermProvider : ITermProvider
         {
             public int TermsCount => 0;
+
+            public bool IsOrdered => true;
 
             public bool Next(out TermMatch term)
             {

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -12,7 +12,7 @@ using Sparrow.Server.Utils;
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public unsafe struct MultiTermMatch<TTermProvider> : IQueryMatch
+    public struct MultiTermMatch<TTermProvider> : IQueryMatch
         where TTermProvider : ITermProvider
     {
 

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -35,6 +35,8 @@ namespace Corax.Queries
         private readonly ByteStringContext _context;
 
         public bool IsBoosting => _isBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
+
         public long Count => _totalResults;
         public long Current => _currentIdx <= QueryMatch.Start ? _currentIdx : _current;
 

--- a/src/Corax/Queries/MultiUnaryMatch.cs
+++ b/src/Corax/Queries/MultiUnaryMatch.cs
@@ -14,7 +14,7 @@ public unsafe struct MultiUnaryItem
     /**
      *  MultiUnaryMatches are using same buffer from Voron to check every single condition per one document. There is no need to call UnaryMatch over and over.
      *  We decided to drop Generics here (like in rest of the code) and push comparers by pointer functions due to problems of creation complex unary queries.
-     *  We've 5 diffrent comparers (Equals are handled by TermMatch, not by scanning) so number of possible permutations grows extremly fast)
+     *  We've 5 different comparers (Equals are handled by TermMatch, not by scanning) so number of possible permutations grows extremly fast)
      */
     public FieldMetadata Binding;
     public DataType Type;
@@ -381,6 +381,8 @@ public struct MultiUnaryMatch<TInner> : IQueryMatch
 
     public QueryCountConfidence Confidence => QueryCountConfidence.Low;
     public bool IsBoosting { get; }
+    
+    public bool IsOrdered => _inner.IsOrdered;
 
     public int Fill(Span<long> matches)
     {

--- a/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
@@ -20,6 +20,8 @@ namespace Corax.Queries.SortingMatches
 
         public long Count => throw new NotSupportedException();
 
+        public bool IsOrdered => _inner.IsOrdered;
+
         public bool DoNotSortResults() => _inner.DoNotSortResults();
 
         public QueryCountConfidence Confidence => throw new NotSupportedException();

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -34,6 +34,8 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
     private NativeIntegersList _results;
     public long TotalResults;
+
+    public bool IsOrdered => true;
     public bool DoNotSortResults() => throw new NotSupportedException();
 
     public SortingMatch(IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, int take = -1)

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -16,6 +16,7 @@ namespace Corax.Queries.SortingMatches
             _functionTable = functionTable;
         }
 
+        public bool IsOrdered => _inner.IsOrdered;
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
 
         public long Count => throw new NotSupportedException();

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -32,7 +32,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
     private NativeIntegersList _results;
     public long TotalResults;
+    
     public bool DoNotSortResults() => throw new NotSupportedException();
+    public bool IsOrdered => true;
 
     public SortingMultiMatch(IndexSearcher searcher, in TInner inner, OrderMetadata[] orderMetadata, int take = -1, in CancellationToken token = default)
     {

--- a/src/Corax/Queries/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Queries/SpatialMatch/SpatialMatch.cs
@@ -21,13 +21,17 @@ public class SpatialMatch : IQueryMatch
     private readonly IShape _shape;
     private readonly CompactTree _tree;
     private readonly FieldMetadata _field;
-    private IEnumerator<(string Geohash, bool isTermMatch)> _termGenerator;
-    private TermMatch _currentMatch;
+    private readonly IEnumerator<(string Geohash, bool isTermMatch)> _termGenerator;
     private readonly ByteStringContext _allocator;
     private readonly Utils.Spatial.SpatialRelation _spatialRelation;
+
+    private TermMatch _currentMatch;
     private bool _isTermMatch;
     private IDisposable _startsWithDisposeHandler;
     private HashSet<long> _alreadyReturned;
+
+    // TODO: Check if there is any way we can consider something ordered.
+    public bool IsOrdered => false;
 
     public SpatialMatch(IndexSearcher indexSearcher, ByteStringContext allocator, SpatialContext spatialContext, FieldMetadata field, IShape shape,
         CompactTree tree,
@@ -175,7 +179,7 @@ public class SpatialMatch : IQueryMatch
 
     public QueryInspectionNode Inspect()
     {
-        return new QueryInspectionNode($"{nameof(StartWithTermProvider)}",
+        return new QueryInspectionNode($"{nameof(SpatialMatch)}",
             parameters: new Dictionary<string, string>()
             {
                 {"Field", _field.ToString()},

--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -33,6 +33,8 @@ namespace Corax.Queries
         private FastPForBufferedReader _containerReader;
         private ByteStringContext _ctx;
         public bool IsBoosting => _scoreFunc != null;
+        public bool IsOrdered => true;
+
         public long Count => _totalResults;
         
 #if DEBUG

--- a/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
@@ -3,19 +3,21 @@ using System.Collections.Generic;
 using Corax.Mappings;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries
 {
-    public struct ContainsTermProvider : ITermProvider
+    public struct ContainsTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
         private readonly CompactKey _term;
 
-        private CompactTreeForwardIterator _iterator;
-        
+        private CompactTree.Iterator<TLookupIterator> _iterator;
+
         public bool IsOrdered => true;
 
         public ContainsTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey term)
@@ -23,14 +25,14 @@ namespace Corax.Queries
             _tree = tree;
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
             _term = term;
         }
 
         public void Reset()
         {
-            _iterator = _tree.Iterate();
+            _iterator = _tree.Iterate<TLookupIterator>();
             _iterator.Reset();
         }
 
@@ -55,7 +57,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(ContainsTermProvider)}",
+            return new QueryInspectionNode($"{nameof(ContainsTermProvider<TLookupIterator>)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Contains.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Corax.Mappings;
 using Voron;
@@ -15,6 +15,9 @@ namespace Corax.Queries
         private readonly CompactKey _term;
 
         private CompactTreeForwardIterator _iterator;
+        
+        public bool IsOrdered => true;
+
         public ContainsTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey term)
         {
             _tree = tree;

--- a/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Corax.Mappings;
 using Voron.Data.CompactTrees;
@@ -16,6 +16,9 @@ namespace Corax.Queries
         private readonly CompactKey _endsWith;
 
         private CompactTreeForwardIterator _iterator;
+        
+        public bool IsOrdered => true;
+
         public EndsWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey endsWith)
         {
             _tree = tree;

--- a/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.EndsWith.cs
@@ -2,12 +2,13 @@ using System;
 using System.Collections.Generic;
 using Corax.Mappings;
 using Voron.Data.CompactTrees;
-
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries
 {
-    public struct EndsWithTermProvider : ITermProvider
+    public struct EndsWithTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
@@ -15,8 +16,8 @@ namespace Corax.Queries
 
         private readonly CompactKey _endsWith;
 
-        private CompactTreeForwardIterator _iterator;
-        
+        private CompactTree.Iterator<TLookupIterator> _iterator;
+
         public bool IsOrdered => true;
 
         public EndsWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey endsWith)
@@ -24,14 +25,14 @@ namespace Corax.Queries
             _tree = tree;
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
             _endsWith = endsWith;
         }
 
         public void Reset()
         {            
-            _iterator = _tree.Iterate();
+            _iterator = _tree.Iterate<TLookupIterator>();
             _iterator.Reset();
         }
 
@@ -56,7 +57,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(EndsWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(EndsWithTermProvider<TLookupIterator>)}",
                 parameters: new Dictionary<string, string>()
                 {
                     { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
@@ -17,6 +17,8 @@ namespace Corax.Queries
 
         private CompactTreeForwardIterator _iterator;
 
+        public bool IsOrdered => true;
+
         public ExistsTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field)
         {
             _tree = tree;

--- a/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
@@ -5,17 +5,19 @@ using Corax.Mappings;
 using Sparrow;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries
 {
-    public unsafe struct ExistsTermProvider : ITermProvider
+    public struct ExistsTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
 
-        private CompactTreeForwardIterator _iterator;
+        private CompactTree.Iterator<TLookupIterator> _iterator;
 
         public bool IsOrdered => true;
 
@@ -24,13 +26,13 @@ namespace Corax.Queries
             _tree = tree;
             _field = field;
             _searcher = searcher;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
         }
 
         public void Reset()
         {            
-            _iterator = _tree.Iterate();
+            _iterator = _tree.Iterate<TLookupIterator>();
             _iterator.Reset();
         }
 
@@ -68,7 +70,7 @@ namespace Corax.Queries
         
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(ExistsTermProvider)}",
+            return new QueryInspectionNode($"{nameof(ExistsTermProvider<TLookupIterator>)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() }

--- a/src/Corax/Queries/TermProviders/TermProvider.In.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.In.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -12,15 +12,19 @@ namespace Corax.Queries
     {
         private readonly IndexSearcher _searcher;
         private readonly List<TTermsType> _terms;
-        private int _termIndex;
         private readonly FieldMetadata _field;
+        private readonly bool _areTermsOrdered;
+        private int _termIndex;
 
-        public InTermProvider(IndexSearcher searcher, FieldMetadata field, List<TTermsType> terms)
+        public bool IsOrdered => _areTermsOrdered;
+
+        public InTermProvider(IndexSearcher searcher, FieldMetadata field, List<TTermsType> terms, bool areTermsOrdered = false)
         {
             _field = field;
             _searcher = searcher;
             _terms = terms;
             _termIndex = -1;
+            _areTermsOrdered = areTermsOrdered;
         }
 
         public void Reset() => _termIndex = -1;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
@@ -17,6 +17,8 @@ namespace Corax.Queries
 
         private CompactTreeForwardIterator _iterator;
 
+        public bool IsOrdered => true;
+
         public NotContainsTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey term)
         {
             _tree = tree;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotContains.cs
@@ -3,19 +3,21 @@ using System.Collections.Generic;
 using Corax.Mappings;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 
 namespace Corax.Queries
 {
-    public unsafe struct NotContainsTermProvider : ITermProvider
+    public struct NotContainsTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
         private readonly CompactKey _term;
 
-        private CompactTreeForwardIterator _iterator;
+        private CompactTree.Iterator<TLookupIterator> _iterator;
 
         public bool IsOrdered => true;
 
@@ -24,14 +26,14 @@ namespace Corax.Queries
             _tree = tree;
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
             _term = term;
         }
 
         public void Reset()
         {            
-            _iterator = _tree.Iterate();
+            _iterator = _tree.Iterate<TLookupIterator>();
             _iterator.Reset();
         }
 
@@ -56,7 +58,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(NotContainsTermProvider)}",
+            return new QueryInspectionNode($"{nameof(NotContainsTermProvider<TLookupIterator>)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
@@ -22,6 +22,8 @@ namespace Corax.Queries
 
         private CompactTreeForwardIterator _iterator;
 
+        public bool IsOrdered => true;
+
         public NotEndsWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey endsWith)
         {
             _searcher = searcher;

--- a/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotEndsWith.cs
@@ -8,19 +8,21 @@ using Corax.Mappings;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public struct NotEndsWithTermProvider : ITermProvider
+    public struct NotEndsWithTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
         private readonly CompactKey _endsWith;
 
-        private CompactTreeForwardIterator _iterator;
+        private CompactTree.Iterator<TLookupIterator> _iterator;
 
         public bool IsOrdered => true;
 
@@ -28,7 +30,7 @@ namespace Corax.Queries
         {
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
             _endsWith = endsWith;
             _tree = tree;
@@ -60,7 +62,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(NotEndsWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(NotEndsWithTermProvider<TLookupIterator>)}",
                 parameters: new Dictionary<string, string>()
                 {
                     { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
@@ -5,27 +5,28 @@ using Corax.Mappings;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
-using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
+using Voron.Data.Lookups;
 
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public struct NotStartsWithTermProvider : ITermProvider
+    public struct NotStartsWithTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
         private readonly CompactKey _startWith;
 
-        private CompactTreeForwardIterator _iterator;
+        private CompactTree.Iterator<TLookupIterator> _iterator;
 
         public bool IsOrdered => true;
 
-        public NotStartsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, FieldMetadata field, CompactKey startWith)
+        public NotStartsWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey startWith)
         {
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _iterator.Reset();
             _startWith = startWith;
             _tree = tree;
@@ -57,7 +58,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(NotStartsWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(NotStartsWithTermProvider<TLookupIterator>)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.NotStartsWith.cs
@@ -10,7 +10,7 @@ using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public struct NotStartWithTermProvider : ITermProvider
+    public struct NotStartsWithTermProvider : ITermProvider
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
@@ -19,7 +19,9 @@ namespace Corax.Queries
 
         private CompactTreeForwardIterator _iterator;
 
-        public NotStartWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, FieldMetadata field, CompactKey startWith)
+        public bool IsOrdered => true;
+
+        public NotStartsWithTermProvider(IndexSearcher searcher, ByteStringContext context, CompactTree tree, FieldMetadata field, CompactKey startWith)
         {
             _searcher = searcher;
             _field = field;
@@ -55,7 +57,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(NotStartWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(NotStartsWithTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.Range.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Range.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -32,6 +32,8 @@ namespace Corax.Queries
 
         private readonly bool _skipHighCheck;
         private bool _skipLowCheck;
+
+        public bool IsOrdered => true;
 
         public TermRangeProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, Slice low, Slice high)
         {
@@ -125,6 +127,10 @@ namespace Corax.Queries
         private readonly TVal _low, _high;
         private Lookup<TVal>.ForwardIterator _iterator;
         private bool _first;
+
+        private const int TermBufferSize = 32;
+        private fixed byte _termsBuffer[TermBufferSize];
+        public bool IsOrdered => true;
 
         public TermNumericRangeProvider(IndexSearcher searcher, Lookup<TVal> set, FieldMetadata field, TVal low, TVal high)
         {

--- a/src/Corax/Queries/TermProviders/TermProvider.Regex.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Regex.cs
@@ -5,18 +5,20 @@ using System.Text.Unicode;
 using Corax.Mappings;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries;
 
-public struct RegexTermProvider : ITermProvider
+public struct RegexTermProvider<TLookupIterator> : ITermProvider
+    where TLookupIterator : struct, ILookupIterator
 {
     private readonly CompactTree _tree;
     private readonly IndexSearcher _searcher;
     private readonly FieldMetadata _field;
     private readonly Regex _regex;
 
-    private CompactTreeForwardIterator _iterator;
+    private CompactTree.Iterator<TLookupIterator> _iterator;
 
     public bool IsOrdered => true;
 
@@ -25,7 +27,7 @@ public struct RegexTermProvider : ITermProvider
         _searcher = searcher;
         _regex = regex;
         _tree = tree;
-        _iterator = tree.Iterate();
+        _iterator = tree.Iterate<TLookupIterator>();
         _iterator.Reset();
         _field = field;
     }
@@ -33,7 +35,7 @@ public struct RegexTermProvider : ITermProvider
 
     public void Reset()
     {
-        _iterator = _tree.Iterate();
+        _iterator = _tree.Iterate<TLookupIterator>();
         _iterator.Reset();
     }
 
@@ -55,7 +57,7 @@ public struct RegexTermProvider : ITermProvider
 
     public QueryInspectionNode Inspect()
     {
-        return new QueryInspectionNode($"{nameof(RegexTermProvider)}",
+        return new QueryInspectionNode($"{nameof(RegexTermProvider<TLookupIterator>)}",
             parameters: new Dictionary<string, string>()
             {
                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.Regex.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Regex.cs
@@ -18,6 +18,8 @@ public struct RegexTermProvider : ITermProvider
 
     private CompactTreeForwardIterator _iterator;
 
+    public bool IsOrdered => true;
+
     public RegexTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, Regex regex)
     {
         _searcher = searcher;

--- a/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
@@ -8,19 +8,21 @@ using System.Threading.Tasks;
 using Corax.Mappings;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
 using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<Voron.Data.Lookups.Lookup<Voron.Data.CompactTrees.CompactTree.CompactKeyLookup>.ForwardIterator>;
 
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public struct StartsWithTermProvider : ITermProvider
+    public struct StartsWithTermProvider<TLookupIterator> : ITermProvider
+        where TLookupIterator : struct, ILookupIterator
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
         private readonly FieldMetadata _field;
         private readonly CompactKey _startWith;
 
-        private  CompactTreeForwardIterator _iterator;
+        private CompactTree.Iterator<TLookupIterator> _iterator;
 
         public bool IsOrdered => true;
 
@@ -28,7 +30,7 @@ namespace Corax.Queries
         {
             _searcher = searcher;
             _field = field;
-            _iterator = tree.Iterate();
+            _iterator = tree.Iterate<TLookupIterator>();
             _startWith = startWith;
             _tree = tree;
 
@@ -59,7 +61,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(StartsWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(StartsWithTermProvider<TLookupIterator>)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.StartWith.cs
@@ -13,7 +13,7 @@ using CompactTreeForwardIterator = Voron.Data.CompactTrees.CompactTree.Iterator<
 namespace Corax.Queries
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public struct StartWithTermProvider : ITermProvider
+    public struct StartsWithTermProvider : ITermProvider
     {
         private readonly CompactTree _tree;
         private readonly IndexSearcher _searcher;
@@ -22,7 +22,9 @@ namespace Corax.Queries
 
         private  CompactTreeForwardIterator _iterator;
 
-        public StartWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey startWith)
+        public bool IsOrdered => true;
+
+        public StartsWithTermProvider(IndexSearcher searcher, CompactTree tree, FieldMetadata field, CompactKey startWith)
         {
             _searcher = searcher;
             _field = field;
@@ -57,7 +59,7 @@ namespace Corax.Queries
 
         public QueryInspectionNode Inspect()
         {
-            return new QueryInspectionNode($"{nameof(StartWithTermProvider)}",
+            return new QueryInspectionNode($"{nameof(StartsWithTermProvider)}",
                             parameters: new Dictionary<string, string>()
                             {
                                 { "Field", _field.ToString() },

--- a/src/Corax/Queries/UnaryMatch.Erasure.cs
+++ b/src/Corax/Queries/UnaryMatch.Erasure.cs
@@ -18,6 +18,7 @@ namespace Corax.Queries
         }
 
         public bool IsBoosting => _inner.IsBoosting;
+        public bool IsOrdered => _inner.IsOrdered;
 
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -59,6 +59,8 @@ namespace Corax.Queries
 
         public QueryCountConfidence Confidence => _confidence;
 
+        public bool IsOrdered => _inner.IsOrdered;
+
         private UnaryMatch(in TInner inner,
             UnaryMatchOperation operation,
             IndexSearcher searcher,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1239,16 +1239,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
             else
             {
-                using (var blittableJson = ParseJsonStringIntoBlittable(moreLikeThisQuery.BaseDocument, context))
-                    mltQuery = mlt.Like(blittableJson);
+                using var blittableJson = ParseJsonStringIntoBlittable(moreLikeThisQuery.BaseDocument, context);
+                mltQuery = mlt.Like(blittableJson);
             }
 
             if (moreLikeThisQuery.FilterQuery != null && moreLikeThisQuery.FilterQuery is AllEntriesMatch == false)
             {
                 mltQuery = IndexSearcher.And(mltQuery, moreLikeThisQuery.FilterQuery);
             }
-
-
 
             var ravenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             long[] ids = QueryPool.Rent(pageSize);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -21,6 +21,9 @@ public struct CoraxBooleanItem : IQueryMatch
     private readonly bool _isTime;
     public bool IsBoosting => Boosting.HasValue;
     public float? Boosting;
+
+    public bool IsOrdered => throw new NotImplementedException("Still not implemented at this level.");
+
     public long Count { get; }
 
     private CoraxBooleanItem(IndexSearcher searcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
@@ -13,6 +13,8 @@ public abstract class CoraxBooleanQueryBase : IQueryMatch
     protected bool _hasBinary;
     public bool HasBinary => _hasBinary;
 
+    public bool IsOrdered => throw new NotImplementedException("Still not implemented at this level.");
+
     protected CoraxBooleanQueryBase(IndexSearcher indexSearcher)
     {
         IndexSearcher = indexSearcher;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -28,7 +28,7 @@ namespace Voron.Data.CompactTrees;
 /// </summary>
 public sealed partial class CompactTree : IPrepareForCommit
 {
-    private Lookup<CompactKeyLookup> _inner;
+    private readonly Lookup<CompactKeyLookup> _inner;
 
     public CompactTree(Lookup<CompactKeyLookup> inner)
     {

--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Data;
 using System.Diagnostics;
-using Voron.Data.CompactTrees;
 
 namespace Voron.Data.Lookups
 {

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -120,6 +120,8 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
 
             var match1 = searcher.BetweenQuery(_longItemFieldMetadata, 95L, 212L);
+            Assert.True(match1.IsOrdered);
+
             var expectedList = _entries.Where(x => x.LongValue is >= 95 and <= 212).Select(x => x.Id).ToList();
             expectedList.Sort();
             var outputList = FetchFromCorax(ref match1);
@@ -158,7 +160,10 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
 
             var match0 = searcher.AllEntries();
+            Assert.False(match0.IsOrdered);
             var match1 = searcher.UnaryQuery<AllEntriesMatch, long>(match0, _longItemFieldMetadata, 3, UnaryMatchOperation.GreaterThan);
+            Assert.False(match1.IsOrdered);
+
             var expectedList = _entries.Where(x => x.LongValue > 3).Select(x => x.Id).ToList();
             expectedList.Sort();
             var outputList = FetchFromCorax(ref match1);
@@ -177,8 +182,11 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
             
             var match0 = searcher.AllEntries();
+            Assert.False(match0.IsOrdered);
             var comparers = new MultiUnaryItem[] {new(_longItemFieldMetadata, 3L, UnaryMatchOperation.GreaterThan), new(_doubleItemFieldMetadata, 20.5, UnaryMatchOperation.LessThan)};
             var match1 = searcher.CreateMultiUnaryMatch(match0, comparers);
+            Assert.False(match1.IsOrdered);
+
             var expectedList = _entries.Where(x => x.LongValue > 3 && x.DoubleValue < 20.5).Select(x => x.Id).ToList();
             expectedList.Sort();
             var outputList = FetchFromCorax(ref match1);
@@ -198,6 +206,7 @@ namespace FastTests.Corax
             using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
             var match0 = searcher.TermQuery(_doubleItemFieldMetadata, 0.0D);
+            Assert.True(match0.IsOrdered);
             var ids = new long[16];
             Assert.Equal(1, match0.Fill(ids)); //match one doc
 
@@ -221,8 +230,12 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
 
             var match0 = searcher.TermQuery(_longItemFieldMetadata, "1");
+            Assert.True(match0.IsOrdered);
             var match1 = searcher.StartWithQuery("Id", "ent");
+            Assert.True(match1.IsOrdered);
             var multiTermTerm = searcher.And(match1, match0);
+            Assert.True(multiTermTerm.IsOrdered);
+
             var first = FetchFromCorax(ref multiTermTerm);
             Assert.Equal(1, first.Count);
 

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1253,7 +1253,7 @@ namespace FastTests.Corax
                 Assert.Equal(2, match.Fill(ids));
                 long id = ids[0];
                 long id1 = ids[1];
-                var results = new string[] {searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id), searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id1)};
+                var results = new[] {searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id), searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName()).GetTermFor(id1)};
                 Array.Sort(results);
                 Assert.Equal("entry/1", results[0]);
                 Assert.Equal("entry/2", results[1]);

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -33,11 +33,15 @@ namespace FastTests.Corax
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
             {
                 var allEntries = searcher.AllEntries();
+                Assert.False(allEntries.IsOrdered);
                 var match1 = searcher.StartWithQuery("Id", "l");
+                Assert.True(match1.IsOrdered);
                 var concat = searcher.And(allEntries, match1);
+                Assert.False(concat.IsOrdered);
 
                 var match = searcher.OrderBy(concat,
                     new OrderMetadata(searcher.FieldMetadataBuilder("Content", ContentId), false, MatchCompareFieldType.Integer));
+                Assert.True(match.IsOrdered);
 
                 List<string> sortedByCorax = new();
                 Span<long> ids = stackalloc long[2048];

--- a/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
+++ b/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
@@ -160,6 +160,8 @@ public class RankingFunctionTests : StorageTest
         IndexEntries(list);
         using var indexSearcher = new IndexSearcher(Env, _mapping);
         var query = indexSearcher.StartWithQuery(_mapping.GetByFieldId(1).Metadata.ChangeScoringMode(true), "mac");
+        Assert.True(query.IsOrdered);
+
         Span<long> matches = stackalloc long[10];
         Span<float> scores = stackalloc float[10];
         scores.Fill(0);

--- a/test/FastTests/Voron/CompactTrees/CompactTreeIteratorTest.cs
+++ b/test/FastTests/Voron/CompactTrees/CompactTreeIteratorTest.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Voron.Data.Lookups;
+using Xunit;
+using Xunit.Abstractions;
+using static Voron.Data.CompactTrees.CompactTree;
+
+namespace FastTests.Voron.CompactTrees
+{
+    public class CompactTreeIteratorTest : StorageTest
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public CompactTreeIteratorTest(ITestOutputHelper output, ITestOutputHelper testOutputHelper) : base(output)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public static IEnumerable<object[]> Configuration =>
+            new List<object[]>
+            {
+                new object[] { Random.Shared.Next(100000), Random.Shared.Next()},
+                new object[] { Random.Shared.Next(10000), Random.Shared.Next(), },
+                new object[] { Random.Shared.Next(1000), Random.Shared.Next()},
+                new object[] { Random.Shared.Next(100), Random.Shared.Next()},
+            };
+
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1, 1337)]
+        [InlineData(380, 1158997728)]
+        [MemberData("Configuration")]
+        public void IterateAndCompare(int itemsToInsert, int randomSeed = 1337)
+        {
+            var currentKeys = new List<string>();
+            var rnd = new Random(randomSeed);
+
+            int maxAmountOfDigits = long.MaxValue.ToString().Length;
+
+            // Initializing the tree with random writes. Depending on the tree size, it may
+            // cause the creation of new dictionaries and transitioning pages. 
+            using (var wtx = Env.WriteTransaction())
+            {
+                var tree = wtx.CompactTreeFor("test");
+                for (int j = 0; j < itemsToInsert; j++)
+                {
+                    long item = Math.Abs((long)rnd.Next() + rnd.Next());
+                    var itemAsString = item.ToString().PadLeft(maxAmountOfDigits, '0');
+                    currentKeys.Add(itemAsString);
+                    tree.Add(itemAsString, item);
+                }
+
+                wtx.Commit();
+            }
+
+            using (var rtx = Env.ReadTransaction())
+            {
+                var tree = rtx.CompactTreeFor("test");
+                var forwardIterator = tree.Iterate<Lookup<CompactKeyLookup>.ForwardIterator>();
+                currentKeys.Sort();
+
+                int i = 0;
+                forwardIterator.Reset();
+                while (forwardIterator.MoveNext(out var scoped, out long value))
+                {
+                    Assert.Equal(value, long.Parse(currentKeys[i]));
+                    scoped.Dispose();
+                    i++;
+                }
+                Assert.Equal(currentKeys.Count, i);
+
+                var backwardIterator = tree.Iterate<Lookup<CompactKeyLookup>.BackwardIterator>();
+                currentKeys.Reverse();
+
+                i = 0;
+                backwardIterator.Reset();
+                while (backwardIterator.MoveNext(out var scoped, out long value))
+                {
+                    Assert.Equal(value, long.Parse(currentKeys[i]));
+                    scoped.Dispose();
+                    i++;
+                }
+
+                Assert.Equal(currentKeys.Count, i);
+            }
+        }
+    }
+}

--- a/test/FastTests/Voron/CompactTrees/CompactTreeIteratorTest.cs
+++ b/test/FastTests/Voron/CompactTrees/CompactTreeIteratorTest.cs
@@ -33,9 +33,11 @@ namespace FastTests.Voron.CompactTrees
         [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(1, 1337)]
         [InlineData(380, 1158997728)]
+        [InlineData(98231, 865390483)]
         [MemberData("Configuration")]
         public void IterateAndCompare(int itemsToInsert, int randomSeed = 1337)
         {
+            var hasSeen = new HashSet<long>();
             var currentKeys = new List<string>();
             var rnd = new Random(randomSeed);
 
@@ -49,9 +51,13 @@ namespace FastTests.Voron.CompactTrees
                 for (int j = 0; j < itemsToInsert; j++)
                 {
                     long item = Math.Abs((long)rnd.Next() + rnd.Next());
-                    var itemAsString = item.ToString().PadLeft(maxAmountOfDigits, '0');
-                    currentKeys.Add(itemAsString);
-                    tree.Add(itemAsString, item);
+                    if (hasSeen.Contains(item) == false)
+                    {
+                        var itemAsString = item.ToString().PadLeft(maxAmountOfDigits, '0');
+                        currentKeys.Add(itemAsString);
+                        tree.Add(itemAsString, item);
+                        hasSeen.Add(item);
+                    }
                 }
 
                 wtx.Commit();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20268

### Additional description
Streaming allows optimizations at the query creation level, because under certain situations we can avoid sorting altogether because we are getting the data in ordered from the underlying storage.

### Type of change
- New feature

### How risky is the change?
- Moderate 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No