### PR TITLE
RavenDB-20636 Validate factory name, before adding sql connection string (v6.0)

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Sparrow.Json.Parsing;
@@ -14,6 +15,20 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         protected override void ValidateImpl(ref List<string> errors)
         {
+            // Validate ConnectionString.FactoryName
+            try
+            {
+                SqlProviderParser.GetSupportedProvider(FactoryName);
+            }
+            catch (NotImplementedException)
+            {
+                errors.Add($"Factory '{FactoryName}' is not implemented yet.");
+            }
+            catch (Exception)
+            {
+                errors.Add($"Unsupported factory '{FactoryName}'");
+            }
+            
             if (string.IsNullOrEmpty(ConnectionString))
                 errors.Add($"{nameof(ConnectionString)} cannot be empty");
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForPutConnectionString.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForPutConnectionString.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             List<string> errors = new ();
             if (GetConnectionString(configuration, connectionStringType).Validate(ref errors) == false)
             {
-                throw new BadRequestException($"Invalid connection string configuration. Errors: {string.Join("\n", errors)}");
+                throw new BadRequestException($"Invalid connection string configuration. Errors: {string.Join($"{Environment.NewLine}", errors)}");
             }
         }
         

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForPutConnectionString.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForPutConnectionString.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -25,6 +28,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
 
         protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration, JsonOperationContext context)
         {
+            var connectionStringType = ConnectionString.GetConnectionStringType(configuration);
             switch (ConnectionString.GetConnectionStringType(configuration))
             {
                 case ConnectionStringType.Olap:
@@ -34,7 +38,34 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                     break;
 
             }
+            
+            List<string> errors = new ();
+            if (GetConnectionString(configuration, connectionStringType).Validate(ref errors) == false)
+            {
+                throw new BadRequestException($"Invalid connection string configuration. Errors: {string.Join("\n", errors)}");
+            }
         }
+        
+        private static ConnectionString GetConnectionString(BlittableJsonReaderObject readerObject, ConnectionStringType connectionStringType)
+        {
+            switch (connectionStringType)
+            {
+                case ConnectionStringType.Raven:
+                    return JsonDeserializationCluster.RavenConnectionString(readerObject); 
+                case ConnectionStringType.Sql:
+                    return JsonDeserializationCluster.SqlConnectionString(readerObject);
+                case ConnectionStringType.Olap:
+                    return JsonDeserializationCluster.OlapConnectionString(readerObject);
+                case ConnectionStringType.ElasticSearch:
+                    return JsonDeserializationCluster.ElasticSearchConnectionString(readerObject);
+                case ConnectionStringType.Queue:
+                    return JsonDeserializationCluster.QueueConnectionString(readerObject);
+                case ConnectionStringType.None:
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(connectionStringType), connectionStringType, "Unexpected connection string type.");
+            }
+        }
+        
 
         protected override async Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -70,6 +70,8 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
+            // Validate ConnectionString.FactoryName
+            SqlProviderParser.GetSupportedProvider(ConnectionString.FactoryName);
             record.SqlConnectionStrings[ConnectionString.Name] = ConnectionString;
         }
     }

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -70,8 +70,6 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            // Validate ConnectionString.FactoryName
-            SqlProviderParser.GetSupportedProvider(ConnectionString.FactoryName);
             record.SqlConnectionStrings[ConnectionString.Name] = ConnectionString;
         }
     }

--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 using Sparrow.Platform;
 using Raven.Tests.Core.Utils.Entities;
 
