### PR TITLE
RavenDB-19967: Notification/warning about tombstone cleaner subscribers disabled

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
@@ -6,16 +6,18 @@
 
 using System.Diagnostics;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
-    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible
+    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible, ITombstoneDeletionBlocker
     {
         public string Name { get; set; }
         public long TaskId { get; set; }
         public bool Disabled { get; set; }
+        public string BlockingSourceName => $"{BackupType} '{Name}'";
         public string MentorNode { get; set; }
         public bool PinToMentorNode { get; set; }
         public RetentionPolicy RetentionPolicy { get; set; }

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
@@ -22,7 +22,9 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         }
 
         public override EtlType EtlType => EtlType.ElasticSearch;
-        
+
+        public override string BlockingSourceName => $"ElasticSearch ETL task '{Name}'";
+
         public override bool UsingEncryptedCommunicationChannel()
         {
             foreach (var url in Connection.Nodes)

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -5,12 +5,13 @@ using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
-    public abstract class EtlConfiguration<T> : IDynamicJsonValueConvertible, IDatabaseTask where T : ConnectionString
+    public abstract class EtlConfiguration<T> : IDynamicJsonValueConvertible, IDatabaseTask, ITombstoneDeletionBlocker where T : ConnectionString
     {
         private bool _initialized;
 
@@ -41,6 +42,8 @@ namespace Raven.Client.Documents.Operations.ETL
         public List<Transformation> Transforms { get; set; } = new List<Transformation>();
 
         public bool Disabled { get; set; }
+
+        public abstract string BlockingSourceName { get; }
 
         public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
         {

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
@@ -27,6 +27,8 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
         public override EtlType EtlType => EtlType.Olap;
 
+        public override string BlockingSourceName => $"OLAP ETL task '{Name}'";
+
         public override bool UsingEncryptedCommunicationChannel()
         {
             if (Connection.FtpSettings == null)

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -35,6 +35,8 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
         }
 
         public override EtlType EtlType => EtlType.Queue;
+
+        public override string BlockingSourceName => $"Queue ETL task '{Name}'";
         
         public override bool UsingEncryptedCommunicationChannel()
         {

--- a/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
@@ -11,6 +11,8 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public override EtlType EtlType => EtlType.Raven;
 
+        public override string BlockingSourceName => $"RavenDB ETL task '{Name}'";
+
         public override string GetDestination()
         {
             return _destination ?? (_destination = $"{Connection.Database}@{string.Join(",",Connection.TopologyDiscoveryUrls)}");

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -26,6 +26,8 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override EtlType EtlType => EtlType.Sql;
 
+        public override string BlockingSourceName => $"SQL ETL task '{Name}'";
+
         public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
         {
             base.Validate(out errors, validateName, validateConnection);

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public class ExternalReplication : ExternalReplicationBase, IExternalReplication
+    public class ExternalReplication : ExternalReplicationBase, IExternalReplication, ITombstoneDeletionBlocker
     {
         public ExternalReplication()
         {

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -133,7 +133,7 @@ namespace Raven.Client.Documents.Operations.Replication
             return MentorNode;
         }
 
-        public virtual string GetDefaultTaskName()
+        public override string GetDefaultTaskName()
         {
             return $"External Replication to {ConnectionStringName}";
         }

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -133,7 +133,7 @@ namespace Raven.Client.Documents.Operations.Replication
             return MentorNode;
         }
 
-        public override string GetDefaultTaskName()
+        public virtual string GetDefaultTaskName()
         {
             return $"External Replication to {ConnectionStringName}";
         }
@@ -152,5 +152,7 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             return PinToMentorNode;
         }
+
+        public override string BlockingSourceName => $"External Replication '{Name}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -42,6 +42,6 @@ namespace Raven.Client.Documents.Operations.Replication
             }
         }
 
-        public override string GetDefaultTaskName() => $"Internal Replication {FromString()}";
+        public override string BlockingSourceName => $"Internal Replication '{FromString()}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -41,5 +41,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 return hashCode;
             }
         }
+
+        public override string GetDefaultTaskName() => $"Internal Replication {FromString()}";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -95,5 +95,7 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             return $"Replication Sink for {HubName}";
         }
