### PR TITLE
RavenDB-20339 Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -787,12 +787,12 @@ namespace Raven.Server.Documents
         {
             public BlittableJsonReaderObject Data;
             public DbIdsHolder DbIdsHolder;
-            public string ChangeVector;
+            public ChangeVector ChangeVector;
             public bool Modified;
             public ByteStringContext.InternalScope KeyScope;
         }
 
-        public bool PutCounters(DocumentsOperationContext context, string documentId, string collection, string changeVector,
+        public bool PutCounters(DocumentsOperationContext context, string documentId, string collection, ChangeVector changeVector,
             BlittableJsonReaderObject sourceData)
         {
             if (context.Transaction == null)
@@ -1006,7 +1006,7 @@ namespace Raven.Server.Documents
                             }
                         }
 
-                        var changeVectorToSave = ChangeVectorUtils.MergeVectors(putCountersData.ChangeVector, changeVector);
+                        var changeVectorToSave = ChangeVector.MergeChangeVectors(putCountersData.ChangeVector, changeVector, context);
 
                         using (Slice.External(context.Allocator, kvp.Key, out var countersGroupKey))
                         {
@@ -1831,7 +1831,7 @@ namespace Raven.Server.Documents
             return tx.OpenTable(tableSchema, tableName);
         }
 
-        private void CreateCounterTombstone(DocumentsOperationContext context, Slice documentKeyPrefix, Slice counterNameSlice, CollectionName collectionName, string remoteChangeVector = null)
+        private void CreateCounterTombstone(DocumentsOperationContext context, Slice documentKeyPrefix, Slice counterNameSlice, CollectionName collectionName, ChangeVector remoteChangeVector = null)
         {
             var table = GetOrCreateCounterTombstonesTable(context.Transaction.InnerTransaction, collectionName);
 
@@ -1863,10 +1863,10 @@ namespace Raven.Server.Documents
             }
         }
 
-        private static string ExtractCounterTombstoneChangeVector(DocumentsOperationContext context, ref TableValueReader reader)
+        private static ChangeVector ExtractCounterTombstoneChangeVector(DocumentsOperationContext context, ref TableValueReader reader)
         {
             var changeVectorPtr = reader.Read((int)CounterTombstonesTable.ChangeVector, out int changeVectorSize);
-            return Encoding.UTF8.GetString(changeVectorPtr, changeVectorSize);
+            return context.GetChangeVector(Encoding.UTF8.GetString(changeVectorPtr, changeVectorSize));
         }
 
         public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesFrom(DocumentsOperationContext context, long etag, long toEtag = long.MaxValue)

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -432,11 +432,12 @@ namespace Raven.Server.Documents.Handlers
                 if (doc != null)
                     docCollection = CollectionName.GetCollectionName(doc.Data);
 
+                var counterGroupChangeVector = context.GetChangeVector(counterGroupDetail.ChangeVector);
                 _database.DocumentsStorage.CountersStorage.PutCounters(context, counterGroupDetail.DocumentId, docCollection,
-                    counterGroupDetail.ChangeVector, counterGroupDetail.Values);
+                    counterGroupChangeVector, counterGroupDetail.Values);
 
                 context.LastDatabaseChangeVector ??= DocumentsStorage.GetDatabaseChangeVector(context);
-                context.LastDatabaseChangeVector = context.LastDatabaseChangeVector.MergeWith(counterGroupDetail.ChangeVector, context);
+                context.LastDatabaseChangeVector = context.LastDatabaseChangeVector.MergeWith(counterGroupChangeVector, context);
 
                 if (doc?.Data != null &&
                     _counterUpdates.ContainsKey(counterGroupDetail.DocumentId) == false)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -415,7 +415,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 break;
 
                             case CounterReplicationItem counter:
