### PR TITLE
RavenDB-20544: Fix the failing test that occurs due to a race condition between PutLicense and UpdateLicenseLimits

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -138,10 +138,7 @@ namespace Raven.Server.Commercial
                 ReloadLicense(firstRun: true);
                 ReloadLicenseLimits(firstRun: true);
 
-                ClusterCommandsVersionManager.OnClusterVersionChange += PutMyNodeInfoClusterVersionChange;
-
-                if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion > 0)
-                    Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
+                Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
             }
             catch (Exception e)
             {
@@ -155,14 +152,6 @@ namespace Raven.Server.Commercial
                     (int)TimeSpan.FromMinutes(1).TotalMilliseconds,
                     (int)TimeSpan.FromHours(24).TotalMilliseconds);
             }
-        }
-
-        public void PutMyNodeInfoClusterVersionChange(object sender, ClusterVersionChangeEventArgs args)
-        {
-            if (args.PreviousClusterVersion != 0)
-                return;
-
-            Task.Run(PutMyNodeInfoAsync).IgnoreUnobservedExceptions();
         }
 
         public async Task PutMyNodeInfoAsync()
@@ -954,7 +943,6 @@ namespace Raven.Server.Commercial
         public void Dispose()
         {
             _leaseLicenseTimer?.Dispose();
-            ClusterCommandsVersionManager.OnClusterVersionChange -= PutMyNodeInfoClusterVersionChange;
         }
 
         private void ThrowIfCannotActivateLicense(LicenseStatus newLicenseStatus)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-20544.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-20544.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.Documents;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    public class RavenDB_20544 : RavenTestBase
+    {
+        public RavenDB_20544(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task CanRunTwoBackupsConcurrently()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var tcs = new TaskCompletionSource<object>();
+            DocumentDatabase documentDatabase = null;
+
+            try
+            {
+                DoNotReuseServer();
+                await Server.ServerStore.EnsureNotPassiveAsync();
+
+                using var store = GetDocumentStore();
+                documentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(documentDatabase);
+                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name= "Lev" });
+                    await session.SaveChangesAsync();
+                }
+
+                var config1 = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
+                var config2 = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+            
+                var taskId1 = await Backup.UpdateConfigAndRunBackupAsync(Server, config1, store, opStatus: OperationStatus.InProgress);
+                var taskId2 = await Backup.UpdateConfigAndRunBackupAsync(Server, config2, store, opStatus: OperationStatus.InProgress);
+
+                var op1 = new GetOngoingTaskInfoOperation(taskId1, OngoingTaskType.Backup);
+                var op2 = new GetOngoingTaskInfoOperation(taskId2, OngoingTaskType.Backup);
+            
+                var backupResult1 = store.Maintenance.Send(op1) as OngoingTaskBackup;
+                var backupResult2 = store.Maintenance.Send(op2) as OngoingTaskBackup;
+
+                Assert.NotNull(backupResult1?.OnGoingBackup);
+                Assert.NotNull(backupResult2?.OnGoingBackup);
+
+                tcs.SetResult(null);
+            }
+            finally
+            {
+                if (documentDatabase != null) 
+                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20544/SlowTests.Sharding.Backup.ShardedRestoreBackupTests.EncryptedBackupAndRestoreShardedDatabaseUsingDatabaseKey

### Additional description

1. Revert #16464 `LicenseManager` changes
2. Test

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed