### PR TITLE
RavenDB-20834 adjust tests & fix topology update during deletion

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -82,6 +82,8 @@ namespace Raven.Client
             public const string AttachmentHash = "Attachment-Hash";
 
             public const string AttachmentSize = "Attachment-Size";
+
+            internal const string DatabaseMissing = "Database-Missing";
         }
 
         public class Platform

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -198,7 +198,12 @@ namespace Raven.Client.Documents
 
             RequestExecutor CreateRequestExecutorForSingleNode()
             {
+#if  DEBUG
+                // passing several Urls here is probably not indented
                 var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls.Single(), database, Certificate, Conventions);
+#else
+                var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls[0], database, Certificate, Conventions);
+#endif
                 RegisterEvents(forSingleNode);
 
                 RequestExecutorCreated?.Invoke(this, forSingleNode);

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -197,7 +198,7 @@ namespace Raven.Client.Documents
 
             RequestExecutor CreateRequestExecutorForSingleNode()
             {
-                var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls[0], database, Certificate, Conventions);
+                var forSingleNode = RequestExecutor.CreateForSingleNodeWithConfigurationUpdates(Urls.Single(), database, Certificate, Conventions);
                 RegisterEvents(forSingleNode);
 
                 RequestExecutorCreated?.Invoke(this, forSingleNode);

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -941,7 +941,7 @@ namespace Raven.Client.Http
                     {
                         if (await HandleUnsuccessfulResponse(chosenNode, nodeIndex, context, command, request, response, url, sessionInfo, shouldRetry, token).ConfigureAwait(false) == false)
                         {
-                            if (response.Headers.TryGetValues("Database-Missing", out var databaseMissing))
+                            if (response.Headers.TryGetValues(Constants.Headers.DatabaseMissing, out var databaseMissing))
                             {
                                 var name = databaseMissing.FirstOrDefault();
                                 if (name != null)

--- a/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
@@ -23,7 +23,13 @@ namespace Raven.Client.ServerWide.Operations
            
         }
 
-        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation = null) : 
+        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode) : 
+            this(ClientShardHelper.ToShardName(databaseName, shardNumber), hardDelete, fromNode: fromNode, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
+        {
+            
+        }
+
+        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation) : 
             this(ClientShardHelper.ToShardName(databaseName, shardNumber), hardDelete, fromNode: fromNode, timeToWaitForConfirmation: timeToWaitForConfirmation)
         {
             

--- a/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
@@ -13,23 +13,7 @@ namespace Raven.Client.ServerWide.Operations
     {
         private readonly Parameters _parameters;
         
-        public DeleteDatabasesOperation(string databaseName, bool hardDelete) : this(databaseName, hardDelete, fromNode: null, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
-        {
-            
-        }
-
-        public DeleteDatabasesOperation(string databaseName, bool hardDelete, string fromNode) : this(databaseName, hardDelete, fromNode: fromNode, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
-        {
-           
-        }
-
-        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode) : 
-            this(ClientShardHelper.ToShardName(databaseName, shardNumber), hardDelete, fromNode: fromNode, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
-        {
-            
-        }
-
-        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation) : 
+        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation = null) : 
             this(ClientShardHelper.ToShardName(databaseName, shardNumber), hardDelete, fromNode: fromNode, timeToWaitForConfirmation: timeToWaitForConfirmation)
         {
             

--- a/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DeleteDatabasesOperation.cs
@@ -12,7 +12,23 @@ namespace Raven.Client.ServerWide.Operations
     public class DeleteDatabasesOperation : IServerOperation<DeleteDatabaseResult>
     {
         private readonly Parameters _parameters;
+        
+        public DeleteDatabasesOperation(string databaseName, bool hardDelete) : this(databaseName, hardDelete, fromNode: null, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
+        {
+            
+        }
 
+        public DeleteDatabasesOperation(string databaseName, bool hardDelete, string fromNode) : this(databaseName, hardDelete, fromNode: fromNode, timeToWaitForConfirmation: TimeSpan.FromSeconds(15))
+        {
+           
+        }
+
+        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation = null) : 
+            this(ClientShardHelper.ToShardName(databaseName, shardNumber), hardDelete, fromNode: fromNode, timeToWaitForConfirmation: timeToWaitForConfirmation)
+        {
+            
+        }
+        
         public DeleteDatabasesOperation(string databaseName, bool hardDelete, string fromNode = null, TimeSpan? timeToWaitForConfirmation = null)
         {
             if (databaseName == null)
@@ -29,23 +45,6 @@ namespace Raven.Client.ServerWide.Operations
                 _parameters.FromNodes = new[] { fromNode };
         }
 
-        public DeleteDatabasesOperation(string databaseName, int shardNumber, bool hardDelete, string fromNode, TimeSpan? timeToWaitForConfirmation = null)
-        {
-            if (databaseName == null)
-                throw new ArgumentNullException(nameof(databaseName));
-
-            if (fromNode == null)
-                throw new ArgumentException(nameof(fromNode));
-            
-            _parameters = new Parameters
-            {
-                DatabaseNames = new[] { ClientShardHelper.ToShardName(databaseName, shardNumber) },
-                HardDelete = hardDelete,
-                TimeToWaitForConfirmation = timeToWaitForConfirmation,
-                FromNodes = new [] {fromNode}
-            };
-        }
-        
         public DeleteDatabasesOperation(Parameters parameters)
         {
             if (parameters == null)

--- a/src/Raven.Client/Util/ClientShardHelper.cs
+++ b/src/Raven.Client/Util/ClientShardHelper.cs
@@ -15,7 +15,9 @@ namespace Raven.Client.Util
             }
 
             ResourceNameValidator.AssertValidDatabaseName(database);
-            
+            if (shardNumber < 0)
+                throw new ArgumentException("Shard number must be non-negative");
+
             return $"{database}${shardNumber}";
         }
 

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractHandlerProcessorForGetDatabaseRecord.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractHandlerProcessorForGetDatabaseRecord.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client;
@@ -43,7 +44,7 @@ internal abstract class AbstractHandlerProcessorForGetDatabaseRecord<TRequestHan
                 if (dbDoc == null)
                 {
                     RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                    RequestHandler.HttpContext.Response.Headers["Database-Missing"] = name;
+                    RequestHandler.HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                     {
                         context.Write(writer,

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1774,6 +1774,15 @@ namespace Raven.Server.Rachis
             term = reader.ReadLittleEndianInt64();
         }
 
+        public void GetLastCommitIndex(out long index, out long term)
+        {
+            using (ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                GetLastCommitIndex(context, out index, out term);
+            }
+        }
+
         public unsafe void SetLastCommitIndex(ClusterOperationContext context, long index, long term)
         {
             Debug.Assert(context.Transaction != null);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -727,17 +727,11 @@ namespace Raven.Server.Web.System
                     index = newIndex;
                 }
 
-                if (parameters.TimeToWaitForConfirmation.HasValue == false)
-                {
-                    await WriteResponseAsync(context, index, pendingDeletes);
-                    return;
-                }
-                
+                var timeToWaitForConfirmation = parameters.TimeToWaitForConfirmation ?? TimeSpan.FromSeconds(15);
+
+                await ServerStore.Cluster.WaitForIndexNotification(index, timeToWaitForConfirmation);
+
                 long actualDeletionIndex = index;
-
-                await ServerStore.Cluster.WaitForIndexNotification(index, parameters.TimeToWaitForConfirmation.Value);
-
-                var timeToWaitForConfirmation = parameters.TimeToWaitForConfirmation.Value;
 
                 var sp = Stopwatch.StartNew();
                 int databaseIndex = 0;
@@ -775,22 +769,17 @@ namespace Raven.Server.Web.System
                     }
                 }
 
-                await WriteResponseAsync(context, actualDeletionIndex, pendingDeletes);
-            }
-        }
-
-        private async Task WriteResponseAsync(TransactionOperationContext context, long actualDeletionIndex, HashSet<string> pendingDeletes)
-        {
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
-            {
-                context.Write(writer, new DynamicJsonValue
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
-                    // we only send the successful index here, we might fail to delete the index
-                    // because a node is down, and we don't want to cause the client to wait on an
-                    // index that doesn't exists in the Raft log
-                    [nameof(DeleteDatabaseResult.RaftCommandIndex)] = actualDeletionIndex, 
-                    [nameof(DeleteDatabaseResult.PendingDeletes)] = new DynamicJsonArray(pendingDeletes)
-                });
+                    context.Write(writer, new DynamicJsonValue
+                    {
+                        // we only send the successful index here, we might fail to delete the index
+                        // because a node is down, and we don't want to cause the client to wait on an
+                        // index that doesn't exists in the Raft log
+                        [nameof(DeleteDatabaseResult.RaftCommandIndex)] = actualDeletionIndex, 
+                        [nameof(DeleteDatabaseResult.PendingDeletes)] = new DynamicJsonArray(pendingDeletes)
+                    });
+                }
             }
         }
 

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Extensions;
@@ -61,7 +62,7 @@ internal class DatabasesHandlerProcessorForGet : AbstractDatabasesHandlerProcess
             if (items.Count == 0 && name != null)
             {
                 await RequestHandler.NoContent(HttpStatusCode.NotFound);
-                HttpContext.Response.Headers["Database-Missing"] = name;
+                HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
                 return;
             }
 

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -897,8 +897,8 @@ namespace RachisTests.DatabaseCluster
             var (_, srcLeader) = await CreateRaftCluster(clusterSize);
             var (dstNodes, dstLeader) = await CreateRaftCluster(clusterSize);
 
