### PR TITLE
RavenDB_19900: added an option to modify the timeout of GetDatabaseTo…

### DIFF
--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -57,7 +57,7 @@ namespace Raven.Client.Http
 
         public RavenCommandResponseType ResponseType { get; protected set; }
 
-        public TimeSpan? Timeout { get; protected set; }
+        public TimeSpan? Timeout { get; protected internal set; }
         public bool CanCache { get; protected set; }
         public bool CanCacheAggressively { get; protected set; }
         public string SelectedNodeTag { get; protected set; }

--- a/test/SlowTests/Issues/RavenDB_19900.cs
+++ b/test/SlowTests/Issues/RavenDB_19900.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using System;
+using System.Threading;
+using FastTests;
+using Raven.Client.Http;
+
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19900 : RavenTestBase
+    {
+        public RavenDB_19900(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task UpdateTopologyTimeoutBehaviourShouldBeAccordingToConfiguration()
+        {
+            var generalTimeout = TimeSpan.FromSeconds(3);
+            var customCommandTimeout = TimeSpan.FromSeconds(1);
+            var delay = 2000;
+
+            using (var store = GetDocumentStore())
+            {
+                var executor = store.GetRequestExecutor();
+
+                try
+                {
+                    // delaying response should result in UpdateTopology timeout
+                    executor.ForTestingPurposesOnly().DelayRequest = () => { Thread.Sleep(delay); };
+                    executor.ForTestingPurposesOnly().SetCommandTimeout = (command) =>
+                    {
+                        command.Timeout = customCommandTimeout;
+                    };
+                    var e = await Assert.ThrowsAsync<TimeoutException>(async () => await UpdateTopology());
+                    Assert.Contains("failed with timeout after 00:00:01", e.ToString());
+
+                    // increasing the general timeout should let UpdateTopology() to be executed
+                    using (store.SetRequestTimeout(generalTimeout))
+                    {
+                        await UpdateTopology();
+                    }
+
+                    async Task UpdateTopology()
+                    {
+                        var node = executor.GetPreferredNode().Result.Node;
+                        var topologyUpdateCommand = new RequestExecutor.UpdateTopologyParameters(node);
+                        await executor.UpdateTopologyAsync(topologyUpdateCommand);
+                    }
+                }
+                finally
+                {
+                    executor.ForTestingPurposes = null;
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
…pologyCommand

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19900/Allow-to-configure-the-timeout-of-GetDatabaseTopologyCommand

### Additional description
timeout value of `GetDatabaseTopologyCommand` will be the maximum between the general and the command timeout

### Type of change
- Bug fix


### How risky is the change?
- Not relevant

### Backward compatibility
- Not relevant

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
