### PR TITLE
RavenDB-20231 & RavenDB-20362 Corax - Include score or distance in projection.

### DIFF
--- a/src/Corax/Queries/SortingMatches/Meta/SortingDataTransfer.cs
+++ b/src/Corax/Queries/SortingMatches/Meta/SortingDataTransfer.cs
@@ -1,0 +1,12 @@
+using Corax.Utils.Spatial;
+
+namespace Corax.Queries.SortingMatches.Meta;
+
+public struct SortingDataTransfer
+{
+    public bool IncludeScores => ScoresBuffer is {Length: > 0};
+    public bool IncludeDistances => DistancesBuffer is {Length: > 0};
+    
+    public float[] ScoresBuffer;
+    public SpatialResult[] DistancesBuffer;
+}

--- a/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
@@ -49,13 +49,20 @@ namespace Corax.Queries.SortingMatches
             _inner.Score(matches, scores, boostFactor);
         }
 
-        internal class FunctionTable(delegate*<ref SortingMatch, Span<long>, int> fillFunc,
-            delegate*<ref SortingMatch, long> totalResultsFunc,
-            delegate*<ref SortingMatch, in SortingDataTransfer, void> setSortingDataTransferFunc)
+        internal class FunctionTable
         {
-            public readonly delegate*<ref SortingMatch, Span<long>, int> FillFunc = fillFunc;
-            public readonly delegate*<ref SortingMatch, long> TotalResultsFunc = totalResultsFunc;
-            public readonly delegate*<ref SortingMatch, in SortingDataTransfer, void> SetSortingDataTransfer = setSortingDataTransferFunc;
+            public readonly delegate*<ref SortingMatch, Span<long>, int> FillFunc;
+            public readonly delegate*<ref SortingMatch, long> TotalResultsFunc;
+            public readonly delegate*<ref SortingMatch, in SortingDataTransfer, void> SetSortingDataTransfer;
+
+            public FunctionTable(delegate*<ref SortingMatch, Span<long>, int> fillFunc,
+                delegate*<ref SortingMatch, long> totalResultsFunc,
+                delegate*<ref SortingMatch, in SortingDataTransfer, void> setSortingDataTransferFunc)
+            {
+                FillFunc = fillFunc;
+                TotalResultsFunc = totalResultsFunc;
+                SetSortingDataTransfer = setSortingDataTransferFunc;
+            }
         }
 
         private static class StaticFunctionCache<TInner>

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
@@ -46,13 +46,20 @@ namespace Corax.Queries.SortingMatches
             _inner.Score(matches, scores, boostFactor);
         }
 
-        internal class FunctionTable(delegate*<ref SortingMultiMatch, Span<long>, int> fillFunc,
-            delegate*<ref SortingMultiMatch, long> totalResultsFunc,
-            delegate*<ref SortingMultiMatch,  in SortingDataTransfer, void> setSortingDataTransfer)
+        public class FunctionTable
         {
-            public readonly delegate*<ref SortingMultiMatch, Span<long>, int> FillFunc = fillFunc;
-            public readonly delegate*<ref SortingMultiMatch, long> TotalResultsFunc = totalResultsFunc;
-            public readonly delegate*<ref SortingMultiMatch, in SortingDataTransfer, void> SetSortingDataTransferFunc = setSortingDataTransfer;
+            public readonly delegate*<ref SortingMultiMatch, Span<long>, int> FillFunc;
+            public readonly delegate*<ref SortingMultiMatch, long> TotalResultsFunc;
+            public readonly delegate*<ref SortingMultiMatch, in SortingDataTransfer, void> SetSortingDataTransferFunc;
+
+            public FunctionTable(delegate*<ref SortingMultiMatch, Span<long>, int> fillFunc,
+                delegate*<ref SortingMultiMatch, long> totalResultsFunc,
+                delegate*<ref SortingMultiMatch,  in SortingDataTransfer, void> setSortingDataTransfer)
+            {
+                FillFunc = fillFunc;
+                TotalResultsFunc = totalResultsFunc;
+                SetSortingDataTransferFunc = setSortingDataTransfer;
+            }
         }
 
         private static class StaticFunctionCache<TInner>

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Corax.Queries.SortingMatches.Meta;
 using System.Threading;
 using Corax.Utils;
