### PR TITLE
RavenDB-20766 Document Refresh does not go into Configuration export …

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/smugglerDatabaseRecord.ts
@@ -15,6 +15,7 @@ class smugglerDatabaseRecord {
     includeTimeSeries = ko.observable<boolean>(true);
     includeSettings = ko.observable<boolean>(true);
     includeRevisions = ko.observable<boolean>(true);
+    includeRefresh = ko.observable<boolean>(true);
     includeExpiration = ko.observable<boolean>(true);
     includePeriodicBackups = ko.observable<boolean>(true);
     includeExternalReplications = ko.observable<boolean>(true);
@@ -100,6 +101,9 @@ class smugglerDatabaseRecord {
         }
         if (this.includeRevisions()) {
             result.push("Revisions");
+        }
+        if (this.includeRefresh()) {
+            result.push("Refresh");
         }
         if (this.includeExpiration()) {
             result.push("Expiration");

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/smugglerDatabaseRecord.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/smugglerDatabaseRecord.html
@@ -74,6 +74,10 @@
                         <label data-bind="attr: { for: 'includeRevisions_' + instanceCounter }" class="margin-right margin-right-sm">Revisions Configuration</label>
                     </div>
                     <div class="toggle">
+                        <input type="checkbox" data-bind="checked: includeRefresh, attr: { id: 'includeRefresh_' + instanceCounter }">
+                        <label data-bind="attr: { for: 'includeRefresh_' + instanceCounter }" class="margin-right margin-right-sm">Document Refresh</label>
+                    </div>
+                    <div class="toggle">
                         <input type="checkbox" data-bind="checked: includeExpiration, attr: { id: 'includeExpiration_' + instanceCounter }">
                         <label data-bind="attr: { for: 'includeExpiration_' + instanceCounter }" class="margin-right margin-right-sm">Document Expiration</label>
                     </div>


### PR DESCRIPTION
…- studio part

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20766 

### Additional description

Exposed ability to import/export document refresh configuration. 

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


