### PR TITLE
RavenDB-19629 Atomic guard is out of sync if it was deleted in a regular tx

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
@@ -21,6 +21,7 @@ namespace Raven.Client.Documents.Commands
         private readonly string[] _includes;
         private readonly string[] _counters;
         private readonly bool _includeAllCounters;
+        private bool _includeAtomicGuardsForMissingDocuments;
 
         private readonly IEnumerable<AbstractTimeSeriesRange> _timeSeriesIncludes;
         private readonly IEnumerable<string> _revisionsIncludeByChangeVector;
@@ -102,6 +103,8 @@ namespace Raven.Client.Documents.Commands
                 .Append(node.Database)
                 .Append("/docs?");
 
+            if (_includeAtomicGuardsForMissingDocuments)
+                pathBuilder.Append("&includeAtomicGuardsForMissingDocuments=true");
             if (_start.HasValue)
                 pathBuilder.Append("&start=").Append(_start);
             if (_pageSize.HasValue)
@@ -265,5 +268,10 @@ namespace Raven.Client.Documents.Commands
         }
 
         public override bool IsReadRequest => true;
+
+        public void IncludeAtomicGuardsForMissingDocuments()
+        {
+            _includeAtomicGuardsForMissingDocuments = true;
+        }
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
@@ -104,7 +104,7 @@ namespace Raven.Client.Documents.Commands
                 .Append("/docs?");
 
             if (_loadFromClusterWideTx)
-                pathBuilder.Append("&loadFromClusterWideTx=true");
+                pathBuilder.Append("&txMode=ClusterWide");
             if (_start.HasValue)
                 pathBuilder.Append("&start=").Append(_start);
             if (_pageSize.HasValue)
@@ -269,7 +269,7 @@ namespace Raven.Client.Documents.Commands
 
         public override bool IsReadRequest => true;
 
-        public void FromClusterWideTx()
+        internal void FromClusterWideTx()
         {
             _loadFromClusterWideTx = true;
         }

--- a/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
@@ -21,7 +21,7 @@ namespace Raven.Client.Documents.Commands
         private readonly string[] _includes;
         private readonly string[] _counters;
         private readonly bool _includeAllCounters;
-        private bool _includeAtomicGuardsForMissingDocuments;
+        private bool _loadFromClusterWideTx;
 
         private readonly IEnumerable<AbstractTimeSeriesRange> _timeSeriesIncludes;
         private readonly IEnumerable<string> _revisionsIncludeByChangeVector;
@@ -103,8 +103,8 @@ namespace Raven.Client.Documents.Commands
                 .Append(node.Database)
                 .Append("/docs?");
 
-            if (_includeAtomicGuardsForMissingDocuments)
-                pathBuilder.Append("&includeAtomicGuardsForMissingDocuments=true");
+            if (_loadFromClusterWideTx)
+                pathBuilder.Append("&loadFromClusterWideTx=true");
             if (_start.HasValue)
                 pathBuilder.Append("&start=").Append(_start);
             if (_pageSize.HasValue)
@@ -269,9 +269,9 @@ namespace Raven.Client.Documents.Commands
 
         public override bool IsReadRequest => true;
 
-        public void IncludeAtomicGuardsForMissingDocuments()
+        public void FromClusterWideTx()
         {
-            _includeAtomicGuardsForMissingDocuments = true;
+            _loadFromClusterWideTx = true;
         }
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
@@ -21,7 +22,7 @@ namespace Raven.Client.Documents.Commands
         private readonly string[] _includes;
         private readonly string[] _counters;
         private readonly bool _includeAllCounters;
-        private bool _loadFromClusterWideTx;
+        private TransactionMode _txMode;
 
         private readonly IEnumerable<AbstractTimeSeriesRange> _timeSeriesIncludes;
         private readonly IEnumerable<string> _revisionsIncludeByChangeVector;
@@ -66,7 +67,7 @@ namespace Raven.Client.Documents.Commands
             _timeSeriesIncludes = timeSeriesIncludes;
             _compareExchangeValueIncludes = compareExchangeValueIncludes;
         }