-                                var changed = database.DocumentsStorage.CountersStorage.PutCounters(context, counter.Id, counter.Collection, counter.ChangeVector,
+                                var changed = database.DocumentsStorage.CountersStorage.PutCounters(context, counter.Id, counter.Collection, incomingChangeVector,
                                     counter.Values);
                                 if (changed && _replicationInfo.SupportedFeatures.Replication.CaseInsensitiveCounters == false)
                                 {

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -167,6 +167,24 @@ public class ChangeVector
         return context.GetChangeVector(versionMerge, orderMerge);
     }
 
+    public static ChangeVector MergeChangeVectors(ChangeVector cv1, ChangeVector cv2, IChangeVectorOperationContext context)
+    {
+        if (cv1.IsNullOrEmpty)
+            return cv2;
+
+        if (cv2.IsNullOrEmpty)
+            return cv1;
+
+        if (cv1.IsSingle && cv2.IsSingle || cv1.IsSingle == false && cv2.IsSingle == false)
+            return Merge(cv1, cv2, context);
+
+        // we are keeping the existing order without merging it with the version of the single change vector
+        var mergedOrder = cv2.IsSingle ? cv1.Order : cv2.Order;
+        var mergedVersion = Merge(cv1.Version, cv2.Version, context);
+        return context.GetChangeVector(mergedVersion, mergedOrder);
+    }
+
+
     public static void MergeWithDatabaseChangeVector(DocumentsOperationContext context, ChangeVector changeVector)
     {
         if (changeVector == null)

--- a/test/SlowTests/Issues/RavenDB-15483.cs
+++ b/test/SlowTests/Issues/RavenDB-15483.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.ServerWide.Context;
@@ -18,12 +17,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ExternalReplicationWithRevisionsBin2()
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ExternalReplicationWithRevisionsBin2(Options options)
         {
-            using (var store1 = GetDocumentStore())
-
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 await RevisionsHelper.SetupRevisionsAsync(store1, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
 
@@ -61,7 +60,7 @@ namespace SlowTests.Issues
                         return user == null;
                     }
                 }, true);
-                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                var database = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -70,7 +69,7 @@ namespace SlowTests.Issues
                     Assert.Equal(1, revisions);
                 }
 
-                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                database = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, "foo/bar");
                 revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -81,12 +80,12 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task ExternalReplicationWithRevisionsBin3()
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ExternalReplicationWithRevisionsBin3(Options options)
         {
-            using (var store1 = GetDocumentStore())
-
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 await RevisionsHelper.SetupRevisionsAsync(store1, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
                 await RevisionsHelper.SetupRevisionsAsync(store2, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
@@ -132,7 +131,7 @@ namespace SlowTests.Issues
                         return user == null;
                     }
                 }, true);
-                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                var database = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, "foo/bar");
                 var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -141,7 +140,7 @@ namespace SlowTests.Issues
                     Assert.Equal(1, revisions);
                 }
 
-                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                database = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -152,12 +151,12 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task ExternalReplicationWithRevisionsBin4()
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ExternalReplicationWithRevisionsBin4(Options options)
         {
-            using (var store1 = GetDocumentStore())
-
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 await RevisionsHelper.SetupRevisionsAsync(store2, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = true);
 
@@ -203,7 +202,7 @@ namespace SlowTests.Issues
                         return user == null;
                     }
                 }, true);
-                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+                var database = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, "foo/bar");
                 var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -212,7 +211,7 @@ namespace SlowTests.Issues
                     Assert.Equal(0, revisions);
                 }
 
-                database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                database = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 revisionsStorage = database.DocumentsStorage.RevisionsStorage;
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())

--- a/test/SlowTests/Issues/RavenDB-5730.cs
+++ b/test/SlowTests/Issues/RavenDB-5730.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Replication;
 using Tests.Infrastructure;
@@ -20,33 +19,36 @@ namespace SlowTests.Issues
             public string Name { get; set; }
         }
 
-        [Fact]
-        public async Task Whitespace_at_the_beginning_of_replication_destination_url_should_not_cause_issues()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Whitespace_at_the_beginning_of_replication_destination_url_should_not_cause_issues(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 var url = " " + storeB.Urls.First();
                 await DoReplicationTest(storeA, storeB, url);
             }
         }
 
-        [Fact]
-        public async Task Whitespace_at_the_end_of_replication_destination_url_should_not_cause_issues()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Whitespace_at_the_end_of_replication_destination_url_should_not_cause_issues(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 var url = storeB.Urls.First() + " ";
                 await DoReplicationTest(storeA, storeB, url);
             }
         }
 
