### PR TITLE
RavenDB-20634 Id property of embedded object is not wrapped in `Id()` JavaScript  function by LINQ.

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3344,7 +3344,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 Array.Resize(ref extensions, newSize);
                 if (_typedParameterSupport != null)
                     extensions[newSize - 2] = _typedParameterSupport;
-                extensions[newSize - 1] = new JavascriptConversionExtensions.IdentityPropertySupport(DocumentQuery.Conventions, _typedParameterSupport?.Name);
+                extensions[newSize - 1] = new JavascriptConversionExtensions.IdentityPropertySupport(DocumentQuery.Conventions, _typedParameterSupport?.Name, _originalQueryType);
             }
 
             return expression.CompileToJavascript(new JavascriptCompilationOptions(ScriptVersion.ECMAScript2017, extensions)

--- a/test/SlowTests/Issues/RavenDB-11767.cs
+++ b/test/SlowTests/Issues/RavenDB-11767.cs
@@ -62,11 +62,11 @@ namespace SlowTests.Issues
                                                 }
                                     };
 
-                    Assert.Equal("from 'Orders' as o load o.CategoryListId as categoryList " +
+                     Assert.Equal("from 'Orders' as o load o.CategoryListId as categoryList " +
                                  "select { Id : id(o), Items : o.OrderItems" +
                                     ".map(i=>({i:i,cat:categoryList.Categories}))" +
                                     ".map(__rvn0=>({__rvn0:__rvn0,id:__rvn0.i.CategoryId}))" +
-                                    ".map(__rvn1=>({__rvn1:__rvn1,first:__rvn1.__rvn0.cat.find(x=>id(x)===__rvn1.id)}))" +
+                                    ".map(__rvn1=>({__rvn1:__rvn1,first:__rvn1.__rvn0.cat.find(x=>x.Id===__rvn1.id)}))" +
                                     ".map(__rvn2=>({__rvn2:__rvn2,name:__rvn2.first.Name}))" +
                                     ".map(__rvn3=>({CategoryName:__rvn3.name})) }"
                                 , queryable.ToString());

--- a/test/SlowTests/Issues/RavenDB-13016.cs
+++ b/test/SlowTests/Issues/RavenDB-13016.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Issues
                     RavenTestHelper.AssertEqualRespectingNewLines(
                         "from 'PostComments' as x select { " +
                             "Comments : x.Comments.map(comment=>({comment:comment,owner:load(comment.OwnerId)}))" +
-                                        ".map(__rvn0=>({Id:id(__rvn0.comment),Owner:{Id:id(__rvn0.owner)}})) }"
+                                        ".map(__rvn0=>({Id:__rvn0.comment.Id,Owner:{Id:id(__rvn0.owner)}})) }"
                         , query.ToString());
 
 

--- a/test/SlowTests/Issues/RavenDB-20634.cs
+++ b/test/SlowTests/Issues/RavenDB-20634.cs
@@ -52,11 +52,21 @@ public class RavenDB_20634 : RavenTestBase
                     let invite = workspace.Invites.FirstOrDefault(x => x.Id == "invites/1")
                     let inviter = RavenQuery.Load<MyUser>(invite.Invitee)
                     select new PendingInvite { Id = invite.Id, Created = invite.Created, Inviter = inviter.UserName });
+                
                 var result = query.ToList();
+                RavenTestHelper.AssertEqualRespectingNewLines(
+@"declare function output(workspace) {
+	var invite = workspace.invites.find(x=>x.id===""invites/1"");
+	var inviter = load(invite.invitee);
+	return { Id : invite.id, Created : invite.created, Inviter : inviter.userName };
+}
+from 'Workspaces' as workspace select output(workspace)", query.ToString());
                 Assert.NotNull(result);
                 Assert.Equal(1, result.Count);
                 Assert.Equal("john", result[0].Inviter);
                 Assert.Equal("invites/1", result[0].Id);
+                
+                
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-20634.cs
+++ b/test/SlowTests/Issues/RavenDB-20634.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20634 : RavenTestBase
+{
+    public RavenDB_20634(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void IdOfEmbeddedObjectIsNotWrappedIntoJavaScriptIdFunction()
+    {
+        using (var store = GetDocumentStore(options: new Options
+               {
+                   ModifyDocumentStore = ss =>
+                   {
+                       ss.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                       {
+                           CustomizeJsonSerializer = s => { s.ContractResolver = new CamelCasePropertyNamesContractResolver(); }
+                       };
+                       ss.Conventions.PropertyNameConverter = mi => $"{Char.ToLower(mi.Name[0])}{mi.Name.Substring(1)}";
+                       ss.Conventions.ShouldApplyPropertyNameConverter = info => true;
+                   }
+               }))
+        {
+            using (var session = store.OpenSession())
+            {
+                var user = new MyUser { Id = "users/1", UserName = "john" };
+
+                session.Store(user);
+
+                var workspace = new Workspace { Id = "workspaces/1", Invites = new List<Invite> { new Invite { Id = "invites/1", Invitee = user.Id } } };
+
+                session.Store(workspace);
+
+                session.SaveChanges();
+            }
+ 
+            using (var session = store.OpenSession())
+            {
+                var query = (from workspace in session.Query<Workspace>()
+                    let invite = workspace.Invites.FirstOrDefault(x => x.Id == "invites/1")
+                    let inviter = RavenQuery.Load<MyUser>(invite.Invitee)
+                    select new PendingInvite { Id = invite.Id, Created = invite.Created, Inviter = inviter.UserName });
+                var result = query.ToList();
+                Assert.NotNull(result);
+                Assert.Equal(1, result.Count);
+                Assert.Equal("john", result[0].Inviter);
+                Assert.Equal("invites/1", result[0].Id);
+            }
+        }
+    }
+
+    private class MyUser
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string UserName { get; set; }
+        public int Age { get; set; }
+
+        public List<Rating> HasRated { get; set; }
+
+        public class Rating
+        {
+            public string Movie { get; set; }
+            public int Score { get; set; }
+        }
+    }
+
+    private class Workspace
+    {
+        public string Id { get; set; }
+        public List<Invite> Invites { get; set; } = new List<Invite>();
+    }
+
+    private class Invite
+    {
+        public string Id { get; set; }
+        public DateTime Created { get; set; } = DateTime.UtcNow;
+        public string Invitee { get; set; }
+    }
+
+    private class PendingInvite
+    {
+        public string Id { get; set; }
+        public DateTime Created { get; set; }
+        public string Inviter { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20634
### Additional description

When a document has an embedded object with `Id` property we've to detect it's not `Id` property of an original document and not apply `id(doc)` javascript method to it.

### Type of change

- Bug fix


### How risky is the change?


- High

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
