### PR TITLE
RavenDB-20782 Corax - autoindex field highlighting with custom prefix/postfix

### DIFF
--- a/src/Raven.Client/Documents/Session/DocumentQuery.Highlightings.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.Highlightings.cs
@@ -27,7 +27,7 @@ namespace Raven.Client.Documents.Session
 
         IDocumentQuery<T> IDocumentQueryBase<T, IDocumentQuery<T>>.Highlight(Expression<Func<T, object>> path, int fragmentLength, int fragmentCount, HighlightingOptions options, out Highlightings highlightings)
         {
-            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, null, out highlightings);
+            Highlight(path.ToPropertyPath(Conventions), fragmentLength, fragmentCount, options, out highlightings);
             return this;
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -164,10 +164,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         if (numberOfPreTags != numberOfPostTags)
                             throw new InvalidOperationException("Number of pre-tags and post-tags must match.");
 
-                        var fieldName =
-                            query.Metadata.IsDynamic
-                                ? AutoIndexField.GetHighlightingAutoIndexFieldName(highlighting.Field.Value)
-                                : highlighting.Field.Value;
+                        var fieldName = highlighting.Field.Value;
 
                         if (highlightingTerms.TryGetValue(fieldName, out var termIndex) == false)
                         {
@@ -175,7 +172,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                             termIndex = new()
                             {
                                 FieldName = highlighting.Field.Value,
-                                DynamicFieldName = AutoIndexField.GetHighlightingAutoIndexFieldName(highlighting.Field.Value),
+                                DynamicFieldName = AutoIndexField.GetSearchAutoIndexFieldName(highlighting.Field.Value),
                                 GroupKey = options.GroupKey
                             };
                             highlightingTerms.Add(query.Metadata.IsDynamic ? termIndex.DynamicFieldName : termIndex.FieldName, termIndex);
@@ -1078,9 +1075,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 if (numberOfPreTags != numberOfPostTags)
                     throw new InvalidOperationException("Number of pre-tags and post-tags must match.");
 
-                var fieldName =
-                    query.Metadata.IsDynamic
-                        ? AutoIndexField.GetHighlightingAutoIndexFieldName(highlighting.Field.Value)
+                var fieldName = query.Metadata.IsDynamic
+                        ? AutoIndexField.GetSearchAutoIndexFieldName(highlighting.Field.Value)
                         : highlighting.Field.Value;
 
                 if (highlightingTerms.TryGetValue(fieldName, out var termIndex) == false)
@@ -1088,7 +1084,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     // the case when we have to create MapReduce highlighter
                     termIndex = new();
                     termIndex.FieldName = highlighting.Field.Value;
-                    termIndex.DynamicFieldName = AutoIndexField.GetHighlightingAutoIndexFieldName(highlighting.Field.Value);
+                    termIndex.DynamicFieldName = AutoIndexField.GetSearchAutoIndexFieldName(highlighting.Field.Value);
                     termIndex.GroupKey = options.GroupKey;
                     highlightingTerms.Add(query.Metadata.IsDynamic ? termIndex.DynamicFieldName : termIndex.FieldName, termIndex);
                 }

--- a/test/SlowTests/Issues/RavenDB-20782.cs
+++ b/test/SlowTests/Issues/RavenDB-20782.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Queries.Highlighting;
+using SlowTests.Tests.Linq;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ public class RavenDB_20782 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CustomHighlightingViaDocumentQueryAsync(Options options)
     {
         using var store = GetDocumentStore(options);
@@ -40,7 +41,7 @@ public class RavenDB_20782 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
     public void CustomHighlightingViaDocumentQuery(Options options)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Issues/RavenDB-20782.cs
+++ b/test/SlowTests/Issues/RavenDB-20782.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Queries.Highlighting;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20782 : RavenTestBase
+{
+    public RavenDB_20782(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CustomHighlightingViaDocumentQueryAsync(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenAsyncSession())
+        {
+            var employee = new Employee() {Notes = new List<string>() {"sales"}};
+            await session.StoreAsync(employee);
+            await session.SaveChangesAsync();
+
+            HighlightingOptions tagsToUse = new HighlightingOptions {PreTags = new[] {"+++"}, PostTags = new[] {"+++"}};
+
+            var employeesResults = await session.Advanced.AsyncDocumentQuery<Employee>()
+                .WaitForNonStaleResults()
+                .Search(x => x.Notes, "sales")
+                .Highlight(x => x.Notes, 35, 4, tagsToUse, out Highlightings salesHighlights)
+                .ToListAsync();
+
+            Assert.Equal("+++sales+++", salesHighlights.GetFragments(employee.Id).First());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void CustomHighlightingViaDocumentQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            var employee = new Employee() {Notes = new List<string>() {"sales"}};
+            session.Store(employee);
+            session.SaveChanges();
+
+            HighlightingOptions tagsToUse = new HighlightingOptions {PreTags = new[] {"+++"}, PostTags = new[] {"+++"}};
+
+            var employeesResults = session.Advanced.DocumentQuery<Employee>()
+                .WaitForNonStaleResults()
+                .Search(x => x.Notes, "sales")
+                .Highlight(x => x.Notes, 35, 4, tagsToUse, out Highlightings salesHighlights)
+                .ToList();
+
+            Assert.Equal("+++sales+++", salesHighlights.GetFragments(employee.Id).First());
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20782 

### Additional description

We tried to match the field name based on the dynamic name but it has to match the original field name. Additionally, the dynamic field name in such case is `search(Field)` since `Highlight([...]) is a marker for Lucene to attach term-offsets in an index.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
