### PR TITLE
RavenDB-19151 In case when Initialization failed we can get NRE on _reduceKeyProcessor disposal.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
         protected override void DisposeIndex()
         {
             base.DisposeIndex();
-            _reduceKeyProcessor.ReleaseBuffer();
+            _reduceKeyProcessor?.ReleaseBuffer();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19151 

### Additional description
 In case when Initialization failed we can get NRE on _reduceKeyProcessor disposal.

### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