+using Corax.Utils.Spatial;
 using Sparrow;
 using Sparrow.Server;
 using Voron;
@@ -22,8 +23,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     private readonly OrderMetadata[] _orderMetadata;
     private readonly delegate*<ref SortingMultiMatch<TInner>, Span<long>, int> _fillFunc;
     private readonly IEntryComparer[] _nextComparers;
-    private float[] _scoringTable;
-
     private readonly int _take;
     private readonly CancellationToken _token;
     private const int NotStarted = -1;
@@ -31,6 +30,11 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     private ByteStringContext<ByteStringMemoryCache>.InternalScope _entriesBufferScope;
 
     private NativeIntegersList _results;
+
+    private SortingDataTransfer _sortingDataTransfer;
+    private NativeUnmanagedList<SpatialResult> _distancesResults;
+    private NativeUnmanagedList<float> _scoresResults;
+    
     public long TotalResults;
     public bool DoNotSortResults() => throw new NotSupportedException();
 
@@ -42,7 +46,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         _take = take;
         _token = token;
         _results = new NativeIntegersList(searcher.Allocator);
-        _scoringTable = Array.Empty<float>();
         TotalResults = NotStarted;
         AssertNoScoreInnerComparer(orderMetadata);
         _fillFunc = SortBy(orderMetadata);
@@ -81,7 +84,14 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         }
     }
 
-    public void SetScoreBuffer(float[] scoringTable) => _scoringTable = scoringTable;
+    public void SetSortingDataTransfer(in SortingDataTransfer sortingDataTransfer)
+    {
+        _sortingDataTransfer = sortingDataTransfer;
+        if (sortingDataTransfer.IncludeDistances)
+            _distancesResults = new(_searcher.Allocator);
+        if (sortingDataTransfer.IncludeScores)
+            _scoresResults = new(_searcher.Allocator);
+    }
 
     private void AssertNoScoreInnerComparer(in OrderMetadata[] orderMetadata)
     {
@@ -124,11 +134,15 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         }
 
         var read = match._results.MoveTo(matches);
+        match._scoresResults.MoveTo(match._sortingDataTransfer.ScoresBuffer);
+        match._distancesResults.MoveTo(match._sortingDataTransfer.DistancesBuffer);
 
         if (read != 0) 
             return read;
             
         match._results.Dispose();
+        match._scoresResults.Dispose();
+        match._distancesResults.Dispose();
         match._entriesBufferScope.Dispose();
 
         return 0;
