### PR TITLE
RavenDB-20656 skipping counters, timeseries and revisions if document is being skipped via transform script

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -31,18 +31,18 @@ namespace Raven.Client.Documents.Smuggler
             */
 
             DatabaseRecord = new DatabaseRecordProgress();
-            Documents = new CountsWithSkippedCountAndLastEtag();
-            RevisionDocuments = new CountsWithLastEtagAndAttachments();
+            Documents = new CountsWithSkippedCountAndLastEtagAndAttachments();
+            RevisionDocuments = new CountsWithSkippedCountAndLastEtagAndAttachments();
             Tombstones = new CountsWithLastEtag();
             Conflicts = new CountsWithLastEtag();
             Identities = new CountsWithLastEtag();
             Indexes = new Counts();
             CompareExchange = new CountsWithLastEtag();
-            Counters = new CountsWithLastEtag();
+            Counters = new CountsWithSkippedCountAndLastEtag();
             CompareExchangeTombstones = new Counts();
             Subscriptions = new Counts();
             ReplicationHubCertificates = new Counts();
-            TimeSeries = new CountsWithLastEtag();
+            TimeSeries = new CountsWithSkippedCountAndLastEtag();
             _progress = new SmugglerProgress(this);
         }
 
@@ -200,9 +200,9 @@ namespace Raven.Client.Documents.Smuggler
     {
         public DatabaseRecordProgress DatabaseRecord { get; set; }
 
-        public CountsWithSkippedCountAndLastEtag Documents { get; set; }
+        public CountsWithSkippedCountAndLastEtagAndAttachments Documents { get; set; }
 
-        public CountsWithLastEtagAndAttachments RevisionDocuments { get; set; }
+        public CountsWithSkippedCountAndLastEtagAndAttachments RevisionDocuments { get; set; }
 
         public CountsWithLastEtag Tombstones { get; set; }
 
@@ -218,9 +218,9 @@ namespace Raven.Client.Documents.Smuggler
 
         public Counts ReplicationHubCertificates { get; set; }
 
-        public CountsWithLastEtag Counters { get; set; }
+        public CountsWithSkippedCountAndLastEtag Counters { get; set; }
 
-        public CountsWithLastEtag TimeSeries { get; set; }
+        public CountsWithSkippedCountAndLastEtag TimeSeries { get; set; }
 
         public Counts CompareExchangeTombstones { get; set; }
 
@@ -542,7 +542,24 @@ namespace Raven.Client.Documents.Smuggler
             }
         }
 
