### PR TITLE
RavenDB-20610 : Operations : avoid using HttpContext.RequestAborted as part of the OperationCancelToken if the operation is not awaited - 5.4 fix

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -18,6 +18,7 @@ using Raven.Server.Web.System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using static Raven.Server.Utils.MetricCacher.Keys;
 
 namespace Raven.Server.Documents
 {
@@ -122,34 +123,44 @@ namespace Raven.Server.Documents
             }
         }
 
-        protected OperationCancelToken CreateTimeLimitedOperationToken()
+        protected OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken()
         {
-            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return CreateHttpRequestBoundTimeLimitedOperationToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan);
         }
 
-        protected OperationCancelToken CreateTimeLimitedQueryToken()
+        protected OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationTokenForQuery()
         {
-            return new OperationCancelToken(Database.Configuration.Databases.QueryTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return CreateHttpRequestBoundTimeLimitedOperationToken(Database.Configuration.Databases.QueryTimeout.AsTimeSpan);
         }
 
-        protected OperationCancelToken CreateTimeLimitedCollectionOperationToken()
+        protected override OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan cancelAfter)
         {
-            return new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(cancelAfter, Database.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
-        protected OperationCancelToken CreateTimeLimitedQueryOperationToken()
-        {
-            return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown, HttpContext.RequestAborted);
-        }
-
-        protected override OperationCancelToken CreateOperationToken()
+        protected override OperationCancelToken CreateHttpRequestBoundOperationToken()
         {
             return new OperationCancelToken(Database.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
-        protected override OperationCancelToken CreateOperationToken(TimeSpan cancelAfter)
+        protected OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForQueryOperation()
         {
-            return new OperationCancelToken(cancelAfter, Database.DatabaseShutdown, HttpContext.RequestAborted);
+            return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        protected OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForCollectionOperation()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+
+        protected OperationCancelToken CreateTimeLimitedBackgroundOperationToken()
+        {
+            return new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+        }
+        
+        protected override OperationCancelToken CreateBackgroundOperationToken()
+        {
+            return new OperationCancelToken(Database.DatabaseShutdown);
         }
 
         protected bool ShouldAddPagingPerformanceHint(long numberOfResults)

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -17,6 +17,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Json;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -325,7 +326,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
 
             var operationId = Database.Operations.GetNextOperationId();
-            var token = CreateTimeLimitedQueryOperationToken();
+            var token = new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
 
             _ = Database.Operations.AddOperation(
                 Database,
@@ -393,7 +394,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 if (index == null)
                     IndexDoesNotExistException.ThrowFor(name);
                 
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(Database.DatabaseShutdown);
                 var result = new IndexOptimizeResult(index.Name);
                 var operationId = Database.Operations.GetNextOperationId();
                 var t = Database.Operations.AddOperation(

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -326,7 +326,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             }
 
             var operationId = Database.Operations.GetNextOperationId();
-            var token = new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            var token = CreateTimeLimitedBackgroundOperationTokenForQueryOperation();
 
             _ = Database.Operations.AddOperation(
                 Database,
@@ -393,8 +393,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                 var index = Database.IndexStore.GetIndex(name);
                 if (index == null)
                     IndexDoesNotExistException.ThrowFor(name);
-                
-                var token = new OperationCancelToken(Database.DatabaseShutdown);
+
+                var token = CreateBackgroundOperationToken();
                 var result = new IndexOptimizeResult(index.Name);
                 var operationId = Database.Operations.GetNextOperationId();
                 var t = Database.Operations.AddOperation(

--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/bulk_insert", "POST", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task BulkInsert()
         {
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var id = GetLongQueryString("id");
             var skipOverwriteIfUnchanged = GetBoolValueQueryString("skipOverwriteIfUnchanged", required: false) ?? false;
 

--- a/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.Handlers
 
                 long numberOfResults;
                 long totalDocumentsSizeInBytes;
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -107,7 +107,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 topology = ServerStore.GetClusterTopology(ctx);
 
             var timeoutInSecPerNode = GetIntValueQueryString("timeoutInSecPerNode", false) ?? 60;
-            var clusterOperationToken = CreateOperationToken();
+            var clusterOperationToken = CreateHttpRequestBoundOperationToken();
             var type = GetDebugInfoPackageContentType();
             var databases = GetStringValuesQueryString("database", required: false);
             var operationId = GetLongQueryString("operationId", false) ?? ServerStore.Operations.GetNextOperationId();
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var debugInfoType = GetDebugInfoPackageContentType();
             var databases = GetStringValuesQueryString("database", required: false);
             var operationId = GetLongQueryString("operationId", false) ?? ServerStore.Operations.GetNextOperationId();
-            var token = CreateOperationToken();
+            var token = CreateHttpRequestBoundOperationToken();
 
             await ServerStore.Operations.AddOperation(null, "Created debug package for current server only", Operations.Operations.OperationType.DebugPackage, async _ =>
             {

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers
             if (newIndex == null)
                 throw new IndexDoesNotExistException($"Could not find side-by-side index for '{name}'.");
 
-            using (var token = CreateOperationToken(TimeSpan.FromMinutes(15)))
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan.FromMinutes(15)))
             {
                 Database.IndexStore.ReplaceIndexes(name, newIndex.Name, token.Token);
             }
@@ -834,7 +834,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var field = GetQueryStringValueAndAssertIfSingleAndNotEmpty("field");
 
-            using (var token = CreateTimeLimitedOperationToken())
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationToken())
             using (var context = QueryOperationContext.Allocate(Database))
             {
                 var name = GetIndexNameFromCollectionAndField(field) ?? GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -542,7 +542,7 @@ namespace Raven.Server.Documents.Handlers
                 Operations.Operations.OperationType operationType)
         {
             var options = GetQueryOperationOptions();
-            var token = CreateTimeLimitedQueryOperationToken();
+            var token = new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
 
             var operationId = Database.Operations.GetNextOperationId();
 

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Documents.Handlers
             {
                 try
                 {
-                    using (var token = CreateTimeLimitedQueryToken())
+                    using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
                     using (var queryContext = QueryOperationContext.Allocate(Database))
                     {
                         var debug = GetStringQueryString("debug", required: false);
@@ -251,7 +251,7 @@ namespace Raven.Server.Documents.Handlers
             var queryRunner = Database.QueryRunner.GetRunner(indexQuery);
             if (!(queryRunner is GraphQueryRunner gqr))
                 throw new InvalidOperationException("The specified query is not a graph query.");
-            using (var token = CreateTimeLimitedQueryToken())
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             await using (var writer = new AsyncBlittableJsonTextWriter(queryContext.Documents, ResponseBodyStream()))
             {
                 await gqr.WriteDetailedQueryResult(indexQuery, queryContext, writer, token);
@@ -265,7 +265,7 @@ namespace Raven.Server.Documents.Handlers
             if (!(queryRunner is GraphQueryRunner gqr))
                 throw new InvalidOperationException("The specified query is not a graph query.");
 
-            using (var token = CreateTimeLimitedQueryToken())
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             {
                 var results = await gqr.GetAnalyzedQueryResults(indexQuery, queryContext, null, token);
 
@@ -542,7 +542,7 @@ namespace Raven.Server.Documents.Handlers
                 Operations.Operations.OperationType operationType)
         {
             var options = GetQueryOperationOptions();
-            var token = new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            var token = CreateTimeLimitedBackgroundOperationTokenForQueryOperation();
 
             var operationId = Database.Operations.GetNextOperationId();
 

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,12 +14,10 @@ using Raven.Client;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session.Operations;
-using Raven.Client.Exceptions.Documents.Revisions;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
-using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -133,7 +130,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/revisions/config/enforce", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task EnforceConfigRevisions()
         {
-            var token = new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            var token = CreateTimeLimitedBackgroundOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();
 
             var t = Database.Operations.AddOperation(
@@ -166,7 +163,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
-            using (var token = CreateOperationToken())
+            using (var token = CreateHttpRequestBoundOperationToken())
             {
                 var changeVectors = GetStringValuesQueryString("changeVector", required: false);
                 var metadataOnly = GetBoolValueQueryString("metadataOnly", required: false) ?? false;
@@ -192,7 +189,7 @@ namespace Raven.Server.Documents.Handlers
             
             HashSet<string> collections = configuration.Collections?.Length > 0 ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
 
-            var token = new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            var token = CreateTimeLimitedBackgroundOperationToken();
             var operationId = ServerStore.Operations.GetNextOperationId();
 
             var t = Database.Operations.AddOperation(
@@ -378,7 +375,7 @@ namespace Raven.Server.Documents.Handlers
             var date = Convert.ToDateTime(since).ToUniversalTime();
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
-            using (var token = CreateOperationToken())
+            using (var token = CreateHttpRequestBoundOperationToken())
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
@@ -416,7 +413,7 @@ namespace Raven.Server.Documents.Handlers
                 long count;
                 long totalDocumentsSizeInBytes;
 
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     writer.WriteStartObject();

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -20,6 +20,7 @@ using Raven.Server.Documents.Revisions;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -132,7 +133,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/revisions/config/enforce", "POST", AuthorizationStatus.DatabaseAdmin)]
         public async Task EnforceConfigRevisions()
         {
-            var token = CreateTimeLimitedOperationToken();
+            var token = new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
             var operationId = ServerStore.Operations.GetNextOperationId();
 
             var t = Database.Operations.AddOperation(
@@ -191,7 +192,7 @@ namespace Raven.Server.Documents.Handlers
             
             HashSet<string> collections = configuration.Collections?.Length > 0 ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
 
-            var token = CreateTimeLimitedOperationToken();
+            var token = new OperationCancelToken(Database.Configuration.Databases.OperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
             var operationId = ServerStore.Operations.GetNextOperationId();
 
             var t = Database.Operations.AddOperation(

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -65,7 +65,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                     },
                     initialState);
 
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 await using (var writer = GetLoadDocumentsResultsWriter(format, context, ResponseBodyStream()))
                 {
                     writer.StartResponse();
@@ -100,7 +100,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     var reader = new TimeSeriesReader(context, documentId, name, from, to, offset, token.Token);
@@ -135,7 +135,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         {
             // ReSharper disable once ArgumentsStyleLiteral
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
-            using (var token = CreateTimeLimitedQueryToken())
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (var queryContext = QueryOperationContext.Allocate(Database))
             {
                 var documentId = GetStringQueryString("fromDocument", false);
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         {
             // ReSharper disable once ArgumentsStyleLiteral
             using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
-            using (var token = CreateTimeLimitedQueryToken())
+            using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (var queryContext = QueryOperationContext.Allocate(Database))
             {
                 var stream = TryGetRequestFromStream("ExportOptions") ?? RequestBodyStream();

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Handlers
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
 
-                using (var operationCancelToken = CreateOperationToken())
+                using (var operationCancelToken = CreateHttpRequestBoundOperationToken())
                 {
                     var result = await Database.Operations.AddOperation(
                         database: Database,

--- a/src/Raven.Server/ServerWide/OperationCancelToken.cs
+++ b/src/Raven.Server/ServerWide/OperationCancelToken.cs
@@ -15,19 +15,19 @@ namespace Raven.Server.ServerWide
 
         public readonly CancellationToken Token;
 
-        public OperationCancelToken(TimeSpan cancelAfter, CancellationToken shutdown, CancellationToken requestAborted)
+        public OperationCancelToken(TimeSpan cancelAfter, params CancellationToken[] tokens)
         {
             if (cancelAfter != Timeout.InfiniteTimeSpan && cancelAfter < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(cancelAfter));
 
-            _cts = CancellationTokenSource.CreateLinkedTokenSource(shutdown, requestAborted);
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(tokens);
             _cancelAfter = cancelAfter;
             Token = _cts.Token;
             _cts.CancelAfter(cancelAfter);
         }
 
-        public OperationCancelToken(CancellationToken shutdown, CancellationToken requestAborted)
-            : this(Timeout.InfiniteTimeSpan, shutdown, requestAborted)
+        public OperationCancelToken(params CancellationToken[] tokens)
+            : this(Timeout.InfiniteTimeSpan, tokens)
         {
         }
 

--- a/src/Raven.Server/ServerWide/OperationCancelToken.cs
+++ b/src/Raven.Server/ServerWide/OperationCancelToken.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.ServerWide
 {
     public class OperationCancelToken : IDisposable
     {
-        public static OperationCancelToken None = new OperationCancelToken(CancellationToken.None, CancellationToken.None);
+        public static readonly OperationCancelToken None = new(CancellationToken.None);
 
         private readonly CancellationTokenSource _cts;
         private bool _disposed;
@@ -15,19 +15,33 @@ namespace Raven.Server.ServerWide
 
         public readonly CancellationToken Token;
 
-        public OperationCancelToken(TimeSpan cancelAfter, params CancellationToken[] tokens)
+        public OperationCancelToken(TimeSpan cancelAfter, CancellationToken token)
         {
-            if (cancelAfter != Timeout.InfiniteTimeSpan && cancelAfter < TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException(nameof(cancelAfter));
+            ValidateCancelAfter(cancelAfter);
 
-            _cts = CancellationTokenSource.CreateLinkedTokenSource(tokens);
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             _cancelAfter = cancelAfter;
             Token = _cts.Token;
             _cts.CancelAfter(cancelAfter);
         }
 
-        public OperationCancelToken(params CancellationToken[] tokens)
-            : this(Timeout.InfiniteTimeSpan, tokens)
+        public OperationCancelToken(TimeSpan cancelAfter, CancellationToken token1, CancellationToken token2)
+        {
+            ValidateCancelAfter(cancelAfter);
+
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(token1, token2);
+            _cancelAfter = cancelAfter;
+            Token = _cts.Token;
+            _cts.CancelAfter(cancelAfter);
+        }
+
+        public OperationCancelToken(CancellationToken token)
+            : this(Timeout.InfiniteTimeSpan, token)
+        {
+        }
+
+        public OperationCancelToken(CancellationToken token1, CancellationToken token2)
+            : this(Timeout.InfiniteTimeSpan, token1, token2)
         {
         }
 
@@ -92,6 +106,12 @@ namespace Raven.Server.ServerWide
             }
 
             _cts?.Dispose();
+        }
+
+        private static void ValidateCancelAfter(TimeSpan cancelAfter)
+        {
+            if (cancelAfter != Timeout.InfiniteTimeSpan && cancelAfter < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(cancelAfter));
         }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -126,7 +126,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
 
                 ApplyBackwardCompatibility(options);
 
-                var token = CreateOperationToken();
+                var token = CreateHttpRequestBoundOperationToken();
 
                 var fileName = options.FileName;
                 if (string.IsNullOrEmpty(fileName))
@@ -239,7 +239,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
 
                 await using (var stream = new GZipStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
-                using (var token = CreateOperationToken())
+                using (var token = CreateHttpRequestBoundOperationToken())
                 using (var source = new StreamSource(stream, context, Database))
                 {
                     var destination = new DatabaseDestination(Database);
@@ -561,7 +561,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
-                var token = new OperationCancelToken(Database.DatabaseShutdown);
+                var token = CreateBackgroundOperationToken();
                 var transformScript = migrationConfiguration.TransformScript;
 
                 var t = Database.Operations.AddOperation(Database, $"Migration from: {migrationConfiguration.DatabaseTypeName}",
@@ -662,7 +662,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
-                var token = CreateOperationToken();
+                var token = CreateHttpRequestBoundOperationToken();
 
                 var result = new SmugglerResult();
                 await Database.Operations.AddOperation(Database, "Import to: " + Database.Name,
@@ -826,7 +826,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                     }
                 }
 
-                var token = CreateOperationToken();
+                var token = CreateHttpRequestBoundOperationToken();
                 var result = new SmugglerResult();
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
                 var collection = GetStringQueryString("collection", false);

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -561,7 +561,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 }
 
                 var operationId = GetLongQueryString("operationId", false) ?? Database.Operations.GetNextOperationId();
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(Database.DatabaseShutdown);
                 var transformScript = migrationConfiguration.TransformScript;
 
                 var t = Database.Operations.AddOperation(Database, $"Migration from: {migrationConfiguration.DatabaseTypeName}",

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Web
         }
 
         public abstract Task CheckForChanges(RequestHandlerContext context);
-        
+
         protected Stream TryGetRequestFromStream(string itemName)
         {
             if (HttpContext.Request.HasFormContentType == false)
@@ -661,7 +661,7 @@ namespace Raven.Server.Web
                 case RavenServer.AuthenticationStatus.Expired:
                 case RavenServer.AuthenticationStatus.NotYetValid:
                     if (Server.Configuration.Security.AuthenticationEnabled == false)
-                        return new AllowedDbs { HasAccess = true};
+                        return new AllowedDbs { HasAccess = true };
 
                     await RequestRouter.UnlikelyFailAuthorizationAsync(HttpContext, dbName, null, requireAdmin ? AuthorizationStatus.DatabaseAdmin : AuthorizationStatus.ValidUser);
                     return new AllowedDbs { HasAccess = false };
@@ -780,15 +780,21 @@ namespace Raven.Server.Web
             HttpContext.Response.Headers.Add("Location", leaderLocation);
         }
 
-        protected virtual OperationCancelToken CreateOperationToken()
+        protected virtual OperationCancelToken CreateHttpRequestBoundOperationToken()
         {
             return new OperationCancelToken(ServerStore.ServerShutdown, HttpContext.RequestAborted);
         }
 
-        protected virtual OperationCancelToken CreateOperationToken(TimeSpan cancelAfter)
+        protected virtual OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan cancelAfter)
         {
             return new OperationCancelToken(cancelAfter, ServerStore.ServerShutdown, HttpContext.RequestAborted);
-    }
+        }
+
+        protected virtual OperationCancelToken CreateBackgroundOperationToken()
+        {
+            return new OperationCancelToken(ServerStore.ServerShutdown);
+        }
+
         /// <summary>
         /// puts the given string in TrafficWatch property of HttpContext.Items
         /// puts the given type in TrafficWatchChangeType property of HttpContext.Items

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -6,6 +6,7 @@ using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
 using Raven.Server.Documents;
 using Raven.Server.Json;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.SqlMigration;
 using Raven.Server.SqlMigration.Model;
@@ -56,7 +57,7 @@ namespace Raven.Server.Web.Studio
 
                     var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
-                    var token = CreateOperationToken();
+                    var token = new OperationCancelToken(Database.DatabaseShutdown);
 
                     var result = new MigrationResult(migrationRequest.Settings);
 
@@ -82,7 +83,7 @@ namespace Raven.Server.Web.Studio
                                 throw;
                             }
 
-                             return (IOperationResult)result;
+                            return (IOperationResult)result;
                         });
                     }, operationId, token: token);
 

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Web.Studio
 
                     var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                     var schema = dbDriver.FindSchema();
-                    var token = new OperationCancelToken(Database.DatabaseShutdown);
+                    var token = CreateBackgroundOperationToken();
 
                     var result = new MigrationResult(migrationRequest.Settings);
 

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -331,7 +331,7 @@ namespace Raven.Server.Web.Studio
         {
             var collectionName = GetStringQueryString("name");
 
-            var token = CreateTimeLimitedCollectionOperationToken();
+            var token = new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
 
             var collectionRunner = new StudioCollectionRunner(Database, docsContext, excludeIds);
 

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -331,7 +331,7 @@ namespace Raven.Server.Web.Studio
         {
             var collectionName = GetStringQueryString("name");
 
-            var token = new OperationCancelToken(Database.Configuration.Databases.CollectionOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);
+            var token = CreateTimeLimitedBackgroundOperationTokenForCollectionOperation();
 
             var collectionRunner = new StudioCollectionRunner(Database, docsContext, excludeIds);
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -599,7 +599,7 @@ namespace Raven.Server.Web.System
                     restoreType = RestoreType.Local;
                 }
                 var operationId = ServerStore.Operations.GetNextOperationId();
-                var cancelToken = new OperationCancelToken(ServerStore.ServerShutdown);
+                var cancelToken = CreateBackgroundOperationToken();
                 RestoreBackupTaskBase restoreBackupTask;
                 switch (restoreType)
                 {
@@ -1090,7 +1090,7 @@ namespace Raven.Server.Web.System
 
                 var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(compactSettings.DatabaseName).ConfigureAwait(false);
 
-                var token = new OperationCancelToken(ServerStore.ServerShutdown);
+                var token = CreateBackgroundOperationToken();
                 var compactDatabaseTask = new CompactDatabaseTask(
                     ServerStore,
                     compactSettings.DatabaseName,

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -599,7 +599,7 @@ namespace Raven.Server.Web.System
                     restoreType = RestoreType.Local;
                 }
                 var operationId = ServerStore.Operations.GetNextOperationId();
-                var cancelToken = CreateOperationToken();
+                var cancelToken = new OperationCancelToken(ServerStore.ServerShutdown);
                 RestoreBackupTaskBase restoreBackupTask;
                 switch (restoreType)
                 {
@@ -1090,7 +1090,7 @@ namespace Raven.Server.Web.System
 
                 var database = await ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(compactSettings.DatabaseName).ConfigureAwait(false);
 
-                var token = CreateOperationToken();
+                var token = new OperationCancelToken(ServerStore.ServerShutdown);
                 var compactDatabaseTask = new CompactDatabaseTask(
                     ServerStore,
                     compactSettings.DatabaseName,
@@ -1269,7 +1269,7 @@ namespace Raven.Server.Web.System
             }
             var (commandline, tmpFile) = configuration.GenerateExporterCommandLine();
             var processStartInfo = new ProcessStartInfo(dataExporter, commandline);
-            var token = new OperationCancelToken(database.DatabaseShutdown, HttpContext.RequestAborted);
+            var token = new OperationCancelToken(database.DatabaseShutdown);
             Task timeout = null;
             if (configuration.Timeout.HasValue)
             {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -463,7 +463,7 @@ namespace Raven.Server.Web.System
                 try
                 {
                     var operationId = ServerStore.Operations.GetNextOperationId();
-                    var cancelToken = CreateOperationToken();
+                    var cancelToken = new OperationCancelToken(Database.DatabaseShutdown);
                     var backupParameters = new BackupParameters
                     {
                         RetentionPolicy = null,

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -463,7 +463,7 @@ namespace Raven.Server.Web.System
                 try
                 {
                     var operationId = ServerStore.Operations.GetNextOperationId();
-                    var cancelToken = new OperationCancelToken(Database.DatabaseShutdown);
+                    var cancelToken = CreateBackgroundOperationToken();
                     var backupParameters = new BackupParameters
                     {
                         RetentionPolicy = null,

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -498,7 +498,7 @@ namespace Raven.Server.Web.System
             AssertOnlyInSetupMode();
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -557,7 +557,7 @@ namespace Raven.Server.Web.System
             AssertOnlyInSetupMode();
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -620,7 +620,7 @@ namespace Raven.Server.Web.System
 
             var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -739,7 +739,7 @@ namespace Raven.Server.Web.System
         {
             AssertOnlyInSetupMode();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)
@@ -767,7 +767,7 @@ namespace Raven.Server.Web.System
         {
             AssertOnlyInSetupMode();
 
-            var operationCancelToken = CreateOperationToken();
+            var operationCancelToken = CreateHttpRequestBoundOperationToken();
             var operationId = GetLongQueryString("operationId", false);
 
             if (operationId.HasValue == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20610

### Additional description

details are in https://github.com/ravendb/ravendb/pull/16813

### Type of change

- Bug fix
- Tests stabilization