-        
+
         public GetDocumentsCommand(string[] ids, string[] includes, string[] counterIncludes, IEnumerable<string> revisionsIncludesByChangeVector, DateTime? revisionIncludeByDateTimeBefore, IEnumerable<AbstractTimeSeriesRange> timeSeriesIncludes, string[] compareExchangeValueIncludes, bool metadataOnly)
             : this(ids, includes, metadataOnly)
         {
@@ -103,7 +104,7 @@ namespace Raven.Client.Documents.Commands
                 .Append(node.Database)
                 .Append("/docs?");
 
-            if (_loadFromClusterWideTx)
+            if (_txMode == TransactionMode.ClusterWide)
                 pathBuilder.Append("&txMode=ClusterWide");
             if (_start.HasValue)
                 pathBuilder.Append("&start=").Append(_start);
@@ -179,7 +180,7 @@ namespace Raven.Client.Documents.Commands
                     pathBuilder.Append("&revisions=").Append(Uri.EscapeDataString(changeVector));
                 }
             }
-            
+
             if (_revisionsIncludeByDateTime != null)
             {
                 pathBuilder.Append("&revisionsBefore=").Append(Uri.EscapeDataString(_revisionsIncludeByDateTime.Value.GetDefaultRavenFormat()));
@@ -269,9 +270,9 @@ namespace Raven.Client.Documents.Commands
 
         public override bool IsReadRequest => true;
 
-        internal void FromClusterWideTx()
+        internal void SetTransactionMode(TransactionMode mode)
         {
-            _loadFromClusterWideTx = true;
+            _txMode = mode;
         }
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetDocumentsResult.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsResult.cs
@@ -17,7 +17,5 @@ namespace Raven.Client.Documents.Commands
         public BlittableJsonReaderObject CompareExchangeValueIncludes { get; set; }
 
         public int NextPageStart { get; set; }
-
-        public string ClusterTransactionId { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Commands/GetDocumentsResult.cs
+++ b/src/Raven.Client/Documents/Commands/GetDocumentsResult.cs
@@ -17,5 +17,7 @@ namespace Raven.Client.Documents.Commands
         public BlittableJsonReaderObject CompareExchangeValueIncludes { get; set; }
 
         public int NextPageStart { get; set; }
+
+        public string ClusterTransactionId { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValue.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Json;
 
 namespace Raven.Client.Documents.Operations.CompareExchange
@@ -10,6 +11,8 @@ namespace Raven.Client.Documents.Operations.CompareExchange
         public long Index { get; internal set; }
         public T Value { get; set; }
 
+        public string ChangeVector { get; set; }
+        
         public IMetadataDictionary Metadata => _metadataAsDictionary ??= new MetadataAsDictionary();
 
         private IMetadataDictionary _metadataAsDictionary;
@@ -25,11 +28,17 @@ namespace Raven.Client.Documents.Operations.CompareExchange
         IMetadataDictionary ICompareExchangeValue.Metadata => Metadata;
         bool ICompareExchangeValue.HasMetadata => HasMetadata;
 
-        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata = null)
+        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata = null) : this(key, index, value, metadata, null)
+        {
+            
+        }
+        
+        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata, string changeVector)
         {
             Key = key;
             Index = index;
             Value = value;
+            ChangeVector = changeVector;
             _metadataAsDictionary = metadata;
         }
     }

--- a/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValue.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValue.cs
@@ -11,7 +11,7 @@ namespace Raven.Client.Documents.Operations.CompareExchange
         public long Index { get; internal set; }
         public T Value { get; set; }
 
-        public string ChangeVector { get; set; }
+        public string ChangeVector { get; internal set; }
         
         public IMetadataDictionary Metadata => _metadataAsDictionary ??= new MetadataAsDictionary();
 
@@ -28,12 +28,13 @@ namespace Raven.Client.Documents.Operations.CompareExchange
         IMetadataDictionary ICompareExchangeValue.Metadata => Metadata;
         bool ICompareExchangeValue.HasMetadata => HasMetadata;
 
-        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata = null) : this(key, index, value, metadata, null)
+        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata = null) 
+            : this(key, index, value, changeVector: null, metadata)
         {
             
         }
         
-        public CompareExchangeValue(string key, long index, T value, IMetadataDictionary metadata, string changeVector)
+        internal CompareExchangeValue(string key, long index, T value, string changeVector, IMetadataDictionary metadata)
         {
             Key = key;
             Index = index;

--- a/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValueResultParser.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValueResultParser.cs
@@ -86,12 +86,12 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             var type = typeof(T);
 
             if (raw == null)
-                return new CompareExchangeValue<T>(key, index, default, null, cv);
+                return new CompareExchangeValue<T>(key, index, default, cv, metadata: null);
 
             MetadataAsDictionary metadata = null;
             if (raw.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject bjro) && bjro != null)
             {
-                metadata = materializeMetadata == false 
+                metadata = materializeMetadata == false
                     ? new MetadataAsDictionary(bjro)
                     : MetadataAsDictionary.MaterializeFromBlittable(bjro);
             }
