### PR TITLE
RavenDB-20610 : Operations : avoid using HttpContext.RequestAborted as part of the OperationCancelToken if the operation is not awaited

### DIFF
--- a/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
@@ -16,9 +16,15 @@ public abstract class AbstractDatabaseRequestHandler<TOperationContext> : Reques
 
     public abstract char IdentityPartsSeparator { get; }
 
-    public abstract OperationCancelToken CreateTimeLimitedOperationToken(bool useRequestAbortedToken = true);
+    public abstract OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken();
 
-    public abstract OperationCancelToken CreateTimeLimitedQueryToken();
+    public abstract OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationTokenForQuery();
+
+    public abstract OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForQueryOperation();
+
+    public abstract OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForCollectionOperation();
+
+    public abstract OperationCancelToken CreateTimeLimitedBackgroundOperationToken();
 
     public JsonContextPoolBase<TOperationContext> ContextPool;
 

--- a/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/AbstractDatabaseRequestHandler.cs
@@ -16,7 +16,7 @@ public abstract class AbstractDatabaseRequestHandler<TOperationContext> : Reques
 
     public abstract char IdentityPartsSeparator { get; }
 
-    public abstract OperationCancelToken CreateTimeLimitedOperationToken();
+    public abstract OperationCancelToken CreateTimeLimitedOperationToken(bool useRequestAbortedToken = true);
 
     public abstract OperationCancelToken CreateTimeLimitedQueryToken();
 

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -77,9 +77,11 @@ namespace Raven.Server.Documents
             }
         }
 
-        public override OperationCancelToken CreateTimeLimitedOperationToken()
+        public override OperationCancelToken CreateTimeLimitedOperationToken(bool useRequestAbortedToken = true)
         {
-            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            if (useRequestAbortedToken)
+                return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
         }
 
         public override OperationCancelToken CreateTimeLimitedQueryToken()

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -77,36 +77,44 @@ namespace Raven.Server.Documents
             }
         }
 
-        public override OperationCancelToken CreateTimeLimitedOperationToken(bool useRequestAbortedToken = true)
+        public override OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken()
         {
-            if (useRequestAbortedToken)
-                return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
-            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            return CreateHttpRequestBoundTimeLimitedOperationToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan);
         }
 
