### PR TITLE
RavenDB-20636

### DIFF
--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -16,8 +16,6 @@ using Xunit.Abstractions;
 using Sparrow.Platform;
 using Raven.Tests.Core.Utils.Entities;
 
-
-
 namespace SlowTests.Issues
 {
     public class RavenDB_19948 : RavenTestBase
@@ -299,7 +297,7 @@ namespace SlowTests.Issues
                         GetBackupConfigurationScript = new GetBackupConfigurationScript { Exec = command, Arguments = scriptPath }
                     }
                 };
-               
+
                 var exception = Assert.Throws<RavenException>(() =>
                     store.Maintenance.ForDatabase(dbName).Send(new PutConnectionStringOperation<OlapConnectionString>(olapConnStr)));
                 Assert.Contains(


### PR DESCRIPTION
- validate all connection string types for security clearance
- deserialize only once

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20636

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