@@ -100,34 +100,34 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             {
                 // simple
                 raw.TryGet(Constants.CompareExchange.ObjectFieldName, out T value);
-                return new CompareExchangeValue<T>(key, index, value, metadata, cv);
+                return new CompareExchangeValue<T>(key, index, value, cv, metadata);
             }
 
             if (type == typeof(BlittableJsonReaderObject))
             {
                 if (raw.TryGetMember(Constants.CompareExchange.ObjectFieldName, out object rawValue) == false)
                 {
-                    return new CompareExchangeValue<T>(key, index, default, metadata, cv);
+                    return new CompareExchangeValue<T>(key, index, default, cv, metadata);
                 }
 
                 switch (rawValue)
                 {
                     case null:
-                        return new CompareExchangeValue<T>(key, index, default, metadata, cv);
+                        return new CompareExchangeValue<T>(key, index, default, cv, metadata);
                     case BlittableJsonReaderObject _:
-                        return new CompareExchangeValue<T>(key, index, (T)rawValue, metadata, cv);
+                        return new CompareExchangeValue<T>(key, index, (T)rawValue, cv, metadata);
                     default:
-                        return new CompareExchangeValue<T>(key, index, (T)(object)raw, metadata, cv);
+                        return new CompareExchangeValue<T>(key, index, (T)(object)raw, cv, metadata);
                 }
             }
 
             if (raw.TryGetMember(Constants.CompareExchange.ObjectFieldName, out _) == false)
             {
-                return new CompareExchangeValue<T>(key, index, default, metadata, cv);
+                return new CompareExchangeValue<T>(key, index, default, cv, metadata);
             }
 
             var converted = conventions.Serialization.DefaultConverter.FromBlittable<ResultHolder>(raw);
-            return new CompareExchangeValue<T>(key, index, converted.Object, metadata, cv);
+            return new CompareExchangeValue<T>(key, index, converted.Object, cv, metadata);
         }
 
         private class ResultHolder

--- a/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValueResultParser.cs
+++ b/src/Raven.Client/Documents/Operations/CompareExchange/CompareExchangeValueResultParser.cs
@@ -81,11 +81,12 @@ namespace Raven.Client.Documents.Operations.CompareExchange
                 throw new InvalidDataException("Response is invalid. Index is missing.");
             if (item.TryGet(nameof(CompareExchangeValue<T>.Value), out BlittableJsonReaderObject raw) == false)
                 throw new InvalidDataException("Response is invalid. Value is missing.");
+            item.TryGet(nameof(CompareExchangeValue<T>.ChangeVector), out string cv);
 
             var type = typeof(T);
 
             if (raw == null)
-                return new CompareExchangeValue<T>(key, index, default);
+                return new CompareExchangeValue<T>(key, index, default, null, cv);
 
             MetadataAsDictionary metadata = null;
             if (raw.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject bjro) && bjro != null)
@@ -99,34 +100,34 @@ namespace Raven.Client.Documents.Operations.CompareExchange
             {
                 // simple
                 raw.TryGet(Constants.CompareExchange.ObjectFieldName, out T value);
-                return new CompareExchangeValue<T>(key, index, value, metadata);
+                return new CompareExchangeValue<T>(key, index, value, metadata, cv);
             }
 
             if (type == typeof(BlittableJsonReaderObject))
             {
                 if (raw.TryGetMember(Constants.CompareExchange.ObjectFieldName, out object rawValue) == false)
                 {
-                    return new CompareExchangeValue<T>(key, index, default, metadata);
+                    return new CompareExchangeValue<T>(key, index, default, metadata, cv);
                 }
 
                 switch (rawValue)
                 {
                     case null:
-                        return new CompareExchangeValue<T>(key, index, default, metadata);
+                        return new CompareExchangeValue<T>(key, index, default, metadata, cv);
                     case BlittableJsonReaderObject _:
-                        return new CompareExchangeValue<T>(key, index, (T)rawValue, metadata);
+                        return new CompareExchangeValue<T>(key, index, (T)rawValue, metadata, cv);
                     default:
-                        return new CompareExchangeValue<T>(key, index, (T)(object)raw, metadata);
+                        return new CompareExchangeValue<T>(key, index, (T)(object)raw, metadata, cv);
                 }
             }
 
             if (raw.TryGetMember(Constants.CompareExchange.ObjectFieldName, out _) == false)
             {
-                return new CompareExchangeValue<T>(key, index, default, metadata);
+                return new CompareExchangeValue<T>(key, index, default, metadata, cv);
             }
 
             var converted = conventions.Serialization.DefaultConverter.FromBlittable<ResultHolder>(raw);
