### PR TITLE
RavenDB-20084: Fix backup status update issue for idle databases (logging and test improvements)

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -90,7 +90,7 @@ namespace Raven.Server.Documents
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
             internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
             internal bool ShouldFetchIdleStateImmediately = false;
-            internal Action<Exception> OnFailedRescheduleNextScheduledActivity;
+            internal Action<Exception, string> OnFailedRescheduleNextScheduledActivity;
             internal bool PreventNodePromotion = false;
         }
 
@@ -1156,7 +1156,7 @@ namespace Raven.Server.Documents
                 if (_logger.IsOperationsEnabled)
                     _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
 
-                ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e);
+                ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e, databaseName);
             }
         }
 

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -90,6 +90,7 @@ namespace Raven.Server.Documents
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
             internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
             internal bool ShouldFetchIdleStateImmediately = false;
+            internal Action<Exception> OnFailedRescheduleNextScheduledActivity;
             internal bool PreventNodePromotion = false;
         }
 
@@ -1148,12 +1149,14 @@ namespace Raven.Server.Documents
                     }
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 // we have to swallow any exception here.
 
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
+
+                ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -46,7 +47,7 @@ public class RavenDB_20084 : ClusterTestBase
             leaderStore.Conventions = new DocumentConventions { DisableTopologyUpdates = true };
             leaderStore.Database = databaseName;
             leaderStore.Initialize();
