### PR TITLE
RavenDB-20749: fix update query for sharded subscription

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                     }
                 }
 
-                options.ChangeVector ??= state.ChangeVectorForNextBatchStartingPoint;
+                SetSubscriptionChangeVectorOnUpdate(options, state);
                 options.MentorNode ??= state.MentorNode;
                 options.Query ??= state.Query;
 
@@ -108,5 +108,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 await CreateSubscriptionInternalAsync(json, id, disabled: false, options, context);
             }
         }
+
+        protected abstract void SetSubscriptionChangeVectorOnUpdate(SubscriptionUpdateOptions options, SubscriptionState state);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPostSubscription.cs
@@ -23,5 +23,10 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 await RequestHandler.CreateInternalAsync(bjro, options, context, id, disabled, sub);
             }
         }
+
+        protected override void SetSubscriptionChangeVectorOnUpdate(SubscriptionUpdateOptions options, SubscriptionState state)
+        {
+            options.ChangeVector ??= state.ChangeVectorForNextBatchStartingPoint;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForPostSubscription.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
@@ -33,6 +35,15 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
         {
             var sub = ParseSubscriptionQuery(options.Query);
             await RequestHandler.CreateSubscriptionInternalAsync(bjro, id, disabled, options, context, sub);
+        }
+
+        protected override void SetSubscriptionChangeVectorOnUpdate(SubscriptionUpdateOptions options, SubscriptionState state)
+        {
+            // the actual validation will happen in TryValidateChangeVector
+            if (string.IsNullOrEmpty(options.ChangeVector))
+            {
+                options.ChangeVector = nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange);
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -99,9 +99,9 @@ namespace Raven.Server.Documents.Sharding.Handlers
             {
                 switch (changeVectorSpecialValue)
                 {
-                    case Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.BeginningOfTime:
+                    case Constants.Documents.SubscriptionChangeVectorSpecialStates.BeginningOfTime:
                         break;
-                    case Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument:
+                    case Constants.Documents.SubscriptionChangeVectorSpecialStates.LastDocument:
                         result.ChangeVectorsCollection = (await ShardExecutor.ExecuteParallelForAllAsync(new ShardedLastChangeVectorForCollectionOperation(HttpContext.Request, sub.Collection, DatabaseContext.DatabaseName))).LastChangeVectors;
                         foreach ((string key, string value) in result.ChangeVectorsCollection)
                         {
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                         }
 
                         break;
-                    case Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange:
+                    case Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange:
                         result.InitialChangeVector = options.ChangeVector;
                         break;
                     default:
@@ -128,7 +128,8 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 result.InitialChangeVector = options.ChangeVector;
                 if (string.IsNullOrEmpty(result.InitialChangeVector) == false)
                 {
-                    throw new InvalidOperationException("Setting initial change vector for sharded subscription is not allowed.");
+                    throw new InvalidOperationException($"Setting initial change vector for sharded subscription is not allowed. " +
+                                                        $"Expected to get '{nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates)}' but got '{result.InitialChangeVector}'.");
                 }
             }
 

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -1394,7 +1394,7 @@ namespace SlowTests.Sharding.Cluster
         private int _current;
         private string NextId => $"users/{Interlocked.Increment(ref _current)}-A";
 
-        private static ((string Id, int ShardNumber) Tuple1, (string Id, int ShardNumber) Tuple2) GetIdsOnDifferentShards(ShardingConfiguration conf,
+        internal static ((string Id, int ShardNumber) Tuple1, (string Id, int ShardNumber) Tuple2) GetIdsOnDifferentShards(ShardingConfiguration conf,
             string collection = "users",
             int start = 1)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20749

### Additional description

We were getting `Setting initial change vector for sharded subscription is not allowed.` exception since the code was using the same flow as non sharded on update subscription.

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
