### PR TITLE
RavenDB-20636 Validate factory name, before adding sql connection string

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Sparrow.Json.Parsing;
@@ -14,6 +15,20 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         protected override void ValidateImpl(ref List<string> errors)
         {
+            // Validate ConnectionString.FactoryName
+            try
+            {
+                SqlProviderParser.GetSupportedProvider(FactoryName);
+            }
+            catch (NotImplementedException)
+            {
+                errors.Add($"Factory '{FactoryName}' is not implemented yet.");
+            }
+            catch (Exception)
+            {
+                errors.Add($"Unsupported factory '{FactoryName}'");
+            }
+            
             if (string.IsNullOrEmpty(ConnectionString))
                 errors.Add($"{nameof(ConnectionString)} cannot be empty");
         }

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -70,6 +70,8 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
+            // Validate ConnectionString.FactoryName
+            SqlProviderParser.GetSupportedProvider(ConnectionString.FactoryName);
             record.SqlConnectionStrings[ConnectionString.Name] = ConnectionString;
         }
     }

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -70,8 +70,6 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            // Validate ConnectionString.FactoryName
-            SqlProviderParser.GetSupportedProvider(ConnectionString.FactoryName);
             record.SqlConnectionStrings[ConnectionString.Name] = ConnectionString;
         }
     }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -788,7 +788,7 @@ namespace Raven.Server.Web.System
                     List<string> errors = new ();
                     if (GetConnectionString(readerObject, connectionStringType).Validate(ref errors) == false)
                     {
-                        throw new BadRequestException($"Invalid connection string configuration. Errors: {string.Join("\n", errors)}");
+                        throw new BadRequestException($"Invalid connection string configuration. Errors: {string.Join(Environment.NewLine, errors)}");
                     }
                 });
         }

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
@@ -274,6 +275,26 @@ namespace SlowTests.Server.Documents.ETL
                 Assert.True(resultElastic.SqlConnectionStrings.Count == 0);
                 Assert.True(resultElastic.RavenConnectionStrings.Count == 0);
                 Assert.True(resultElastic.ElasticSearchConnectionStrings.Count > 0);
+            }
+        }
+
+        [RequiresMsSqlFact]
+        public void CannotAddSqlConnectionStringWithInvalidFactoryName()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                {
+                    Name = "Invalid Factory Connection String",
+                    ConnectionString = "some-connection-string-that-doesnt-matter",
+                    FactoryName = "Invalid.Factory.4.20-final.stable"
+                })));
+                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                {
+                    Name = "Not-supported Factory Connection String",
+                    ConnectionString = "some-connection-string-that-doesnt-matter",
+                    FactoryName = "System.Data.OleDb"
+                })));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -40,6 +39,7 @@ namespace SlowTests.Server.Documents.ETL
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
 
                 var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -129,6 +129,7 @@ namespace SlowTests.Server.Documents.ETL
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
 
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -198,7 +199,8 @@ namespace SlowTests.Server.Documents.ETL
                     var sqlConnectionStr = new SqlConnectionString
                     {
                         Name = $"SqlConnectionString{i}",
-                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                        FactoryName = "Npgsql"
                     };
                     var elasticConnectionStr = new ElasticSearchConnectionString
                     {
@@ -252,7 +254,8 @@ namespace SlowTests.Server.Documents.ETL
                 var sqlConnectionStr = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
                 var elasticConnectionStr = new ElasticSearchConnectionString
                 {

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress" });
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);
@@ -72,7 +72,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress" });
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1326,7 +1326,8 @@ namespace SlowTests.Smuggler
 
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<ElasticSearchConnectionString>(new ElasticSearchConnectionString
                 {
-                    Name = "elasticsearch-cs"
+                    Name = "elasticsearch-cs",
+                    Nodes = new[]{"http://127.0.0.1:8080" }
                 }));
 
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(new QueueConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20636/Putting-a-SqlConnectionString-with-invalid-FactoryName-corrupts-the-studio

### Additional description

There was a possibility to add a SQL Connection String with an invalid factory name, which caused it impossible to look at connection strings in the studio. I've applied extra validation of that string, which will prevent adding incorrect ones. It throws an error on such an operation. To ensure good validation and code integrity, I've used already implemented function for getting the `SqlProvider` based on the factory name string `SqlProviderParser.GetSupportedProvider`. 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
