### PR TITLE
RavenDB-19644 WaitForIndexesAfterSaveChanges: wait for attachments

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -26,6 +26,18 @@ using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents
 {
+    public sealed class AttachmentDetailsServer : AttachmentDetails
+    {
+        public CollectionName CollectionName;
+    }
+
+    public struct MoveAttachmentDetailsServer
+    {
+        public AttachmentDetails Result;
+        public CollectionName SourceCollectionName;
+        public CollectionName DestinationCollectionName;
+    }
+    
     public unsafe class AttachmentsStorage
     {
         private readonly DocumentDatabase _documentDatabase;
@@ -155,8 +167,8 @@ namespace Raven.Server.Documents
             }
         }
 
-        public AttachmentDetails PutAttachment(DocumentsOperationContext context, string documentId, string name, string contentType,
-            string hash, string expectedChangeVector, Stream stream, bool updateDocument = true)
+        public AttachmentDetailsServer PutAttachment(DocumentsOperationContext context, string documentId, string name, string contentType,
+            string hash, string expectedChangeVector, Stream stream, bool updateDocument = true, bool extractCollectionName = false)
         {
             if (context.Transaction == null)
             {
@@ -290,17 +302,22 @@ namespace Raven.Server.Documents
 
                     _documentDatabase.Metrics.Attachments.PutsPerSec.MarkSingleThreaded(1);
 
+                    CollectionName collectionName = null;
                     if (updateDocument)
-                        UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, changeVector);
+                        UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, changeVector, extractCollectionName , out collectionName);
+                    else if (extractCollectionName)
+                        collectionName = GetDocumentCollectionName(context, tvr);
+                    
 
-                    return new AttachmentDetails
+                    return new AttachmentDetailsServer
                     {
                         ChangeVector = changeVector,
                         ContentType = contentType,
                         Name = name,
                         DocumentId = documentId,
                         Hash = hash,
-                        Size = stream?.Length ?? -1
+                        Size = stream?.Length ?? -1,
+                        CollectionName = collectionName
                     };
                 }
             }
@@ -340,12 +357,19 @@ namespace Raven.Server.Documents
             _documentDatabase.Metrics.Attachments.PutsPerSec.MarkSingleThreaded(1);
         }
 
+        private CollectionName GetDocumentCollectionName(DocumentsOperationContext context, TableValueReader tvr)
+        {
+            var data = new BlittableJsonReaderObject(tvr.Read((int)DocumentsTable.Data, out int size), size, context);
+
+            return _documentsStorage.ExtractCollectionName(context, data);
+        }
+
         /// <summary>
         /// Update the document with an etag which is bigger than the attachmentEtag
         /// We need to call this after we already put the attachment, so it can version also this attachment
         /// </summary>
         private string UpdateDocumentAfterAttachmentChange(DocumentsOperationContext context, Slice lowerDocumentId, string documentId,
-            TableValueReader tvr, string changeVector)
+            TableValueReader tvr, string changeVector, bool extractCollectionName, out CollectionName collectionName)
         {
             // We can optimize this by copy just the document's data instead of the all tvr
             var copyOfDoc = context.GetMemory(tvr.Size);
@@ -396,6 +420,7 @@ namespace Raven.Server.Documents
                 }
 
                 data = context.ReadObject(data, documentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                collectionName = extractCollectionName ? _documentsStorage.ExtractCollectionName(context, data) : default;
                 return _documentsStorage.Put(context, documentId, null, data, null, null, null, flags, NonPersistentDocumentFlags.ByAttachmentUpdate).ChangeVector;
             }
             finally
@@ -411,7 +436,7 @@ namespace Raven.Server.Documents
                 var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out TableValueReader tvr);
                 if (exists == false)
                     return null;
-                return UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, null);
+                return UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, null, extractCollectionName: false, out var _);
             }
         }
         public void DeleteAttachmentBeforeRevert(DocumentsOperationContext context, LazyStringValue lowerDocId)
