### PR TITLE
RavenDB-7070 x86 CompactTree test fix | CompactKey - missing disposals.

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
@@ -61,6 +61,7 @@ unsafe partial class CompactTree
             prevKey = prevKeyStorage.AsSpan();
             key.CopyTo(prevKey);
             prevKey = prevKey.Slice(0, key.Length);
+            compactKey.Dispose();
         }
     }
 }

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -338,7 +338,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
     public bool TryRemove(ReadOnlySpan<byte> key, out long oldValue)
     {
-        var compactKey = new CompactKey(_inner.Llt);
+        using var compactKey = new CompactKey(_inner.Llt);
         compactKey.Set(key);
         compactKey.ChangeDictionary(_inner.State.DictionaryId);
         return _inner.TryRemove(new CompactKeyLookup(compactKey), out oldValue);


### PR DESCRIPTION

### Additional description

CompactTree test fix | CompactKey - missing disposals.

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works | fixes old tests on x86 platform.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