-            return new CompareExchangeValue<T>(key, index, converted.Object, metadata);
+            return new CompareExchangeValue<T>(key, index, converted.Object, metadata, cv);
         }
 
         private class ResultHolder

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -42,7 +42,7 @@ namespace Raven.Client.Documents.Session
         {
             if (_missingDocumentsToAtomicGuardIndex?.TryGetValue(docId, out var index) == true)
             {
-                changeVector = $"RAFT:{index}-{_clusterTransactionId}";
+                changeVector = $"TXRN:{index}-{_clusterTransactionId}";
                 return true;
             }
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -816,6 +816,14 @@ more responsive application.
             if (id != null)
                 _knownMissingIds.Remove(id);
 
+            if (TransactionMode == TransactionMode.ClusterWide)
+            {
+                if (changeVector == null)
+                {
+                    GetClusterSession().TryGetMissingAtomicGuardFor(id, out changeVector);
+                }
+            }
+
             var documentInfo = new DocumentInfo
             {
                 Id = id,

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -45,8 +45,7 @@ namespace Raven.Client.Documents.Session.Operations
                 : new GetDocumentsCommand(_ids, _includes, _countersToInclude, _revisionsToIncludeByChangeVector, _revisionsToIncludeByDateTimeBefore,
                     _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
 
-            if (_session.TransactionMode == TransactionMode.ClusterWide)
-                cmd.FromClusterWideTx();
+            cmd.SetTransactionMode(_session.TransactionMode);
             return cmd;
         }
 

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -46,7 +46,7 @@ namespace Raven.Client.Documents.Session.Operations
                     _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
 
             if (_session.TransactionMode == TransactionMode.ClusterWide)
-                cmd.IncludeAtomicGuardsForMissingDocuments();
+                cmd.FromClusterWideTx();
             return cmd;
         }
 

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -228,7 +228,6 @@ namespace Raven.Client.Documents.Session.Operations
             {
                 var clusterSession = _session.GetClusterSession();
                 clusterSession.RegisterCompareExchangeValues(result.CompareExchangeValueIncludes, includingMissingAtomicGuards);
-                clusterSession.SetClusterTransactionId(result.ClusterTransactionId);
             }
 
             foreach (var document in GetDocumentsFromResult(result))

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -39,10 +39,15 @@ namespace Raven.Client.Documents.Session.Operations
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Requesting the following ids '{string.Join(", ", _ids)}' from {_session.StoreIdentifier}");
 
-            if (_includeAllCounters)
-                return new GetDocumentsCommand(_ids, _includes, includeAllCounters: true, timeSeriesIncludes: _timeSeriesToInclude, compareExchangeValueIncludes: _compareExchangeValuesToInclude, metadataOnly: false);
-            
-            return new GetDocumentsCommand(_ids, _includes, _countersToInclude, _revisionsToIncludeByChangeVector, _revisionsToIncludeByDateTimeBefore, _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
+            var cmd = _includeAllCounters
+                ? new GetDocumentsCommand(_ids, _includes, includeAllCounters: true, timeSeriesIncludes: _timeSeriesToInclude,
+                    compareExchangeValueIncludes: _compareExchangeValuesToInclude, metadataOnly: false)
+                : new GetDocumentsCommand(_ids, _includes, _countersToInclude, _revisionsToIncludeByChangeVector, _revisionsToIncludeByDateTimeBefore,
+                    _timeSeriesToInclude, _compareExchangeValuesToInclude, metadataOnly: false);
+
+            if (_session.TransactionMode == TransactionMode.ClusterWide)
+                cmd.IncludeAtomicGuardsForMissingDocuments();
+            return cmd;
         }
 
         public LoadOperation ById(string id)
@@ -218,9 +223,12 @@ namespace Raven.Client.Documents.Session.Operations
                _session.RegisterRevisionIncludes(result.RevisionIncludes);
             }
 
