### PR TITLE
RavenDB-20870 Unselect all on cancel

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
@@ -23,6 +23,7 @@ interface IndexSelectActionProps {
     pauseSelectedIndexes: () => Promise<void>;
     setLockModeSelectedIndexes: (lockMode: IndexLockMode) => Promise<void>;
     toggleSelectAll: () => void;
+    onCancel: () => void;
 }
 
 export default function IndexSelectAction(props: IndexSelectActionProps) {
@@ -35,6 +36,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
         pauseSelectedIndexes,
         setLockModeSelectedIndexes,
         toggleSelectAll,
+        onCancel,
     } = props;
 
     const [globalLockChanges] = useState(false);
@@ -132,7 +134,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                             <span>Delete</span>
                         </Button>
                     </ButtonGroup>
-                    <Button onClick={toggleSelectAll} color="link">
+                    <Button onClick={onCancel} color="link">
                         Cancel
                     </Button>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -44,6 +44,7 @@ export function IndexesPage(props: IndexesPageProps) {
         stats,
         selectedIndexes,
         toggleSelectAll,
+        onSelectCancel,
         filter,
         setFilter,
         filterByStatusOptions,
@@ -117,6 +118,7 @@ export function IndexesPage(props: IndexesPageProps) {
                             pauseSelectedIndexes={pauseSelectedIndexes}
                             setLockModeSelectedIndexes={confirmSetLockModeSelectedIndexes}
                             toggleSelectAll={toggleSelectAll}
+                            onCancel={onSelectCancel}
                         />
                     )}
                 </StickyHeader>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -592,6 +592,7 @@ export function useIndexesPage(database: database, stale: boolean) {
         stats,
         selectedIndexes,
         toggleSelectAll,
+        onSelectCancel: () => setSelectedIndexes([]),
         filter,
         setFilter,
         filterByStatusOptions,

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
@@ -201,7 +201,7 @@ export function DatabasesSelectActions({
                             </Button>
                         )}
                     </ButtonGroup>
-                    <Button onClick={toggleSelectAll} color="link">
+                    <Button onClick={() => setSelectedDatabaseNames([])} color="link">
                         Cancel
                     </Button>
                 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20870/Database-Index-select-actions-Cancel-should-unselect-all

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
