### PR TITLE
RavenDB-20339 - handle TimeSeries change vectors & move & fix tests […

### DIFF
--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -203,10 +203,13 @@ public class ChangeVector
         MergeWithDatabaseChangeVector(context, context.GetChangeVector(changeVector));
     }
 
-    public static ChangeVector MergeWithNewDatabaseChangeVector(DocumentsOperationContext context, ChangeVector changeVector)
+    public static ChangeVector MergeWithNewDatabaseChangeVector(DocumentsOperationContext context, ChangeVector changeVector, long? newEtag = null)
     {
-        var databaseChangeVector = context.DocumentDatabase.DocumentsStorage.GetNewChangeVector(context).ChangeVector;
-        if (changeVector.IsNullOrEmpty)
+        newEtag ??= context.DocumentDatabase.DocumentsStorage.GenerateNextEtag();
+        var databaseChangeVector = context.DocumentDatabase.DocumentsStorage.GetNewChangeVector(context, newEtag.Value);
+        context.LastDatabaseChangeVector = databaseChangeVector;
+
+        if (changeVector == null)
             return databaseChangeVector;
 
         if (changeVector.IsSingle)

--- a/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
+++ b/test/SlowTests/Client/TimeSeries/IncrementalTimeSeriesTests.cs
@@ -1462,14 +1462,16 @@ namespace SlowTests.Client.TimeSeries
                     session.SaveChanges();
                 }
 
-                var replicationA = await SetupReplicationAndGetManagerAsync(storeA, options.DatabaseMode, toStores: storeB);
-                var replicationB = await SetupReplicationAndGetManagerAsync(storeB, options.DatabaseMode, toStores: storeA);
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await replicationA.EnsureNoReplicationLoopAsync();
-                await replicationB.EnsureNoReplicationLoopAsync();
+                await Task.Delay(3_000); // wait for replication ping-pong to settle down
+
+                await EnsureNoReplicationLoopAsync(storeA, options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(storeB, options.DatabaseMode);
 
                 var pageSize = 100;
                 var values = storeA.Operations
@@ -1531,14 +1533,16 @@ namespace SlowTests.Client.TimeSeries
                     session.SaveChanges();
                 }
 
-                var replicationA = await SetupReplicationAndGetManagerAsync(storeA, options.DatabaseMode, toStores: storeB);
-                var replicationB = await SetupReplicationAndGetManagerAsync(storeB, options.DatabaseMode, toStores: storeA);
+                await SetupReplicationAsync(storeA, storeB);
+                await SetupReplicationAsync(storeB, storeA);
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await replicationA.EnsureNoReplicationLoopAsync();
-                await replicationB.EnsureNoReplicationLoopAsync();
+                await Task.Delay(3_000); // wait for replication ping-pong to settle down
+
+                await EnsureNoReplicationLoopAsync(storeA, options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(storeB, options.DatabaseMode);
 
                 for (int start = 0; start < size; start += pageSize)
                 {

--- a/test/SlowTests/Issues/RavenDB_17317.cs
+++ b/test/SlowTests/Issues/RavenDB_17317.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
@@ -15,13 +14,14 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries()
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries(Options options)
         {
             var baseline = DateTime.UtcNow;
 
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -61,9 +61,6 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
-
                 using (var session = storeA.OpenSession())
                 {
                     var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
@@ -73,9 +70,6 @@ namespace SlowTests.Issues
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
-
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
 
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())
@@ -96,13 +90,15 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries2()
+
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanReplicateEntireSegmentOnUpdate_TimeSeries2(Options options)
         {
             var baseline = DateTime.UtcNow;
 
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -142,9 +138,6 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
-
                 using (var session = storeA.OpenSession())
                 {
                     var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
@@ -154,9 +147,6 @@ namespace SlowTests.Issues
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
-
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
 
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())
@@ -185,9 +175,6 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
-
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())
                 {
@@ -201,13 +188,14 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanUpdateExistingSegmentWithMoreValues()
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUpdateExistingSegmentWithMoreValues(Options options)
         {
             var baseline = DateTime.UtcNow;
 
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -247,9 +235,6 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
-
                 using (var session = storeA.OpenSession())
                 {
                     var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
@@ -259,9 +244,6 @@ namespace SlowTests.Issues
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
-
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
 
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())
@@ -281,13 +263,14 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanDeleteEntireSegment()
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanDeleteEntireSegment(Options options)
         {
             var baseline = DateTime.UtcNow;
 
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -327,9 +310,6 @@ namespace SlowTests.Issues
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
 
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
-
                 using (var session = storeA.OpenSession())
                 {
                     var ts = session.TimeSeriesFor("users/ayende", "HeartRates");
@@ -339,9 +319,6 @@ namespace SlowTests.Issues
 
                 await EnsureReplicatingAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeB, storeA);
-
-                await EnsureNoReplicationLoop(Server, storeA.Database);
-                await EnsureNoReplicationLoop(Server, storeB.Database);
 
                 using (var sessionA = storeA.OpenSession())
                 using (var sessionB = storeB.OpenSession())
@@ -355,15 +332,16 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task ClusterNodesShouldHaveTheSameChangeVectorAfterTimeSeriesValueDelete()
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Cluster | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterNodesShouldHaveTheSameChangeVectorAfterTimeSeriesValueDelete(Options options)
         {
             DateTime baseline = DateTime.Today;
             var cluster = await CreateRaftCluster(3);
             var database = GetDatabaseName();
-            await CreateDatabaseInCluster(database, 3, cluster.Leader.WebUrl);
+            await CreateDatabaseInClusterForMode(database, 3, cluster, options.DatabaseMode);
 
-            using (var store = GetDocumentStore(new Options
+            using (var store = GetDocumentStore(new Options(options)
             {
                 CreateDatabase = false,
                 Server = cluster.Leader,
@@ -401,7 +379,7 @@ namespace SlowTests.Issues
                     Assert.True(await WaitForDocumentInClusterAsync<User>((DocumentSession)session, markerId, (u) => u.Id == markerId, Debugger.IsAttached ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(15)));
                 }
 
-                Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes, database));
+                Assert.True(await WaitForChangeVectorInClusterForModeAsync(cluster.Nodes, database, options.DatabaseMode));
             }
         }
 


### PR DESCRIPTION
…RavenDB_17317.cs]

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Handle TS conflicts:
Before those changes, we relied on the database change vector for TS (replication update/conflict) - but with the recent Sharding changes, we had to change the implementation and merge the TS cv with the cv from the replication (in case of a conflict or update). 
Now the behavior is pretty much as in Update/Conflict of Documents or Attachments.

Files:
-  `RavenDB_17317.cs`

### Type of change

- Bug fix
- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
