### PR TITLE
RavenDB-20883

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -194,20 +194,6 @@ namespace Raven.Client
 
             public class Metadata
             {
-                internal static readonly HashSet<string> SystemKeys = new()
-                {
-                    Key,
-                    Projection,
-                    Id,
-                    TimeSeriesNamedValues,
-                    IndexScore,
-                    SpatialResult,
-                    LastModified,
-                    ChangeVector,
-                    Etag,
-                    Flags
-                };
-
                 private Metadata()
                 {
                 }

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Raven.Client
 {
     public static class Constants
@@ -123,7 +125,7 @@ namespace Raven.Client
             public const string Prefix = "certificates/";
             public const int MaxNumberOfCertsWithSameHash = 5;
         }
-        
+
         internal class Network
         {
             public const string AnyIp = "0.0.0.0";
@@ -152,7 +154,7 @@ namespace Raven.Client
             {
                 internal const string IndexingStaticSearchEngineType = "Indexing.Static.SearchEngineType";
             }
-            
+
             public const string ClientId = "Configuration/Client";
 
             public const string StudioId = "Configuration/Studio";
@@ -192,6 +194,20 @@ namespace Raven.Client
 
             public class Metadata
             {
+                internal static readonly HashSet<string> SystemKeys = new()
+                {
+                    Key,
+                    Projection,
+                    Id,
+                    TimeSeriesNamedValues,
+                    IndexScore,
+                    SpatialResult,
+                    LastModified,
+                    ChangeVector,
+                    Etag,
+                    Flags
+                };
+
                 private Metadata()
                 {
                 }
@@ -310,15 +326,15 @@ namespace Raven.Client
                         private JavaScript()
                         {
                         }
-                        
+
                         public const string ValuePropertyName = "$value";
-                        
+
                         public const string OptionsPropertyName = "$options";
-                        
+
                         public const string NamePropertyName = "$name";
-                        
+
                         public const string SpatialPropertyName = "$spatial";
-                        
+
                         public const string BoostPropertyName = "$boost";
                     }
                 }
@@ -424,7 +440,7 @@ namespace Raven.Client
                 public const string Size = "@raven-blob-size";
             }
         }
