### PR TITLE
RavenDB-20842: fix NRE in Subscription PreparePerformanceStats

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
@@ -220,16 +220,18 @@ namespace Raven.Server.Documents.Subscriptions
                     using (context.OpenReadTransaction())
                     {
                         var inProgressConnections = Database.SubscriptionStorage.GetSubscriptionConnectionsState(context, subscriptionName);
-
-                        foreach (var connection in inProgressConnections.GetConnections())
+                        if (inProgressConnections != null)
                         {
-                            var inProgressBatchStats = connection.GetBatchPerformanceStats();
-
-                            if (inProgressBatchStats?.Completed == false &&
-                                inProgressBatchStats.ToBatchPerformanceLiveStatsWithDetails().NumberOfDocuments > 0 &&
-                                batchAggregators.Contains(inProgressBatchStats) == false)
+                            foreach (var connection in inProgressConnections.GetConnections())
                             {
-                                batchAggregators.Add(inProgressBatchStats);
+                                var inProgressBatchStats = connection.GetBatchPerformanceStats();
+
+                                if (inProgressBatchStats?.Completed == false &&
+                                    inProgressBatchStats.ToBatchPerformanceLiveStatsWithDetails().NumberOfDocuments > 0 &&
+                                    batchAggregators.Contains(inProgressBatchStats) == false)
+                                {
+                                    batchAggregators.Add(inProgressBatchStats);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20842

### Additional description
fix NRE in Subscription PreparePerformanceStats

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Yes