-            var debugInfo = new List<string> { $"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
+            var debugInfo = new ConcurrentBag<string> { $"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
 
             leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().OnFailedRescheduleNextScheduledActivity = (exception, erroredDatabaseName) =>
                 debugInfo.Add($"Failed to schedule the next activity for the idle database '{erroredDatabaseName}': {exception}");

--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -48,8 +48,8 @@ public class RavenDB_20084 : ClusterTestBase
             leaderStore.Initialize();
             var debugInfo = new List<string> { $"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
 
-            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().OnFailedRescheduleNextScheduledActivity = exception =>
-                debugInfo.Add(exception.ToString());
+            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().OnFailedRescheduleNextScheduledActivity = (exception, erroredDatabaseName) =>
+                debugInfo.Add($"Failed to schedule the next activity for the idle database '{erroredDatabaseName}': {exception}");
 
             // Populating the database and forcibly transitioning it to an idle state
             await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 1, leaderStore, clusterSize);

--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -1,27 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Net.Http;
+using System.IO;
 using System.Threading.Tasks;
-using Amazon.S3.Util;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
-using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using XunitLogger;
 
 namespace SlowTests.Issues;
 
@@ -47,119 +41,154 @@ public class RavenDB_20084 : ClusterTestBase
             customSettings: new Dictionary<string, string>()
             {
                 [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1"
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1",
+                [RavenConfiguration.GetKey(x => x.Logs.Mode)] = nameof(LogMode.Information)
             });
 
         await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
 
-        using (var leaderStore = new DocumentStore
-               {
-                   Urls = new[] { leaderServer.WebUrl }, Conventions = new DocumentConventions { DisableTopologyUpdates = true }, Database = databaseName
-               })
+        await using var logStream = new MemoryStream();
+        LoggingSource.Instance.AttachPipeSink(logStream);
+        try
         {
-            leaderStore.Initialize();
-            var debugInfo = new List<string>();
-            debugInfo.Add($"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
-
-            // Populating the database and forcibly transitioning it to an idle state
-            await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 1, leaderStore, clusterSize);
-
-            var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 1", incrementalBackupFrequency: $"*/{backupIntervalInMinutes} * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
-            var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, leaderStore);
-
-            var onGoingTaskBackup = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-            Assert.True(onGoingTaskBackup is { LastFullBackup: { } });
-            var expectedTime = onGoingTaskBackup.NextBackup.DateTime;
-            
-            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
-            leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
-            
-            using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverStoreContext))
-            using (serverStoreContext.OpenReadTransaction())
+            using (var leaderStore = new DocumentStore
+                   {
+                       Urls = new[] { leaderServer.WebUrl }, Conventions = new DocumentConventions { DisableTopologyUpdates = true }, Database = databaseName
+                   })
             {
-                // Ensuring the database is in an idle state
-                WaitForValue( () => leaderServer.ServerStore.IdleDatabases.Count, 
-                    expectedVal: 1,
-                    timeout: Convert.ToInt32(TimeSpan.FromMinutes(5).TotalMilliseconds),
-                    interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
-                Assert.Equal(1, leaderServer.ServerStore.IdleDatabases.Count);
+                leaderStore.Initialize();
+                var debugInfo = new List<string> { $"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
 
-                // No longer forcing the idle state for the database
-                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = false;
-                leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                // Populating the database and forcibly transitioning it to an idle state
+                await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 1, leaderStore, clusterSize);
 
-                // Awaiting the next backup event to verify that the '/database' endpoint provides an updated value for the last incremental backup timestamp
-                var client = leaderStore.GetRequestExecutor().HttpClient;
-                DateTime lastBackupTime = default;
-                await WaitForValueAsync(async () =>
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 1",
+                    incrementalBackupFrequency: $"*/{backupIntervalInMinutes} * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, leaderStore);
+
+                var onGoingTaskBackup = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                Assert.True(onGoingTaskBackup is { LastFullBackup: { } });
+                var expectedTime = onGoingTaskBackup.NextBackup.DateTime;
+
+                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
+                leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+
+                using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverStoreContext))
+                using (serverStoreContext.OpenReadTransaction())
+                {
+                    // Ensuring the database is in an idle state
+                    WaitForValue(() => leaderServer.ServerStore.IdleDatabases.Count,
+                        expectedVal: 1,
+                        timeout: Convert.ToInt32(TimeSpan.FromMinutes(5).TotalMilliseconds),
+                        interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+                    Assert.Equal(1, leaderServer.ServerStore.IdleDatabases.Count);
+
+                    // No longer forcing the idle state for the database
+                    leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = false;
+                    leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+
+                    // Awaiting the next backup event to verify that the '/database' endpoint provides an updated value for the last incremental backup timestamp
+                    var client = leaderStore.GetRequestExecutor().HttpClient;
+                    DateTime lastBackupTime = default;
+                    await WaitForValueAsync(async () =>
+                        {
+                            try
+                            {
+                                var response = await client.GetAsync($"{leaderServer.WebUrl}/databases");
+                                string result = response.Content.ReadAsStringAsync().Result;
+
+                                var databaseResponse = serverStoreContext.Sync.ReadForMemory(result, "Databases");
+
+                                if (databaseResponse.TryGet("Databases", out BlittableJsonReaderArray array) == false)
+                                {
+                                    debugInfo.Add("Unable to get Databases array from context");
+                                    debugInfo.Add(result);
+                                    return false;
+                                }
+
+                                debugInfo.Add($"Successfully extracted Databases array from context, array.Length = '{array.Length}'");
+
+                                if (((BlittableJsonReaderObject)array[0]).TryGet("BackupInfo", out BlittableJsonReaderObject backupInfo) == false)
+                                {
+                                    debugInfo.Add("Unable to get BackupInfo from Database");
+                                    debugInfo.Add(array.ToString());
+                                    return false;
+                                }
+
+                                if (backupInfo == null)
+                                {
+                                    debugInfo.Add("Unable to get BackupInfo from Database");
+                                    debugInfo.Add(array.ToString());
+                                    return false;
+                                }
+
+                                debugInfo.Add("Successfully extracted BackupInfo from Database");
+
+                                if (backupInfo.TryGet("LastBackup", out lastBackupTime) == false)
+                                {
+                                    debugInfo.Add("Unable to get LastBackup from BackupInfo");
+                                    debugInfo.Add(backupInfo.ToString());
+                                    return false;
+                                }
+
+                                debugInfo.Add($"Successfully extracted LastBackup from Database: {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+                            }
+                            catch (Exception e)
+                            {
+                                debugInfo.Add(e.Message);
+                            }
+
+                            return lastBackupTime >= expectedTime;
+                        },
+                        expectedVal: true,
+                        timeout: Convert.ToInt32(TimeSpan.FromMinutes(3).TotalMilliseconds),
+                        interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+
+                    debugInfo.Add($"'lastBackupTime': {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+                    debugInfo.Add($"'expectedTime':   {expectedTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+
+                    var backupInfoUpdated = lastBackupTime >= expectedTime;
+                    if (backupInfoUpdated == false)
                     {
-                        try
-                        {
-                            var response = await client.GetAsync($"{leaderServer.WebUrl}/databases");
-                            string result = response.Content.ReadAsStringAsync().Result;
+                        var response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/databases/idle");
+                        debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/databases/idle");
+                        debugInfo.Add(response.Content.ReadAsStringAsync().Result);
 
-                            var databaseResponse = serverStoreContext.Sync.ReadForMemory(result, "Databases");
+                        response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
+                        debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
+                        debugInfo.Add(response.Content.ReadAsStringAsync().Result);
 
-                            if (databaseResponse.TryGet("Databases", out BlittableJsonReaderArray array) == false)
-                            {
-                                debugInfo.Add("Unable to get Databases array from context");
-                                debugInfo.Add(result);
-                                return false;
-                            }
+                        LoggingSource.Instance.DetachPipeSink();
+                        await logStream.FlushAsync();
+                        debugInfo.Add(Encodings.Utf8.GetString(logStream.ToArray()));
+                    }
 
-                            if (((BlittableJsonReaderObject)array[0]).TryGet("BackupInfo", out BlittableJsonReaderObject backupInfo) == false)
-                            {
-                                debugInfo.Add("Unable to get BackupInfo from Database");
-                                debugInfo.Add(array.ToString());
-                                return false;
-                            }
+                    Assert.True(backupInfoUpdated, $"lastBackupTime >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                    Assert.True(leaderServer.ServerStore.IdleDatabases.Count == 1,
+                        $"leaderServer.ServerStore.IdleDatabases.Count == 1: Count is {leaderServer.ServerStore.IdleDatabases.Count}{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
 
-                            if (backupInfo == null)
-                            {
-                                debugInfo.Add("Unable to get BackupInfo from Database");
-                                debugInfo.Add(array.ToString());
-                                return false;
-                            }
+                    // Verifying that the cluster storage contains the same value for consistency
+                    var operation = new GetPeriodicBackupStatusOperation(taskId);
+                    var backupStatus = (await leaderStore.Maintenance.SendAsync(operation)).Status;
 
-                            if (backupInfo.TryGet("LastBackup", out lastBackupTime) == false)
-                            {
-                                debugInfo.Add("Unable to get LastBackup from BackupInfo");
-                                debugInfo.Add(backupInfo.ToString());
-                                return false;
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            debugInfo.Add(e.Message);
-                        }
+                    var lastBackupTimeInClusterStorage = backupStatus.LastIncrementalBackup > backupStatus.LastFullBackup
+                        ? backupStatus.LastIncrementalBackup
+                        : backupStatus.LastFullBackup;
 
-                        return lastBackupTime >= expectedTime;
-                    },
-                    expectedVal: true,
-                    timeout: Convert.ToInt32(TimeSpan.FromMinutes(5).TotalMilliseconds),
-                    interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+                    var lastInternalBackupTimeInClusterStorage = backupStatus.LastIncrementalBackupInternal > backupStatus.LastFullBackupInternal
+                        ? backupStatus.LastIncrementalBackupInternal
+                        : backupStatus.LastFullBackupInternal;
 
-                debugInfo.Add($"'lastBackupTime': {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
-                debugInfo.Add($"'expectedTime':   {expectedTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
-
-                Assert.True(lastBackupTime >= expectedTime,$"lastBackupTime >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
-                Assert.True(leaderServer.ServerStore.IdleDatabases.Count == 1, $"leaderServer.ServerStore.IdleDatabases.Count == 1: Count is {leaderServer.ServerStore.IdleDatabases.Count}{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
-
-                // Verifying that the cluster storage contains the same value for consistency
-                var operation = new GetPeriodicBackupStatusOperation(taskId);
-                var backupStatus = (await leaderStore.Maintenance.SendAsync(operation)).Status;
-
-                var lastBackupTimeInClusterStorage = backupStatus.LastIncrementalBackup > backupStatus.LastFullBackup
-                    ? backupStatus.LastIncrementalBackup
-                    : backupStatus.LastFullBackup;
-
-                var lastInternalBackupTimeInClusterStorage = backupStatus.LastIncrementalBackupInternal > backupStatus.LastFullBackupInternal
-                    ? backupStatus.LastIncrementalBackupInternal
-                    : backupStatus.LastFullBackupInternal;
-
-                Assert.True(lastBackupTimeInClusterStorage >= expectedTime, $"lastBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
-                Assert.True(lastInternalBackupTimeInClusterStorage >= expectedTime, $"lastInternalBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                    Assert.True(lastBackupTimeInClusterStorage >= expectedTime,
+                        $"lastBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                    Assert.True(lastInternalBackupTimeInClusterStorage >= expectedTime,
+                        $"lastInternalBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+                }
             }
+        }
+        finally
+        {
+            LoggingSource.Instance.DetachPipeSink();
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20347/SlowTests.Issues.RavenDB20084.ShouldUpdateBackupInfoIfDatabaseUnloaded

### Additional description

Another attempt to identify the cause of the test failure.
- Logging has been added in case of "Failed to schedule the next activity for the idle database".
- Collection of logs and their output in case of test failure has been added.

### Type of change

- Improving the informativeness of logs and test errors.

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed