### PR TITLE
RavenDB-20914 await all the tasks when determining the fastest node to avoid leaking the tasks and running them after session is disposed

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1254,6 +1254,8 @@ namespace Raven.Client.Http
         private async Task ExecuteOnAllToFigureOutTheFastest<TResult>(ServerNode chosenNode, RavenCommand<TResult> command, Task<HttpResponseMessage> preferredTask,
             CancellationToken token = default)
         {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
             long numberOfFailedTasks = 0;
 
             var nodes = _nodeSelector.Topology.Nodes;
@@ -1277,7 +1279,7 @@ namespace Raven.Client.Http
                     Interlocked.Increment(ref NumberOfServerRequests);
 
                     var copy = disposable;
-                    tasks[i] = command.SendAsync(HttpClient, request, token).ContinueWith(x =>
+                    tasks[i] = command.SendAsync(HttpClient, request, cts.Token).ContinueWith(x =>
                     {
                         try
                         {
@@ -1296,7 +1298,7 @@ namespace Raven.Client.Http
                         {
                             copy.Dispose();
                         }
-                    }, token);
+                    }, cts.Token);
                 }
                 catch (Exception)
                 {
@@ -1319,9 +1321,33 @@ namespace Raven.Client.Http
                     numberOfFailedTasks++;
                     continue;
                 }
+
                 _nodeSelector.RecordFastest(index, nodes[index]);
+
+                cts.Cancel();
+
+                // we need to await all the tasks to avoid them running after e.g. session is disposed
+                foreach (var task in tasks)
+                {
+                    if (task.IsCompleted || task.IsCanceled || task.IsFaulted)
+                        continue;
+
+                    if (task == NeverEndingRequest)
+                        continue;
+
+                    try
+                    {
+                        await task.ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+
                 return;
             }
+
             // we can reach here if the number of failed task equal to the number
             // of the nodes, in which case we have nothing to do
         }
@@ -1772,7 +1798,7 @@ namespace Raven.Client.Http
 
                 return;
             }
-            
+
             if (serverNode == null)
                 return;
 
@@ -2328,9 +2354,9 @@ namespace Raven.Client.Http
 
             private bool Equals(HttpClientCacheKey other)
             {
-                return _certificateThumbprint == other._certificateThumbprint 
-                       && _useCompression == other._useCompression 
-                       && Nullable.Equals(_pooledConnectionLifetime, other._pooledConnectionLifetime) 
+                return _certificateThumbprint == other._certificateThumbprint
+                       && _useCompression == other._useCompression
+                       && Nullable.Equals(_pooledConnectionLifetime, other._pooledConnectionLifetime)
                        && Nullable.Equals(_pooledConnectionIdleTimeout, other._pooledConnectionIdleTimeout)
                        && _httpClientType == other._httpClientType;
             }

--- a/test/SlowTests/Issues/RavenDB_20914.cs
+++ b/test/SlowTests/Issues/RavenDB_20914.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20914 : ClusterTestBase
+{
+    public RavenDB_20914(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task ReadBalanceBehavior_FastestNode_Should_Not_Leak_Tasks()
+    {
+        var databaseName = GetDatabaseName();
+        var (_, leader) = await CreateRaftCluster(3);
+
+        var (index, _) = await CreateDatabaseInCluster(databaseName, 3, leader.WebUrl);
+        await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(30));
+
+        using (var leaderStore = new DocumentStore
+        {
+            Urls = new[] { leader.WebUrl },
+            Database = databaseName,
+            Conventions =
+            {
+                ReadBalanceBehavior = ReadBalanceBehavior.FastestNode
+            }
+        })
+        {
+            leaderStore.Initialize();
+
+            Task[] tasks = null;
+
+            leaderStore.GetRequestExecutor().ForTestingPurposesOnly().ExecuteOnAllToFigureOutTheFastestOnTaskCompletion = _ => Thread.Sleep(1000);
+            leaderStore.GetRequestExecutor().ForTestingPurposesOnly().ExecuteOnAllToFigureOutTheFastestOnBeforeWait = t => tasks = t;
+
+
+            using (var session = leaderStore.OpenAsyncSession())
+            {
+                await session.Query<object>().ToListAsync();
+            }
+
+            Assert.NotNull(tasks);
+
+            foreach (var task in tasks)
+            {
+                if (task.IsCompleted || task.IsCanceled || task.IsFaulted)
+                    continue;
+
+                if (task == RequestExecutor.NeverEndingRequest)
+                    continue;
+
+                throw new InvalidOperationException("Task is not completed!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20914

### Type of change

- Bug fix


### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