@@ -958,7 +983,7 @@ namespace Raven.Server.Documents
             };
         }
 
-        public AttachmentDetails CopyAttachment(DocumentsOperationContext context, string documentId, string name, string destinationId, string destinationName, LazyStringValue changeVector, AttachmentType attachmentType)
+        public AttachmentDetailsServer CopyAttachment(DocumentsOperationContext context, string documentId, string name, string destinationId, string destinationName, LazyStringValue changeVector, AttachmentType attachmentType, bool extractCollectionName = false)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentException("Argument cannot be null or whitespace.", nameof(documentId));
@@ -976,11 +1001,10 @@ namespace Raven.Server.Documents
                 AttachmentDoesNotExistException.ThrowFor(documentId, name);
 
             var hash = attachment.Base64Hash.ToString();
-            return PutAttachment(context, destinationId, destinationName, attachment.ContentType, hash, string.Empty, attachment.Stream);
+            return PutAttachment(context, destinationId, destinationName, attachment.ContentType, hash, string.Empty, attachment.Stream, extractCollectionName: extractCollectionName);
         }
 
-        public AttachmentDetails MoveAttachment(DocumentsOperationContext context, string sourceDocumentId, string sourceName, string destinationDocumentId, string destinationName, LazyStringValue changeVector,
-            string hash = null, string contentType = null, bool usePartialKey = true, bool updateDocument = true)
+        public MoveAttachmentDetailsServer MoveAttachment(DocumentsOperationContext context, string sourceDocumentId, string sourceName, string destinationDocumentId, string destinationName, LazyStringValue changeVector, string hash = null, string contentType = null, bool usePartialKey = true, bool updateDocument = true, bool extractCollectionName = false)
         {
             if (string.IsNullOrWhiteSpace(sourceDocumentId))
                 throw new ArgumentException("Argument cannot be null or whitespace.", nameof(sourceDocumentId));
@@ -997,10 +1021,13 @@ namespace Raven.Server.Documents
             if (attachment == null)
                 AttachmentDoesNotExistException.ThrowFor(sourceDocumentId, sourceName);
 
-            var result = PutAttachment(context, destinationDocumentId, destinationName, attachment.ContentType, attachment.Base64Hash.ToString(), string.Empty, attachment.Stream);
-            DeleteAttachment(context, sourceDocumentId, sourceName, changeVector, updateDocument, hash, contentType, usePartialKey);
+            var result = PutAttachment(context, destinationDocumentId, destinationName, attachment.ContentType, attachment.Base64Hash.ToString(), string.Empty, attachment.Stream, extractCollectionName: extractCollectionName);
+            DeleteAttachment(context, sourceDocumentId, sourceName, changeVector, out var sourceCollectionName, updateDocument, hash, contentType, usePartialKey, extractCollectionName: extractCollectionName);
 
-            return result;
+            return new MoveAttachmentDetailsServer()
+            {
+                Result = result, DestinationCollectionName = result.CollectionName, SourceCollectionName = sourceCollectionName
+            };
         }
 
         public string ResolveAttachmentName(DocumentsOperationContext context, Slice lowerId, string name)
@@ -1025,8 +1052,8 @@ namespace Raven.Server.Documents
             return newName;
         }
 
-        public void DeleteAttachment(DocumentsOperationContext context, string documentId, string name, LazyStringValue expectedChangeVector, bool updateDocument = true,
-            string hash = null, string contentType = null, bool usePartialKey = true)
+        public void DeleteAttachment(DocumentsOperationContext context, string documentId, string name, LazyStringValue expectedChangeVector, out CollectionName collectionName, bool updateDocument = true,
+            string hash = null, string contentType = null, bool usePartialKey = true, bool extractCollectionName = false)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentException("Argument is null or whitespace", nameof(documentId));
@@ -1034,7 +1061,8 @@ namespace Raven.Server.Documents
                 throw new ArgumentException("Argument is null or whitespace", nameof(name));
             if (context.Transaction == null)
                 throw new ArgumentException("Context must be set with a valid transaction before calling Get", nameof(context));
