### PR TITLE
RavenDB-19847: Fix for SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.ShouldScheduleNextBackupAfterServerRestartCorrectly()

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2954,7 +2954,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotNull(database);
                 database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
+                await Backup.RunBackupAsync(leaderServer, taskId, leaderStore, opStatus: OperationStatus.InProgress);
                 
                 // Let's delay the backup task to 1 hour
                 var delayDuration = TimeSpan.FromHours(1);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19847/SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.ShouldScheduleNextBackupAfterServerRestartCorrectly

### Additional description

The tests were failing because we were blocking the backup execution by waiting for a `TaskCompletionSource` in `PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution` on one Node, while initiating the backup not specifically on this Node, but across the entire cluster. As a result of cluster instability, the backup task predictably shifted to another Node where backup blocking was not performed.

The situation has been rectified by starting the backup specifically on the Node where the blocking was implemented.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed