### PR TITLE
RavenDB-20915 changed Databases.MaxIdleTimeInSec scope to ServerWideOrPerDatabase

### DIFF
--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Config.Categories
         [Description("Specifies the maximum idle time for the database. After this time an idle database will be unloaded from memeory.")]
         [DefaultValue(900)]
         [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Databases.MaxIdleTimeInSec", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Databases.MaxIdleTimeInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting MaxIdleTime { get; set; }
 
         /// <summary>

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2493,11 +2493,9 @@ namespace Raven.Server.ServerWide
                 {
                     _server.Statistics.MaybePersist(ContextPool, Logger);
 
-                    var maxTimeDatabaseCanBeIdle = Configuration.Databases.MaxIdleTime.AsTimeSpan;
-
                     foreach (var databaseKvp in DatabasesLandlord.LastRecentlyUsed.ForceEnumerateInThreadSafeManner())
                     {
-                        if (CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, maxTimeDatabaseCanBeIdle, statistics: null, out DocumentDatabase database) == false)
+                        if (CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics: null, out DocumentDatabase database) == false)
                             continue;
 
                         var dbIdEtagDictionary = new Dictionary<string, long>();
@@ -2535,7 +2533,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public bool CanUnloadDatabase(StringSegment databaseName, DateTime lastRecentlyUsed, TimeSpan maxTimeDatabaseCanBeIdle, DatabasesDebugHandler.IdleDatabaseStatistics statistics, out DocumentDatabase database)
+        public bool CanUnloadDatabase(StringSegment databaseName, DateTime lastRecentlyUsed, DatabasesDebugHandler.IdleDatabaseStatistics statistics, out DocumentDatabase database)
         {
             database = null;
             var now = SystemTime.UtcNow;
@@ -2544,16 +2542,6 @@ namespace Raven.Server.ServerWide
                 statistics.LastRecentlyUsed = lastRecentlyUsed;
 
             var diff = now - lastRecentlyUsed;
-
-            if (diff <= maxTimeDatabaseCanBeIdle)
-            {
-                if (statistics == null)
-                    return false;
-                else
-                {
-                    statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
-                }
-            }
 
             if (DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out Task<DocumentDatabase> resourceTask) == false
                 || resourceTask == null
@@ -2569,6 +2557,21 @@ namespace Raven.Server.ServerWide
             }
 
             database = resourceTask.Result;
+
+            var maxTimeDatabaseCanBeIdle = database.Configuration.Databases.MaxIdleTime.AsTimeSpan;
+
+            if (statistics != null)
+                statistics.MaxIdleTime = maxTimeDatabaseCanBeIdle;
+
+            if (diff <= maxTimeDatabaseCanBeIdle)
+            {
+                if (statistics == null)
+                    return false;
+                else
+                {
+                    statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
+                }
+            }
 
             if (statistics != null)
                 statistics.IsLoaded = true;

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -16,7 +16,6 @@ namespace Raven.Server.Web.System
         public async Task Idle()
         {
             //var name = GetStringQueryString("name", required: false);
-
             var maxTimeDatabaseCanBeIdle = ServerStore.Configuration.Databases.MaxIdleTime.AsTimeSpan;
             var results = new List<DynamicJsonValue>();
 
@@ -27,7 +26,7 @@ namespace Raven.Server.Web.System
                     Name = databaseKvp.Key.ToString()
                 };
 
-                statistics.CanCleanup = ServerStore.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, maxTimeDatabaseCanBeIdle, statistics, out _);
+                statistics.CanCleanup = ServerStore.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics, out _);
 
                 results.Add(statistics.ToJson());
             }
@@ -60,6 +59,8 @@ namespace Raven.Server.Web.System
 
             public string Name { get; set; }
 
+            public TimeSpan? MaxIdleTime { get; set; }
+
             public DateTime LastRecentlyUsed { get; set; }
 
             public DateTime LastWork { get; set; }
@@ -85,6 +86,7 @@ namespace Raven.Server.Web.System
                 return new DynamicJsonValue
                 {
                     [nameof(Name)] = Name,
+                    [nameof(MaxIdleTime)] = MaxIdleTime,
                     [nameof(LastRecentlyUsed)] = LastRecentlyUsed,
                     [nameof(LastWork)] = LastWork,
                     [nameof(IsLoaded)] = IsLoaded,

--- a/test/SlowTests/Issues/RavenDB_20915.cs
+++ b/test/SlowTests/Issues/RavenDB_20915.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20915 : RavenTestBase
+{
+    public RavenDB_20915(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Configuration)]
+    public async Task Allow_To_Set_MaxIdleTime_Per_Database()
+    {
+        UseNewLocalServer(new Dictionary<string, string>
+        {
+            { RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle), "1" }
+        });
+
+        using (var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false,
+            ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "1"
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "HR" });
+                await session.SaveChangesAsync(); // update last work time
+            }
+
+            Server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
+
+            Assert.False(WaitForValue(() => Server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(store.Database, out _), false));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20915

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