-        public override OperationCancelToken CreateTimeLimitedQueryToken()
+        public override OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationTokenForQuery()
         {
-            return new OperationCancelToken(Database.Configuration.Databases.QueryTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return CreateHttpRequestBoundTimeLimitedOperationToken(Database.Configuration.Databases.QueryTimeout.AsTimeSpan);
         }
 
-        public OperationCancelToken CreateTimeLimitedCollectionOperationToken()
+        public override OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan cancelAfter)
         {
-            return new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(cancelAfter, Database.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
-        public OperationCancelToken CreateTimeLimitedQueryOperationToken()
-        {
-            return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
-        }
-
-        public override OperationCancelToken CreateOperationToken()
+        public override OperationCancelToken CreateHttpRequestBoundOperationToken()
         {
             return new OperationCancelToken(Database.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
-        public override OperationCancelToken CreateOperationToken(TimeSpan cancelAfter)
+        public override OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForQueryOperation()
         {
-            return new OperationCancelToken(cancelAfter, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        public override OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForCollectionOperation()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        public override OperationCancelToken CreateTimeLimitedBackgroundOperationToken()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+        
+        public override OperationCancelToken CreateBackgroundOperationToken()
+        {
+            return new OperationCancelToken(Database.DatabaseShutdown);
         }
 
         public override bool ShouldAddPagingPerformanceHint(long numberOfResults)

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -135,7 +135,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 if (index == null)
                     IndexDoesNotExistException.ThrowFor(name);
 
-                var token = new OperationCancelToken(Database.DatabaseShutdown);
+                var token = CreateBackgroundOperationToken();
                 var result = new IndexOptimizeResult(index.Name);
                 var operationId = Database.Operations.GetNextOperationId();
                 var t = Database.Operations.AddLocalOperation(

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -9,6 +9,7 @@ using Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -134,7 +135,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 if (index == null)
                     IndexDoesNotExistException.ThrowFor(name);
 
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(Database.DatabaseShutdown);
                 var result = new IndexOptimizeResult(index.Name);
                 var operationId = Database.Operations.GetNextOperationId();
                 var t = Database.Operations.AddLocalOperation(

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForDump.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForDump.cs
@@ -32,8 +32,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes
             }
 
             var operationId = RequestHandler.Database.Operations.GetNextOperationId();
-            var token = new OperationCancelToken(RequestHandler.Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan,
-                RequestHandler.Database.DatabaseShutdown);
+            var token = RequestHandler.CreateTimeLimitedBackgroundOperationTokenForQueryOperation();
 
             _ = RequestHandler.Database.Operations.AddLocalOperation(
                 operationId,

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForDump.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForDump.cs
@@ -32,7 +32,8 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes
             }
 
             var operationId = RequestHandler.Database.Operations.GetNextOperationId();
-            var token = RequestHandler.CreateTimeLimitedQueryOperationToken();
+            var token = new OperationCancelToken(RequestHandler.Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan,
+                RequestHandler.Database.DatabaseShutdown);
 
             _ = RequestHandler.Database.Operations.AddLocalOperation(
                 operationId,

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         public override async ValueTask ExecuteAsync()
         {
-            var token = RequestHandler.CreateTimeLimitedOperationToken(useRequestAbortedToken: false);
+            var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
             var operationId = RequestHandler.GetLongQueryString("operationId", false) ?? GetNextOperationId();
 
             ScheduleEnforceConfigurationOperation(operationId, token);

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         public override async ValueTask ExecuteAsync()
         {
-            var token = RequestHandler.CreateTimeLimitedOperationToken();
+            var token = RequestHandler.CreateTimeLimitedOperationToken(useRequestAbortedToken: false);
             var operationId = RequestHandler.GetLongQueryString("operationId", false) ?? GetNextOperationId();
 
             ScheduleEnforceConfigurationOperation(operationId, token);

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -549,7 +549,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             {
                 if (nodeTag == ServerStore.Engine.Tag)
                 {
-                    using (var token = CreateOperationToken())
+                    using (var token = CreateHttpRequestBoundOperationToken())
                     {
                         // cannot remove the leader, let's change the leader
                         ServerStore.Engine.CurrentLeader?.StepDown();

--- a/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.Handlers.BulkInsert
         [RavenAction("/databases/*/bulk_insert", "POST", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task BulkInsert()
         {
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var id = GetLongQueryString("id");
             var skipOverwriteIfUnchanged = GetBoolValueQueryString("skipOverwriteIfUnchanged", required: false) ?? false;
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -111,7 +111,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 topology = ServerStore.GetClusterTopology(ctx);
 
             var timeoutInSecPerNode = GetIntValueQueryString("timeoutInSecPerNode", false) ?? 60;
-            var clusterOperationToken = CreateOperationToken();
+            var clusterOperationToken = CreateHttpRequestBoundOperationToken();
             var type = GetDebugInfoPackageContentType();
             var databases = GetStringValuesQueryString("database", required: false);
             var operationId = GetLongQueryString("operationId", false) ?? ServerStore.Operations.GetNextOperationId();
@@ -181,7 +181,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var debugInfoType = GetDebugInfoPackageContentType();
             var databases = GetStringValuesQueryString("database", required: false);
             var operationId = GetLongQueryString("operationId", false) ?? ServerStore.Operations.GetNextOperationId();
-            var token = CreateOperationToken();
+            var token = CreateHttpRequestBoundOperationToken();
 
             await ServerStore.Operations.AddLocalOperation(
                 operationId,

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                             if (debugInfoType.HasFlag(DebugInfoPackageContentType.ServerWide))
                             {
-                            await WriteServerInfo(archive, context, localEndpointClient, token.Token);
+                                await WriteServerInfo(archive, context, localEndpointClient, token.Token);
                             }
 
                             if (debugInfoType.HasFlag(DebugInfoPackageContentType.Databases))
@@ -211,8 +211,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                             if (debugInfoType.HasFlag(DebugInfoPackageContentType.LogFile))
                             {
-                            await WriteLogFile(archive, token.Token);
-                        }
+                                await WriteLogFile(archive, token.Token);
+                            }
                         }
                         catch (Exception e)
                         {

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Handlers
 
             var result = await ServerStore.SendToLeaderAsync(command);
 
-            using (var token = CreateOperationToken())
+            using (var token = CreateHttpRequestBoundOperationToken())
                 await Database.RachisLogIndexNotifications.WaitForIndexNotification(result.Index, token.Token);
 
             NoContentStatus();

--- a/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerProxyReadProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerProxyReadProcessor.cs
@@ -36,7 +36,7 @@ internal abstract class AbstractHandlerProxyReadProcessor<TResult, TRequestHandl
 
             var proxyCommand = new ProxyCommand<TResult>(command, RequestHandler.HttpContext.Response);
 
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                 await HandleRemoteNodeAsync(proxyCommand, token);
         }
     }
@@ -68,7 +68,7 @@ internal abstract class AbstractServerHandlerProxyReadProcessor<TResult> : Abstr
                 var command = await CreateCommandForNodeAsync(nodeTag, context);
                 var proxyCommand = new ProxyCommand<TResult>(command, RequestHandler.HttpContext.Response);
 
-                using (var token = RequestHandler.CreateOperationToken())
+                using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                     await HandleRemoteNodeAsync(proxyCommand, context, token);
             }
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerWebSocketProxyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerWebSocketProxyProcessor.cs
@@ -30,7 +30,7 @@ internal abstract class AbstractHandlerWebSocketProxyProcessor<TRequestHandler, 
     public override async ValueTask ExecuteAsync()
     {
         using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             if (IsCurrentNode(out var nodeTag))
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForGetAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForGetAttachment.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
             var name = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
 
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var type = AttachmentType.Document;
                 string changeVector = null;

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForPutAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForPutAttachment.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
         public override async ValueTask ExecuteAsync()
         {
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var id = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
                 var name = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -43,7 +43,7 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
 
         using (var commandsReader = GetCommandsReader())
         using (ContextPool.AllocateOperationContext(out TOperationContext context))
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var contentType = HttpContext.Request.ContentType;
             try

--- a/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
@@ -36,7 +36,7 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
 
             var connection = CreateChangesClientConnection(webSocket, throttleConnection, fromStudio);
             
-            using (var token = RequestHandler.CreateOperationToken(connection.DisposeToken))
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken(connection.DisposeToken))
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 try
@@ -151,7 +151,7 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
                                 reader.TryGet("Param", out string commandParameter);
                                 reader.TryGet("Params", out BlittableJsonReaderArray commandParameters);
 
-                                using (var commandToken = RequestHandler.CreateOperationToken(TimeSpan.FromSeconds(30)))
+                                using (var commandToken = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan.FromSeconds(30)))
                                     await connection.HandleCommandAsync(command, commandParameter, commandParameters, commandToken.Token);
 
                                 if (reader.TryGet("CommandId", out int commandId))

--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/AbstractCollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/AbstractCollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Collections
             var sw = Stopwatch.StartNew();
             long numberOfResults, totalDocumentsSizeInBytes;
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 (numberOfResults, totalDocumentsSizeInBytes) = await GetCollectionDocumentsAndWriteAsync(context, name, start, pageSize, token.Token);
             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForTerms.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForTerms.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Indexes
 
         public override async ValueTask ExecuteAsync()
         {
-            using (var token = RequestHandler.CreateTimeLimitedOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationToken())
             using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 var field = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("field");

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReplace.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReplace.cs
@@ -31,7 +31,7 @@ internal class IndexHandlerProcessorForReplace : AbstractIndexHandlerProcessorFo
         if (newIndex == null)
             throw new IndexDoesNotExistException($"Could not find side-by-side index for '{name}'.");
 
-        using (var token = RequestHandler.CreateOperationToken(TimeSpan.FromMinutes(15)))
+        using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan.FromMinutes(15)))
         {
             RequestHandler.Database.IndexStore.ReplaceIndexes(name, newIndex.Name, token.Token);
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 ServerStore.ConcurrentBackupsCounter.StartBackup(backupName, Logger);
                 try
                 {
-                    var cancelToken = new OperationCancelToken(ServerStore.ServerShutdown);
+                    var cancelToken = RequestHandler.CreateBackgroundOperationToken();
                     ScheduleBackup(backupConfiguration, operationId, backupName, sw, startTime, cancelToken);
 
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -58,8 +58,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 ServerStore.ConcurrentBackupsCounter.StartBackup(backupName, Logger);
                 try
                 {
-                    var cancelToken = RequestHandler.CreateOperationToken();
-
+                    var cancelToken = new OperationCancelToken(ServerStore.ServerShutdown);
                     ScheduleBackup(backupConfiguration, operationId, backupName, sw, startTime, cancelToken);
 
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
@@ -59,7 +59,7 @@ internal abstract class AbstractDatabaseOperationQueriesHandlerProcessor : Abstr
         IDisposable returnContextToPool,
         OperationType operationType)
     {
-        var token =  new OperationCancelToken(RequestHandler.Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, RequestHandler.Database.DatabaseShutdown);
+        var token =  RequestHandler.CreateTimeLimitedBackgroundOperationTokenForQueryOperation();
 
         var description = GetOperationDescription(query);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
@@ -59,7 +59,7 @@ internal abstract class AbstractDatabaseOperationQueriesHandlerProcessor : Abstr
         IDisposable returnContextToPool,
         OperationType operationType)
     {
-        var token = RequestHandler.CreateTimeLimitedQueryOperationToken();
+        var token =  new OperationCancelToken(RequestHandler.Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, RequestHandler.Database.DatabaseShutdown);
 
         var description = GetOperationDescription(query);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -96,7 +96,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
         {
             try
             {
-                using (var token = RequestHandler.CreateTimeLimitedQueryToken())
+                using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
                 using (AllocateContextForQueryOperation(out var queryContext, out var context))
                 {
                     var addSpatialProperties = RequestHandler.GetBoolValueQueryString("addSpatialProperties", required: false) ?? false;

--- a/src/Raven.Server/Documents/Handlers/Processors/Rachis/RachisHandlerProcessorForWaitForIndexNotifications.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Rachis/RachisHandlerProcessorForWaitForIndexNotifications.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Rachis
 
         protected override async ValueTask WaitForCommandsAsync(TransactionOperationContext _, WaitForIndexNotificationRequest commands)
         {
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 foreach (var index in commands.RaftCommandIndexes)
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetResolvedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetResolvedRevisions.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
             var date = Convert.ToDateTime(since).ToUniversalTime();
 
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await GetResolvedRevisionsAndWriteAsync(context, since: date, take, token.Token);
             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForGetRevisions.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
         public override async ValueTask ExecuteAsync()
         {
             using(ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var changeVectors = RequestHandler.GetStringValuesQueryString("changeVector", required: false);
                 var metadataOnly = RequestHandler.GetBoolValueQueryString("metadataOnly", required: false) ?? false;

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForRevertRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForRevertRevisions.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
                 configuration = JsonDeserializationServer.RevertRevisions(json);
             }
 
-            var token = RequestHandler.CreateTimeLimitedOperationToken();
+            var token = RequestHandler.CreateTimeLimitedOperationToken(useRequestAbortedToken: false);
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
 
             ScheduleRevertRevisions(operationId, configuration, token);

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForRevertRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForRevertRevisions.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
                 configuration = JsonDeserializationServer.RevertRevisions(json);
             }
 
-            var token = RequestHandler.CreateTimeLimitedOperationToken(useRequestAbortedToken: false);
+            var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
 
             ScheduleRevertRevisions(operationId, configuration, token);

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsBin.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForGetRevisionsBin.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
                 long count;
                 long totalDocumentsSizeInBytes;
 
-                using (var token = RequestHandler.CreateOperationToken())
+                using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
                     writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForExport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForExport.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
                 HttpContext.Response.Headers[Constants.Headers.ContentType] = "application/octet-stream";
                 ApplyBackwardCompatibility(options);
 
-                var token = RequestHandler.CreateOperationToken();
+                var token = RequestHandler.CreateHttpRequestBoundOperationToken();
 
                 await ExportAsync(context, returnContextToPool, operationId, options, startDocumentEtag, startRaftIndex, token);
             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
                 }
             }
 
-            var token = RequestHandler.CreateOperationToken();
+            var token = RequestHandler.CreateHttpRequestBoundOperationToken();
 
             var result = new SmugglerResult();
             BlittableJsonReaderObject blittableJson = null;

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
@@ -48,7 +48,7 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportDir<TRequestHan
         var tasks = new Task[Math.Max(1, maxTasks)];
 
         var finalResult = new SmugglerResult();
-        var token = RequestHandler.CreateOperationToken();
+        var token = RequestHandler.CreateHttpRequestBoundOperationToken();
 
         for (int i = 0; i < tasks.Length; i++)
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -35,7 +35,7 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
         var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
         await using (var file = await GetImportStream())
         await using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var result = await DoImport(context, stream, options, result: null, onProgress: null, operationId.Value, token);
             await WriteSmugglerResultAsync(context, result, RequestHandler.ResponseBodyStream());

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
         public override async ValueTask ExecuteAsync()
         {
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await GetDocumentsAndWriteAsync(context, RequestHandler.GetStart(), RequestHandler.GetPageSize(), RequestHandler.GetStringQueryString("startsWith", required: false),
                     RequestHandler.GetStringQueryString("excludes", required: false), RequestHandler.GetStringQueryString("matches", required: false),

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -56,7 +56,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
 
             // ReSharper disable once ArgumentsStyleLiteral
             using (var tracker = GetTimeTracker())
-            using (var token = RequestHandler.CreateTimeLimitedQueryToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using(AllocateContext(out TOperationContext context))
             {
                 IndexQueryServerSide query;

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetTimeSeries.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetTimeSeries.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
 
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
             using (OpenReadTransaction(context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await GetAndWriteTimeSeriesAsync(context, documentId, name, from, to, offset, token.Token);
             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             DocumentsOperationContext docsContext, IDisposable returnToContextPool, OperationType operationType, string collectionName, long operationId,
             HashSet<string> excludeIds)
         {
-            var token = new OperationCancelToken(RequestHandler.Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, RequestHandler.Database.DatabaseShutdown);
+            var token = RequestHandler.CreateTimeLimitedBackgroundOperationTokenForCollectionOperation();
 
             var collectionRunner = new StudioCollectionRunner(RequestHandler.Database, docsContext, excludeIds);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             DocumentsOperationContext docsContext, IDisposable returnToContextPool, OperationType operationType, string collectionName, long operationId,
             HashSet<string> excludeIds)
         {
-            var token = RequestHandler.CreateTimeLimitedCollectionOperationToken();
+            var token = new OperationCancelToken(RequestHandler.Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, RequestHandler.Database.DatabaseShutdown);
 
             var collectionRunner = new StudioCollectionRunner(RequestHandler.Database, docsContext, excludeIds);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeriesRanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeriesRanges.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Handlers.Processors.TimeSeries
             var returnFullResults = RequestHandler.GetBoolValueQueryString("full", required: false) ?? false;
 
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
-            using(var token = RequestHandler.CreateOperationToken())
+            using(var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await GetTimeSeriesRangesAndWriteAsync(context, documentId, names, fromList, toList, start, pageSize, includeDoc, includeTags, returnFullResults, token.Token);
             }

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.Documents.Handlers
                 Results = new List<TimeSeriesDetails>()
             };
 
-            using (var token = CreateOperationToken())
+            using (var token = CreateHttpRequestBoundOperationToken())
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -46,7 +46,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
 
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 {
                     var result = await Database.Operations.AddLocalOperation(
                         operationId,

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForDeleteRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForDeleteRevisions.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
                 cmds[shard] = new DeleteRevisionsOperation.DeleteRevisionsCommand(DocumentConventions.Default, context,
                     new DeleteRevisionsOperation.Parameters() {DocumentIds = ids.Ids.ToArray()});
             }
-            using(var token = RequestHandler.CreateOperationToken())
+            using(var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                 await RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shardsToDocs.Keys.ToArray(), new ShardedDeleteRevisionsOperation(RequestHandler.HttpContext, cmds), token.Token);
         }
         

--- a/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
@@ -9,7 +9,7 @@ public class ShardedBulkInsertHandler : ShardedDatabaseRequestHandler
     [RavenShardedAction("/databases/*/bulk_insert", "POST")]
     public async Task BulkInsert()
     {
-        var operationCancelToken = CreateOperationToken();
+        var operationCancelToken = CreateHttpRequestBoundOperationToken();
         var id = GetLongQueryString("id");
         var skipOverwriteIfUnchanged = GetBoolValueQueryString("skipOverwriteIfUnchanged", required: false) ?? false;
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForDeleteAttachment.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForDeleteAttachment.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Attachments
 
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
             
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(cmd, shardNumber, token.Token);
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetAttachmentMetadataWithCounts.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForGetAttachmentMetadataWithCounts.cs
@@ -21,7 +21,7 @@ internal class ShardedAttachmentHandlerProcessorForGetAttachmentMetadataWithCoun
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, documentId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<GetAttachmentMetadataWithCountsCommand.Response>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForHeadAttachment.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Attachments/ShardedAttachmentHandlerProcessorForHeadAttachment.cs
@@ -22,7 +22,7 @@ internal class ShardedAttachmentHandlerProcessorForHeadAttachment : AbstractAtta
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, documentId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<string>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
 
         protected override async ValueTask<DynamicJsonValue> GetStatsAsync(TransactionOperationContext context, bool detailed)
         {
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 if (detailed)
                 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForGetCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForGetCounters.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
 
             var shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 return await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(op, shardNumber, token.Token);
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Counters/ShardedCountersHandlerProcessorForPostCounters.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Counters
                 
             }
 
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 return await RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shardsToPositions.Keys.ToArray(),
                     new ShardedCounterBatchOperation(RequestHandler.HttpContext.Request, commandsPerShard), token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForDelete.cs
@@ -21,7 +21,7 @@ internal class ShardedDocumentHandlerProcessorForDelete : AbstractDocumentHandle
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand(command, HttpContext.Response);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGenerateClassFromDocument.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGenerateClassFromDocument.cs
@@ -21,7 +21,7 @@ internal class ShardedDocumentHandlerProcessorForGenerateClassFromDocument : Abs
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, id);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<string>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -29,7 +29,7 @@ internal class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
     public ShardedDocumentHandlerProcessorForGet(HttpMethod method, [NotNull] ShardedDocumentHandler requestHandler) : base(method, requestHandler)
     {
-        _operationCancelToken = requestHandler.CreateOperationToken();
+        _operationCancelToken = requestHandler.CreateHttpRequestBoundOperationToken();
     }
 
     protected override bool SupportsShowingRequestInTrafficWatch => false;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGetDocSize.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGetDocSize.cs
@@ -21,7 +21,7 @@ internal class ShardedDocumentHandlerProcessorForGetDocSize : AbstractDocumentHa
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<DocumentSizeDetails>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForHead.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForHead.cs
@@ -21,7 +21,7 @@ internal class ShardedDocumentHandlerProcessorForHead : AbstractDocumentHandlerP
         using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<string>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPatch.cs
@@ -20,7 +20,7 @@ internal class ShardedDocumentHandlerProcessorForPatch : AbstractDocumentHandler
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, id);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<PatchResult>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForPut.cs
@@ -21,7 +21,7 @@ internal class ShardedDocumentHandlerProcessorForPut : AbstractDocumentHandlerPr
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, id);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<PutResult>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/AbstractShardedEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/AbstractShardedEtlHandlerProcessorForTest.cs
@@ -33,7 +33,7 @@ internal abstract class AbstractShardedEtlHandlerProcessorForTest<TTestEtlScript
 
     protected override async ValueTask HandleRemoteNodeAsync(TransactionOperationContext context, TTestEtlScript testScript, BlittableJsonReaderObject testScriptJson)
     {
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             if (string.IsNullOrEmpty(testScript.DocumentId))
             {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/HiLo/ShardedHiLoHandlerProcessorForGetNextHiLo.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/HiLo/ShardedHiLoHandlerProcessorForGetNextHiLo.cs
@@ -19,7 +19,7 @@ internal class ShardedHiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerPr
 
     public override async ValueTask ExecuteAsync()
     {
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var tag = GetTag();
             var hiloDocId = HiLoHandler.RavenHiloIdPrefix + tag;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/HiLo/ShardedHiLoHandlerProcessorForReturnHiLo.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/HiLo/ShardedHiLoHandlerProcessorForReturnHiLo.cs
@@ -19,7 +19,7 @@ internal class ShardedHiLoHandlerProcessorForReturnHiLo : AbstractHiLoHandlerPro
 
     public override async ValueTask ExecuteAsync()
     {
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var tag = GetTag();
             var hiloDocId = HiLoHandler.RavenHiloIdPrefix + tag;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
@@ -17,7 +18,8 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
 
         protected override ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? _)
         {
-            var token = RequestHandler.CreateTimeLimitedOperationToken();
+            var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
+
             var startTime = SystemTime.UtcNow;
             var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(operationId,
                 Server.Documents.Operations.OperationType.DatabaseBackup,

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
 
         protected override ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? _)
         {
-            var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
+            var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
             var startTime = SystemTime.UtcNow;
             var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(operationId,

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
@@ -47,7 +47,7 @@ internal abstract class AbstractShardedOperationQueriesHandlerProcessor : Abstra
             throw new NotSupportedInShardingException("Query with limit is not supported in patch / delete by query operation");
         }
 
-        var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
+        var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
         var op = GetOperation(query, operationId, options);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
@@ -9,6 +9,7 @@ using Raven.Server.Documents.Handlers.Processors.Queries;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Queries;
 using Raven.Server.NotificationCenter;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Utils;
@@ -46,7 +47,7 @@ internal abstract class AbstractShardedOperationQueriesHandlerProcessor : Abstra
             throw new NotSupportedInShardingException("Query with limit is not supported in patch / delete by query operation");
         }
 
-        var token = RequestHandler.CreateTimeLimitedOperationToken();
+        var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
 
         var op = GetOperation(query, operationId, options);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForPatchTest.cs
@@ -26,7 +26,7 @@ internal class ShardedQueriesHandlerProcessorForPatchTest : AbstractQueriesHandl
 
         int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
 
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var proxyCommand = new ProxyCommand<PatchByQueryTestCommand.Response>(command, HttpContext.Response);
             await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(proxyCommand, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsCount.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisionsCount.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
             }
 
             long count;
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var op = new GetRevisionsCountOperation.GetRevisionsCountCommand(docId);
                 count = await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(op, shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForDatabaseHealthCheck.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForDatabaseHealthCheck.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Stats
 
         protected override async Task GetNoContentStatusAsync()
         {
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(new GetShardedDatabaseHealthCheckOperation(RequestHandler.HttpContext.Request), token.Token);
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Stats/ShardedStatsHandlerProcessorForEssentialStats.cs
@@ -22,7 +22,7 @@ internal class ShardedStatsHandlerProcessorForEssentialStats : AbstractStatsHand
 
     protected override async ValueTask<EssentialDatabaseStatistics> GetEssentialDatabaseStatisticsAsync(TransactionOperationContext context)
     {
-        using (var token = RequestHandler.CreateOperationToken())
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
             var stats = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(new GetShardedEssentialStatisticsOperation(RequestHandler.HttpContext.Request), token.Token);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
 
         protected override async ValueTask<Dictionary<LazyStringValue, FieldType>> GetFieldsAsync(TransactionOperationContext context, string collection, string prefix)
         {
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var etag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
                 var op = new ShardedGetCollectionFieldsOperation(context, HttpContext, collection, prefix, etag);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
         {
             using (returnToContextPool)
             {
-                var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
+                var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
                 var shardToIds = ShardLocator.GetDocumentIdsByShards(context, RequestHandler.DatabaseContext, excludeIds);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Server.Documents.Commands.Studio;
 using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Documents.Operations;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
@@ -20,7 +21,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
         {
             using (returnToContextPool)
             {
-                var token = RequestHandler.CreateTimeLimitedOperationToken();
+                var token = new OperationCancelToken(RequestHandler.DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, RequestHandler.DatabaseContext.DatabaseShutdown);
 
                 var shardToIds = ShardLocator.GetDocumentIdsByShards(context, RequestHandler.DatabaseContext, excludeIds);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForGetDebugSegmentsSummary.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForGetDebugSegmentsSummary.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.TimeSeries
         {
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
             var op = new ProxyCommand<SegmentsSummary>(new GetSegmentsSummaryOperation.GetSegmentsSummaryCommand(docId, name, from, to), RequestHandler.HttpContext.Response);
-            using(var token = RequestHandler.CreateOperationToken())
+            using(var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                 await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(op, shardNumber, token.Token);
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForGetTimeSeries.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForGetTimeSeries.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.TimeSeries
                 var fetchDocsOp = new FetchDocumentsFromShardsOperation(context, RequestHandler.HttpContext.Request, RequestHandler.DatabaseContext, idsByShards, includePaths: null, includeRevisions: null, counterIncludes: default, timeSeriesIncludes: null, compareExchangeValueIncludes: null, etag: null, metadataOnly: false);
 
                 ShardedReadResult<GetShardedDocumentsResult> result;
-                using (var token = RequestHandler.CreateOperationToken())
+                using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
                     result = await RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(idsByShards.Keys.ToArray(), fetchDocsOp, token.Token);
 
                 var includesDocId = $"TimeSeriesRangeIncludes/{docId}";

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForPostTimeSeries.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/TimeSeries/ShardedTimeSeriesHandlerProcessorForPostTimeSeries.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.TimeSeries
         protected override async ValueTask ApplyTimeSeriesOperationAsync(string docId, TimeSeriesOperation operation, TransactionOperationContext context)
         {
             int shardNumber = RequestHandler.DatabaseContext.GetShardNumberFor(context, docId);
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var cmd = new TimeSeriesBatchOperation.TimeSeriesBatchCommand(RequestHandler.ShardExecutor.Conventions, docId, operation);
                 await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new ProxyCommand<object>(cmd, RequestHandler.HttpContext.Response), shardNumber, token.Token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web;
@@ -47,7 +48,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 ToBucket = toBucket,   
                 ToShard = toShard
             };
-            var token = CreateOperationToken();
+            var token = new OperationCancelToken(ServerStore.ServerShutdown);
             _ = ServerStore.Operations.AddLocalOperation(operationId, OperationType.Resharding, $"Move to shard {toShard} buckets [{fromBucket}-{toBucket}]", opDesc, async action =>
             {
                 var result = new ReshardingResult();

--- a/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
@@ -45,10 +45,10 @@ namespace Raven.Server.Documents.Sharding.Handlers
             var opDesc = new ReshardingOperationDetails
             {
                 FromBucket = fromBucket,
-                ToBucket = toBucket,   
+                ToBucket = toBucket,
                 ToShard = toShard
             };
-            var token = new OperationCancelToken(ServerStore.ServerShutdown);
+            var token = CreateBackgroundOperationToken();
             _ = ServerStore.Operations.AddLocalOperation(operationId, OperationType.Resharding, $"Move to shard {toShard} buckets [{fromBucket}-{toBucket}]", opDesc, async action =>
             {
                 var result = new ReshardingResult();

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
@@ -124,9 +124,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
             return new OperationCancelToken(cancelAfter, DatabaseContext.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
-        public override OperationCancelToken CreateTimeLimitedOperationToken()
+        public override OperationCancelToken CreateTimeLimitedOperationToken(bool useRequestAbortedToken = true)
         {
-            return new OperationCancelToken(DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, DatabaseContext.DatabaseShutdown, HttpContext.RequestAborted);
+            if (useRequestAbortedToken) 
+                return new OperationCancelToken(DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, DatabaseContext.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(DatabaseContext.Configuration.Databases.OperationTimeout.AsTimeSpan, DatabaseContext.DatabaseShutdown);
+
         }
 
         public override OperationCancelToken CreateTimeLimitedQueryToken()

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -334,7 +334,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
-                var token = new OperationCancelToken(Database.DatabaseShutdown);
+                var token = CreateBackgroundOperationToken();
                 var transformScript = migrationConfiguration.TransformScript;
 
                 _ = Database.Operations.AddLocalOperation(
@@ -444,7 +444,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                     }
                 }
 
-                var token = CreateOperationToken();
+                var token = CreateHttpRequestBoundOperationToken();
                 var result = new SmugglerResult();
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
                 var collection = GetStringQueryString("collection", false);

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -12,7 +12,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.WebUtilities;
@@ -21,7 +20,6 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.Exceptions.Security;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors.Smuggler;
@@ -336,7 +334,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(Database.DatabaseShutdown);
                 var transformScript = migrationConfiguration.TransformScript;
 
                 _ = Database.Operations.AddLocalOperation(

--- a/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractBucketsHandlerProcessorForGetBuckets.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Web.Studio.Processors
             (int fromBucket, int toBucket, int range) = GetParameters();
             
             using(ContextPool.AllocateOperationContext(out TOperationContext context))
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var bucketsResults = await GetBucketsResults(context, fromBucket, toBucket, range,token.Token);
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBucket.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBucket.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
         }
         protected override async ValueTask<BucketInfo> GetBucketInfo(TransactionOperationContext context, int bucket)
         {
-            using (var token = RequestHandler.CreateOperationToken())
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
             {
                 var shardNumber = ShardHelper.GetShardNumberFor(RequestHandler.DatabaseContext.DatabaseRecord.Sharding, bucket);
                 var cmd = new GetBucketInfoCommand(bucket);

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.SqlMigration;
 using Raven.Server.SqlMigration.Model;
@@ -57,8 +58,7 @@ namespace Raven.Server.Web.Studio
 
                     var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
-                    var token = CreateOperationToken();
-
+                    var token = new OperationCancelToken(Database.DatabaseShutdown);
                     var result = new MigrationResult(migrationRequest.Settings);
 
                     var collectionsCount = migrationRequest.Settings.Collections.Count;

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Web.Studio
 
                     var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
-                    var token = new OperationCancelToken(Database.DatabaseShutdown);
+                    var token = CreateBackgroundOperationToken();
                     var result = new MigrationResult(migrationRequest.Settings);
 
                     var collectionsCount = migrationRequest.Settings.Collections.Count;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -568,7 +568,8 @@ namespace Raven.Server.Web.System
 
                 await ServerStore.EnsureNotPassiveAsync();
 
-                var cancelToken = CreateOperationToken();
+                var cancelToken =  new OperationCancelToken(ServerStore.ServerShutdown);
+
                 var operationId = ServerStore.Operations.GetNextOperationId();
 
                 _ = ServerStore.Operations.AddLocalOperation(
@@ -1043,8 +1044,7 @@ namespace Raven.Server.Web.System
                 }
 
                 var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(compactSettings.DatabaseName).ConfigureAwait(false);
-
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(ServerStore.ServerShutdown);
                 var compactDatabaseTask = new CompactDatabaseTask(
                     ServerStore,
                     compactSettings.DatabaseName,
@@ -1224,7 +1224,9 @@ namespace Raven.Server.Web.System
             }
             var (commandline, tmpFile) = configuration.GenerateExporterCommandLine();
             var processStartInfo = new ProcessStartInfo(dataExporter, commandline);
-            var token = CreateOperationToken();
+
+            var token = new OperationCancelToken(ServerStore.ServerShutdown);
+
             Task timeout = null;
             if (configuration.Timeout.HasValue)
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -568,7 +568,7 @@ namespace Raven.Server.Web.System
 
                 await ServerStore.EnsureNotPassiveAsync();
 
-                var cancelToken =  new OperationCancelToken(ServerStore.ServerShutdown);
+                var cancelToken =  CreateBackgroundOperationToken();
 
                 var operationId = ServerStore.Operations.GetNextOperationId();
 
@@ -604,7 +604,7 @@ namespace Raven.Server.Web.System
             if (database == null)
                 DatabaseDoesNotExistException.Throw(databaseName);
 
-            using (var token = CreateOperationToken())
+            using (var token = CreateHttpRequestBoundOperationToken())
             {
                 await database.PeriodicBackupRunner.DelayAsync(id, delay.Value, GetCurrentCertificate(), token.Token);
             }
@@ -1044,7 +1044,7 @@ namespace Raven.Server.Web.System
                 }
 
                 var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(compactSettings.DatabaseName).ConfigureAwait(false);
-                var token = new OperationCancelToken(ServerStore.ServerShutdown);
+                var token = CreateBackgroundOperationToken();
                 var compactDatabaseTask = new CompactDatabaseTask(
                     ServerStore,
                     compactSettings.DatabaseName,
@@ -1225,7 +1225,7 @@ namespace Raven.Server.Web.System
             var (commandline, tmpFile) = configuration.GenerateExporterCommandLine();
             var processStartInfo = new ProcessStartInfo(dataExporter, commandline);
 
-            var token = new OperationCancelToken(ServerStore.ServerShutdown);
+            var token = new OperationCancelToken(database.DatabaseShutdown);
 
             Task timeout = null;
             if (configuration.Timeout.HasValue)

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -500,7 +500,7 @@ namespace Raven.Server.Web.System
             AssertOnlyInSetupMode();
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -555,7 +555,7 @@ namespace Raven.Server.Web.System
             AssertOnlyInSetupMode();
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -619,7 +619,7 @@ namespace Raven.Server.Web.System
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -740,7 +740,7 @@ namespace Raven.Server.Web.System
         {
             AssertOnlyInSetupMode();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -770,7 +770,7 @@ namespace Raven.Server.Web.System
         {
             AssertOnlyInSetupMode();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20610

### Additional description

- in `RestoreDatabase` endpoint we create an `OperationCancelToken` with `HttpContext.RequestAborted` as one of its cancelation tokens, and then we pass it to `AddLocalOperation`
- relying on `HttpContext.RequestAborted` here is wrong, since the http request finishes pretty fast - 
we start the restore process by calling `AddLocalOperation` without awaiting it, and immediately return results to the client (operation id + node tag)
- worst than that, if for some reason the `HttpContext` is aborted (even if it happens after the restore request has finished) then it can cause the ongoing restore process to abort.  this was reproduced in test `EncryptedBackupAndRestoreShardedDatabaseInCluster_UsingDatabaseKey`
- changed `RestoreDatabase`  endpoint to not use `HttpContext.RequestAborted` token
- applied the same fix to other endpoints that call `AddLocalOperation` or `AddRemoteOperation` without awaiting it 

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
