### PR TITLE
RavenDB-20702 - RequestedNodeUnavailableException after manual cluster creation

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1507,7 +1507,7 @@ namespace Raven.Server.Documents
                     record = _serverStore.Cluster.ReadDatabase(context, Name);
                 }
 
-                if (ServerStore.HasDatabaseRecordTopologyChanged(record.Topology.Stamp.Index, _lastTopologyIndex, out string url))
+                if (ServerStore.ShouldUpdateTopology(record.Topology.Stamp.Index, _lastTopologyIndex, out string url))
                 {
                     _lastTopologyIndex = record.Topology.Stamp.Index;
 
@@ -1519,7 +1519,7 @@ namespace Raven.Server.Documents
 
                     _ = RequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode()
                     {
-                        ClusterTag = _serverStore.NodeTag, Database = Name, Url = _serverStore.Server.WebUrl
+                        ClusterTag = _serverStore.NodeTag, Database = Name, Url = ServerStore.GetNodeHttpServerUrl()
                     })
                     {
                         DebugTag = "database-topology-update"

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1507,20 +1507,23 @@ namespace Raven.Server.Documents
                     record = _serverStore.Cluster.ReadDatabase(context, Name);
                 }
 
-                if (_lastTopologyIndex < record.Topology.Stamp.Index)
+                if (ServerStore.HasDatabaseRecordTopologyChanged(record.Topology.Stamp.Index, _lastTopologyIndex, out string url))
                 {
-                    var clusterTopology = ServerStore.GetClusterTopology();
-                    var url = clusterTopology.GetUrlFromTag(ServerStore.NodeTag);
-                    if (url != null)
-                    {
-                        _lastTopologyIndex = record.Topology.Stamp.Index;
+                    _lastTopologyIndex = record.Topology.Stamp.Index;
 
-                        Changes.RaiseNotifications(new TopologyChange
-                        {
-                            Url = url,
-                            Database = Name
-                        });
-                    }
+                    Changes.RaiseNotifications(new TopologyChange
+                    {
+                        Url = url,
+                        Database = Name
+                    });
+
+                    _ = RequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode()
+                    {
+                        ClusterTag = _serverStore.NodeTag, Database = Name, Url = _serverStore.Server.WebUrl
+                    })
+                    {
+                        DebugTag = "database-topology-update"
+                    });
                 }
 
                 ClientConfiguration = record.Client;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Sharding
                     {
                         _ = ShardExecutor.GetRequestExecutorAt(shardNumber).UpdateTopologyAsync(
                             new RequestExecutor.UpdateTopologyParameters(
-                                    new ServerNode() { ClusterTag = ServerStore.NodeTag, Database = ShardHelper.ToShardName(DatabaseName, shardNumber), Url = ServerStore.Server.WebUrl })
+                                    new ServerNode() { ClusterTag = ServerStore.NodeTag, Database = ShardHelper.ToShardName(DatabaseName, shardNumber), Url = ServerStore.GetNodeHttpServerUrl() })
                             { DebugTag = "shard-topology-update" });
                     }
                 }
@@ -153,7 +153,7 @@ namespace Raven.Server.Documents.Sharding
         {
             var topologyIndex = topology.Stamp?.Index ?? 0;
             var oldTopologyIndex = oldTopology.Stamp?.Index ?? 0;
-            if (ServerStore.HasDatabaseRecordTopologyChanged(topologyIndex, oldTopologyIndex, out string url))
+            if (ServerStore.ShouldUpdateTopology(topologyIndex, oldTopologyIndex, out string url))
             {
                 Changes.RaiseNotifications(new TopologyChange
                 {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Sharding
                     Debug.Assert(record.Sharding.Shards.ContainsKey(shardNumber));
                     if (CheckForTopologyChangesAndRaiseNotification(topology, _record.Sharding.Shards[shardNumber]))
                     {
-                        var t = ShardExecutor.GetRequestExecutorAt(shardNumber).UpdateTopologyAsync(
+                        _ = ShardExecutor.GetRequestExecutorAt(shardNumber).UpdateTopologyAsync(
                             new RequestExecutor.UpdateTopologyParameters(
                                     new ServerNode() { ClusterTag = ServerStore.NodeTag, Database = ShardHelper.ToShardName(DatabaseName, shardNumber), Url = ServerStore.Server.WebUrl })
                             { DebugTag = "shard-topology-update" });

--- a/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateTopologyCommand.cs
@@ -35,7 +35,6 @@ namespace Raven.Server.ServerWide.Commands
                 if (record.IsSharded)
                 {
                     record.Sharding.Orchestrator.Topology.Update(Topology);
-                    SetLeaderStampForTopology(record.Sharding.Orchestrator.Topology, etag);
                     return;
                 }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -527,6 +527,19 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        public bool HasDatabaseRecordTopologyChanged(long newRecordIndex, long currentIndex, out string url)
+        {
+            if (currentIndex < newRecordIndex)
+            {
+                var clusterTopology = GetClusterTopology();
+                url = clusterTopology.GetUrlFromTag(NodeTag);
+                if (url != null)
+                    return true;
+            }
+            url = null;
+            return false;
+        }
+
         public bool HasTopologyChanged(long topologyEtag)
         {
             return _lastClusterTopologyIndex != topologyEtag;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1192,10 +1192,11 @@ namespace Raven.Server.ServerWide
         {
             if (_lastClusterTopologyIndex < topology.Etag)
                 _lastClusterTopologyIndex = topology.Etag;
+            
+            _ = ClusterRequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode() {ClusterTag = NodeTag, Url = Server.WebUrl}));
 
             NotificationCenter.Add(ClusterTopologyChanged.Create(topology, LeaderTag,
                 NodeTag, _engine.CurrentTerm, _engine.CurrentState, status ?? GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));
-
         }
 
         private Task OnDatabaseChanged(string databaseName, long index, string type, DatabasesLandlord.ClusterDatabaseChangeType _, object state)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1193,7 +1193,10 @@ namespace Raven.Server.ServerWide
             if (_lastClusterTopologyIndex < topology.Etag)
                 _lastClusterTopologyIndex = topology.Etag;
             
-            _ = ClusterRequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode() {ClusterTag = NodeTag, Url = Server.WebUrl}));
+            _ = ClusterRequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode() {ClusterTag = NodeTag, Url = Server.WebUrl})
+            {
+                DebugTag = "cluster-topology-update"
+            });
 
             NotificationCenter.Add(ClusterTopologyChanged.Create(topology, LeaderTag,
                 NodeTag, _engine.CurrentTerm, _engine.CurrentState, status ?? GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -976,7 +976,7 @@ namespace RachisTests
                 await serverD.ServerStore.Engine.WaitForTopology(Leader.TopologyModification.NonVoter);
             }
 
-            await AssertWaitForValueAsync(async () =>
+            var res = WaitForValue(() =>
             {
                 if (nodes[1].ServerStore.ClusterRequestExecutor?.TopologyNodes?.Count != 4)
                 {
@@ -985,6 +985,7 @@ namespace RachisTests
 
                 return true;
             }, true);
+            Assert.True(res);
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20702

### Additional description

Cluster request executor didn't detect changes in cluster topology and didn't update its nodes. Now updating the topology when it changes.
Also checking topology changes for all shards topologies and updating accordingly.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
