### PR TITLE
RavenDB-20880 Indexes list view: Index status icon sometimes goes dark

### DIFF
--- a/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
+++ b/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
@@ -4,7 +4,7 @@ export interface ProgressCircleProps {
     state: "success" | "failed" | "running";
     children?: ReactNode;
     icon?: IconName;
-    progress?: number | null;
+    progress?: number;
     inline?: boolean;
     onClick?: () => void;
 }
@@ -20,7 +20,7 @@ const circumference = 2 * Math.PI * stateIndicatorProgressRadius;
 export function ProgressCircle(props: ProgressCircleProps) {
     const { state, children, inline, icon, progress, onClick } = props;
 
-    const showProgress = progress > 0 && progress < 1;
+    const showProgress = progress != null;
 
     return (
         <div

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -275,7 +275,7 @@ export function JoinedIndexProgress(props: JoinedIndexProgressProps) {
             inline
             state={getState(index)}
             icon={getIcon(index)}
-            progress={overallProgress}
+            progress={getStateText(index) === "Running" ? overallProgress : null}
             onClick={onClick}
         >
             {getStateText(index)}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20880/Indexes-list-view-Index-status-icon-sometimes-goes-dark

### Additional description

It happens when index is 'Running' and overall progress equal 0% or 100%.
Now it will be displayed only for 'Running' indexes (skipped 0 < x < 100 check)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