-
 namespace SlowTests.Issues
 {
     public class RavenDB_19948 : RavenTestBase

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -238,7 +238,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [RequiresMsSqlFact]
+        [Fact]
         public void CanGetConnectionStringByName()
         {
             using (var store = GetDocumentStore())
@@ -279,23 +279,26 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [RequiresMsSqlFact]
+        [Fact]
         public void CannotAddSqlConnectionStringWithInvalidFactoryName()
         {
             using (var store = GetDocumentStore())
             {
-                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                var e = Assert.Throws<BadRequestException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
                 {
                     Name = "Invalid Factory Connection String",
                     ConnectionString = "some-connection-string-that-doesnt-matter",
                     FactoryName = "Invalid.Factory.4.20-final.stable"
-                })));
-                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
-                {
-                    Name = "Not-supported Factory Connection String",
-                    ConnectionString = "some-connection-string-that-doesnt-matter",
-                    FactoryName = "System.Data.OleDb"
-                })));
+                }))); 
+                Assert.Contains("Invalid connection string configuration. Errors: Unsupported factory 'Invalid.Factory.4.20-final.stable'", e.Message);
+                
+                e = Assert.Throws<BadRequestException>(()=>store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                    {
+                        Name = "Not-supported Factory Connection String",
+                        ConnectionString = "some-connection-string-that-doesnt-matter",
+                        FactoryName = "System.Data.OleDb"
+                    }))); 
+                Assert.Contains("Raven.Client.Exceptions.BadRequestException: Invalid connection string configuration. Errors: Factory 'System.Data.OleDb' is not implemented yet.", e.Message);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -40,6 +40,7 @@ namespace SlowTests.Server.Documents.ETL
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
 
                 var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -129,6 +130,7 @@ namespace SlowTests.Server.Documents.ETL
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
 
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -198,7 +200,8 @@ namespace SlowTests.Server.Documents.ETL
                     var sqlConnectionStr = new SqlConnectionString
                     {
                         Name = $"SqlConnectionString{i}",
-                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                        FactoryName = "Npgsql"
                     };
                     var elasticConnectionStr = new ElasticSearchConnectionString
                     {
@@ -252,7 +255,8 @@ namespace SlowTests.Server.Documents.ETL
                 var sqlConnectionStr = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "Npgsql"
                 };
                 var elasticConnectionStr = new ElasticSearchConnectionString
                 {

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
@@ -275,6 +276,26 @@ namespace SlowTests.Server.Documents.ETL
                 Assert.True(resultElastic.SqlConnectionStrings.Count == 0);
                 Assert.True(resultElastic.RavenConnectionStrings.Count == 0);
                 Assert.True(resultElastic.ElasticSearchConnectionStrings.Count > 0);
+            }
+        }
+
+        [RequiresMsSqlFact]
+        public void CannotAddSqlConnectionStringWithInvalidFactoryName()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                {
+                    Name = "Invalid Factory Connection String",
+                    ConnectionString = "some-connection-string-that-doesnt-matter",
+                    FactoryName = "Invalid.Factory.4.20-final.stable"
+                })));
+                Assert.Throws<RavenException>(() => store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+                {
+                    Name = "Not-supported Factory Connection String",
+                    ConnectionString = "some-connection-string-that-doesnt-matter",
+                    FactoryName = "System.Data.OleDb"
+                })));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress" });
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);
@@ -73,7 +73,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress" });
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -879,7 +879,8 @@ person.addCounter(loadCounter('down'));
                 var sqlConnectionStr = new SqlConnectionString
                 {
                     Name = "SqlConnectionString",
-                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "System.Data.SqlClient"
                 };
                 ravenConnectionStrings.Add(ravenConnectionStr);
                 sqlConnectionStrings.Add(sqlConnectionStr);
@@ -914,7 +915,8 @@ person.addCounter(loadCounter('down'));
                     var sqlConnectionStr = new SqlConnectionString
                     {
                         Name = $"SqlConnectionString{i}",
-                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}"
+                        ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                        FactoryName = "System.Data.SqlClient"
                     };
 
                     ravenConnectionStrings.Add(ravenConnectionStr);
@@ -960,6 +962,7 @@ person.addCounter(loadCounter('down'));
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "System.Data.SqlClient"
                 };
 
                 var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -1016,6 +1019,7 @@ person.addCounter(loadCounter('down'));
                 {
                     Name = "SqlConnectionString",
                     ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "System.Data.SqlClient"
                 };
 
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -1972,7 +1976,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
 
                 error = Assert.ThrowsAny<RavenException>(() =>
                 {
-                    SetupLocalOlapEtl(src, script: null, path: "", mentor: "A");
+                    SetupLocalOlapEtl(src, script: "some script", path: "./", mentor: "A");
                 });
 
                 Assert.Contains("Choosing a mentor node for an ongoing task is not supported in sharding", error.Message);

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -1983,7 +1983,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
 
                 error = Assert.ThrowsAny<RavenException>(() =>
                 {
-                    SetupSqlEtl(src, connectionString: "", script: null, mentor: "A");
+                    SetupSqlEtl(src, connectionString: "Test", script: null, mentor: "A");
                 });
 
                 Assert.Contains("Choosing a mentor node for an ongoing task is not supported in sharding", error.Message);

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1324,7 +1324,8 @@ namespace SlowTests.Smuggler
 
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<ElasticSearchConnectionString>(new ElasticSearchConnectionString
                 {
-                    Name = "elasticsearch-cs"
+                    Name = "elasticsearch-cs",
+                    Nodes = new[]{"http://127.0.0.1:8080" }
                 }));
 
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(new QueueConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20636/Putting-a-SqlConnectionString-with-invalid-FactoryName-corrupts-the-studio


### Additional description

The same changes from https://github.com/ravendb/ravendb/pull/16881, but rebased (after solving a couple of conflicts) on v6.0.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