-
+            
+            collectionName = null;
             using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
                 var hasDoc = TryGetDocumentTableValueReaderForAttachment(context, documentId, name, lowerDocumentId, out TableValueReader docTvr);
@@ -1083,7 +1111,9 @@ namespace Raven.Server.Documents
                 }
 
                 if (updateDocument)
-                    UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, docTvr, changeVector);
+                    UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, docTvr, changeVector, extractCollectionName: extractCollectionName, out collectionName);
+                else if (extractCollectionName)
+                    collectionName = GetDocumentCollectionName(context, docTvr);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -423,7 +423,7 @@ namespace Raven.Server.Documents.Handlers
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
-                Database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, DocumentId, Name, ExpectedChangeVector);
+                Database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, DocumentId, Name, ExpectedChangeVector, collectionName: out _);
                 return 1;
             }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -951,7 +951,7 @@ namespace Raven.Server.Documents.Handlers
                             EtlGetDocIdFromPrefixIfNeeded(ref docId, cmd, lastPutResult);
 
                             var attachmentPutResult = Database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, docId, cmd.Name,
-                                cmd.ContentType, attachmentStream.Hash, cmd.ChangeVector, stream, updateDocument: false);
+                                cmd.ContentType, attachmentStream.Hash, cmd.ChangeVector, stream, updateDocument: false, extractCollectionName: ModifiedCollections is not null);
                             LastChangeVector = attachmentPutResult.ChangeVector;
 
                             var apReply = new DynamicJsonValue
@@ -965,6 +965,9 @@ namespace Raven.Server.Documents.Handlers
                                 [nameof(AttachmentDetails.Size)] = attachmentPutResult.Size
                             };
 
+                            if (attachmentPutResult.CollectionName != null)
+                                ModifiedCollections?.Add(attachmentPutResult.CollectionName.Name);
+
                             if (_documentsToUpdateAfterAttachmentChange == null)
                                 _documentsToUpdateAfterAttachmentChange = new Dictionary<string, List<(DynamicJsonValue Reply, string FieldName)>>(StringComparer.OrdinalIgnoreCase);
 
@@ -976,8 +979,11 @@ namespace Raven.Server.Documents.Handlers
                             break;
 
                         case CommandType.AttachmentDELETE:
-                            Database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, cmd.Id, cmd.Name, cmd.ChangeVector, updateDocument: false);
+                            Database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, cmd.Id, cmd.Name, cmd.ChangeVector, out var collectionName, updateDocument: false, extractCollectionName: ModifiedCollections is not null);
 
+                            if (collectionName != null)
+                                ModifiedCollections?.Add(collectionName.Name);
+                            
                             var adReply = new DynamicJsonValue
                             {
                                 ["Type"] = nameof(CommandType.AttachmentDELETE),
@@ -996,7 +1002,13 @@ namespace Raven.Server.Documents.Handlers
                             break;
 
                         case CommandType.AttachmentMOVE:
-                            var attachmentMoveResult = Database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, cmd.Id, cmd.Name, cmd.DestinationId, cmd.DestinationName, cmd.ChangeVector);
+                            var attachmentMoveOutput = Database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, cmd.Id, cmd.Name, cmd.DestinationId, cmd.DestinationName, cmd.ChangeVector, extractCollectionName: ModifiedCollections is not null);
+                            var attachmentMoveResult = attachmentMoveOutput.Result;
+                            
+                            if (attachmentMoveOutput.DestinationCollectionName != null)
+                                ModifiedCollections?.Add(attachmentMoveOutput.DestinationCollectionName.Name);
+                            if (attachmentMoveOutput.SourceCollectionName != null)
+                                ModifiedCollections?.Add(attachmentMoveOutput.SourceCollectionName.Name);
 
                             LastChangeVector = attachmentMoveResult.ChangeVector;
 
