### PR TITLE
RavenDB-20780 Add information about `Patching.MaxStepsForScript` configuration option when patching throws `StatementsCountOverflowException `.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20780.cs
+++ b/test/SlowTests/Issues/RavenDB-20780.cs
@@ -1,0 +1,46 @@
+﻿using FastTests;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using SlowTests.Core.Utils.Entities.Faceted;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20780 : RavenTestBase
+{
+    public RavenDB_20780(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void PatchStatementsCountOverflowExceptionLimit()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Order());
+            session.SaveChanges();
+        }
+        var query = new IndexQuery
+        {
+            Query = @"
+from ""Orders"" update {
+    for (var i = 0; i < 10000; i++){
+        this.Count = 0;
+    }
+}",
+        };
+
+        var exception = Assert.Throws<Raven.Client.Exceptions.Documents.Patching.JavaScriptException>(() =>
+        {
+            var operation =  store.Operations.Send(new PatchByQueryOperation(query));
+            operation.WaitForCompletion();
+        });
+
+        Assert.Contains("The maximum number of statements executed have been reached - 10000. You can configure it by modifying the configuration option: 'Patching.MaxStepsForScript'.",
+            exception.ToString());
+
+
+    }
+}

--- a/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -430,7 +430,7 @@ namespace SlowTests.Server.Documents.Patching
                 {
                     await commands.PutAsync("doc", null, _test, null);
 
-                    await Assert.ThrowsAsync<RavenException>(async () =>
+                    await Assert.ThrowsAsync<JavaScriptException>(async () =>
                     {
                         await store.Operations.SendAsync(new PatchOperation("doc", null, new PatchRequest
                         {

--- a/test/SlowTests/Server/Documents/Patching/PatchingConfigurationsTests.cs
+++ b/test/SlowTests/Server/Documents/Patching/PatchingConfigurationsTests.cs
@@ -72,7 +72,7 @@ namespace SlowTests.Server.Documents.Patching
                     session.SaveChanges();
                 }
 
-                await Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(() => store.Operations.SendAsync(new PatchOperation<User>("users/2", null, new PatchRequest
+                await Assert.ThrowsAsync<Raven.Client.Exceptions.Documents.Patching.JavaScriptException>(() => store.Operations.SendAsync(new PatchOperation<User>("users/2", null, new PatchRequest
                 {
                     Script = @"for (var i=0; i< this.Lines.length; i++){}"
                 })));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20780 

### Additional description

Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR.

_Please delete below the options that are not relevant_

### Type of change

- Usability 
- 
### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