-        [Fact]
-        public async Task Whitespace_at_the_beginning_and_end_of_replication_destination_url_should_not_cause_issues()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Whitespace_at_the_beginning_and_end_of_replication_destination_url_should_not_cause_issues(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 var url = " " + storeB.Urls.First() + " ";
                 await DoReplicationTest(storeA, storeB, url);

--- a/test/SlowTests/Issues/RavenDB_11909.cs
+++ b/test/SlowTests/Issues/RavenDB_11909.cs
@@ -9,6 +9,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Integrations;
 using Raven.Server.ServerWide;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,12 +21,13 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CreateDatabaseOperationShouldThrowOnPassedTaskConfigurations()
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CreateDatabaseOperationShouldThrowOnPassedTaskConfigurations(Options options)
         {
             var dbName1 = $"db1_{Guid.NewGuid().ToString()}";
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var dbRecord = new DatabaseRecord(dbName1)
                 {
@@ -55,10 +57,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void ThrowOnUpdateDatabaseRecordContainsTasksConfigurations()
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.BackupExportImport)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void ThrowOnUpdateDatabaseRecordContainsTasksConfigurations(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
 
@@ -79,7 +82,7 @@ namespace SlowTests.Issues
                     }
                 };
 
-                Assert.Throws<RavenException>(() => store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, etag)));
+                Assert.Throws<RavenException>(() => store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, replicationFactor: 1, etag)));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_15076.cs
+++ b/test/SlowTests/Issues/RavenDB_15076.cs
@@ -19,11 +19,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task Counters_and_force_revisions()
+        [RavenTheory(RavenTestCategory.Counters | RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Counters_and_force_revisions(Options options)
         {
-            using var storeA = GetDocumentStore();
-            using var storeB = GetDocumentStore();
+            using var storeA = GetDocumentStore(options);
+            using var storeB = GetDocumentStore(options);
 
             using (var s = storeA.OpenAsyncSession())
             {

--- a/test/SlowTests/Issues/RavenDB_18473.cs
+++ b/test/SlowTests/Issues/RavenDB_18473.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Tests.Core.Utils.Entities;
@@ -16,14 +15,15 @@ public class RavenDB_18473 : ReplicationTestBase
     {
     }
 
-    [Fact]
-    public async Task MustNotThrowVoronConcurrencyErrorExceptionDuringReplication()
+    [RavenTheory(RavenTestCategory.Replication)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task MustNotThrowVoronConcurrencyErrorExceptionDuringReplication(Options options)
     {
         var file = GetTempFileName();
         try
         {
-            using (var store1 = GetDocumentStore())
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 // Important: the issue reproduces only when RevisionsCollectionConfiguration.PurgeOnDelete is true
                 // that is the setup for "Users" collection. Let's verify that during the setup.
@@ -81,5 +81,4 @@ public class RavenDB_18473 : ReplicationTestBase
             File.Delete(file);
         }
     }
-
 }

--- a/test/SlowTests/Issues/RavenDB_19421_2.cs
+++ b/test/SlowTests/Issues/RavenDB_19421_2.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
+using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,12 +12,13 @@ public class RavenDB_19421_2 : ReplicationTestBase
     {
     }
 
-    [Fact]
-    public async Task ConflictsOnIdenticalDocument()
+    [RavenTheory(RavenTestCategory.Replication)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ConflictsOnIdenticalDocument(Options options)
     {
-        using var store1 = GetDocumentStore();
-        using var store2 = GetDocumentStore();
-        using var store3 = GetDocumentStore();
+        using var store1 = GetDocumentStore(options);
+        using var store2 = GetDocumentStore(options);
+        using var store3 = GetDocumentStore(options);
 
         using (var s1 = store1.OpenAsyncSession())
         {
@@ -27,7 +28,7 @@ public class RavenDB_19421_2 : ReplicationTestBase
 
         await SetupReplicationAsync(store1, store3);
         await EnsureReplicatingAsync(store1, store3);
-          
+
         using (var s3 = store3.OpenAsyncSession())
         {
             await s3.StoreAsync(new { Val = 3 }, "users/1");
@@ -48,7 +49,7 @@ public class RavenDB_19421_2 : ReplicationTestBase
             await s3.StoreAsync(new { Val = 4 }, "users/4");
             await s3.SaveChangesAsync();
         }
-        
+
         // here we resolve identical value, merging the change vectors
         using (var s1 = store1.OpenAsyncSession())
         {
@@ -56,10 +57,10 @@ public class RavenDB_19421_2 : ReplicationTestBase
             await s1.SaveChangesAsync();
         }
         await EnsureReplicatingAsync(store1, store3);
-        
+
         await SetupReplicationAsync(store3, store1);
         await EnsureReplicatingAsync(store3, store1);
-        
+
         await SetupReplicationAsync(store3, store2);
         await SetupReplicationAsync(store1, store2);
 
@@ -73,9 +74,17 @@ public class RavenDB_19421_2 : ReplicationTestBase
             var u1 = await s1.LoadAsync<object>("users/1");
             var u2 = await s2.LoadAsync<object>("users/1");
             var u3 = await s3.LoadAsync<object>("users/1");
-            
-            Assert.Equal(s1.Advanced.GetChangeVectorFor(u1), s2.Advanced.GetChangeVectorFor(u2));
-            Assert.Equal(s2.Advanced.GetChangeVectorFor(u2), s3.Advanced.GetChangeVectorFor(u3));
+
+            var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var cv1 = context.GetChangeVector(s1.Advanced.GetChangeVectorFor(u1)).Version.AsString().TrimStart();
+                var cv2 = context.GetChangeVector(s2.Advanced.GetChangeVectorFor(u2)).Version.AsString().TrimStart();
+                var cv3 = context.GetChangeVector(s3.Advanced.GetChangeVectorFor(u3)).Version.AsString().TrimStart();
+
+                Assert.Equal(cv1, cv2);
+                Assert.Equal(cv2, cv3);
+            }
         }
     }
 }

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Replication;
@@ -20,7 +19,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task ReduceOutputShouldNotBeReplicated()
         {
             var date = new DateTime(2017, 2, 14);
@@ -63,7 +62,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 database.TombstoneCleaner.Subscribe(this);
                 database2.TombstoneCleaner.Subscribe(this);
 
-                var operation = await store1.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery { Query = "FROM Invoices"}));
+                var operation = await store1.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery { Query = "FROM Invoices" }));
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                 using (var session = store1.OpenAsyncSession())
                 {

--- a/test/SlowTests/Server/Documents/Replication/ReplicateLargeDatabase.cs
+++ b/test/SlowTests/Server/Documents/Replication/ReplicateLargeDatabase.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
@@ -17,7 +16,7 @@ namespace SlowTests.Server.Documents.Replication
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task AutomaticResolveWithIdenticalContent()
         {
             DocumentStore store1;
@@ -34,14 +33,14 @@ namespace SlowTests.Server.Documents.Replication
             Assert.Empty(errors);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         public async Task AutomaticResolveWithIdenticalContentForSharding()
         {
             using (var store1 = Sharding.GetDocumentStore())
             using (var store2 = Sharding.GetDocumentStore())
             {
-                CallCreateSampleDatabaseEndpoint((DocumentStore)store1);
-                CallCreateSampleDatabaseEndpoint((DocumentStore)store2);
+                CallCreateSampleDatabaseEndpoint(store1);
+                CallCreateSampleDatabaseEndpoint(store2);
 
                 await SetupReplicationAsync(store1, store2);
 

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -378,12 +378,12 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store3, store1);
                 await SetupReplicationAsync(store3, store2);
 
+                await EnsureReplicatingAsync(store2, store1);
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);
                 await EnsureReplicatingAsync(store3, store1);
 
-                var dbName1 = options.DatabaseMode == RavenDatabaseMode.Single ? store1.Database : await Sharding.GetShardDatabaseNameForDocAsync(store1, "foo/bar");
-                var db1 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName1);
+                var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
                 await db1.DocumentsStorage.RevisionsStorage.EnforceConfiguration(onProgress: null, token);
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20487.cs
@@ -1,6 +1,10 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Utils;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -135,6 +139,126 @@ namespace SlowTests.Sharding.Issues
                 }, expectedRevisionsCount, timeout: 30_000, interval: 333);
 
                 Assert.Equal(expectedRevisionsCount, res);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Replication)]