@@ -141,8 +155,13 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     {
         var llt = match._searcher.Transaction.LowLevelTransaction;
         var allocator = match._searcher.Allocator;
-
-        var bufScope = allocator.Allocate( batchResults.Length * (sizeof(long)+sizeof(UnmanagedSpan)), out ByteString bs);
+        
+        var sizeToAllocate = batchResults.Length * (sizeof(long) + sizeof(UnmanagedSpan));
+        //OrderBySpatial relay on this order of data. If you change it please review Spatial ordering to ensure that everything works fine. [[ids], [terms], [spatial_distances]]
+        if (match._sortingDataTransfer.IncludeDistances)
+            sizeToAllocate += batchResults.Length * sizeof(SpatialResult);
+        
+        var bufScope = allocator.Allocate(sizeToAllocate, out ByteString bs);
         Span<long> batchTermIds = new(bs.Ptr, batchResults.Length);
         UnmanagedSpan* termsPtr = (UnmanagedSpan*)(bs.Ptr + batchResults.Length * sizeof(long));
 

--- a/src/Corax/Utils/Spatial/SpatialResult.cs
+++ b/src/Corax/Utils/Spatial/SpatialResult.cs
@@ -1,0 +1,10 @@
+namespace Corax.Utils.Spatial;
+
+public struct SpatialResult
+{
+    public double Distance;
+    public double Latitude;
+    public double Longitude;
+
+    public static readonly SpatialResult Invalid = new() {Distance = double.NaN, Latitude = double.NaN, Longitude = double.NaN};
+}

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -481,6 +481,18 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Lucene.ReaderTermsIndexDivisor", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int ReaderTermsIndexDivisor { get; set; }
+        
+        [Description("Include score value in the metadata when sorting by score. Disabling this option could enhance query performance.")]
+        [ConfigurationEntry("Indexing.Corax.IncludeDocumentScore", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        public bool CoraxIncludeDocumentScore { get; set; }
+        
+        [Description("Include spatial information in the metadata when sorting by distance. Disabling this option could enhance query performance.")]
+        [ConfigurationEntry("Indexing.Corax.IncludeSpatialDistance", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        public bool CoraxIncludeSpatialDistance { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -169,6 +169,14 @@ namespace Raven.Server.Documents
             Longitude = double.NaN
         };
 
+        public static explicit operator SpatialResult?(Corax.Utils.Spatial.SpatialResult? coraxSpatialResult)
+        {
+            if (coraxSpatialResult is null)
+                return null;
+            
+            return new SpatialResult {Distance = coraxSpatialResult.Value.Distance, Latitude = coraxSpatialResult.Value.Latitude, Longitude = coraxSpatialResult.Value.Longitude};
+        }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -669,7 +669,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         var key = _documentIdReader.GetTermFor(ids[i]);
                         float? documentScore = sortingData.IncludeScores ? sortingData.ScoresBuffer[i] : null;
                         CoraxSpatialResult? documentDistance = hasOrderByDistance ? sortingData.DistancesBuffer[i] : null;
-                        var retrieverInput = new RetrieverInput(IndexSearcher, _fieldMappings, entryTermsReader, key, _index.IndexFieldsPersistence, documentScore, documentDistance);
+                        var retrieverInput = new RetrieverInput(IndexSearcher, _fieldMappings, entryTermsReader, key, documentScore, documentDistance);
 
                         var filterResult = queryFilter.Apply(ref retrieverInput, key);
                         if (filterResult is not FilterResult.Accepted)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -601,7 +601,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 bool willAlwaysIncludeInResults = WillAlwaysIncludeInResults(_index.Type, fieldsToFetch, query);
                 totalResults.Value = 0;
 
-                var hasOrderByDistance = query.Metadata.OrderBy is [{OrderingType: OrderByFieldType.Distance}, ..];
+                var hasOrderByDistance = query.Metadata.OrderBy is [{OrderingType: OrderByFieldType.Distance}, ..] && _index.Configuration.CoraxIncludeSpatialDistance;
                 if (builderParameters.HasBoost || hasOrderByDistance)
                 {
                     sortingData = new()

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -42,6 +42,8 @@ namespace Raven.Server.Documents.Queries.Results
         public ScoreDoc Score;
 
         public float? CoraxScore;
+        
+        public Corax.Utils.Spatial.SpatialResult? CoraxDistance;
 
         public Corax.IndexSearcher CoraxIndexSearcher;
 
@@ -56,14 +58,15 @@ namespace Raven.Server.Documents.Queries.Results
             CoraxIndexSearcher = null;
         }
 
-        public RetrieverInput(Corax.IndexSearcher searcher, IndexFieldsMapping knownFields, EntryTermsReader reader, string id, float? score = null)
+        public RetrieverInput(Corax.IndexSearcher searcher, IndexFieldsMapping knownFields, EntryTermsReader reader, string id, float? score = null, Corax.Utils.Spatial.SpatialResult? distance = null)
         {
             CoraxTermsReader = reader;
             KnownFields = knownFields;
             DocumentId = id;
             CoraxIndexSearcher = searcher;
             CoraxScore = score;
-
+            CoraxDistance = distance;
+            
             State = null;
             Score = null;
             LuceneDocument = null;

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -115,9 +115,13 @@ namespace Raven.Server.Documents.Queries.Results
                 return;
 
             doc.IndexScore = retrieverInput.Score?.Score ?? retrieverInput.CoraxScore ;
-            if (_query?.Distances != null && retrieverInput.IsLuceneDocument())
+            if ((_query?.Distances != null && retrieverInput.IsLuceneDocument()))
             {
                 doc.Distance = _query.Distances.Get(retrieverInput.Score.Doc);
+            }
+            else if (retrieverInput.CoraxDistance != null)
+            {
+                doc.Distance = (SpatialResult)retrieverInput.CoraxDistance;
             }
         }
 

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -38,7 +38,10 @@ class configurationItem {
         "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
         "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
         "Query.RegexTimeoutInMs",
-        "Indexing.Lucene.ReaderTermsIndexDivisor"
+        "Indexing.Lucene.ReaderTermsIndexDivisor",
+        "Indexing.Corax.IncludeDocumentScore",
+        "Indexing.Corax.IncludeSpatialDistance"
+
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Corax/CompoundSorting.cs
+++ b/test/FastTests/Corax/CompoundSorting.cs
@@ -111,9 +111,9 @@ public class CompoundSorting : RavenTestBase
         Assert.Equal(new[]{"2", "1", "3"}, queryStrAscFloatDesc);
     }
 
-    private IDocumentStore GetDatabaseWithDocuments(out string indexName)
+    private IDocumentStore GetDatabaseWithDocuments(out string indexName, bool includeScoresAndDistances = false)
     { 
-        var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax, includeScoresAndDistances));
         var index = new SortingIndex();
         index.Execute(store);
         indexName = index.IndexName;
@@ -163,7 +163,7 @@ public class CompoundSorting : RavenTestBase
     [RavenFact(RavenTestCategory.Querying)]
     public void GetIndexScoreAsMetadataCompound()
     {
-        using var store = GetDatabaseWithDocuments(out var indexName);
+        using var store = GetDatabaseWithDocuments(out var indexName, includeScoresAndDistances: true);
         using var session = store.OpenSession();
         var queryResults = session.Advanced
             .DocumentQuery<Dto, SortingIndex>()
@@ -182,7 +182,7 @@ public class CompoundSorting : RavenTestBase
     [RavenFact(RavenTestCategory.Querying)]
     public void GetIndexScoreAsMetadataSingle()
     {
-        using var store = GetDatabaseWithDocuments(out var indexName);
+        using var store = GetDatabaseWithDocuments(out var indexName, includeScoresAndDistances: true);
         using var session = store.OpenSession();
         var queryResults = session.Advanced
             .DocumentQuery<Dto, SortingIndex>()
@@ -200,7 +200,7 @@ public class CompoundSorting : RavenTestBase
     [RavenFact(RavenTestCategory.Querying)]
     public void CompoundAndNonCompoundShouldReturnExactlyTheSameScore()
     {
-        using var store = GetDatabaseWithDocuments(out var indexName);
+        using var store = GetDatabaseWithDocuments(out var indexName, includeScoresAndDistances: true);
         using var session = store.OpenSession();
         var singleCmp = session.Advanced
             .DocumentQuery<Dto, SortingIndex>()

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -82,6 +82,9 @@ namespace FastTests.Issues
                 "Query.RegexTimeoutInMs",
                 "Indexing.Lucene.ReaderTermsIndexDivisor",
                 "Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation",
+                "Indexing.Corax.IncludeDocumentScore",
+                "Indexing.Corax.IncludeSpatialDistance",
+                
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
@@ -97,7 +100,7 @@ namespace FastTests.Issues
 
             var sortedStudioList = propertiesDeclaredInStudio.OrderBy(x => x).ToList();
 
-            Assert.Equal(perIndexSettings, sortedStudioList);
+             Assert.Equal(perIndexSettings, sortedStudioList);
         }
     }
 }

--- a/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
+++ b/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class IncludeScoresAndDistancesCorax(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private string[] _data = {"maciej", "gracjan", "michal", "arek", "pawel"};
+    private Random _random = new(123124);
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanGetScoreInMetadata(bool compoundSorting)
+    {
+        using var store = PrepareData();
+        using var session = store.OpenSession();
+
+        var query = session.Advanced.DocumentQuery<StringAndSpatial, SpatialIndex>()
+            .Search(x => x.Name, string.Join(" ", _data))
+            .OrderByScore();
+
+        if (compoundSorting)
+            query = query.OrderBy(x => x.Lat);
+
+        IEnumerator<StreamResult<StringAndSpatial>> streamResults = session.Advanced.Stream(query, out StreamQueryStatistics streamQueryStats);
+        while (streamResults.MoveNext())
+        {
+            Assert.NotNull(streamResults.Current);
+            Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanGetSpatialResults(bool compoundSorting)
+    {
+        using var store = PrepareData();
+        using var session = store.OpenSession();
+
+        var query = session.Advanced.DocumentQuery<StringAndSpatial, SpatialIndex>()
+            .Search(x => x.Name, string.Join(" ", _data))
+            .OrderByDistance(s => s.SpatialField, 0, 0);
+
+        if (compoundSorting)
+            query = query.OrderBy(x => x.Lat);
+
+        IEnumerator<StreamResult<StringAndSpatial>> streamResults = session.Advanced.Stream(query, out StreamQueryStatistics streamQueryStats);
+        while (streamResults.MoveNext())
+        {
+            Assert.NotNull(streamResults.Current);
+            var spatialResult = (IDictionary<string, object>)streamResults.Current.Metadata[Constants.Documents.Metadata.SpatialResult];
+            Assert.NotNull(spatialResult);
+            Assert.Equal(streamResults.Current.Document.Lat, (double)spatialResult["Latitude"], precision: 5);
+            Assert.Equal(streamResults.Current.Document.Lng, (double)spatialResult["Longitude"], precision: 5);
+        }
+    }
+
+    [Fact]
+    public void DefaultBufferSizeForCoraxHasNotChanged()
+    {
+        // The tests in this file were designed for a pageSize of 4096. In case the default buffer has changed, please update the number of documents above that limit.
+        // These tests need to call .Fill at least twice to ensure that distances/scores can be transferred from Corax to Raven in a streaming manner.
+
+        Type type = typeof(Raven.Server.Documents.Indexes.Persistence.IndexOperationBase);
+        FieldInfo field = type.GetField("DefaultBufferSizeForCorax",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+        Assert.NotNull(field);
+        Assert.True(field.IsLiteral);
+        var coraxDefaultPageSize = (int)field.GetValue(null);
+        Assert.Equal(4096, coraxDefaultPageSize);
+    }
+
+    private IDocumentStore PrepareData()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeSpatialDistance)] = true.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = true.ToString();
+        };
+
+        var store = GetDocumentStore(options);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int idX = 0; idX < 5_000; ++idX)
+            {
+                var dto = new StringAndSpatial(_data[_random.Next(_data.Length)], _random.NextDouble() * 40 + 0.1d, _random.NextDouble() * 40 + 0.1d);
+                bulk.Store(dto);
+            }
+        }
+
+        new SpatialIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        return store;
+    }
+
+    private record StringAndSpatial(string Name, double Lat, double Lng, string Id = null, object SpatialField = null);
+
+    private class SpatialIndex : AbstractIndexCreationTask<StringAndSpatial>
+    {
+        public SpatialIndex()
+        {
+            Map = spatials => spatials.Select(x => new {SpatialField = CreateSpatialField(x.Lat, x.Lng), Name = x.Name, Lat = x.Lat});
+            Index(x => x.Name, FieldIndexing.Search);
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -792,13 +792,27 @@ namespace FastTests
                 _frozen = options._frozen;
             }
 
-            public static Options ForSearchEngine(RavenSearchEngineMode mode)
+            public static Options ForSearchEngine(RavenSearchEngineMode mode, bool includeScoresAndDistances = false)
             {
-                var config = new RavenTestParameters() { SearchEngine = mode };
-                return ForSearchEngine(config);
+                var config = new RavenTestParameters() {SearchEngine = mode};
+                var options = ForSearchEngine(config);
+                return includeScoresAndDistances
+                    ? IncludeDistancesAndScores(options)
+                    : options;
             }
 
-            public static Options ForSearchEngine(RavenTestParameters config)
+            private static Options IncludeDistancesAndScores(Options options)
+            {
+                options.ModifyDatabaseRecord += record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeSpatialDistance)] = true.ToString();
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = true.ToString();
+                };
+
+                return options;
+            }
+
+        public static Options ForSearchEngine(RavenTestParameters config)
             {
                 return new Options()
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20362
https://issues.hibernatingrhinos.com/issue/RavenDB-20231 
### Additional description

Distance part:
- Include SpatialResult when the user is sorting by spatial.

Score part:
Fix: When the user sorts more documents than there are in the default buffer, we encounter an out-of-range error. This happens because SortBatch is called only once and memoizes all documents, but our score buffer was set to the default corax buffer size (usually 4K). Therefore, I had to create a similar list for scoring as we do for matches.

Common:
Since including this information requires creating additional buffers to hold the information and could be very costly when the index is big, I have introduced a configuration option to include it.


### Type of change

- Bug fix
- New feature

### How risky is the change?

- Moderate 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
