### PR TITLE
RavenDB-20783 NullReferenceException in NodeSelector.SelectFastest

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -260,8 +260,10 @@ namespace Raven.Client.Http
         {
             state.Fastest = index;
             Interlocked.Exchange(ref state.SpeedTestMode, 0);
-
-            _updateFastestNodeTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            if (_updateFastestNodeTimer == null)
+                _updateFastestNodeTimer = new Timer(SwitchToSpeedTestPhase, null, TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            else
+                _updateFastestNodeTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
         }
 
         public void ScheduleSpeedTest()

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -260,19 +260,19 @@ namespace Raven.Client.Http
         {
             state.Fastest = index;
             Interlocked.Exchange(ref state.SpeedTestMode, 0);
-            if (_updateFastestNodeTimer == null)
-                _updateFastestNodeTimer = new Timer(SwitchToSpeedTestPhase, null, TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
-            else
-                _updateFastestNodeTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            EnsureFastestNodeTimerExists();
+            _updateFastestNodeTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
         }
 
         public void ScheduleSpeedTest()
         {
-            if (_updateFastestNodeTimer == null)
-            {
-                _updateFastestNodeTimer = new Timer(SwitchToSpeedTestPhase, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-            }
+            EnsureFastestNodeTimerExists();
             SwitchToSpeedTestPhase(null);
+        }
+
+        private void EnsureFastestNodeTimerExists()
+        {
+            _updateFastestNodeTimer ??= new Timer(SwitchToSpeedTestPhase, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
 
         public void Dispose()

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -496,10 +496,9 @@ namespace Raven.Client.Http
                     {
                         _nodeSelector = new NodeSelector(topology);
 
-                        ForTestingPurposes?.WaitForRecoredfastest.Invoke(_nodeSelector);
-
                         if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                         {
+                            ForTestingPurposes.OnBeforeScheduleSpeedTest?.Invoke(_nodeSelector);
                             _nodeSelector.ScheduleSpeedTest();
                         }
                     }
@@ -2370,7 +2369,7 @@ namespace Raven.Client.Http
             internal ConcurrentDictionary<ServerNode, Lazy<NodeStatus>> FailedNodesTimers => _requestExecutor._failedNodesTimers;
             internal (int Index, ServerNode Node) PreferredNode => _requestExecutor._nodeSelector.GetPreferredNode();
 
-            internal Action<NodeSelector> WaitForRecoredfastest;
+            internal Action<NodeSelector> OnBeforeScheduleSpeedTest;
         }
     }
 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -496,6 +496,8 @@ namespace Raven.Client.Http
                     {
                         _nodeSelector = new NodeSelector(topology);
 
+                        ForTestingPurposes?.WaitForRecoredfastest.Invoke(_nodeSelector);
+
                         if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                         {
                             _nodeSelector.ScheduleSpeedTest();
@@ -2367,6 +2369,8 @@ namespace Raven.Client.Http
             internal int[] NodeSelectorFailures => _requestExecutor._nodeSelector.NodeSelectorFailures;
             internal ConcurrentDictionary<ServerNode, Lazy<NodeStatus>> FailedNodesTimers => _requestExecutor._failedNodesTimers;
             internal (int Index, ServerNode Node) PreferredNode => _requestExecutor._nodeSelector.GetPreferredNode();
+
+            internal Action<NodeSelector> WaitForRecoredfastest;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-20783.cs
+++ b/test/SlowTests/Issues/RavenDB-20783.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Http;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20783 : ReplicationTestBase
+    {
+        public RavenDB_20783(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task NullTimerInRecordFatest()
+        {
+            var (servers, leader) = await CreateRaftCluster(3, watcherCluster: true);
+            var mre = new ManualResetEvent(false);
+            using (var store1 = GetDocumentStore(new Options
+                   {
+                       Server = servers[0],
+                       ModifyDatabaseName = s => $"{s}_1",
+                       ReplicationFactor = 3,
+                       ModifyDocumentStore = s => s.Conventions.ReadBalanceBehavior = Raven.Client.Http.ReadBalanceBehavior.FastestNode
+                   }))
+            {
+                var e = store1.GetRequestExecutor();
+                NodeSelector node = null;
+                e.ForTestingPurposesOnly().WaitForRecoredfastest = async (n) =>
+                {
+                    node = n;
+                    mre.WaitOne();
+                };
+                _ = e.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode { Url = servers[0].WebUrl, Database = store1.Database })
+                {
+                    TimeoutInMs = Timeout.Infinite,
+                    ForceUpdate = true,
+                    DebugTag = "first-topology-update",
+                });
+                await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+                for (int i = 0; i < 10; i++)
+                {
+                    try
+                    {
+                        node.RecordFastest(0, node.Topology.Nodes[0]);
+                    }
+                    catch (Exception exception)
+                    {
+                        Assert.Fail(exception.Message + "Stack Track : " + exception.StackTrace);
+                    }
+                }
+
+                mre.Set();
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-20783.cs
+++ b/test/SlowTests/Issues/RavenDB-20783.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task NullTimerInRecordFatest()
+        public async Task NullTimerInRecordFastest()
         {
             var (servers, leader) = await CreateRaftCluster(3, watcherCluster: true);
             var mre = new ManualResetEvent(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20783

### Additional description

We can have NullReferenceException when we use SelectFastest before we call ScheduleSpeedTest

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
