### PR TITLE
RavenDB-20785 Avoid sharing allocator between threads.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -95,7 +95,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         {
             try
             {
-                return CoraxIndexingHelpers.CreateMappingWithAnalyzers(Allocator, _index, _index.Definition, _keyFieldName, storeValue, storeValueFieldName, true, _canContainSourceDocumentId);
+                return CoraxIndexingHelpers.CreateMappingWithAnalyzers(_index, _index.Definition, _keyFieldName, storeValue, storeValueFieldName, true, _canContainSourceDocumentId);
             }
             catch (Exception e)
             {
@@ -112,7 +112,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         {
             try
             {
-                KnownFieldsForWriter = CoraxIndexingHelpers.CreateMappingWithAnalyzers(Allocator, _index, _index.Definition, _keyFieldName, _storeValue, _storeValueFieldName, false, _canContainSourceDocumentId);
+                KnownFieldsForWriter = CoraxIndexingHelpers.CreateMappingWithAnalyzers(_index, _index.Definition, _keyFieldName, _storeValue, _storeValueFieldName, false, _canContainSourceDocumentId);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
@@ -17,6 +17,7 @@ using Corax;
 using Corax.Mappings;
 using Constants = Raven.Client.Constants;
 using Sparrow.Server;
+using Sparrow.Threading;
 using Voron;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
@@ -47,8 +48,9 @@ public static class CoraxIndexingHelpers
         return analyzerInstance;
     }
 
-    public static IndexFieldsMapping CreateMappingWithAnalyzers(ByteStringContext context, Index index, IndexDefinitionBaseServerSide indexDefinition, string keyFieldName, bool storedValue, string storedValueFieldName,  bool forQuerying = false, bool canContainSourceDocumentId = false)
+    public static IndexFieldsMapping CreateMappingWithAnalyzers(Index index, IndexDefinitionBaseServerSide indexDefinition, string keyFieldName, bool storedValue, string storedValueFieldName,  bool forQuerying = false, bool canContainSourceDocumentId = false)
     {
+        using var context = new ByteStringContext(SharedMultipleUseFlag.None);
         if (indexDefinition.IndexFields.ContainsKey(Constants.Documents.Indexing.Fields.AllFields))
             throw new InvalidOperationException(
                 $"Detected '{Constants.Documents.Indexing.Fields.AllFields}'. This field should not be present here, because inheritance is done elsewhere.");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20785 

### Additional description

When we create reader mapping while indexing is not yet finished, calling allocate at the same time could potentially lead to an AVE error.
### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
