### PR TITLE
RavenDB-19987 do not keep more than 16k loaded documents during query execution

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -11,14 +11,10 @@ using Jint.Native.Object;
 using Jint.Runtime;
 using Lucene.Net.Documents;
 using Lucene.Net.Store;
-using Microsoft.Extensions.Azure;
-using Nest;
-using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Includes;
-using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries.AST;
@@ -31,7 +27,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
-using Voron;
 using Constants = Raven.Client.Constants;
 using IndexField = Raven.Server.Documents.Indexes.IndexField;
 using RangeType = Raven.Client.Documents.Indexes.RangeType;
@@ -40,6 +35,8 @@ namespace Raven.Server.Documents.Queries.Results
 {
     public abstract class QueryResultRetrieverBase : IQueryResultRetriever
     {
+        public static readonly int LoadedDocumentsCacheSize = 16 * 1024;
+
         public static readonly Lucene.Net.Search.ScoreDoc ZeroScore = new Lucene.Net.Search.ScoreDoc(-1, 0f);
 
         public static readonly Lucene.Net.Search.ScoreDoc OneScore = new Lucene.Net.Search.ScoreDoc(-1, 1f);
@@ -52,7 +49,7 @@ namespace Raven.Server.Documents.Queries.Results
         private readonly IncludeCompareExchangeValuesCommand _includeCompareExchangeValuesCommand;
         private readonly BlittableJsonTraverser _blittableTraverser;
 
-        private Dictionary<string, Document> _loadedDocuments;
+        private LruDictionary<string, Document> _loadedDocuments;
         private Dictionary<string, Document> _loadedDocumentsByAliasName;
         private HashSet<string> _loadedDocumentIds;
 
@@ -873,7 +870,7 @@ namespace Raven.Server.Documents.Queries.Results
             if (_loadedDocumentIds == null)
             {
                 _loadedDocumentIds = new HashSet<string>();
-                _loadedDocuments = new Dictionary<string, Document>();
+                _loadedDocuments = new LruDictionary<string, Document>(LoadedDocumentsCacheSize);
                 _loadedDocumentsByAliasName = new Dictionary<string, Document>();
             }
             _loadedDocumentIds.Clear();

--- a/src/Raven.Server/Utils/LruDictionary.cs
+++ b/src/Raven.Server/Utils/LruDictionary.cs
@@ -1,0 +1,64 @@
+﻿namespace Raven.Server.Utils;
+
+using System.Collections.Generic;
+
+public sealed class LruDictionary<TKey, TValue> where TKey : notnull
+{
+    private readonly int _maxCapacity;
+    private readonly Dictionary<TKey, (LinkedListNode<TKey> Node, TValue Value)> _cache;
+    private readonly LinkedList<TKey> _list;
+
+    public LruDictionary(int maxCapacity)
+    {
+        _maxCapacity = maxCapacity;
+        _cache = new Dictionary<TKey, (LinkedListNode<TKey> Node, TValue Value)>(maxCapacity);
+        _list = new LinkedList<TKey>();
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        if (_cache.TryGetValue(key, out var node) == false)
+        {
+            value = default;
+            return false;
+        }
+
+        _list.Remove(node.Node);
+        _list.AddFirst(node.Node);
+
+        value = node.Value;
+        return true;
+    }
+
+    public TValue this[TKey key]
+    {
+        get
+        {
+            TryGetValue(key, out var value);
+            return value;
+        }
+
+        set
+        {
+            if (_cache.TryGetValue(key, out var node))
+            {
+                _list.Remove(node.Node);
+                _list.AddFirst(node.Node);
+
+                _cache[key] = (node.Node, value);
+            }
+            else
+            {
+                if (_cache.Count >= _maxCapacity)
+                {
+                    var removeKey = _list.Last!.Value;
+                    _cache.Remove(removeKey);
+                    _list.RemoveLast();
+                }
+
+                // add cache
+                _cache.Add(key, (_list.AddFirst(key), value));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19987

### Additional description

For queries with projection we are keeping loaded documents during the query execution, this is problematic for streaming where the loaded documents can bloat to enormous numbers, the advantage of this cache is to avoid calls to the store to retrieve the documents, but if they are not used it is not worth keeping them at all

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