-            source = AdjustOptionsToClusterSize(source, srcLeader, clusterSize);
-            destination = AdjustOptionsToClusterSize(destination, dstLeader, clusterSize);
+            source = Replication.AdjustOptionsToClusterSize(source, srcLeader, clusterSize);
+            destination = Replication.AdjustOptionsToClusterSize(destination, dstLeader, clusterSize);
 
             using (var src = GetDocumentStore(source))
             using (var dst = GetDocumentStore(destination))
@@ -963,21 +963,6 @@ namespace RachisTests.DatabaseCluster
 
                 Assert.True(WaitForDocument(dst, "users/2", 30_000));
             }
-        }
-
-        private Options AdjustOptionsToClusterSize(Options options, RavenServer leader, int clusterSize)
-        {
-            if (options.DatabaseMode == RavenDatabaseMode.Sharded)
-            {
-                options = Sharding.GetOptionsForCluster(leader, clusterSize, clusterSize, clusterSize);
-            }
-            else
-            {
-                options.Server = leader;
-                options.ReplicationFactor = clusterSize;
-            }
-
-            return options;
         }
 
         [Fact]

--- a/test/SlowTests/Client/UpdateTopologyTests.cs
+++ b/test/SlowTests/Client/UpdateTopologyTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client
+{
+    public class UpdateTopologyTests : ClusterTestBase
+    {
+        public UpdateTopologyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+        [Fact]
+        public async Task CanUpdateTopologyDuringNodeDeletion()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+
+            using (var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 2 }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges();
+
+                    var entity = new User();
+                    await session.StoreAsync(entity);
+                    await session.SaveChangesAsync();
+                }
+
+                var serverA = nodes.Single(n => n.ServerStore.NodeTag == "A");
+                var mre = new ManualResetEventSlim(false);
+                try
+                {
+                    serverA.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().BeforeActualDelete = () => mre.Wait(TimeSpan.FromSeconds(30));
+
+                    await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, "A", timeToWaitForConfirmation: null));
+
+                    await store.GetRequestExecutor().UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode { Url = leader.WebUrl, Database = store.Database }));
+                }
+                finally
+                {
+                    mre.Set(); 
+                }
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
@@ -150,16 +150,6 @@ public partial class ClusterTestBase
             return record.Sharding?.Shards;
         }
 
