### PR TITLE
RavenDB-20697 - have topology endpoint return promotables as well

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -19,7 +19,7 @@ namespace Raven.Client.Http
         }
 
         [Obsolete("Not supported", error: true)]
-        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool userPrivateUrls = false)
+        public new static ClusterRequestExecutor Create(string[] urls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions, bool userPrivateUrls = false, bool includePromotables = false)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -132,14 +132,8 @@ namespace Raven.Client.Http
                     await ClusterTopologyLocalCache.TrySavingAsync(TopologyHash, command.Result, Conventions, context, CancellationToken.None).ConfigureAwait(false);
 
                     var results = command.Result;
-                    var nodes = ServerNode.CreateFrom(results.Topology);
+                    var newTopology = ServerNode.CreateFrom(results.Topology, results.Etag);
 
-                    var newTopology = new Topology
-                    {
-                        Nodes = nodes,
-                        Etag = results.Etag
-                    };
-                    
                     UpdateNodeSelector(newTopology, parameters.ForceUpdate);
 
                     OnTopologyUpdatedInvoke(newTopology, parameters.DebugTag);
@@ -176,12 +170,9 @@ namespace Raven.Client.Http
             if (clusterTopology == null)
                 return false;
 
-            var nodes = ServerNode.CreateFrom(clusterTopology.Topology);
+            var topology = ServerNode.CreateFrom(clusterTopology.Topology, 0);
 
-            _nodeSelector = new NodeSelector(new Topology
-            {
-                Nodes = nodes
-            });
+            _nodeSelector = new NodeSelector(topology);
 
             return true;
         }

--- a/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/ClusterTopologyLocalCache.cs
@@ -84,6 +84,7 @@ namespace Raven.Client.Http
                         [nameof(clusterTopology.Topology)] = clusterTopology.Topology.ToJson(),
                         [nameof(clusterTopology.Leader)] = clusterTopology.Leader,
                         [nameof(clusterTopology.NodeTag)] = clusterTopology.NodeTag,
+                        [nameof(clusterTopology.ServerRole)] = clusterTopology.ServerRole,
                         [nameof(clusterTopology.Etag)] = clusterTopology.Etag,
                         ["PersistedAt"] = DateTimeOffset.UtcNow.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite),
                     };

--- a/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
+++ b/src/Raven.Client/Http/DatabaseTopologyLocalCache.cs
@@ -104,6 +104,18 @@ namespace Raven.Client.Http
                         WriteNode(writer, node, context);
                     }
                     writer.WriteEndArray();