-        
+
         internal static class Smuggler
         {
             public const string ImportOptions = "importOptions";

--- a/src/Raven.Client/Json/BlittableOperation.cs
+++ b/src/Raven.Client/Json/BlittableOperation.cs
@@ -59,12 +59,12 @@ namespace Raven.Client.Json
 
             foreach (var field in removedFields)
             {
-                if (changes == null)
-                    return true;
                 if (field.Equals(LastModified) ||
                     field.Equals(ChangeVector) ||
                     field.Equals(Id))
                     continue;
+                if (changes == null)
+                    return true;
                 NewChange(fieldPath, field, null, null, docChanges, DocumentsChanges.ChangeType.RemovedField);
             }
 

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -57,12 +57,6 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
 
                 foreach (var prop in _documentInfo.Metadata.Modifications.Properties)
                 {
-                    if (prop.Name.Length > 0 && prop.Name[0] == '@')
-                    {
-                        if (Constants.Documents.Metadata.SystemKeys.Contains(prop.Name))
-                            continue; // system property, ignoring it
-                    }
-
                     _manualBlittableJsonDocumentBuilder.WritePropertyName(prop.Item1);
                     WritePropertyValue(prop.Name, prop.Value);
                 }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -59,10 +59,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 {
                     if (prop.Name.Length > 0 && prop.Name[0] == '@')
                     {
-                        if (prop.Name != Constants.Documents.Metadata.Collection &&
-                            prop.Name != Constants.Documents.Metadata.Expires &&
-                            prop.Name != Constants.Documents.Metadata.Refresh &&
-                            prop.Name != Constants.Documents.Metadata.Edges)
+                        if (Constants.Documents.Metadata.SystemKeys.Contains(prop.Name))
                             continue; // system property, ignoring it
                     }
 

--- a/test/FastTests/Server/Basic/RavenDB5743.cs
+++ b/test/FastTests/Server/Basic/RavenDB5743.cs
@@ -13,7 +13,7 @@ namespace FastTests.Server.Basic
         }
 
         [Fact]
-        public async Task WillFilterMetadataPropertiesStartingWithAt()
+        public async Task WillNotFilterMetadataPropertiesStartingWithAt()
         {
             using (var store = GetDocumentStore())
             {
@@ -33,7 +33,7 @@ namespace FastTests.Server.Basic
                 {
                     var company3 = await session.LoadAsync<Company>("users/1");
                     var metadata = session.Advanced.GetMetadataFor(company3);
-                    Assert.False(metadata.ContainsKey("@foo"));
+                    Assert.True(metadata.ContainsKey("@foo"));
                     Assert.Equal("should be there", metadata.GetString("custom-info"));
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-17996.cs
+++ b/test/SlowTests/Issues/RavenDB-17996.cs
@@ -32,8 +32,9 @@ namespace SlowTests.Issues
                     id = user.Id;
                     session.SaveChanges();
                 }
-                
-                AssertRequestCountEqual(metadataFor => {
+
+                AssertRequestCountEqual(metadataFor =>
+                {
                     foreach (var keyValue in metadataFor)
                     {
 
@@ -77,21 +78,19 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                AssertRequestCountNotEqual(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.LastModified));
-                AssertRequestCountNotEqual(metadataFor =>
-                    metadataFor.Remove(
-                        new KeyValuePair<string, object>(Constants.Documents.Metadata.LastModified, metadataFor[Constants.Documents.Metadata.LastModified])));
-                AssertRequestCountNotEqual(metadataFor => metadataFor["@last-modified"] = "Users");
-                AssertRequestCountNotEqual(metadataFor =>
+                AssertRequestCount(metadataFor => metadataFor.Remove(Constants.Documents.Metadata.LastModified), requestCountEqual: true);
+                AssertRequestCount(metadataFor => metadataFor.Remove(new KeyValuePair<string, object>(Constants.Documents.Metadata.LastModified, metadataFor[Constants.Documents.Metadata.LastModified])), requestCountEqual: true);
+                AssertRequestCount(metadataFor => metadataFor["@last-modified"] = "Users", requestCountEqual: true);
+                AssertRequestCount(metadataFor =>
                 {
                     metadataFor["@last-modified"] = null;
                     metadataFor["@last-modified"] = "Users";
-                } );
-                AssertRequestCountNotEqual(metadataFor => metadataFor["@1234"] = "Users");
-                AssertRequestCountNotEqual(metadataFor => metadataFor.Add(new KeyValuePair<string, object>("@sfddfdsf", "fgffffg")));
-                AssertRequestCountNotEqual(metadataFor => metadataFor.Add("@ewewrewr", "fdsfdgfdg"));
+                }, requestCountEqual: true);
+                AssertRequestCount(metadataFor => metadataFor["@1234"] = "Users");
+                AssertRequestCount(metadataFor => metadataFor.Add(new KeyValuePair<string, object>("@sfddfdsf", "fgffffg")));
+                AssertRequestCount(metadataFor => metadataFor.Add("@ewewrewr", "fdsfdgfdg"));
 
-                void AssertRequestCountNotEqual(Action<IMetadataDictionary> action)
+                void AssertRequestCount(Action<IMetadataDictionary> action, bool requestCountEqual = false)
                 {
                     using (var session = store.OpenSession())
                     {
@@ -104,7 +103,10 @@ namespace SlowTests.Issues
 
                         session.SaveChanges();
 
-                        Assert.NotEqual(requestsBefore, session.Advanced.NumberOfRequests);
+                        if (requestCountEqual == false)
+                            Assert.NotEqual(requestsBefore, session.Advanced.NumberOfRequests);
+                        else
+                            Assert.Equal(requestsBefore, session.Advanced.NumberOfRequests);
                     }
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_20883.cs
+++ b/test/SlowTests/Issues/RavenDB_20883.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Json;
+using Raven.Server.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20883 : RavenTestBase
+{
+    public RavenDB_20883(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Attachments)]
+    public async Task Number_Of_Attachments_Needs_To_Match_Async()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.OnBeforeStore += (_, args) =>
+            {
+                if (args.Entity is User)
+                {
+                    args.DocumentMetadata["@collection"] = "Users";
+                    args.DocumentMetadata["Prop"] = Guid.NewGuid().ToString();
+                }
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User { Name = "Test" };
+
+                await session.StoreAsync(user, "users/1");
+
+                session.Advanced.Attachments.Store(user, "attachment-1", new MemoryStream(new byte[] { 1, 2, 3 }));
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+
+                var metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Attachments));
+                Assert.Contains(DocumentFlags.HasAttachments.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                var attachments = session.Advanced.Attachments.GetNames(user);
+                Assert.NotEmpty(attachments);
+                Assert.Equal(1, attachments.Length);
+
+                user.Name = "Test 2";
+                await session.SaveChangesAsync();
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Attachments));
+                Assert.Contains(DocumentFlags.HasAttachments.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                attachments = session.Advanced.Attachments.GetNames(user);
+                Assert.NotEmpty(attachments);
+                Assert.Equal(1, attachments.Length);
+
+                session.Advanced.Clear();
+                user = await session.LoadAsync<User>("users/1");
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Attachments));
+                Assert.Contains(DocumentFlags.HasAttachments.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                attachments = session.Advanced.Attachments.GetNames(user);
+                Assert.NotEmpty(attachments);
+                Assert.Equal(1, attachments.Length);
+
+
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.TimeSeries)]
+    public async Task Number_Of_TimeSeries_Needs_To_Match_Async()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.OnBeforeStore += (_, args) =>
+            {
+                if (args.Entity is User)
+                {
+                    args.DocumentMetadata["@collection"] = "Users";
+                    args.DocumentMetadata["Prop"] = Guid.NewGuid().ToString();
+                }
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User { Name = "Test" };
+
+                await session.StoreAsync(user, "users/1");
+
+                session.TimeSeriesFor(user, "timeseries-1").Append(DateTime.Now, 1);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+
+                var metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.TimeSeries));
+                Assert.Contains(DocumentFlags.HasTimeSeries.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                user.Name = "Test 2";
+                await session.SaveChangesAsync();
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.TimeSeries));
+                Assert.Contains(DocumentFlags.HasTimeSeries.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                session.Advanced.Clear();
+                user = await session.LoadAsync<User>("users/1");
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.TimeSeries));
+                Assert.Contains(DocumentFlags.HasTimeSeries.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Counters)]
+    public async Task Number_Of_Counters_Needs_To_Match_Async()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.OnBeforeStore += (_, args) =>
+            {
+                if (args.Entity is User)
+                {
+                    args.DocumentMetadata["@collection"] = "Users";
+                    args.DocumentMetadata["Prop"] = Guid.NewGuid().ToString();
+                }
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User { Name = "Test" };
+
+                await session.StoreAsync(user, "users/1");
+
+                session.CountersFor(user).Increment("counter-1", 3);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+
+                var metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Counters));
+                Assert.Contains(DocumentFlags.HasCounters.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                user.Name = "Test 2";
+                await session.SaveChangesAsync();
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Counters));
+                Assert.Contains(DocumentFlags.HasCounters.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+
+                session.Advanced.Clear();
+                user = await session.LoadAsync<User>("users/1");
+
+                metadata = (MetadataAsDictionary)session.Advanced.GetMetadataFor(user);
+                foreach (var _ in metadata)
+                {
+                }
+                Assert.True(metadata.Keys.Contains(Constants.Documents.Metadata.Counters));
+                Assert.Contains(DocumentFlags.HasCounters.ToString(), metadata.GetString(Constants.Documents.Metadata.Flags));
+                Assert.False(metadata.Changed);
+            }
+        }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
- nested objects in @metadata (like @attachments) should not mark metadata as changed
- we should not strip @attachments, @counters, @timeseries from metadata

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20883

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