+
+        public override string BlockingSourceName => $"Replication Sink task '{Name}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Replication.Messages;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public class PullReplicationDefinition : IDynamicJsonValueConvertible
+    public class PullReplicationDefinition : IDynamicJsonValueConvertible, ITombstoneDeletionBlocker
     {
         [Obsolete("You cannot use Certificates on the PullReplicationDefinition any more, please use the dedicated commands: RegisterReplicationHubAccessOperation and UnregisterReplicationHubAccessOperation")]
         public Dictionary<string, string> Certificates; // <thumbprint, base64 cert>
 
         public TimeSpan DelayReplicationFor;
-        public bool Disabled;
+        public bool Disabled { get; set; }
 
         public string MentorNode;
 
@@ -113,7 +114,7 @@ namespace Raven.Client.Documents.Operations.Replication
             };
         }
 
-        public string GetDefaultTaskName() => $"Replication Hub ({Mode}) for {Name}";
+        public string BlockingSourceName => $"Replication Hub task '{Name}'";
     }
 
     [Flags]

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -112,6 +112,8 @@ namespace Raven.Client.Documents.Operations.Replication
                 TaskId = taskId
             };
         }
+
+        public string GetDefaultTaskName() => $"Replication Hub ({Mode}) for {Name}";
     }
 
     [Flags]

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow;
 using Sparrow.Json.Parsing;
 
@@ -13,7 +14,7 @@ namespace Raven.Client.Documents.Replication
     /// <summary>
     /// Data class for replication destination
     /// </summary>
-    public abstract class ReplicationNode : IEquatable<ReplicationNode>
+    public abstract class ReplicationNode : IEquatable<ReplicationNode>, ITombstoneDeletionBlocker
     {
         /// <summary>
         /// The name of the connection string specified in the 
@@ -48,6 +49,8 @@ namespace Raven.Client.Documents.Replication
         /// Used to indicate whether external replication is disabled.
         /// </summary>
         public bool Disabled { get; set; }
+
+        public abstract string BlockingSourceName { get; } 
 
         public bool Equals(ReplicationNode other) => IsEqualTo(other);
 
@@ -94,8 +97,5 @@ namespace Raven.Client.Documents.Replication
         }
 
         public abstract string FromString();
-        public abstract string GetDefaultTaskName();
     }
-
-   
 }

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -94,6 +94,7 @@ namespace Raven.Client.Documents.Replication
         }
 
         public abstract string FromString();
+        public abstract string GetDefaultTaskName();
     }
 
    

--- a/src/Raven.Client/ServerWide/Operations/OngoingTasks/ITombstoneDeletionBlocker.cs
+++ b/src/Raven.Client/ServerWide/Operations/OngoingTasks/ITombstoneDeletionBlocker.cs
@@ -1,0 +1,7 @@
+﻿namespace Raven.Client.ServerWide.Operations.OngoingTasks;
+
+public interface ITombstoneDeletionBlocker
+{
+    string BlockingSourceName { get; }
+    bool Disabled { get; set; }
+}

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -850,33 +850,13 @@ namespace Raven.Server.Documents.ETL
 
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
-            var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            foreach (ElasticSearchEtlConfiguration config in ElasticSearchDestinations)
-            {
-                if (config.Disabled)
-                    dict[config.Name] = tombstoneCollections;
-            }
-            foreach (OlapEtlConfiguration config in OlapDestinations)
-            {
-                if (config.Disabled)
-                    dict[config.Name] = tombstoneCollections;
-            }
-            foreach (QueueEtlConfiguration config in QueueDestinations)
-            {
-                if (config.Disabled)
-                    dict[config.Name] = tombstoneCollections;
-            }
+            var dict = new Dictionary<string, HashSet<string>>();
 