@@ -1035,8 +1047,11 @@ namespace Raven.Server.Documents.Handlers
                                 // if attachment type is not sent, we fallback to default, which is Document
                                 cmd.AttachmentType = AttachmentType.Document;
                             }
-                            var attachmentCopyResult = Database.DocumentsStorage.AttachmentsStorage.CopyAttachment(context, cmd.Id, cmd.Name, cmd.DestinationId, cmd.DestinationName, cmd.ChangeVector, cmd.AttachmentType);
+                            var attachmentCopyResult = Database.DocumentsStorage.AttachmentsStorage.CopyAttachment(context, cmd.Id, cmd.Name, cmd.DestinationId, cmd.DestinationName, cmd.ChangeVector, cmd.AttachmentType, extractCollectionName: ModifiedCollections is not null);
 
+                            if (attachmentCopyResult.CollectionName != null)
+                                ModifiedCollections?.Add(attachmentCopyResult.CollectionName.Name);
+                                
                             LastChangeVector = attachmentCopyResult.ChangeVector;
 
                             var acReply = new DynamicJsonValue

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -517,7 +517,7 @@ namespace Raven.Server.Documents.Replication
                     if (resolvedToLatest)
                     {
                         // delete duplicates
-                        _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, resolved.LowerId, attachment.Name, expectedChangeVector: null,
+                        _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, resolved.LowerId, attachment.Name, expectedChangeVector: null, collectionName: out _,
                             updateDocument: false,
                             attachment.Hash, attachment.ContentType, usePartialKey: false);
                     }
@@ -531,9 +531,7 @@ namespace Raven.Server.Documents.Replication
                         }
                         // rename duplicates
                         var newName = _database.DocumentsStorage.AttachmentsStorage.ResolveAttachmentName(context, lowerId, attachment.Name);
-                        _database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, resolved.LowerId, attachment.Name, resolved.LowerId, newName,
-                            changeVector: null,
-                            attachment.Hash, attachment.ContentType, usePartialKey: false, updateDocument: false);
+                        _database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, resolved.LowerId, attachment.Name, resolved.LowerId, newName, changeVector: null, attachment.Hash, attachment.ContentType, usePartialKey: false, updateDocument: false, extractCollectionName: false);
                     }
                 }
             }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1896,7 +1896,7 @@ namespace Raven.Server.Smuggler.Documents
 
                         foreach (var toRemove in attachmentsToRemoveNames)
                         {
-                            _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, id, toRemove, null, updateDocument: false);
+                            _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, id, toRemove,  null, collectionName: out _, updateDocument: false, extractCollectionName: false);
                         }
 
                         metadata.Modifications = new DynamicJsonValue(metadata);