+                    
+                    writer.WriteComma();
+                    writer.WritePropertyName(context.GetLazyString(nameof(topology.Promotables)));
+                    writer.WriteStartArray();
+                    for (var i = 0; i < topology.Promotables.Count; i++)
+                    {
+                        var node = topology.Promotables[i];
+                        if (i != 0)
+                            writer.WriteComma();
+                        WriteNode(writer, node, context);
+                    }
+                    writer.WriteEndArray();
 
                     writer.WriteComma();
                     writer.WritePropertyName(context.GetLazyString(nameof(topology.Etag)));

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -12,7 +12,7 @@ namespace Raven.Client.Http
         private sealed class NodeSelectorState
         {
             public readonly Topology Topology;
-            public readonly List<ServerNode> Nodes;
+            public List<ServerNode> Nodes => Topology.Nodes;
             public readonly int[] Failures;
             public readonly int[] FastestRecords;
             public int Fastest;
@@ -22,7 +22,6 @@ namespace Raven.Client.Http
             public NodeSelectorState(Topology topology)
             {
                 Topology = topology;
-                Nodes = topology.Nodes;
                 Failures = new int[topology.Nodes.Count];
                 FastestRecords = new int[topology.Nodes.Count];
                 UnlikelyEveryoneFaultedChoiceIndex = 0;

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -84,15 +84,21 @@ namespace Raven.Client.Http
             _lastServerVersionCheck = 0;
         }
 
-        internal static List<ServerNode> CreateFrom(ClusterTopology topology)
+        internal static Topology CreateFrom(ClusterTopology topology, long etag)
         {
-            var nodes = new List<ServerNode>();
+            var newTopology = new Topology()
+            {
+                Etag = etag,
+                Nodes = new List<ServerNode>(),
+                Promotables = new List<ServerNode>()
+            };
+           
             if (topology == null)
-                return nodes;
-
+                return newTopology;
+            
             foreach (var member in topology.Members)
             {
-                nodes.Add(new ServerNode
+                newTopology.Nodes.Add(new ServerNode
                 {
                     Url = member.Value,
                     ClusterTag = member.Key,
@@ -102,15 +108,15 @@ namespace Raven.Client.Http
 
             foreach (var watcher in topology.Watchers)
             {
-                nodes.Add(new ServerNode
+                newTopology.Nodes.Add(new ServerNode
                 {
                     Url = watcher.Value,
                     ClusterTag = watcher.Key,
                     ServerRole = Role.Member
                 });
             }
-
-            return nodes;
+            
+            return newTopology;
         }
     }
 }

--- a/src/Raven.Client/Http/Topology.cs
+++ b/src/Raven.Client/Http/Topology.cs
@@ -6,5 +6,6 @@ namespace Raven.Client.Http
     {
         public long Etag;
         public List<ServerNode> Nodes;
+        public List<ServerNode> Promotables = new List<ServerNode>();
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -11,6 +11,7 @@ namespace Raven.Client.ServerWide.Commands
         private readonly Guid? _applicationIdentifier;
         private readonly bool _usePrivateUrls;
         private readonly string _debugTag;
+        private readonly bool _includePromotables;
 
         public GetDatabaseTopologyCommand()
         {
@@ -18,10 +19,11 @@ namespace Raven.Client.ServerWide.Commands
             Timeout = TimeSpan.FromSeconds(15);
         }
 
-        internal GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier, bool usePrivateUrls)
+        internal GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier, bool usePrivateUrls, bool includePromotables)
             : this(debugTag, applicationIdentifier)
         {
             _usePrivateUrls = usePrivateUrls;
+            _includePromotables = includePromotables;
         }
 
         public GetDatabaseTopologyCommand(string debugTag, Guid? applicationIdentifier)
@@ -45,6 +47,8 @@ namespace Raven.Client.ServerWide.Commands
                 url += "&applicationIdentifier=" + _applicationIdentifier;
             if (_usePrivateUrls)
                 url += "&private=true";
+            if (_includePromotables)
+                url += "&includePromotables=true";
 
             if (node.Url.IndexOf(".fiddler", StringComparison.OrdinalIgnoreCase) != -1)
             {

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Utils
 
         private static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, GetTcpInfoCommand getTcpInfoCommand, X509Certificate2 certificate, CancellationToken token)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))//TODO stav: createForFixed instead?
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 await requestExecutor.ExecuteAsync(getTcpInfoCommand, context, token: token);

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -109,6 +109,7 @@ namespace Raven.Server.Web.System
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
             var applicationIdentifier = GetStringQueryString("applicationIdentifier", required: false);
             var usePrivate = GetBoolValueQueryString("private", required: false) ?? false;
+            var includePromotables = GetBoolValueQueryString("includePromotables", required: false) ?? false;
 
             if (applicationIdentifier != null)
             {
@@ -184,10 +185,14 @@ namespace Raven.Server.Web.System
                             dbNodes = rawRecord.Topology.Members.Select(x =>
                                     TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Member))
                                 .Concat(rawRecord.Topology.Rehabs.Select(x =>
-                                    TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Rehab))
-                                .Concat(rawRecord.Topology.Promotables.Select(x =>
-                                    TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Promotable)))
-                                );
+                                    TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Rehab)));
+                            
+                            if (includePromotables)
+                            {
+                                dbNodes = dbNodes.Concat(rawRecord.Topology.Promotables.Select(x =>
+                                    TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Promotable)));
+                            }
+
                             stampIndex = rawRecord.Topology.Stamp?.Index ?? -1;
                         }
 

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -185,6 +185,8 @@ namespace Raven.Server.Web.System
                                     TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Member))
                                 .Concat(rawRecord.Topology.Rehabs.Select(x =>
                                     TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Rehab))
+                                .Concat(rawRecord.Topology.Promotables.Select(x =>
+                                    TopologyNodeToJson(x, GetUrl(x, clusterTopology, usePrivate), name, ServerNode.Role.Promotable)))
                                 );
                             stampIndex = rawRecord.Topology.Stamp?.Index ?? -1;
                         }

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -497,11 +497,12 @@ namespace RachisTests.DatabaseCluster
                     await orchestratorRequestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(preferredNode.Node));
                 }
                 
-                var error = await Assert.ThrowsAnyAsync<RavenException>(async () =>
+                var error = await Assert.ThrowsAnyAsync<Exception>(async () =>
                 {
                     await store.Maintenance.SendAsync(new GetEssentialStatisticsOperation("test"));
                 });
-                Assert.Contains("no nodes in the topology", error.Message);
+                Assert.True(error is RavenException || error is AllTopologyNodesDownException);
+                Assert.True(error.Message.Contains("no nodes in the topology") || error.Message.Contains("to all configured nodes in the topology"));
             }
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -236,6 +236,27 @@ public partial class RavenTestBase
             return orchestrator;
         }
 
+        public List<ShardedDatabaseContext> GetOrchestratorsInCluster(string database, List<RavenServer> servers)
+        {
+            var orchestrators = new List<ShardedDatabaseContext>();
+            ShardedDatabaseContext orchestrator = null;
+            foreach (var server in servers)
+            {
+                try
+                {
+                    orchestrator = GetOrchestrator(database, server);
+                }
+                catch (InvalidOperationException)
+                {
+                    // expected
+                }
+            }
+
+            Assert.NotNull(orchestrator);
+            orchestrators.Add(orchestrator);
+            return orchestrators;
+        }
+
         public async Task WaitForOrchestratorsToUpdate(string database, long index)
         {
             var servers = _parent.GetServers();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20697

### Additional description

Studio was trying to fetch info from a promotable node directly, but since topology didn't return promotable nodes (only members and rehabs) then it threw an error.
Promotables are now populated in the topology of the shard executors and proxy executor and `SelectedNodeTag` operations will work for promotables in these executors.

**Regular all-shards requests and other non-`SelectedNodeTag` operations will fail when their only option is a promotable.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed

### Testing by Contributor

- It has been verified by manual testing

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Need to display a message when the promotable node hasn't caught up to the entire index