-            foreach (RavenEtlConfiguration config in RavenDestinations)
-            {
-                if (config.Disabled)
-                    dict[config.Name] = tombstoneCollections;
-            }
-            foreach (SqlEtlConfiguration config in SqlDestinations)
-            {
-                if (config.Disabled)
-                    dict[config.Name] = tombstoneCollections;
-            }
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, ElasticSearchDestinations, tombstoneCollections);
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, OlapDestinations, tombstoneCollections);
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, QueueDestinations, tombstoneCollections);
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, RavenDestinations, tombstoneCollections);
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, SqlDestinations, tombstoneCollections);
 
             return dict;
         }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/tombstones/state", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
         public async Task State()
         {
-            var state = Database.TombstoneCleaner.GetState();
+            var state = Database.TombstoneCleaner.GetState(addInfoForDebug: true);
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/tombstones/state", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
         public async Task State()
         {
-            var state = Database.TombstoneCleaner.GetState(addInfoForDebug: true);
+            var state = Database.TombstoneCleaner.GetState();
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4154,6 +4154,8 @@ namespace Raven.Server.Documents.Indexes
 
         public string TombstoneCleanerIdentifier => $"Index '{Name}'";
 
+        public string BlockingSourceName => TombstoneCleanerIdentifier;
+
         public virtual Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
@@ -4174,8 +4176,9 @@ namespace Raven.Server.Documents.Indexes
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            if (Status == IndexRunningStatus.Disabled || Status == IndexRunningStatus.Paused)
-                dict[TombstoneCleanerIdentifier] = Collections;
+
+            if (Status is IndexRunningStatus.Disabled or IndexRunningStatus.Paused)
+                dict[BlockingSourceName] = Collections;
 
             return dict;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -14,7 +14,6 @@ using Nito.AsyncEx;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions.Corax;
@@ -4176,7 +4175,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             if (Status == IndexRunningStatus.Disabled || Status == IndexRunningStatus.Paused)
-                dict[Name] = Collections;
+                dict[TombstoneCleanerIdentifier] = Collections;
 
             return dict;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1043,11 +1043,8 @@ namespace Raven.Server.Documents.PeriodicBackup
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var periodicBackup in PeriodicBackups.Where(x => x.Configuration.Disabled))
-            {
-                var source = $"{periodicBackup.Configuration.BackupType} '{periodicBackup.Configuration.Name}'";
-                dict[source] = tombstoneCollections;
-            }
+
+            TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, PeriodicBackups.Select(x => x.Configuration), tombstoneCollections);
 
             return dict;
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1043,10 +1043,10 @@ namespace Raven.Server.Documents.PeriodicBackup
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var periodicBackup in PeriodicBackups)
+            foreach (var periodicBackup in PeriodicBackups.Where(x => x.Configuration.Disabled))
             {
-                if (periodicBackup.Configuration.Disabled)
-                    dict[periodicBackup.Configuration.Name] = tombstoneCollections;
+                var source = $"{periodicBackup.Configuration.BackupType} '{periodicBackup.Configuration.Name}'";
+                dict[source] = tombstoneCollections;
             }
 
             return dict;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -37,7 +37,6 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Json.Sync;
 using Sparrow.Logging;
-using Sparrow.Platform;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Server.Utils;
 using Sparrow.Threading;
@@ -1920,29 +1919,38 @@ namespace Raven.Server.Documents.Replication
         public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var replicationDestination in Destinations)
+            foreach (var replicationDestination in Destinations.Where(x => x.Disabled))
             {
-                if (replicationDestination.Disabled)
-                    dict[replicationDestination.FromString()] = tombstoneCollections;
+                dict[replicationDestination.GetDefaultTaskName()] = tombstoneCollections;
             }
 
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var externals = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name)?.ExternalReplications;
+                var hubPullReplications = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name)?.GetHubPullReplications();
+                var sinkPullReplications = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name)?.GetSinkPullReplications();
+                
                 if (externals != null)
-                {
-                    foreach (var external in externals)
+                    foreach (var external in externals.Where(x => x.Disabled))
                     {
-                        if (external.Disabled)
-                        {
-                            dict[external.Name] = tombstoneCollections;
-                        }
+                        dict[external.Name] = tombstoneCollections;
                     }
-                }
-            }
 
