### PR TITLE
RavenDB-20702 - RequestedNodeUnavailableException after manual cluster creation

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -21,7 +21,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Documents
 {
-    public abstract class DatabaseRequestHandler : RequestHandler
+    public abstract class DatabaseRequestHandler : ServerRequestHandler
     {
         protected DocumentsContextPool ContextPool;
         protected DocumentDatabase Database;
@@ -40,10 +40,6 @@ namespace Raven.Server.Documents
 
         public Task CheckForChanges(RequestHandlerContext context)
         {
-            var topologyEtag = GetLongFromHeaders(Constants.Headers.TopologyEtag);
-            if (topologyEtag.HasValue && Database.HasTopologyChanged(topologyEtag.Value))
-                context.HttpContext.Response.Headers[Constants.Headers.RefreshTopology] = "true";
-
             var clientConfigurationEtag = GetLongFromHeaders(Constants.Headers.ClientConfigurationEtag);
             if (clientConfigurationEtag.HasValue && Database.HasClientConfigurationChanged(clientConfigurationEtag.Value))
                 context.HttpContext.Response.Headers[Constants.Headers.RefreshClientConfiguration] = "true";

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminMemoryHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminMemoryHandler.cs
@@ -9,7 +9,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin
 {
-    public class AdminMemoryHandler : RequestHandler
+    public class AdminMemoryHandler : ServerRequestHandler
     {
         [RavenAction("/admin/memory/gc", "GET", AuthorizationStatus.Operator)]
         public async Task CollectGarbage()

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminScriptRunnersDebugInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminScriptRunnersDebugInfoHandler.cs
@@ -5,7 +5,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin
 {
-    public class AdminScriptRunnersDebugInfoHandler : RequestHandler
+    public class AdminScriptRunnersDebugInfoHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/script-runners", "GET", AuthorizationStatus.Operator)]
         public async Task GetJSAdminDebugInfo()

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -33,7 +33,7 @@ using Raven.Server.TrafficWatch;
 
 namespace Raven.Server.Documents.Handlers.Admin
 {
-    public class RachisAdminHandler : RequestHandler
+    public class RachisAdminHandler : ServerRequestHandler
     {
         [RavenAction("/admin/rachis/send", "POST", AuthorizationStatus.Operator)]
         public async Task ApplyCommand()

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -23,7 +23,7 @@ using Size = Raven.Client.Util.Size;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class MemoryDebugHandler : RequestHandler
+    public class MemoryDebugHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/memory/gc", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task GcInfo()

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -24,7 +24,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class NodeDebugHandler : RequestHandler
+    public class NodeDebugHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/node/clear-http-clients-pool", "GET", AuthorizationStatus.ClusterAdmin)]
         public Task ClearHttpClientsPool()

--- a/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ProcStatsHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ProcStatsHandler : RequestHandler
+    public class ProcStatsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/cpu/stats", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task CpuStats()

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerInfoHandler.cs
@@ -7,7 +7,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ServerInfoHandler : RequestHandler
+    public class ServerInfoHandler : ServerRequestHandler
     {
         [RavenAction("/debug/server-id", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task ServerId()

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerTransactionDebugHandler.cs
@@ -8,7 +8,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ServerTransactionDebugHandler : RequestHandler
+    public class ServerTransactionDebugHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/txinfo", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task TxInfo()

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -26,7 +26,7 @@ using Sparrow.Server.Platform.Posix;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ServerWideDebugInfoPackageHandler : RequestHandler
+    public class ServerWideDebugInfoPackageHandler : ServerRequestHandler
     {
         internal const string _serverWidePrefix = "server-wide";
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideQueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideQueriesDebugHandler.cs
@@ -9,7 +9,7 @@ using Raven.Server.Web;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ServerWideQueriesDebugHandler : RequestHandler
+    public class ServerWideQueriesDebugHandler : ServerRequestHandler
     {
         [RavenAction("/debug/queries/running/live", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task RunningQueriesLive()

--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -21,7 +21,7 @@ using Sparrow.Server.Platform.Posix;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
-    public class ThreadsHandler : RequestHandler
+    public class ThreadsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/threads/stack-trace", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task StackTrace()

--- a/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
@@ -15,7 +15,7 @@ using Sparrow.Platform;
 
 namespace Raven.Server.Documents.Handlers
 {
-    public class SecretKeyHandler : RequestHandler
+    public class SecretKeyHandler : ServerRequestHandler
     {
         [RavenAction("/admin/secrets", "GET", AuthorizationStatus.Operator)]
         public async Task GetKeys()

--- a/src/Raven.Server/Monitoring/Snmp/SnmpHandler.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpHandler.cs
@@ -11,7 +11,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Monitoring.Snmp
 {
-    public class SnmpHandler : RequestHandler
+    public class SnmpHandler : ServerRequestHandler
     {
         [RavenAction("/monitoring/snmp", "GET", AuthorizationStatus.Operator)]
         public async Task Get()

--- a/src/Raven.Server/NotificationCenter/Handlers/ServerNotificationCenterHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ServerNotificationCenterHandler.cs
@@ -106,7 +106,7 @@ namespace Raven.Server.NotificationCenter.Handlers
         }
     }
 
-    public abstract class ServerNotificationHandlerBase : RequestHandler
+    public abstract class ServerNotificationHandlerBase : ServerRequestHandler
     {
         protected CanAccessDatabase GetDatabaseAccessValidationFunc(RavenServer.AuthenticateConnection authenticationStatus = null)
         {

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -17,7 +17,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.TrafficWatch
 {
-    public class TrafficWatchHandler : RequestHandler
+    public class TrafficWatchHandler : ServerRequestHandler
     {
         private static readonly Logger _logger = LoggingSource.Instance.GetLogger<TrafficWatchHandler>("Server");
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -73,8 +73,11 @@ namespace Raven.Server.Web
         public virtual void Init(RequestHandlerContext context)
         {
             _context = context;
+            context.HttpContext.Response.OnStarting(() => CheckForChanges(context));
         }
 
+        public abstract Task CheckForChanges(RequestHandlerContext context);
+        
         protected Stream TryGetRequestFromStream(string itemName)
         {
             if (HttpContext.Request.HasFormContentType == false)

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -5,14 +5,7 @@ namespace Raven.Server.Web
 {
     public abstract class ServerRequestHandler : RequestHandler
     {
-        public override void Init(RequestHandlerContext context)
-        {
-            base.Init(context);
-
-            context.HttpContext.Response.OnStarting(() => CheckForTopologyChanges(context));
-        }
-
-        public Task CheckForTopologyChanges(RequestHandlerContext context)
+        public override Task CheckForChanges(RequestHandlerContext context)
         {
             var topologyEtag = GetLongFromHeaders(Constants.Headers.TopologyEtag);
             if (topologyEtag.HasValue && Server.ServerStore.HasTopologyChanged(topologyEtag.Value))

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -13,7 +13,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Web.Studio
 {
-    public class LicenseHandler : RequestHandler
+    public class LicenseHandler : ServerRequestHandler
     {
         [RavenAction("/license/eula", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Eula()

--- a/src/Raven.Server/Web/Studio/StudioFeedbackHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioFeedbackHandler.cs
@@ -6,7 +6,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.Studio
 {
-    public class StudioFeedbackHandler : RequestHandler
+    public class StudioFeedbackHandler : ServerRequestHandler
     {
         [RavenAction("/studio/feedback", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Feedback()

--- a/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
@@ -30,7 +30,7 @@ using Voron.Util.Settings;
 
 namespace Raven.Server.Web.Studio
 {
-    public class StudioTasksHandler : RequestHandler
+    public class StudioTasksHandler : ServerRequestHandler
     {
         // return the calculated full data directory for the database before it is created according to the name & path supplied
         [RavenAction("/admin/studio-tasks/full-data-directory", "GET", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
+++ b/src/Raven.Server/Web/System/AdminAllocationDebugHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public sealed class AdminAllocationDebugHandler : RequestHandler
+    public sealed class AdminAllocationDebugHandler : ServerRequestHandler
     {
         public const string AllocationEventName = "GCAllocationTick_V4";
 

--- a/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminCpuCreditsHandler.cs
@@ -14,7 +14,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminCpuCreditsHandler : RequestHandler
+    public class AdminCpuCreditsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/cpu-credits", "POST", AuthorizationStatus.ClusterAdmin)]
         public async Task UpdateCpuCredits()

--- a/src/Raven.Server/Web/System/AdminDebugQueryClauseCacheHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDebugQueryClauseCacheHandler.cs
@@ -11,7 +11,7 @@ using Sparrow.Json.Sync;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminDebugQueryClauseCacheHandler : RequestHandler
+    public class AdminDebugQueryClauseCacheHandler : ServerRequestHandler
     {
         [RavenAction("/admin/indexes/lucene/query-clause-cache", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task QueryClauseCache()

--- a/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
@@ -12,7 +12,7 @@ using Voron;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminIoMetricsHandler : RequestHandler
+    public class AdminIoMetricsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/io-metrics", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task IoMetrics()

--- a/src/Raven.Server/Web/System/AdminMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminMetricsHandler.cs
@@ -9,7 +9,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminMetricsHandler : RequestHandler
+    public class AdminMetricsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/metrics", "GET", AuthorizationStatus.Operator)]
         public async Task GetRootStats()

--- a/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminMonitoringHandler.cs
@@ -15,7 +15,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminMonitoringHandler : RequestHandler
+    public class AdminMonitoringHandler : ServerRequestHandler
     {
         [RavenAction("/admin/monitoring/v1/server", "GET", AuthorizationStatus.Operator)]
         public async Task MonitoringServer()

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -16,7 +16,7 @@ using Sparrow.LowMemory;
 
 namespace Raven.Server.Web.System
 {
-    public sealed class AdminPrometheusMonitoringHandler : RequestHandler
+    public sealed class AdminPrometheusMonitoringHandler : ServerRequestHandler
     {
         public const string PrometheusContentType = "text/plain; version=0.0.4; charset=utf-8";
         public const string MetricsPrefix = "ravendb_";

--- a/src/Raven.Server/Web/System/AdminStatsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStatsHandler.cs
@@ -5,7 +5,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminStatsHandler : RequestHandler
+    public class AdminStatsHandler : ServerRequestHandler
     {
         [RavenAction("/admin/stats", "GET", AuthorizationStatus.Operator, SkipLastRequestTimeUpdate = true, IsDebugInformationEndpoint = true)]
         public async Task GetRootStats()

--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -7,7 +7,7 @@ using Voron;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminStorageHandler : RequestHandler
+    public class AdminStorageHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/storage/environment/report", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = false)]
         public async Task SystemEnvironmentReport()

--- a/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
+++ b/src/Raven.Server/Web/System/AdminTcpConnectionDebugInfoHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Server.Extensions;
 
 namespace Raven.Server.Web.System
 {
-    public class AdminTcpConnectionDebugInfoHandler : RequestHandler
+    public class AdminTcpConnectionDebugInfoHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/info/tcp/stats", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task Statistics()

--- a/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public sealed class BackupDatabaseHandler : RequestHandler
+    public sealed class BackupDatabaseHandler : ServerRequestHandler
     {
         [RavenAction("/periodic-backup", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetPeriodicBackup()

--- a/src/Raven.Server/Web/System/CorsPreflightHandler.cs
+++ b/src/Raven.Server/Web/System/CorsPreflightHandler.cs
@@ -20,7 +20,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Web.System
 {
-    public class CorsPreflightHandler : RequestHandler
+    public class CorsPreflightHandler : ServerRequestHandler
     {
         public Task HandlePreflightRequest()
         {

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -10,7 +10,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Web.System
 {
-    public class DatabasesDebugHandler : RequestHandler
+    public class DatabasesDebugHandler : ServerRequestHandler
     {
         [RavenAction("/admin/debug/databases/idle", "GET", AuthorizationStatus.Operator)]
         public async Task Idle()

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -35,7 +35,7 @@ using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Web.System
 {
-    public sealed class DatabasesHandler : RequestHandler
+    public sealed class DatabasesHandler : ServerRequestHandler
     {
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<DatabasesHandler>("Server");
 

--- a/src/Raven.Server/Web/System/DebugHandler.cs
+++ b/src/Raven.Server/Web/System/DebugHandler.cs
@@ -6,7 +6,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Web.System
 {
-    public sealed class DebugHandler : RequestHandler
+    public sealed class DebugHandler : ServerRequestHandler
     {
         [RavenAction("/debug/routes", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Routes()

--- a/src/Raven.Server/Web/System/EmptyMessageHandler.cs
+++ b/src/Raven.Server/Web/System/EmptyMessageHandler.cs
@@ -10,7 +10,7 @@ using Raven.Server.Routing;
 
 namespace Raven.Server.Web.System
 {
-    public class EmptyMessageHandler : RequestHandler
+    public class EmptyMessageHandler : ServerRequestHandler
     {
         [RavenAction("/test/empty-message", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public Task Get()

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -39,7 +39,7 @@ using StudioConfiguration = Raven.Client.Documents.Operations.Configuration.Stud
 
 namespace Raven.Server.Web.System
 {
-    public class SetupHandler : RequestHandler
+    public class SetupHandler : ServerRequestHandler
     {
         [RavenAction("/setup/alive", "GET", AuthorizationStatus.UnauthenticatedClients, CorsMode = CorsMode.Public)]
         public Task ServerAlive()

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -29,7 +29,7 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Web.System
 {
-    public class StudioHandler : RequestHandler
+    public class StudioHandler : ServerRequestHandler
     {
         /// <summary>
         /// Control structure for a cached file

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -17,7 +17,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Web.System
 {
-    public class TcpConnectionInfoHandler : RequestHandler
+    public class TcpConnectionInfoHandler : ServerRequestHandler
     {
         [RavenAction("/info/tcp", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Get()

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -20,7 +20,7 @@ using Sparrow.Logging;
 
 namespace Raven.Server.Web.System
 {
-    public class TestConnectionHandler : RequestHandler
+    public class TestConnectionHandler : ServerRequestHandler
     {
         [RavenAction("/admin/test-connection", "POST", AuthorizationStatus.Operator)]
         public async Task TestConnection()

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -21,6 +22,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Subscriptions;
+using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -31,6 +33,7 @@ using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using static RachisTests.AddNodeToClusterTests;
 
 namespace RachisTests
 {
@@ -825,6 +828,74 @@ namespace RachisTests
             }
         }
 
+        [Fact]
+        public async Task ClientRequestExecutorTopologyWillUpdateWhenAddingNewNodeToCluster_RavenDB_20702()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true);
+
+            var executorB = ClusterRequestExecutor.Create(new string[] { leader.WebUrl }, null, DocumentConventions.Default);
+            
+            await WaitForValueAsync(() =>
+            {
+                foreach (var node in nodes)
+                {
+                    if (executorB?.TopologyNodes == null)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }, true);
+            
+            var serverD = GetNewServer();
+            var serverDUrl = serverD.ServerStore.GetNodeHttpServerUrl();
+            Servers.Add(serverD);
+            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+            using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
+            {
+                await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(serverDUrl, "D", watcher: true), ctx);
+                await serverD.ServerStore.Engine.WaitForTopology(Leader.TopologyModification.NonVoter);
+            }
+
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                //first request to D will not work since the request executor did not update its topology
+                var error = await Assert.ThrowsAnyAsync<RequestedNodeUnavailableException>(async () => await executorB.ExecuteAsync(new GetDatabasesCommand("D"), ctx));
+                Assert.Contains("Could not find requested node", error.Message);
+                //first request will update the topology
+                await executorB.ExecuteAsync(new GetDatabasesCommand("B"), ctx);
+                //second will request straight to D will already have it in the topology
+                await executorB.ExecuteAsync(new GetDatabasesCommand("D"), ctx);
+            }
+        }
+
+        internal class GetDatabasesCommand : RavenCommand
+        {
+            public GetDatabasesCommand(string nodeTag)
+            {
+                SelectedNodeTag = nodeTag;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases";
+                
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    return;
+            }
+        }
+        
         [Fact]
         public async Task AddNodeToClusterWithoutError()
         {

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Tests
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
                 from handler in GetAssemblyTypes(assembly)
                 where handler != typeof(DatabaseRequestHandler) && handler != typeof(ServerRequestHandler)
-                where handler.IsSubclassOf(typeof(RequestHandler)) && handler.IsSubclassOf(typeof(ServerRequestHandler)) == false
+                where handler.IsSubclassOf(typeof(RequestHandler)) && handler.IsSubclassOf(typeof(ServerRequestHandler)) == false && handler.IsSubclassOf(typeof(DatabaseRequestHandler)) == false
                 select handler;
 
             var array = types.ToArray();

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FastTests;
+using Raven.Server.Documents;
+using Raven.Server.Web;
 using Raven.TestDriver;
 using Tests.Infrastructure;
 using Xunit;
@@ -50,6 +52,23 @@ namespace SlowTests.Tests
                 where test.GetMethods().Any(x => x.GetCustomAttributes(typeof(FactAttribute), true).Count() != 0 || x.GetCustomAttributes(typeof(TheoryAttribute), true).Count() != 0)
                 where test.IsSubclassOf(typeof(ParallelTestBase)) == false && test.IsSubclassOf(typeof(RavenTestDriver)) == false && test.Namespace.StartsWith("EmbeddedTests") == false
                 select test;
+
+            var array = types.ToArray();
+            if (array.Length == 0)
+                return;
+
+            var userMessage = string.Join(Environment.NewLine, array.Select(x => x.FullName));
+            throw new Exception(userMessage);
+        }
+
+        [NonLinuxFact]
+        public void HandlersShouldNotInheritStraightFromRequestHandler()
+        {
+            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
+                from handler in GetAssemblyTypes(assembly)
+                where handler != typeof(DatabaseRequestHandler) && handler != typeof(ServerRequestHandler)
+                where handler.IsSubclassOf(typeof(RequestHandler)) && handler.IsSubclassOf(typeof(ServerRequestHandler)) == false
+                select handler;
 
             var array = types.ToArray();
             if (array.Length == 0)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20702

### Additional description

When creating a cluster and adding a new node, the client's topology doesn't include it. So when we make a request to the new node we get the `RequestedNodeUnavailableException`.
Replaced all places where handlers inherit from `RequestHandler` with `ServerRequestHandler` since it includes functionality that is responsible for refreshing the client topology.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
