### PR TITLE
RavenDB-20789 - Don't save topology for the sever request executor (and the shards one)

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -49,7 +49,8 @@ namespace Raven.Client.Documents.Conventions
 #if NETCOREAPP3_1_OR_GREATER
             HttpPooledConnectionLifetime = TimeSpan.FromMinutes(19),
 #endif
-            DisposeCertificate = false
+            DisposeCertificate = false,
+            DisableTopologyCache = true
         };
 
         private static readonly bool DefaultDisableTcpCompression = false;

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -103,7 +103,8 @@ namespace Raven.Server.ServerWide
                 UseHttpDecompression = _serverStore.Configuration.Sharding.ShardExecutorUseHttpDecompression,
                 GlobalHttpClientTimeout = _serverStore.Configuration.Sharding.OrchestratorTimeout.AsTimeSpan,
                 HttpClientType = typeof(ShardingStore),
-                DisableTopologyCache = true,
+                DisableTopologyCache = DocumentConventions.DefaultForServer.DisableTopologyCache,
+                DisposeCertificate = DocumentConventions.DefaultForServer.DisposeCertificate,
                 CreateHttpClient = handler =>
                 {
                     handler.ServerCertificateCustomValidationCallback = ShardingCustomValidationCallback;

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -103,6 +103,7 @@ namespace Raven.Server.ServerWide
                 UseHttpDecompression = _serverStore.Configuration.Sharding.ShardExecutorUseHttpDecompression,
                 GlobalHttpClientTimeout = _serverStore.Configuration.Sharding.OrchestratorTimeout.AsTimeSpan,
                 HttpClientType = typeof(ShardingStore),
+                DisableTopologyCache = true,
                 CreateHttpClient = handler =>
                 {
                     handler.ServerCertificateCustomValidationCallback = ShardingCustomValidationCallback;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20789

### Additional description

When creating a sharded database, its request executor which resides on the server uses conventions with `DisableTopologyCache=false`. Server does not have permission to create files for the topology cache so it throws when it reaches `UpdateTopologyAsync` which tries to save the cache. 
Disabled the topology cache in all conventions that are used by server's request executors.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Has been verified by manual testing

### UI work

- No UI work is needed