--- a/test/SlowTests/RavenDB-19644.cs
+++ b/test/SlowTests/RavenDB-19644.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Sparrow;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests
+{
+    public class RavenDB_19644 : RavenTestBase
+    {
+        private const string AttachmentName = "Attachment";
+        private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(100);
+
+        public RavenDB_19644(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void WaitForIndexesAfterSaveChangesSupportsPut()
+        {
+            using var store = GetDocumentStore();
+            new AttachmentIndex().Execute(store);
+            var attachmentDocument = new AttachmentDocument("");
+            using (var session = store.OpenSession())
+            {
+                session.Store(attachmentDocument);
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            using (var session = store.OpenSession())
+            {
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(attachmentDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        private static void AssertIndexIsStale(IDocumentSession session)
+        {
+            var exception = Assert.Throws<RavenTimeoutException>(() => session!.SaveChanges());
+            Assert.Contains("could not verify that all indexes has caught up with the changes as of etag", exception.ToString());
+        }
+
+        [Fact]
+        public void WaitForIndexesAfterSaveChangesSupportsCopy()
+        {
+            using var store = GetDocumentStore();
+            new AttachmentIndex().Execute(store);
+            var sourceDocument = new AttachmentDocument("");
+            var destinationDocument = new AttachmentDocument("");
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(sourceDocument);
+                session.Store(destinationDocument);
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(sourceDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Copy(sourceDocument.Id, AttachmentName, destinationDocument.Id, AttachmentName);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        [Fact]
+        public void WaitForIndexesAfterSaveChangesSupportsMove()
+        {
+            using var store = GetDocumentStore();
+            new AttachmentIndex().Execute(store);
+            var sourceDocument = new AttachmentDocument("");
+            var destinationDocument = new AttachmentDocument("");
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(sourceDocument);
+                session.Store(destinationDocument);
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(sourceDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Move(sourceDocument.Id, AttachmentName, destinationDocument.Id, AttachmentName);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        [Fact]
+        public void WaitForIndexesAfterSaveChangesSupportsCopyToDifferentCollection()
+        {
+            using var store = GetDocumentStore();
+            var sourceIndex = new AttachmentIndex();
+            sourceIndex.Execute(store);
+
+            var destinationIndex = new DestinationAttachmentIndex();
+            destinationIndex.Execute(store);
+
+            var srcDocument = new AttachmentDocument("");
+            var dstDocument = new AttachmentDestinationDocument("");
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(srcDocument);
+                session.Store(dstDocument);
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(srcDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexOperation(destinationIndex.IndexName));
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Copy(srcDocument.Id, AttachmentName, dstDocument.Id, AttachmentName);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void WaitForIndexesAfterSaveChangesSupportsMoveToDifferentCollection(bool sourceActive, bool destinationActive)
+        {
+            using var store = GetDocumentStore();
+            var sourceIndex = new AttachmentIndex();
+            sourceIndex.Execute(store);
+
+            var destinationIndex = new DestinationAttachmentIndex();
+            destinationIndex.Execute(store);
+
+            var srcDocument = new AttachmentDocument("");
+            var dstDocument = new AttachmentDestinationDocument("");
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(srcDocument);
+                session.Store(dstDocument);
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(srcDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            if (sourceActive == false)
+                store.Maintenance.Send(new StopIndexOperation(sourceIndex.IndexName));
+
+            if (destinationActive == false)
+                store.Maintenance.Send(new StopIndexOperation(destinationIndex.IndexName));
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Move(srcDocument.Id, AttachmentName, dstDocument.Id, AttachmentName);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        [Fact]
+        public void WaitForIndexesAfterSaveChangesSupportsDelete()
+        {
+            using var store = GetDocumentStore();
+            new AttachmentIndex().Execute(store);
+            var attachmentDocument = new AttachmentDocument("");
+            using (var session = store.OpenSession())
+            {
+                session.Store(attachmentDocument);
+                using var memoryStream = new MemoryStream(Encodings.Utf8.GetBytes("Maciej"));
+                session.Advanced.Attachments.Store(attachmentDocument.Id, AttachmentName, memoryStream, "txt");
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            store.Maintenance.Send(new StopIndexingOperation());
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Attachments.Delete(attachmentDocument.Id, AttachmentName);
+                session.Advanced.WaitForIndexesAfterSaveChanges(timeout: _timeout);
+                AssertIndexIsStale(session);
+            }
+        }
+
+        private record AttachmentDocument(string Name, string Id = null);
+
+        private record AttachmentDestinationDocument(string Name, string Id = null);
+
+        private class AttachmentIndex : AbstractIndexCreationTask<AttachmentDocument>
+        {
+            public AttachmentIndex()
+            {
+                Map = documents => from doc in documents
+                    let attachments = LoadAttachment(doc, AttachmentName).GetContentAsString() ?? ""
+                    select new {Name = attachments};
+            }
+        }
+
+        private class DestinationAttachmentIndex : AbstractIndexCreationTask<AttachmentDestinationDocument>
+        {
+            public DestinationAttachmentIndex()
+            {
+                Map = documents => from doc in documents
+                    let attachments = LoadAttachment(doc, AttachmentName).GetContentAsString() ?? ""
+                    select new {Name = attachments};
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19644 

### Additional description

We've to wait for indexes when we change attachments in a document.

### Type of change

- Bug fix


### How risky is the change?


- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