-        public class CountsWithSkippedCountAndLastEtag : CountsWithLastEtagAndAttachments
+        public class CountsWithSkippedCountAndLastEtag : CountsWithLastEtag
+        {
+            public long SkippedCount { get; set; }
+
+            public override DynamicJsonValue ToJson()
+            {
+                var json = base.ToJson();
+                json[nameof(SkippedCount)] = SkippedCount;
+                return json;
+            }
+
+            public override string ToString()
+            {
+                return $"Skipped: {SkippedCount}. {base.ToString()}";
+            }
+        }
+
+        public class CountsWithSkippedCountAndLastEtagAndAttachments : CountsWithLastEtagAndAttachments
         {
             public long SkippedCount { get; set; }
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -275,7 +275,7 @@ namespace Raven.Server.Smuggler.Documents
             private readonly ConcurrentDictionary<string, CollectionName> _missingDocumentsForRevisions;
             private readonly HashSet<string> _documentIdsOfMissingAttachments;
             private readonly DuplicateDocsHandler _duplicateDocsHandler;
-            private bool _throwOnCollectionMismatchError;
+            private readonly bool _throwOnCollectionMismatchError;
 
             public DatabaseDocumentActions(DocumentDatabase database, BuildVersionType buildType, DatabaseSmugglerOptionsServerSide options, bool isRevision, Logger log, DuplicateDocsHandler duplicateDocsHandler, bool throwOnCollectionMismatchError)
             {

--- a/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
@@ -13,6 +14,8 @@ namespace Raven.Server.Smuggler.Documents
         private readonly DocumentDatabase _database;
         private ScriptRunner.SingleRun _run;
 
+        private readonly HashSet<string> _skippedDocumentIds = new(StringComparer.OrdinalIgnoreCase);
+
         public SmugglerPatcher(DatabaseSmugglerOptions options, DocumentDatabase database)
         {
             if (string.IsNullOrWhiteSpace(options.TransformScript))
@@ -24,9 +27,9 @@ namespace Raven.Server.Smuggler.Documents
         public Document Transform(Document document)
         {
             var ctx = document.Data._context;
-            object translatedResult;
             using (document)
             {
+                object translatedResult;
                 using (_run.ScriptEngine.ChangeMaxStatements(_options.MaxStepsForTransformScript))
                 {
                     try
@@ -39,7 +42,10 @@ namespace Raven.Server.Smuggler.Documents
                     catch (Client.Exceptions.Documents.Patching.JavaScriptException e)
                     {
                         if (e.InnerException is Jint.Runtime.JavaScriptException innerException && string.Equals(innerException.Message, "skip", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _skippedDocumentIds.Add(document.Id);
                             return null;
+                        }
 
                         throw;
                     }
@@ -60,8 +66,15 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
+        public bool ShouldSkip(LazyStringValue documentId)
+        {
+            return _skippedDocumentIds.Count > 0 && _skippedDocumentIds.Contains(documentId);
+        }
+
         public IDisposable Initialize()
         {
+            _skippedDocumentIds.Clear();
+
             var key = new PatchRequest(_options.TransformScript, PatchRequestType.Smuggler);
             return _database.Scripts.GetScriptRunner(key, true, out _run);
         }

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -80,13 +80,13 @@ namespace Raven.Server.Smuggler.Migration
                     if ((_buildVersion >= 40000 && _buildVersion < 41000) || _buildVersion == 40)
                     {
                         // prevent NRE, counter were added in 4.1
-                        smugglerResult.Counters = new SmugglerProgressBase.CountsWithLastEtag();
+                        smugglerResult.Counters = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
                     if ((_buildVersion >= 40000 && _buildVersion < 50000) || (_buildVersion >= 40 && _buildVersion < 50))
                     {
                         // prevent NRE, time series were added in 5.0
-                        smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithLastEtag();
+                        smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
                     var importInfo = new ImportInfo

--- a/test/SlowTests/Issues/RavenDB_20656.cs
+++ b/test/SlowTests/Issues/RavenDB_20656.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Smuggler;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20656 : RavenTestBase
+{
+    public RavenDB_20656(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Should_Not_Export_TimeSeries_Counters_Attachments_Revisions_Of_Skipped_Document()
+    {
+        var exportPath = NewDataPath();
+        var exportFile1 = Path.Combine(exportPath, "export1.ravendbdump");
+        var exportFile2 = Path.Combine(exportPath, "export2.ravendbdump");
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var company1 = new Company { Id = "companies/1", Name = "HR" };
+                var company2 = new Company { Id = "companies/2", Name = "CF" };
+
+                await session.StoreAsync(company1);
+                await session.StoreAsync(company2);
+
+                session.TimeSeriesFor(company1, "HR_TS").Append(DateTime.Now, 3);
+                session.TimeSeriesFor(company2, "CF_TS").Append(DateTime.Now, 3);
+
+                session.Advanced.Attachments.Store(company1, "A1", new MemoryStream(new byte[] { 1, 2, 3 }));
+                session.Advanced.Attachments.Store(company2, "A1", new MemoryStream(new byte[] { 3, 2, 1 }));
+
+                session.CountersFor(company1).Increment("C1", 6);
+                session.CountersFor(company2).Increment("C1", 3);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.Revisions.ForceRevisionCreationFor("companies/1");
+                session.Advanced.Revisions.ForceRevisionCreationFor("companies/2");
+
+                await session.SaveChangesAsync();
+            }
+
+            var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportFile1);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(2, result.Documents.ReadCount);
+            Assert.Equal(0, result.Documents.SkippedCount);
+            Assert.Equal(0, result.Documents.ErroredCount);
+
+            Assert.Equal(2, result.Documents.Attachments.ReadCount);
+            Assert.Equal(0, result.Documents.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.SkippedCount);
+            Assert.Equal(0, result.RevisionDocuments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.Counters.ReadCount);
+            Assert.Equal(0, result.Counters.SkippedCount);
+            Assert.Equal(0, result.Counters.ErroredCount);
+
+            Assert.Equal(2, result.TimeSeries.ReadCount);
+            Assert.Equal(0, result.TimeSeries.SkippedCount);
+            Assert.Equal(0, result.TimeSeries.ErroredCount);
+
+            operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions
+            {
+                TransformScript = @"
+var name = this.Name;
+if (name == 'CF')
+   throw 'skip';
+"
+            }, exportFile2);
+            result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(2, result.Documents.ReadCount);
+            Assert.Equal(1, result.Documents.SkippedCount);
+            Assert.Equal(0, result.Documents.ErroredCount);
+
+            Assert.Equal(1, result.Documents.Attachments.ReadCount);
+            Assert.Equal(0, result.Documents.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.ReadCount);
+            Assert.Equal(1, result.RevisionDocuments.SkippedCount);
+            Assert.Equal(0, result.RevisionDocuments.ErroredCount);
+
+            Assert.Equal(1, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.Counters.ReadCount);
+            Assert.Equal(1, result.Counters.SkippedCount);
+            Assert.Equal(0, result.Counters.ErroredCount);
+
+            Assert.Equal(2, result.TimeSeries.ReadCount);
+            Assert.Equal(1, result.TimeSeries.SkippedCount);
+            Assert.Equal(0, result.TimeSeries.ErroredCount);
+        }
+
+        using (var store = GetDocumentStore())
+        {
+            var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile1);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(2, result.Documents.ReadCount);
+            Assert.Equal(0, result.Documents.SkippedCount);
+            Assert.Equal(0, result.Documents.ErroredCount);
+
+            Assert.Equal(2, result.Documents.Attachments.ReadCount);
+            Assert.Equal(0, result.Documents.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.SkippedCount);
+            Assert.Equal(0, result.RevisionDocuments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.Counters.ReadCount);
+            Assert.Equal(0, result.Counters.SkippedCount);
+            Assert.Equal(0, result.Counters.ErroredCount);
+
+            Assert.Equal(2, result.TimeSeries.ReadCount);
+            Assert.Equal(0, result.TimeSeries.SkippedCount);
+            Assert.Equal(0, result.TimeSeries.ErroredCount);
+        }
+
+        using (var store = GetDocumentStore())
+        {
+            var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions
+            {
+                TransformScript = @"
+var name = this.Name;
+if (name == 'CF')
+   throw 'skip';
+"
+            }, exportFile1);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(2, result.Documents.ReadCount);
+            Assert.Equal(1, result.Documents.SkippedCount);
+            Assert.Equal(0, result.Documents.ErroredCount);
+
+            Assert.Equal(1, result.Documents.Attachments.ReadCount);
+            Assert.Equal(0, result.Documents.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.RevisionDocuments.ReadCount);
+            Assert.Equal(1, result.RevisionDocuments.SkippedCount);
+            Assert.Equal(0, result.RevisionDocuments.ErroredCount);
+
+            Assert.Equal(1, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
+
+            Assert.Equal(2, result.Counters.ReadCount);
+            Assert.Equal(1, result.Counters.SkippedCount);
+            Assert.Equal(0, result.Counters.ErroredCount);
+
+            Assert.Equal(2, result.TimeSeries.ReadCount);
+            Assert.Equal(1, result.TimeSeries.SkippedCount);
+            Assert.Equal(0, result.TimeSeries.ErroredCount);
+        }
+
+        using (var store = GetDocumentStore())
+        {
+            var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile2);
+            var result = await operation.WaitForCompletionAsync<SmugglerResult>(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(1, result.Documents.ReadCount);
+            Assert.Equal(0, result.Documents.SkippedCount);
+            Assert.Equal(0, result.Documents.ErroredCount);
+
+            Assert.Equal(1, result.Documents.Attachments.ReadCount);
+            Assert.Equal(0, result.Documents.Attachments.ErroredCount);
+
+            Assert.Equal(1, result.RevisionDocuments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.SkippedCount);
+            Assert.Equal(0, result.RevisionDocuments.ErroredCount);
+
+            Assert.Equal(1, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
+
+            Assert.Equal(1, result.Counters.ReadCount);
+            Assert.Equal(0, result.Counters.SkippedCount);
+            Assert.Equal(0, result.Counters.ErroredCount);
+
+            Assert.Equal(1, result.TimeSeries.ReadCount);
+            Assert.Equal(0, result.TimeSeries.SkippedCount);
+            Assert.Equal(0, result.TimeSeries.ErroredCount);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20656

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