-            if (_compareExchangeValuesToInclude != null)
+            var includingMissingAtomicGuards = _session.TransactionMode == TransactionMode.ClusterWide;
+            if (_compareExchangeValuesToInclude != null || includingMissingAtomicGuards)
             {
-                _session.GetClusterSession().RegisterCompareExchangeValues(result.CompareExchangeValueIncludes);
+                var clusterSession = _session.GetClusterSession();
+                clusterSession.RegisterCompareExchangeValues(result.CompareExchangeValueIncludes, includingMissingAtomicGuards);
+                clusterSession.SetClusterTransactionId(result.ClusterTransactionId);
             }
 
             foreach (var document in GetDocumentsFromResult(result))

--- a/src/Raven.Client/Documents/Session/Operations/QueryOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/QueryOperation.cs
@@ -186,7 +186,7 @@ namespace Raven.Client.Documents.Session.Operations
                         queryResult.TimeSeriesIncludes);
                 }
                 if (queryResult.CompareExchangeValueIncludes != null)
-                    _session.GetClusterSession().RegisterCompareExchangeValues(queryResult.CompareExchangeValueIncludes);
+                    _session.GetClusterSession().RegisterCompareExchangeValues(queryResult.CompareExchangeValueIncludes, includingMissingAtomicGuards: false);
 
                 if (queryResult.RevisionIncludes != null) 
                     _session.RegisterRevisionIncludes(queryResult.RevisionIncludes);

--- a/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
@@ -63,13 +63,18 @@ namespace Raven.Server.Documents.Includes
             if (_includes == null || _includes.Length == 0)
                 return;
 
-            if (_includedKeys == null)
-                _includedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _includedKeys ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var include in _includes)
                 IncludeUtil.GetDocIdFromInclude(document.Data, new StringSegment(include), _includedKeys, _database.IdentityPartsSeparator);
         }
 
+        public void AddDocument(string id)
+        {
+            _includedKeys ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _includedKeys.Add(id);
+        }
+        
         internal void Materialize()
         {
             if (_includedKeys == null || _includedKeys.Count == 0)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3290,10 +3290,10 @@ namespace Raven.Server.Documents.Indexes
                                         token.Token);
                                 }
 
+                                long lastRaftId = DocumentDatabase.RachisLogIndexNotifications.LastModifiedIndex;
                                 try
                                 {
                                     var enumerator = documents.GetEnumerator();
-
                                     if (pulseDocsReadingTransaction)
                                     {
                                         var originalEnumerator = enumerator;
@@ -3352,7 +3352,7 @@ namespace Raven.Server.Documents.Indexes
                                 using (fillScope?.Start())
                                 {
                                     includeDocumentsCommand.Fill(resultToFill.Includes);
-                                    includeCompareExchangeValuesCommand?.Materialize();
+                                    includeCompareExchangeValuesCommand?.Materialize(lastRaftId);
                                 }
 
                                 if (includeCountersCommand != null)

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -145,6 +145,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 var scannedResults = new Reference<int>();
                 IEnumerator<Document> enumerator;
 
+                var lastRaftId = Database.RachisLogIndexNotifications.LastModifiedIndex;
                 if (pulseReadingTransaction == false)
                 {
                     var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, fieldsToFetch, collection, query, queryScope, context.Documents,
@@ -238,7 +239,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 {
                     includeDocumentsCommand.Fill(resultToFill.Includes);
 
-                    includeCompareExchangeValuesCommand.Materialize();
+                    includeCompareExchangeValuesCommand.Materialize(lastRaftId);
                 }
 
                 if (includeCompareExchangeValuesCommand != null)

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1779,6 +1779,13 @@ namespace Raven.Server.Json
                 writer.WritePropertyName(nameof(kvp.Value));
                 writer.WriteObject(kvp.Value.Value);
 
+                if (kvp.Value.ChangeVector != null)
+                {
+                    writer.WriteComma();
+                    writer.WritePropertyName(nameof(kvp.Value.ChangeVector));
+                    writer.WriteString(kvp.Value.ChangeVector);
+                }
+
                 writer.WriteEndObject();
 
                 await writer.MaybeFlushAsync(token);

--- a/test/SlowTests/Issues/RavenDB-19629.cs
+++ b/test/SlowTests/Issues/RavenDB-19629.cs
@@ -11,6 +11,36 @@ public class RavenDB_19629 : RavenTestBase
     public RavenDB_19629(ITestOutputHelper output) : base(output)
     {
     }
+    [Fact]
+    public async Task CanDeleteCmpXchgValue2()
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            await session.StoreAsync(new User { Name = "arava" }, "users/arava");
+            await session.SaveChangesAsync();
+        }
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Delete("users/arava");
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "arava-new" }, "users/arava");
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            var arava = await session.LoadAsync<User>("users/arava");
+            arava.Name = "new-new";
+            await session.SaveChangesAsync();
+        }
+    }
     
     [Fact]
     public async Task TestSessionMixture2()
