### PR TITLE
RavenDB-20150 fixed issue with compare exchange tombstones not being cleaned when replication factor is less than number of nodes in the cluster

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -606,13 +606,19 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (state != null)
             {
-                if (state.DatabaseTopology.Count != state.Current.Count) // we have a state change, do not remove anything
-                    return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
-
-                foreach (var node in state.DatabaseTopology.AllNodes)
+                // we are checking this here, not in the main loop, to avoid returning 'NoMoreTombstones' when maxEtag is 0
+                foreach (var nodeTag in state.DatabaseTopology.AllNodes)
                 {
-                    if (state.Current.TryGetValue(node, out var nodeReport) == false)
-                        continue;
+                    if (state.Current.ContainsKey(nodeTag) == false) // we have a state change, do not remove anything
+                        return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
+                }
+
+                foreach (var nodeTag in state.DatabaseTopology.AllNodes)
+                {
+                    var hasState = state.Current.TryGetValue(nodeTag, out var nodeReport);
+                    Debug.Assert(hasState, $"Could not find state for node '{nodeTag}' for database '{state.Name}'.");
+                    if (hasState == false)
+                        return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 
                     if (nodeReport.Report.TryGetValue(state.Name, out var report) == false)
                         continue;

--- a/test/SlowTests/Issues/RavenDB-16595.cs
+++ b/test/SlowTests/Issues/RavenDB-16595.cs
@@ -154,7 +154,7 @@ namespace SlowTests.Issues
             await AssertWaitForValueAsync(async () => await GetMembersCount(store1, databaseName: databaseCopyName), 2);
         }
 
-        public class User
+        private class User
         {
             public string Id { get; set; }
             public string Name { get; set; }

--- a/test/SlowTests/Issues/RavenDB_17373.cs
+++ b/test/SlowTests/Issues/RavenDB_17373.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Issues
         {
         }
 
-        public class User
+        private class User
         {
             public string Name;
             public DateTime Registered;

--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20150 : ClusterTestBase
+{
+    public RavenDB_20150(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.CompareExchange | RavenTestCategory.Cluster)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task CompareExchangeTombstoneWillBeCleanedOnlyWhenAllNodesHaveBackedUpPreviousOnes(int replicationFactor)
+    {
+        var database = GetDatabaseName();
+        var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), "0" },
+            };
+        var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true, leaderIndex: 0, customSettings: settings);
+        var (_, databaseServers) = await CreateDatabaseInCluster(database, replicationFactor, leader.WebUrl);
+
+        var backupPath = NewDataPath(suffix: $"BackupFolderNonSharded");
+
+        using (var store = new DocumentStore()
+        {
+            Database = database,
+            Urls = new[] { databaseServers[Math.Max(0, databaseServers.Count - 2)].WebUrl }
+        }.Initialize())
+        {
+            var user = new User
+            {
+                Name = "🤡"
+            };
+
+            //create one compare exchange on each shard
+            var cxRes = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", user, 0));
+
+            //suspend observer to stall tombstone cleaning
+            leader.ServerStore.Observer.Suspended = true;
+
+            var timeBeforeCxDeletion = DateTime.UtcNow;
+
+            //delete the compare exchanges
+            await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cxRes.Index));
+
+            //run periodic backup on other database server
+            var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 * *");
+            var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+            foreach (var dbServer in databaseServers)
+            {
+                var server2Database = await dbServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                var periodicBackupRunner = server2Database.PeriodicBackupRunner;
+                var op = periodicBackupRunner.StartBackupTask(result.TaskId, isFullBackup: false);
+                var value = await WaitForValueAsync(() =>
+                {
+                    var status = server2Database.Operations.GetOperation(op)?.State.Status;
+                    return status;
+                }, OperationStatus.Completed);
+                Assert.Equal(OperationStatus.Completed, value);
+
+                //wait for periodic backup to finish running
+                var done = await WaitForValueAsync(() =>
+                {
+                    using (dbServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        var itemName = PeriodicBackupStatus.GenerateItemName(database, result.TaskId);
+                        var status = dbServer.ServerStore.Cluster.Read(context, itemName);
+                        if (status == null)
+                            return false;
+                        status.TryGet(nameof(LastRaftIndex), out BlittableJsonReaderObject lastRaftIndexBlittable);
+                        lastRaftIndexBlittable.TryGet(nameof(LastRaftIndex.LastEtag), out long etag);
+                        return etag >= cxRes.Index;
+                    }
+                }, true);
+
+                Assert.True(done);
+            }
+
+            //unsuspend and wait for the tombstone cleaner
+            leader.ServerStore.Observer.Suspended = false;
+
+            await WaitAndAssertForValueAsync(() => leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks > timeBeforeCxDeletion.Ticks, true);
+
+            //ensure compare exchange tombstones were deleted after the tombstone cleanup
+            foreach (var node in nodes)
+            {
+                long numOfCompareExchangeTombstones = -1;
+                long numOfCompareExchanges = -1;
+                await WaitForValueAsync(() =>
+                {
+                    using (node.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        numOfCompareExchangeTombstones = node.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
+                        numOfCompareExchanges = node.ServerStore.Cluster.GetNumberOfCompareExchange(context, store.Database);
+
+                        return numOfCompareExchanges == 0 && numOfCompareExchangeTombstones == 0;
+                    }
+                }, true);
+
+                Assert.Equal(0, numOfCompareExchangeTombstones);
+                Assert.Equal(0, numOfCompareExchanges);
+            }
+        }
+    }
+}

--- a/test/SlowTests/MailingList/IndexCompilation.cs
+++ b/test/SlowTests/MailingList/IndexCompilation.cs
@@ -1076,7 +1076,7 @@ namespace SlowTests.MailingList
             }
         }
 
-        public class Visitor
+        private class Visitor
         {
             public string Id { get; set; }
             public Dictionary<int, int> DictionaryOfIntegers { get; set; }
@@ -1085,14 +1085,14 @@ namespace SlowTests.MailingList
             public Dictionary<int, int> DictionaryOfIntegersToExcept { get; set; }
         }
 
-        public class User
+        private class User
         {
             public string Id { get; set; }
             public Dictionary<DateTime, int> LoginCountByDate { get; set; }
             public List<decimal> ListOfDecimals { get; set; }
         }
 
-        public class Employee
+        private class Employee
         {
             public string Id { get; set; }
             public Dictionary<DateTime, int> LoginCountByDate { get; set; }

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -771,7 +771,7 @@ namespace SlowTests.Server.Replication
             await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
         }
 
-        public class User
+        private class User
         {
             public string Id;
             public string Name;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20150

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
