### PR TITLE
RavenDB-20800 avoid virtual member call in constructor for abstract database changes

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationChangesTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationChangesTests.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Raven.Client.Documents.Changes;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,8 +18,9 @@ namespace SlowTests.Authentication
         {
         }
 
-        [Fact]
-        public async Task ChangesWithAuthentication()
+        [RavenTheory(RavenTestCategory.ChangesApi | RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesWithAuthentication(Options options)
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbName = GetDatabaseName();
@@ -28,12 +30,11 @@ namespace SlowTests.Authentication
                 [dbName] = DatabaseAccess.ReadWrite
             });
 
-            using (var store = GetDocumentStore(new Options
-            {
-                AdminCertificate = adminCert,
-                ClientCertificate = userCert,
-                ModifyDatabaseName = s => dbName
-            }))
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = userCert;
+            options.ModifyDatabaseName = s => dbName;
+
+            using (var store = GetDocumentStore(options))
             {
                 var list = new BlockingCollection<DocumentChange>();
                 var taskObservable = store.Changes();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20800

### Additional description

We create the `_client` with a virtual method `CreateClientWebSocket` inside of the abstract constructor.
For sharded changes we wanted to use arguments from the constructor inside the `CreateClientWebSocket` which are `null` at the time of the method calling.

So we moved the client creation code path (`DoWork` & `CreateClientWebSocket`) to be lazy

### Type of change

- Bug fix

### How risky is the change?

- Low+

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