@@ -45,5 +75,8 @@ public class RavenDB_19629 : RavenTestBase
     }
 
 
-    private record User();
+    private class User
+    {
+        public string Name;
+    };
 }

--- a/test/SlowTests/Issues/RavenDB-19629.cs
+++ b/test/SlowTests/Issues/RavenDB-19629.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19629 : RavenTestBase
+{
+    public RavenDB_19629(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public async Task TestSessionMixture2()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession(new SessionOptions
+                   {
+                       TransactionMode = TransactionMode.ClusterWide
+                   }))
+            {
+                await session.StoreAsync(new User(),"foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession(new SessionOptions
+                   {
+                       TransactionMode = TransactionMode.ClusterWide
+                   }))
+            {
+                var user = await session.LoadAsync<User>("foo/bar");
+                Assert.Null(user);
+                await session.StoreAsync(new User(),"foo/bar");
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+
+    private record User();
+}

--- a/test/SlowTests/Issues/RavenDB-19629.cs
+++ b/test/SlowTests/Issues/RavenDB-19629.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,8 @@ public class RavenDB_19629 : RavenTestBase
     public RavenDB_19629(ITestOutputHelper output) : base(output)
     {
     }
-    [Fact]
+
+    [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
     public async Task CanDeleteCmpXchgValue2()
     {
         using var store = GetDocumentStore();
@@ -21,7 +23,7 @@ public class RavenDB_19629 : RavenTestBase
             await session.StoreAsync(new User { Name = "arava" }, "users/arava");
             await session.SaveChangesAsync();
         }
-        
+
         using (var session = store.OpenAsyncSession())
         {
             session.Delete("users/arava");
@@ -41,18 +43,18 @@ public class RavenDB_19629 : RavenTestBase
             await session.SaveChangesAsync();
         }
     }
-    
-    [Fact]
+
+    [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
     public async Task TestSessionMixture2()
     {
         using (var store = GetDocumentStore())
         {
             using (var session = store.OpenAsyncSession(new SessionOptions
-                   {
-                       TransactionMode = TransactionMode.ClusterWide
-                   }))
             {
-                await session.StoreAsync(new User(),"foo/bar");
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(new User(), "foo/bar");
                 await session.SaveChangesAsync();
             }
 
@@ -62,13 +64,13 @@ public class RavenDB_19629 : RavenTestBase
                 await session.SaveChangesAsync();
             }
             using (var session = store.OpenAsyncSession(new SessionOptions
-                   {
-                       TransactionMode = TransactionMode.ClusterWide
-                   }))
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
             {
                 var user = await session.LoadAsync<User>("foo/bar");
                 Assert.Null(user);
-                await session.StoreAsync(new User(),"foo/bar");
+                await session.StoreAsync(new User(), "foo/bar");
                 await session.SaveChangesAsync();
             }
         }


### PR DESCRIPTION
When we attempt to load a document in a cluster wide transaction, and it is missing, we now also fetch the associated atomic guard.
That enables us to handle scenarios where the deletion happened outside of a cluster wide transaction.
When we save the "new" document, we'll attach to it the existing index (missing) that we had for the atomic guard, so everything works.


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19629/Atomic-guard-is-out-of-sync-if-it-was-deleted-in-a-regular-tx


### Additional description

Now when a cluster wide transaction is loading a document that was deleted in a normal transaction, it'll get back its atomic guard (that was orphaned) and be able to proceed from there.

### Type of change

- Bug fix

### How risky is the change?

- Low 
- 
### Backward compatibility

This is both backward & forward compatible. 
Older servers on newer clients will just ignore this (resulting in the same behavior)
Older clients on newer servers will not trigger this

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