+        public async Task ReplicationWithCountersToShardedAndThenToNonShardedShouldWork()
+        {
+            using (var store1 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r =>
+                {
+                    r.Settings[RavenConfiguration.GetKey(c => c.Replication.MaxItemsCount)] = "1";
+                }
+            }))
+            using (var store2 = Sharding.GetDocumentStore())
+            using (var store3 = GetDocumentStore())
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Store(new User { Name = "EGR" }, $"user/322/{i}");
+                        session.SaveChanges();
+
+                        var cf = session.CountersFor($"user/322/{i}");
+                        cf.Increment("Likes", 100);
+                        session.SaveChanges();
+
+                        cf.Increment("Likes2", 200);
+                        session.SaveChanges();
+                    }
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var replication = await ShardedReplicationTestBase.ShardedReplicationManager.GetShardedReplicationManager(await Sharding.GetShardingConfigurationAsync(store2),
+                    new List<RavenServer>() { Server }, store2.Database, new ReplicationManager.ReplicationOptions
+                    {
+                        BreakReplicationOnStart = true,
+                        MaxItemsCount = 1
+                    });
+
+                var externalList = await SetupReplicationAsync(store2, store3);
+                replication.ShardReplications[2].Mend();
+                var id = Sharding.GetRandomIdForShard(await Sharding.GetShardingConfigurationAsync(store2), 2);
+                EnsureReplicating(store2, store3, id);
+
+                var external = new ExternalReplication(store2.Database, $"ConnectionString-{store3.Identifier}")
+                {
+                    TaskId = externalList.First().TaskId,
+                    Disabled = true
+                };
+
+                await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+                external.Disabled = false;
+                await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+
+                replication.ShardReplications[0].Mend();
+                replication.ShardReplications[1].Mend();
+
+                await EnsureReplicatingAsync(store2, store3);
+
+                var stats = await GetDatabaseStatisticsAsync(store3);
+                Assert.Equal(100, stats.CountOfCounterEntries);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ReplicationToShardedAndThenToNonShardedShouldWork2()
+        {
+            using (var store1 = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r =>
+                {
+                    r.Settings[RavenConfiguration.GetKey(c => c.Replication.MaxItemsCount)] = "1";
+                }
+            }))
+            using (var store2 = Sharding.GetDocumentStore())
+            using (var store3 = GetDocumentStore())
+            {
+                await store1.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.TimeSeries | DatabaseItemType.RevisionDocuments | DatabaseItemType.Documents | 
+                                                                                 DatabaseItemType.Attachments | DatabaseItemType.Tombstones | DatabaseItemType.CounterGroups));
+              
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var replication = await ShardedReplicationTestBase.ShardedReplicationManager.GetShardedReplicationManager(await Sharding.GetShardingConfigurationAsync(store2),
+                    new List<RavenServer>() { Server }, store2.Database, new ReplicationManager.ReplicationOptions
+                    {
+                        BreakReplicationOnStart = true,
+                        MaxItemsCount = 1
+                    });
+
+                var externalList = await SetupReplicationAsync(store2, store3);
+                replication.ShardReplications[2].Mend();
+                var id = Sharding.GetRandomIdForShard(await Sharding.GetShardingConfigurationAsync(store2), 2);
+                EnsureReplicating(store2, store3, id);
+
+                var external = new ExternalReplication(store2.Database, $"ConnectionString-{store3.Identifier}")
+                {
+                    TaskId = externalList.First().TaskId,
+                    Disabled = true
+                };
+
+                await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+                external.Disabled = false;
+                await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+
+                replication.ShardReplications[0].Mend();
+                replication.ShardReplications[1].Mend();
+
+                await EnsureReplicatingAsync(store2, store3);
+
+                var stats2 = await GetDatabaseStatisticsAsync(store2);
+                var stats3 = await GetDatabaseStatisticsAsync(store3);
+
+                Assert.Equal(stats2.CountOfCounterEntries, stats3.CountOfCounterEntries);
+                Assert.Equal(stats2.CountOfRevisionDocuments, stats3.CountOfRevisionDocuments);
+                Assert.Equal(stats2.CountOfAttachments, stats3.CountOfAttachments);
+                Assert.Equal(stats2.CountOfTimeSeriesSegments, stats3.CountOfTimeSeriesSegments);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:
- `RevertRevisionsTests.cs`
- `ReplicateLargeDatabase.cs`
- `OutputReduceToCollectionReplicationTests.cs`
- `CountersTombstoneCleaner.cs`
- `RavenDB_15076.cs`
- `RavenDB_11909.cs`
- `RavenDB_10664.cs`
- `RavenDB-5730.cs`
- `RavenDB-15483.cs`
- `RavenDB_6415.cs`
- `RavenDB_6292.cs`
- `RavenDB_19421_2.cs`
- `RavenDB_18496.cs`
- `RavenDB_18473.cs`

Additional fixes:
- handle counters replication for sharding (see `SlowTests.Sharding.Issues.RavenDB_20487.ReplicationWithCountersToShardedAndThenToNonShardedShouldWork` test)
- fix failing test `SlowTests.Server.Replication.ReplicationOfConflicts.RemoveDeleteRevisionFromDifferentCollection`

### Type of change

- Bug fix
- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