-        public async Task EnsureNoReplicationLoopForSharding(RavenServer server, string database)
-        {
-            var stores = server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(database);
-
-            foreach (var store in stores)
-            {
-                var storage = await store;
-
-                await EnsureNoReplicationLoop(storage);
-            }
-        }
+        public Task EnsureNoReplicationLoopForSharding(RavenServer server, string database) => _parent.Sharding.EnsureNoReplicationLoopForShardingAsync(server, database);
     }
 }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -868,6 +868,9 @@ namespace Tests.Infrastructure
                     {
                         await follower.ServerStore.WaitForTopology(Leader.TopologyModification.Voter, cts.Token);
                     }
+
+                    leader.ServerStore.Engine.GetLastCommitIndex(out var index, out _);
+                    await follower.ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, cts.Token);
                 }
             }
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -269,36 +269,7 @@ namespace Tests.Infrastructure
             }
         }
 
-        protected static async Task EnsureNoReplicationLoop(RavenServer server, string database)
-        {
-            var replication = await ReplicationInstance.GetReplicationInstanceAsync(server, database, new ReplicationManager.ReplicationOptions
-            {
-                BreakReplicationOnStart = false
-            });
-            await replication.EnsureNoReplicationLoopAsync();
-        }
-
-        protected static async Task EnsureNoReplicationLoop(DocumentDatabase storage)
-        {
-            using (var collector = new LiveReplicationPulsesCollector(storage))
-            {
-                var etag1 = storage.DocumentsStorage.GenerateNextEtag();
-
-                await Task.Delay(3000);
-
-                var etag2 = storage.DocumentsStorage.GenerateNextEtag();
-
-                Assert.True(etag1 + 1 == etag2, "Replication loop found :(");
-
-                var groups = collector.Pulses.GetAll().GroupBy(p => p.Direction);
-                foreach (var group in groups)
-                {
-                    var key = group.Key;
-                    var count = group.Count();
-                    Assert.True(count < 50, $"{key} seems to be excessive ({count})");
-                }
-            }
-        }
+        public Task EnsureNoReplicationLoop(RavenServer server, string database) => Replication.EnsureNoReplicationLoopAsync(server, database);
 
         private class GetDatabaseDocumentTestCommand : RavenCommand<DatabaseRecord>
         {

--- a/test/Tests.Infrastructure/RavenExternalReplicationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenExternalReplicationAttribute.cs
@@ -12,8 +12,8 @@ public class RavenExternalReplicationAttribute : DataAttribute
     private object[] _data;
 
     public RavenExternalReplicationAttribute(
-        RavenDatabaseMode source = RavenDatabaseMode.Single,
-        RavenDatabaseMode destination = RavenDatabaseMode.Single
+        RavenDatabaseMode source,
+        RavenDatabaseMode destination
     )
     {
         _source = source;
@@ -21,8 +21,8 @@ public class RavenExternalReplicationAttribute : DataAttribute
     }
 
     public RavenExternalReplicationAttribute(
-        RavenDatabaseMode source = RavenDatabaseMode.Single,
-        RavenDatabaseMode destination = RavenDatabaseMode.Single,
+        RavenDatabaseMode source,
+        RavenDatabaseMode destination,
         params object[] data
     ) : this ( source, destination )
     {
@@ -36,11 +36,11 @@ public class RavenExternalReplicationAttribute : DataAttribute
         {
             if (_data == null || _data.Length == 0)
             {
-                yield return new object[] { dstOptions, srcOptions };
+                yield return new object[] { srcOptions, dstOptions };
                 continue;
             }
 
-            yield return new object[] { dstOptions, srcOptions }.Concat(_data).ToArray();
+            yield return new object[] { srcOptions, dstOptions }.Concat(_data).ToArray();
         }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -414,6 +414,22 @@ public partial class RavenTestBase
             return docIdPerShard;
         }
 
+        
+        public async Task EnsureNoReplicationLoopForShardingAsync(RavenServer server, string database)
+        {
+            // wait for the replication ping-pong to settle down
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            var stores = server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(database);
+
+            foreach (var store in stores)
+            {
+                var storage = await store;
+
+                await _parent.Replication.EnsureNoReplicationLoopAsync(storage);
+            }
+        }
+
         public async Task EnsureNoDatabaseChangeVectorLeakAsync(string database)
         {
             var ids = new Dictionary<string, int>(StringComparer.Ordinal);

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -168,6 +168,7 @@ namespace FastTests
                             Certificate = options.AdminCertificate,
                             Conventions =
                             {
+                                DisableTopologyCache = true,
                                 DisposeCertificate = false
                             }
                         };
@@ -270,7 +271,7 @@ namespace FastTests
                         if (servers.Count > 1)
                         {
                             var timeout = TimeSpan.FromMinutes(Debugger.IsAttached ? 5 : 1);
-                            AsyncHelpers.RunSync(async () => await Cluster.WaitForRaftIndexToBeAppliedInClusterWithNodesValidationAsync(raftCommand, timeout, servers));
+                            AsyncHelpers.RunSync(() => Cluster.WaitForRaftIndexToBeAppliedInClusterWithNodesValidationAsync(raftCommand, timeout, servers));
                         }
 
                         // skip 'wait for requests' on DocumentDatabase dispose


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20834

### Additional description


- due to `rawRecord.Topologies.Sum(t => t.Topology.Count) == rawRecord.DeletionInProgress.Count` we throw missing database when we still had nodes in the topology.

Test related fixes:

- Due to the changes here https://github.com/ravendb/ravendb/pull/16815 we now have 2 Urls instead of one, and we might pick the wrong url for the topology update.

- For better test stability, upon creating, new node in the cluster will wait for last leader index to be committed.
 
- ~~The `DeleteDatabasesOperation` now can accept `null` as `timeToWaitForConfirmation` which means it will not wait at all.~~
 
### Type of change

- Bug fix

### How risky is the change?

- Low +


### Backward compatibility

- ~~Breaking change~~

~~The `DeleteDatabasesOperation` now can accept `null` as `timeToWaitForConfirmation` which means it will not wait at all.
Previously passing `null` would result in 15 seconds~~

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
