### PR TITLE
RavenDB-20543 Missing collection name fix

### DIFF
--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -284,7 +284,11 @@ namespace Raven.Server.SqlMigration
                             switch (refInfo.EmbeddedDocumentsSqlKeysStorage)
                             {
                                 case EmbeddedDocumentSqlKeysStorage.OnDocumentMetadata:
-                                    value[Constants.Documents.Metadata.Key] = new DynamicJsonValue{["@sql-keys"] = embeddedObjectValue.SpecialColumnsValues};
+                                    var metadata = (DynamicJsonValue)value[Constants.Documents.Metadata.Key];
+                                    if (metadata is not null) // Prevent metadata overwrites
+                                        metadata["@sql-keys"] = embeddedObjectValue.SpecialColumnsValues;
+                                    else
+                                        value[Constants.Documents.Metadata.Key] = new DynamicJsonValue {["@sql-keys"] = embeddedObjectValue.SpecialColumnsValues};
                                     break;
                                 case EmbeddedDocumentSqlKeysStorage.AsNestedDocumentProperty:
                                     foreach (var specialField in embeddedObjectValue.SpecialColumnsValues.Properties)

--- a/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
+++ b/test/SlowTests/Server/Documents/Migration/BasicMigrationTests.cs
@@ -786,6 +786,9 @@ namespace SlowTests.Server.Documents.Migration
                     using (var session = store.OpenSession())
                     {
                         var order = session.Load<JObject>("Orders/1");
+                        
+                        Assert.NotNull(order["@metadata"]);
+                        Assert.NotNull(order["@metadata"]["@collection"]);
 
                         Assert.NotNull(order);
                         Assert.NotNull(order["Items"]);
@@ -849,6 +852,8 @@ namespace SlowTests.Server.Documents.Migration
                     using (var session = store.OpenSession())
                     {
                         var order = session.Load<JObject>("Orders/1");
+                        Assert.NotNull(order["@metadata"]);
+                        Assert.NotNull(order["@metadata"]["@collection"]);
 
                         Assert.NotNull(order);
                         Assert.NotNull(order["Items"]);
@@ -920,7 +925,9 @@ namespace SlowTests.Server.Documents.Migration
                         Assert.NotNull(order["Items"]);
                         Assert.NotNull(order["@metadata"]);
                         Assert.NotNull(order["@metadata"]["@sql-keys"]);
-                        
+
+                        Assert.NotNull(order["@metadata"]["@collection"]);
+
                         var sqlKeysMetadata = order["@metadata"]["@sql-keys"];
                         Assert.Equal(1, sqlKeysMetadata["o_id"]);
                         


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20453/Import-from-SQL-Allow-to-add-the-reference-key-of-embeded-object

### Additional description

Addition to this PR https://github.com/ravendb/ravendb/pull/16545 - fix that prevents overwriting metadata instance.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix


### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
