### PR TITLE
RavenDB-20859 Show index operation messages

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/index/disableIndexCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/disableIndexCommand.ts
@@ -1,14 +1,13 @@
 import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
+import genUtils = require("common/generalUtils");
 
 class disableIndexCommand extends commandBase {
 
-    private indexName: string;
-
-    private db: database;
-
-    private location: databaseLocationSpecifier;
+    private readonly indexName: string;
+    private readonly db: database;
+    private readonly location: databaseLocationSpecifier;
 
     constructor(indexName: string, db: database, location: databaseLocationSpecifier) {
         super();
@@ -26,8 +25,10 @@ class disableIndexCommand extends commandBase {
         
         const url = endpoints.databases.adminIndex.adminIndexesDisable + this.urlEncodeArgs(args);
         
-        //tODO: report messages
-        return this.post(url, null, this.db, { dataType: undefined });
+        const locationText = genUtils.formatLocation(this.location);
+
+        return this.post(url, null, this.db, { dataType: undefined })
+            .fail((response: JQueryXHR) => this.reportError(`Failed to disable index ${this.indexName} for ${locationText}`, response.responseText));
     }
 }
 

--- a/src/Raven.Studio/typescript/commands/database/index/enableIndexCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/enableIndexCommand.ts
@@ -1,6 +1,7 @@
 import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
+import genUtils = require("common/generalUtils");
 
 class enableIndexCommand extends commandBase {
 
@@ -25,9 +26,11 @@ class enableIndexCommand extends commandBase {
         };
         
         const url = endpoints.databases.adminIndex.adminIndexesEnable + this.urlEncodeArgs(args);
+
+        const locationText = genUtils.formatLocation(this.location);
         
-        //TODO: report messages
-        return this.post(url, null, this.db, { dataType: undefined });
+        return this.post(url, null, this.db, { dataType: undefined })
+            .fail((response: JQueryXHR) => this.reportError(`Failed to enable index ${this.indexName} for ${locationText}`, response.responseText));
     }
 }
 

--- a/src/Raven.Studio/typescript/commands/database/index/forceIndexReplace.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/forceIndexReplace.ts
@@ -1,6 +1,7 @@
 import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
+import genUtils = require("common/generalUtils");
 
 class forceIndexReplace extends commandBase {
 
@@ -22,9 +23,10 @@ class forceIndexReplace extends commandBase {
         }
         const url = endpoints.databases.index.indexesReplace + this.urlEncodeArgs(args);
 
+        const locationText = genUtils.formatLocation(this.location);
+
         return this.post(url, null, this.db, { dataType: undefined })
-            .done(() => this.reportSuccess("Replaced index " + this.indexName))
-            .fail((response: JQueryXHR) => this.reportError("Failed to replace index.", response.responseText, response.statusText));
+            .fail((response: JQueryXHR) => this.reportError(`Failed to replace index ${this.indexName} for ${locationText}`, response.responseText, response.statusText));
     }
 }
 

--- a/src/Raven.Studio/typescript/commands/database/index/resetIndexCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/resetIndexCommand.ts
@@ -1,30 +1,32 @@
 import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
+import genUtils = require("common/generalUtils");
 
 class resetIndexCommand extends commandBase {
 
-    private indexNameToReset: string;
+    private readonly indexName: string;
+    private readonly db: database;
+    private readonly location: databaseLocationSpecifier;
 
-    private db: database;
-
-    private location: databaseLocationSpecifier;
-
-    constructor(indexNameToReset: string, db: database, location: databaseLocationSpecifier) {
+    constructor(indexName: string, db: database, location: databaseLocationSpecifier) {
         super();
         this.location = location;
         this.db = db;
-        this.indexNameToReset = indexNameToReset;
+        this.indexName = indexName;
     }
 
     execute(): JQueryPromise<{ IndexId: number }> {
         const args = {
-            name: this.indexNameToReset, 
+            name: this.indexName, 
             ...this.location
         };
         const url = endpoints.databases.index.indexes + this.urlEncodeArgs(args);
+
+        const locationText = genUtils.formatLocation(this.location);
+
         return this.reset<{ IndexId: number }>(url, null, this.db)
-            .fail((response: JQueryXHR) => this.reportError("Failed to reset index: " + this.indexNameToReset, response.responseText, response.statusText));
+            .fail((response: JQueryXHR) => this.reportError(`Failed to reset index ${this.indexName} for ${locationText}`, response.responseText, response.statusText));
     }
 }
 

--- a/src/Raven.Studio/typescript/commands/database/index/togglePauseIndexingCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/togglePauseIndexingCommand.ts
@@ -2,6 +2,7 @@
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
 import { DatabaseSharedInfo } from "components/models/databases";
+import genUtils = require("common/generalUtils");
 
 type optsNames = {
     name: string;
@@ -53,10 +54,18 @@ class togglePauseIndexingCommand extends commandBase {
         }
 
         const url = basicUrl + (args ? this.urlEncodeArgs(args) : "");
-        //TODO: report messages!
-        return this.post(url, null, this.db, { dataType: undefined });
+        
+
+        return this.post(url, null, this.db, { dataType: undefined })
+            .fail((response: JQueryXHR) => this.reportError(this.getFailTitle(), response.responseText));
     }
 
+    getFailTitle() {
+        const locationText = genUtils.formatLocation(this.location);
+        const failText = `Failed to ${this.start ? "resume" : "pause"} ${this.name ? `index ${this.name}` : "all indexes"} for ${locationText}`;
+
+        return failText;
+    }
 }
 
 export = togglePauseIndexingCommand;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20859/Invalid-index-state-after-disable-if-request-returns-timeout

### Additional description

Now request are collected and run by `Primise.all()`
If one fails -> displays an error message
If all successful -> displays success message

This includes index:
- disable
- pause
- enable / resume
- reset
- swap

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
