### PR TITLE
RavenDB-20898 The new "Test Index" footer does not allow you to selec…

### DIFF
--- a/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
+++ b/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
@@ -247,6 +247,7 @@
 //
 // Note: These variables are not generated into the Customizer.
 @zindex-ace-fullScreenModeLabel: 950;
+@zindex-text-index: 980;
 @zindex-navbar: 1000;
 @zindex-dropdown: 1000;
 @zindex-notification-center: 1035;

--- a/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/edit-index.less
@@ -121,7 +121,7 @@
     .text-index {
         position: sticky;
         bottom: 0;
-        z-index: 1000;
+        z-index: @zindex-text-index;
     }
     .index-test-results {
         position: absolute;


### PR DESCRIPTION
…t "Corax" as indexing engine.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20898/The-new-Test-Index-footer-does-not-allow-you-to-select-Corax-as-indexing-engine.

### Additional description

fix text index z-index

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