-            return dict;
+                if (hubPullReplications != null)
+                    foreach (var hubPullReplication in hubPullReplications.Where(x => x.Disabled))
+                    {
+                        dict[hubPullReplication.GetDefaultTaskName()] = tombstoneCollections;
+                    }
+
+                if (sinkPullReplications != null)
+                    foreach (var sinkPullReplication in sinkPullReplications.Where(x => x.Disabled))
+                    {
+                        dict[sinkPullReplication.Name] = tombstoneCollections;
+                    }
+                
+                return dict;
+            }
         }
 
         public class IncomingConnectionRejectionInfo

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -37,8 +37,10 @@ namespace Raven.Server.NotificationCenter
             var list = new List<BlockingTombstoneDetails>();
             using (_notificationsStorage.Read(id, out var value))
             {
-                value.Json.TryGet(nameof(AlertRaised.Details), out BlittableJsonReaderObject details);
-                details.TryGet(nameof(BlockingTombstonesDetails.BlockingTombstones), out BlittableJsonReaderArray blockingTombstonesDetails);
+                if (value == null ||
+                    value.Json.TryGet(nameof(AlertRaised.Details), out BlittableJsonReaderObject details) == false ||
+                    details.TryGet(nameof(BlockingTombstonesDetails.BlockingTombstones), out BlittableJsonReaderArray blockingTombstonesDetails) == false) 
+                    return list;
 
                 foreach (BlittableJsonReaderObject detail in blockingTombstonesDetails)
                 {
@@ -48,8 +50,8 @@ namespace Raven.Server.NotificationCenter
 
                     list.Add(new BlockingTombstoneDetails
                     {
-                        Source = source, 
-                        Collection = collection, 
+                        Source = source,
+                        Collection = collection,
                         NumberOfTombstones = numOfTombstones
                     });
                 }

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.NotificationCenter
             _notificationCenter.Add(AlertRaised.Create(
                 _database, 
                 title: "Blockage in tombstone deletion", 
-                msg: "We have detected a blockage in tombstone deletion. Deletion or enabling certain processes may be required.", 
+                msg: "We have detected a blockage in tombstone deletion due to certain processes being in the disabled, errored, or paused states. Deletion or enabling of certain processes may be required.", 
                 type: AlertType.BlockingTombstones,
                 severity: NotificationSeverity.Warning,
                 key: nameof(AlertType.BlockingTombstones), 

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -295,38 +295,62 @@ namespace Raven.Server.ServerWide
                 if (_materializedRecord != null)
                     return _materializedRecord.ExternalReplications;
 
-                if (_externalReplications == null)
-                {
-                    _externalReplications = new List<ExternalReplication>();
-                    if (_record.TryGet(nameof(DatabaseRecord.ExternalReplications), out BlittableJsonReaderArray bjra) && bjra != null)
-                    {
-                        foreach (BlittableJsonReaderObject element in bjra)
-                            _externalReplications.Add(JsonDeserializationCluster.ExternalReplication(element));
-                    }
-                }
+                if (_externalReplications != null) 
+                    return _externalReplications;
 
+                if (_record.TryGet(nameof(DatabaseRecord.ExternalReplications), out BlittableJsonReaderArray bjra) == false || bjra == null)
+                    return new List<ExternalReplication>();
+                
+                _externalReplications = (from BlittableJsonReaderObject element in bjra
+                    select JsonDeserializationClient.ExternalReplication(element)).ToList();
+                
                 return _externalReplications;
             }
         }
 
-        public IEnumerable<PullReplicationDefinition> GetHubPullReplications()
-        {
-            if (_record.TryGet(nameof(DatabaseRecord.HubPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null) 
-                return null;
+        private List<PullReplicationDefinition> _hubPullReplications;
 
-            return from BlittableJsonReaderObject element in bjra
-                select JsonDeserializationClient.PullReplicationDefinition(element);
+        public List<PullReplicationDefinition> HubPullReplications
+        {
+            get
+            {
+                if (_materializedRecord != null)
+                    return _materializedRecord.HubPullReplications;
+
+                if (_hubPullReplications != null)
+                    return _hubPullReplications;
+                
+                if (_record.TryGet(nameof(DatabaseRecord.HubPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null)
+                    return new List<PullReplicationDefinition>();
+
+                _hubPullReplications = (from BlittableJsonReaderObject element in bjra
+                    select JsonDeserializationClient.PullReplicationDefinition(element)).ToList();
+
+                return _hubPullReplications;
+            }
         }
 
-        public IEnumerable<PullReplicationDefinition> GetSinkPullReplications()
+        private List<PullReplicationAsSink> _sinkPullReplications;
+
+        public List<PullReplicationAsSink> SinkPullReplications
         {
-            if (_record.TryGet(nameof(DatabaseRecord.SinkPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null)
-                return null;
+            get
+            {
+                if (_materializedRecord != null)
+                    return _materializedRecord.SinkPullReplications;
 
-            return from BlittableJsonReaderObject element in bjra
-                select JsonDeserializationClient.PullReplicationDefinition(element);
+                if (_sinkPullReplications != null)
+                    return _sinkPullReplications;
+
+                if (_record.TryGet(nameof(DatabaseRecord.SinkPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null)
+                    return new List<PullReplicationAsSink>();
+
+                _sinkPullReplications = (from BlittableJsonReaderObject element in bjra
+                    select JsonDeserializationClient.PullReplicationAsSink(element)).ToList();
+
+                return _sinkPullReplications;
+            }
         }
-
 
         public PullReplicationDefinition GetHubPullReplicationByName(string name)
         {
@@ -341,8 +365,7 @@ namespace Raven.Server.ServerWide
 
             return null;
         }
-        
-        
+
         public PullReplicationDefinition GetHubPullReplicationById(in long key)
         {
             if (_record.TryGet(nameof(DatabaseRecord.HubPullReplications), out BlittableJsonReaderArray bjra) && bjra != null)

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -308,8 +308,26 @@ namespace Raven.Server.ServerWide
                 return _externalReplications;
             }
         }
-        
-        
+
+        public IEnumerable<PullReplicationDefinition> GetHubPullReplications()
+        {
+            if (_record.TryGet(nameof(DatabaseRecord.HubPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null) 
+                return null;
+
+            return from BlittableJsonReaderObject element in bjra
+                select JsonDeserializationClient.PullReplicationDefinition(element);
+        }
+
+        public IEnumerable<PullReplicationDefinition> GetSinkPullReplications()
+        {
+            if (_record.TryGet(nameof(DatabaseRecord.SinkPullReplications), out BlittableJsonReaderArray bjra) == false || bjra == null)
+                return null;
+
+            return from BlittableJsonReaderObject element in bjra
+                select JsonDeserializationClient.PullReplicationDefinition(element);
+        }
+
+
         public PullReplicationDefinition GetHubPullReplicationByName(string name)
         {
             if (_record.TryGet(nameof(DatabaseRecord.HubPullReplications), out BlittableJsonReaderArray bjra) && bjra != null)

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlEditModel.ts
@@ -110,7 +110,8 @@ class ongoingTaskElasticSearchEtlEditModel extends ongoingTaskEditModel {
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
-            ElasticIndexes: this.elasticIndexes().map(x => x.toDto())
+            ElasticIndexes: this.elasticIndexes().map(x => x.toDto()),
+            BlockingSourceName: this.blockingSourceName()
         };
         
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskModel.ts
@@ -14,7 +14,9 @@ abstract class ongoingTaskModel {
     responsibleNode = ko.observable<Raven.Client.ServerWide.Operations.NodeId>();
     
     taskConnectionStatus = ko.observable<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskConnectionStatus>();    
-    
+
+    blockingSourceName = ko.observable<string>();
+
     badgeText: KnockoutComputed<string>;
     badgeClass: KnockoutComputed<string>;
     stateText: KnockoutComputed<string>;

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
@@ -133,7 +133,8 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             CustomPartitionValue: this.customPartitionEnabled() ? this.customPartition() : null,
             RunFrequency: this.runFrequency(),
             OlapTables: this.olapTables().map(x => x.toDto()),
-            Format: undefined
+            Format: undefined,
+            BlockingSourceName: this.blockingSourceName()
         };
         
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlEditModel.ts
@@ -169,7 +169,8 @@ abstract class ongoingTaskQueueEtlEditModel extends ongoingTaskEditModel {
             TaskId: this.taskId,
             BrokerType: broker,
             SkipAutomaticQueueDeclaration: this.skipAutomaticQueueDeclaration(),
-            Queues: this.queueOptionsToDto()
+            Queues: this.queueOptionsToDto(),
+            BlockingSourceName: this.blockingSourceName()
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
@@ -122,6 +122,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             PinToMentorNode: this.pinMentorNode(),
             TaskId: this.taskId,
             LoadRequestTimeoutInSec: this.loadRequestTimeout() || null,
+            BlockingSourceName: this.blockingSourceName()
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
@@ -56,7 +56,8 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Url: undefined,
             Disabled: this.taskState() === "Disabled",
-            Database: undefined
+            Database: undefined,
+            BlockingSourceName: this.blockingSourceName(),
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
@@ -8,6 +8,7 @@ class ongoingTaskReplicationHubEditModel {
     taskType = ko.observable<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskType>();
 
     disabled = ko.observable<boolean>();
+    blockingSourceName = ko.observable<string>();
     stateText: KnockoutComputed<string>;
 
     responsibleNode = ko.observable<Raven.Client.ServerWide.Operations.NodeId>();
@@ -94,7 +95,8 @@ class ongoingTaskReplicationHubEditModel {
             Disabled: this.disabled(),
             PreventDeletionsMode: this.preventDeletions() ? "PreventSinkToHubDeletions" : "None",
             WithFiltering: this.withFiltering(),
-            Certificates: undefined
+            Certificates: undefined,
+            BlockingSourceName: this.blockingSourceName()
         };
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -132,7 +132,8 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             CommandTimeout: this.commandTimeout() || null,
             QuoteTables: this.tableQuotation(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
-            SqlTables: this.sqlTables().map(x => x.toDto())
+            SqlTables: this.sqlTables().map(x => x.toDto()),
+            BlockingSourceName: this.blockingSourceName()
         
         } as Raven.Client.Documents.Operations.ETL.SQL.SqlEtlConfiguration;
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -46,6 +46,8 @@ abstract class backupConfiguration {
     locationInfo = ko.observableArray<Raven.Server.Web.Studio.SingleNodeDataDirectoryResult>([]);
     folderPathOptions = ko.observableArray<string>([]);
 
+    blockingSourceName = ko.observable<string>();
+
     spinners = {
         locationInfoLoading: ko.observable<boolean>(false)
     };
@@ -205,6 +207,7 @@ abstract class backupConfiguration {
             BackupEncryptionSettings: null,
             SnapshotSettings: null,
             RetentionPolicy: null,
+            BlockingSourceName: null,
         }
     }
 }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -163,7 +163,8 @@ class periodicBackupConfiguration extends backupConfiguration {
             GlacierSettings: this.glacierSettings().toDto(),
             AzureSettings: this.azureSettings().toDto(),
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
-            FtpSettings: this.ftpSettings().toDto()
+            FtpSettings: this.ftpSettings().toDto(),
+            BlockingSourceName: this.blockingSourceName()
         };
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/ongoingTasks.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/ongoingTasks.ts
@@ -550,7 +550,17 @@ class ongoingTasks extends viewModelBase {
         const db = this.activeDatabase();
 
         this.confirmationMessage("Disable Task",
-            `You're disabling ${model.taskType()} task:<br><ul><li><strong>${model.taskName()}</strong></li></ul>`, {
+            `You're disabling ${model.taskType()} task:<br><ul><li><strong>${generalUtils.escapeHtml(model.taskName())}</strong></li></ul>
+<div class="margin-top margin-top-lg text-warning bg-warning padding padding-xs flex-horizontal">
+                <div class="flex-start">
+                    <small><i class="icon-warning"></i></small>
+                </div>
+                <div>
+                    <small>Warning: Please note that disabling this task will cause continuous tombstone accumulation until it is re-enabled or deleted, leading to increased disk space usage.</small>
+                </div>
+             </div>
+
+`, {
                 buttons: ["Cancel", "Disable"],
                 html: true
             })

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -301,7 +301,6 @@ namespace FastTests.Server.Replication
                 {
                     MentorNode = responsibleNode
                 };
-                ModifyReplicationDestination(databaseWatcher);
                 tasks.Add(AddWatcherToReplicationTopology(fromStore, databaseWatcher, store.Urls));
             }
             await Task.WhenAll(tasks);
@@ -377,11 +376,7 @@ namespace FastTests.Server.Replication
         {
             await UpdateConflictResolver(store, null, conflictResolution == StraightforwardConflictResolution.ResolveToLatest);
         }
-
-        protected virtual void ModifyReplicationDestination(ReplicationNode replicationNode)
-        {
-        }
-
+        
         protected static async Task SetupReplicationWithCustomDestinations(DocumentStore fromStore, params ReplicationNode[] toNodes)
         {
             foreach (var node in toNodes)

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -283,8 +283,6 @@ namespace SlowTests.Issues
         [InlineData(EtlType.Queue)]
         public async Task TombstoneCleaningAfterEtlLoaderDisabled(EtlType etlType)
         {
-            string expectedSource = default;
-
             using (var store = GetDocumentStore())
             {
                 // Documents creation
@@ -305,6 +303,7 @@ namespace SlowTests.Issues
                     Script = "loadToUsers(this)"
                 };
 
+                string expectedSource;
                 switch (etlType)
                 {
                     case EtlType.Raven:

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Documents.Replication;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using Xunit;
@@ -89,11 +88,6 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     Assert.DoesNotContain("DailyInvoices", collections, StringComparer.OrdinalIgnoreCase);
                 }
             }
-        }
-
-        protected override void ModifyReplicationDestination(ReplicationNode replicationNode)
-        {
-            //replicationNode.SkipIndexReplication = true;
         }
 
         public string TombstoneCleanerIdentifier => nameof(OutputReduceToCollectionReplicationTests);

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -312,7 +312,7 @@ namespace SlowTests.Server.Replication
 
                 pull.Disabled = false;
                 await AddWatcherToReplicationTopology(sink, pull, hub.Urls);
-
+                
                 using (var main = hub.OpenSession())
                 {
                     main.Store(new User(), "hub/3");
@@ -691,12 +691,12 @@ namespace SlowTests.Server.Replication
 
         //TODO write test for deletion! - make sure replication is stopped after we delete hub!
 
-        public Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, params DocumentStore[] hub)
+        public static Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, params DocumentStore[] hub)
         {
             return SetupPullReplicationAsync(remoteName, sink, null, hub);
         }
 
-        public async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, X509Certificate2 certificate, params DocumentStore[] hub)
+        public static async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, X509Certificate2 certificate, params DocumentStore[] hub)
         {
             var tasks = new List<Task<ModifyOngoingTaskResult>>();
             var resList = new List<ModifyOngoingTaskResult>();
@@ -707,7 +707,6 @@ namespace SlowTests.Server.Replication
                 {
                     pull.CertificateWithPrivateKey = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
                 }
-                ModifyReplicationDestination(pull);
                 tasks.Add(AddWatcherToReplicationTopology(sink, pull, store.Urls));
             }
             await Task.WhenAll(tasks);

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -312,7 +312,7 @@ namespace SlowTests.Server.Replication
 
                 pull.Disabled = false;
                 await AddWatcherToReplicationTopology(sink, pull, hub.Urls);
-                
+
                 using (var main = hub.OpenSession())
                 {
                     main.Store(new User(), "hub/3");

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -111,7 +111,6 @@ namespace StressTests.Server.Replication
                 {
                     pull.CertificateWithPrivateKey = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
                 }
-                ModifyReplicationDestination(pull);
                 tasks.Add(AddWatcherToReplicationTopology(sink, pull, store.Urls));
             }
             await Task.WhenAll(tasks);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.

### Additional description

1. Reworded notification's title and message.
2. Clarified the source name of the `Tombstones` blockage.
3. Extended test coverage to assert valid display of `Tombstones` blockage source.
4. Added handling for the case of `Tombstones` blockage when disabling hub/sink replication and all types of `Etl`s.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.