### PR TITLE
RavenDB-20336: modify test so loaded docs are on the same shard

### DIFF
--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1114,7 +1114,7 @@ namespace FastTests.Client.Subscriptions
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Skip = "RavenDB-20336")]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
         public async Task Subscription_WhenProjectLoad_ShouldTranslateToJavascriptLoad(Options options)
         {
             using var store = GetDocumentStore(options);
@@ -1123,8 +1123,8 @@ namespace FastTests.Client.Subscriptions
             using (var session = store.OpenAsyncSession())
             {
                 var b = new B { SomeProp = someProp };
-                await session.StoreAsync(b);
-                await session.StoreAsync(new A { BId = b.Id });
+                await session.StoreAsync(b, "b1$a/1");
+                await session.StoreAsync(new A { BId = b.Id }, "a/1");
                 await session.SaveChangesAsync();
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20336

### Additional description
fix failing test

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
