### PR TITLE
RavenDB-20813 Remove link from connected clients section

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/panels/SubscriptionPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/panels/SubscriptionPanel.tsx
@@ -191,9 +191,7 @@ function ConnectedClients(props: ConnectedClientsProps) {
                         </div>
                         <div className="p-2">
                             <div className="small-label">Client URI</div>
-                            <a href={connection.ClientUri} className="no-decor">
-                                {connection.ClientUri}
-                            </a>
+                            <span>{connection.ClientUri}</span>
                         </div>
                         <div>
                             <Button


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20813/The-IP-of-connected-client-should-not-be-a-link-in-subscription-task-view

### Additional description
Removed `<a>` tag from Client URI

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
