### PR TITLE
RavenDB-20762 Write result of CompareExchangeCommandBase on each command request context

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -51,16 +51,9 @@ namespace Raven.Server.Documents.Handlers.Admin
                 try
                 {
                     var command = CommandBase.CreateFrom(commandJson);
-                    switch (command)
-                    {
-                        case AddOrUpdateCompareExchangeBatchCommand batchCmpExchangeCommand:
-                            batchCmpExchangeCommand.ContextToWriteResult = context;
-                            break;
-
-                        case CompareExchangeCommandBase cmpExchange:
-                            cmpExchange.ContextToWriteResult = context;
-                            break;
-                    }
+                    if (command is IContextResultCommand contextResultCommand)
+                        contextResultCommand.ContextToWriteResult = context;
+                    
                     if (TrafficWatchManager.HasRegisteredClients)
                         AddStringToHttpContext(commandJson.ToString(), TrafficWatchChangeType.ClusterCommands);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -51,8 +51,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                 try
                 {
                     var command = CommandBase.CreateFrom(commandJson);
-                    if (command is IContextResultCommand contextResultCommand)
-                        contextResultCommand.ContextToWriteResult = context;
+                    if (command is IBlittableResultCommand blittableResultCommand)
+                        blittableResultCommand.ContextToWriteResult = context;
                     
                     if (TrafficWatchManager.HasRegisteredClients)
                         AddStringToHttpContext(commandJson.ToString(), TrafficWatchChangeType.ClusterCommands);

--- a/src/Raven.Server/Rachis/BlittableResultWriter.cs
+++ b/src/Raven.Server/Rachis/BlittableResultWriter.cs
@@ -1,0 +1,31 @@
+using System;
+using Sparrow.Threading;
+
+namespace Raven.Server.Rachis;
+
+public class BlittableResultWriter(Func<object, object> writeResultFunc) : IDisposable
+{
+    private readonly SingleUseFlag _invalid = new SingleUseFlag();
+
+    public object Result { private set; get; }
+
+    public void CopyResult(object result)
+    {
+        lock (this)
+        {
+            Result =  _invalid.IsRaised() 
+                ? null : 
+                writeResultFunc.Invoke(result);
+        }
+    }
+
+    public void InvalidateWriter()
+    {
+        lock (this)
+        {
+            _invalid.Raise();
+        }
+    }
+
+    public void Dispose() => InvalidateWriter();
+}

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -768,6 +768,7 @@ namespace Raven.Server.Rachis
                                 continue;
                             }
 
+                            list.Add(cmd.Tcs);
                             _engine.InvokeBeforeAppendToRaftLog(context, cmd.Command);
 
                             if (_engine.LogHistory.HasHistoryLog(context, cmd.Command.UniqueRequestId, out var index, out var result, out var exception))
@@ -791,6 +792,7 @@ namespace Raven.Server.Rachis
 
                                         cmd.Tcs.TrySetResult(Task.FromResult<(long, object)>((index, result)));
                                     }
+                                    list.Remove(cmd.Tcs);
                                     continue;
                                 }
                             }
@@ -800,7 +802,6 @@ namespace Raven.Server.Rachis
                                 var cmdJson = context.ReadObject(djv, "raft/command");
                                 index = _engine.InsertToLeaderLog(context, Term, cmdJson, RachisEntryFlags.StateMachineCommand);
                             }
-                            list.Add(cmd.Tcs);
 
                             if (_entries.TryGetValue(index, out var state) == false)
                             {

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -784,6 +784,8 @@ namespace Raven.Server.Rachis
                                         if (result != null && cmd.BlittableResultWriter != null)
                                         {
                                             cmd.BlittableResultWriter.CopyResult(result);
+                                            //The result are consumed by the `CopyResult` and the context of the result from `HasHistoryLog` is not valid outside
+                                            //so we `TrySetResult` to null to make sure no use of invalid context 
                                             result = null;
                                         }
 

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -434,13 +434,17 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public unsafe bool HasHistoryLog(ClusterOperationContext context, BlittableJsonReaderObject cmd, out long index, out object result, out Exception exception)
+        public bool HasHistoryLog(ClusterOperationContext context, BlittableJsonReaderObject cmd, out long index, out object result, out Exception exception)
+        {
+            var guid = GetGuidFromCommand(cmd);
+            return HasHistoryLog(context, guid, out index, out result, out exception);
+        }
+        public unsafe bool HasHistoryLog(ClusterOperationContext context, string guid, out long index, out object result, out Exception exception)
         {
             result = null;
             exception = null;
             index = 0;
 
-            var guid = GetGuidFromCommand(cmd);
             if (guid == null) // shouldn't happened in new cluster version!
                 return false;
 

--- a/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
@@ -8,23 +8,19 @@ namespace Raven.Server.ServerWide.Commands
     {
         public List<AddOrUpdateCompareExchangeCommand> Commands;
         public List<RemoveCompareExchangeCommand> RemoveCommands;
-        [JsonDeserializationIgnore]
-        public JsonOperationContext ContextToWriteResult;
 
         public AddOrUpdateCompareExchangeBatchCommand()
         {
         }
 
-        public AddOrUpdateCompareExchangeBatchCommand(List<AddOrUpdateCompareExchangeCommand> addCommands, JsonOperationContext contextToWriteResult, string uniqueRequestId) : base(uniqueRequestId)
+        public AddOrUpdateCompareExchangeBatchCommand(List<AddOrUpdateCompareExchangeCommand> addCommands, string uniqueRequestId) : base(uniqueRequestId)
         {
             Commands = addCommands;
-            ContextToWriteResult = contextToWriteResult;
         }
 
-        public AddOrUpdateCompareExchangeBatchCommand(List<RemoveCompareExchangeCommand> removeCommands, JsonOperationContext contextToWriteResult, string uniqueRequestId) : base(uniqueRequestId)
+        public AddOrUpdateCompareExchangeBatchCommand(List<RemoveCompareExchangeCommand> removeCommands, string uniqueRequestId) : base(uniqueRequestId)
         {
             RemoveCommands = removeCommands;
-            ContextToWriteResult = contextToWriteResult;
         }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AddOrUpdateCompareExchangeBatchCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Raven.Server.Rachis;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -11,9 +10,6 @@ namespace Raven.Server.ServerWide.Commands
         public List<RemoveCompareExchangeCommand> RemoveCommands;
         [JsonDeserializationIgnore]
         public JsonOperationContext ContextToWriteResult;
-
-        [JsonDeserializationIgnore]
-        public Leader.ConvertResultAction ConvertResultAction;
 
         public AddOrUpdateCompareExchangeBatchCommand()
         {

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -15,7 +15,7 @@ using Voron.Data.Tables;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public abstract class CompareExchangeCommandBase : CommandBase, IContextResultCommand
+    public abstract class CompareExchangeCommandBase : CommandBase, IBlittableResultCommand
     {
         public string Key;
         public string Database;
@@ -186,7 +186,7 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        object IContextResultCommand.WriteResult(object result)
+        object IBlittableResultCommand.WriteResult(object result)
         {
             var compareExchangeResult =  result switch
             {

--- a/src/Raven.Server/ServerWide/Commands/IBlittableResultCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IBlittableResultCommand.cs
@@ -2,7 +2,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.ServerWide.Commands;
 
-public interface IContextResultCommand
+public interface IBlittableResultCommand
 {
     public JsonOperationContext ContextToWriteResult { set; }
 

--- a/src/Raven.Server/ServerWide/Commands/IContextResultCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IContextResultCommand.cs
@@ -1,0 +1,10 @@
+using Sparrow.Json;
+
+namespace Raven.Server.ServerWide.Commands;
+
+public interface IContextResultCommand
+{
+    public JsonOperationContext ContextToWriteResult { set; }
+
+    public object WriteResult(object result);
+}

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -759,7 +759,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (_compareExchangeAddOrUpdateCommands.Count == 0)
                     return;
 
-                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(context, new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, context, RaftIdGenerator.DontCareId));
+                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, context, RaftIdGenerator.DontCareId));
                 foreach (var command in _compareExchangeAddOrUpdateCommands)
                 {
                     command.Value.Dispose();
@@ -773,7 +773,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (_compareExchangeRemoveCommands.Count == 0)
                     return;
-                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(context, new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, context, RaftIdGenerator.DontCareId));
+                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, context, RaftIdGenerator.DontCareId));
                 _compareExchangeRemoveCommands.Clear();
 
                 _lastAddOrUpdateOrRemoveResultIndex = addOrUpdateResult.Index;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -759,7 +759,7 @@ namespace Raven.Server.Smuggler.Documents
                 if (_compareExchangeAddOrUpdateCommands.Count == 0)
                     return;
 
-                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, context, RaftIdGenerator.DontCareId));
+                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeAddOrUpdateCommands, RaftIdGenerator.DontCareId));
                 foreach (var command in _compareExchangeAddOrUpdateCommands)
                 {
                     command.Value.Dispose();
@@ -773,7 +773,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (_compareExchangeRemoveCommands.Count == 0)
                     return;
-                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, context, RaftIdGenerator.DontCareId));
+                var addOrUpdateResult = await _database.ServerStore.SendToLeaderAsync(new AddOrUpdateCompareExchangeBatchCommand(_compareExchangeRemoveCommands, RaftIdGenerator.DontCareId));
                 _compareExchangeRemoveCommands.Clear();
 
                 _lastAddOrUpdateOrRemoveResultIndex = addOrUpdateResult.Index;

--- a/src/Raven.Server/Web/System/CompareExchangeHandler.cs
+++ b/src/Raven.Server/Web/System/CompareExchangeHandler.cs
@@ -137,7 +137,7 @@ namespace Raven.Server.Web.System
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
                     ServerStore.ForTestingPurposes?.ModifyCompareExchangeTimeout?.Invoke(command);
-                    (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(context, command);
+                    (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(command);
                     await ServerStore.Cluster.WaitForIndexNotification(raftIndex);
 
                     var result = (CompareExchangeCommandBase.CompareExchangeResult)response;
@@ -167,7 +167,7 @@ namespace Raven.Server.Web.System
                 var command = new RemoveCompareExchangeCommand(Database.Name, key, index, context, raftRequestId);
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
-                    (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(context, command);
+                    (var raftIndex, var response) = await ServerStore.SendToLeaderAsync(command);
                     await ServerStore.Cluster.WaitForIndexNotification(raftIndex);
 
                     var result = (CompareExchangeCommandBase.CompareExchangeResult)response;

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Cluster;
+
+public class CompareExchangeTests : RavenTestBase
+{
+    public CompareExchangeTests(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public async Task AddOrUpdateCompareExchangeCommand_WhenCommandSentTwice_SecondAttemptShouldNotReturnNull()
+    {
+        var leader = GetNewServer();
+        using var store = GetDocumentStore(new Options { Server = leader});
+
+        var longCommandTasks =  Enumerable.Range(0, 5 * 1024).Select(i => Task.Run(async () =>
+        {
+            string uniqueRequestId = RaftIdGenerator.NewId();
+            string mykey = $"mykey{i}";
+            _ = Task.Run(async () =>
+            {
+                using JsonOperationContext context = JsonOperationContext.ShortTermSingleUse();
+                var value = context.ReadObject(new DynamicJsonValue {[$"prop{i}"] = "my value"}, "compare exchange");
+                var toRunTwiceCommand1 = new AddOrUpdateCompareExchangeCommand(store.Database, mykey, value, 0, context, uniqueRequestId);
+                toRunTwiceCommand1.Timeout = TimeSpan.FromSeconds(1);
+                await leader.ServerStore.Engine.CurrentLeader.PutAsync(toRunTwiceCommand1, toRunTwiceCommand1.Timeout.Value);
+            });
+
+            await Task.Delay(1);
+                
+            using JsonOperationContext context = JsonOperationContext.ShortTermSingleUse();
+            var value = context.ReadObject(new DynamicJsonValue {[$"prop{i}"] = "my value"}, "compare exchange");
+            var toRunTwiceCommand2 = new AddOrUpdateCompareExchangeCommand(store.Database, mykey, value, 0, context, uniqueRequestId);
+            toRunTwiceCommand2.Timeout = TimeSpan.FromSeconds(40);
+            var (_, result) = await leader.ServerStore.Engine.CurrentLeader.PutAsync(toRunTwiceCommand2, toRunTwiceCommand2.Timeout.Value);
+            Assert.NotNull(result);
+            var compareExchangeResult = (CompareExchangeCommandBase.CompareExchangeResult)result;
+            Assert.Equal(value, compareExchangeResult.Value);
+        })).ToArray();
+
+        await Task.WhenAll(longCommandTasks);
+    }
+}

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -18,7 +18,7 @@ public class CompareExchangeTests : RavenTestBase
     {
     }
     
-    [NightlyBuildFact]
+    [Fact]
     public async Task AddOrUpdateCompareExchangeCommand_WhenCommandSentTwice_SecondAttemptShouldNotReturnNull()
     {
         var leader = GetNewServer();

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -6,6 +6,7 @@ using Raven.Client.Util;
 using Raven.Server.ServerWide.Commands;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,7 +18,7 @@ public class CompareExchangeTests : RavenTestBase
     {
     }
     
-    [Fact]
+    [NightlyBuildFact]
     public async Task AddOrUpdateCompareExchangeCommand_WhenCommandSentTwice_SecondAttemptShouldNotReturnNull()
     {
         var leader = GetNewServer();

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -18,7 +18,7 @@ public class CompareExchangeTests : RavenTestBase
     {
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.CompareExchange)]
     public async Task AddOrUpdateCompareExchangeCommand_WhenCommandSentTwice_SecondAttemptShouldNotReturnNull()
     {
         var leader = GetNewServer();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20762

### Additional description
The base issue is that the results of put/delete compare exchange commands are billable and need context.
The implementation is using the context of the command.
The current issue happens when there are two attempts to run the same command.
* Each command contains a guid created on the client to identify a second command is a second attempt of the same command

In the previous implementation, we used the context of the first attempt for both attempt results.
If the first command fails for timeout we mark his context as invalid and we return null in future access so potentially the second attempt can get null.
Basically from the RaveDB client perspective, the second attempt is the attempt it waits for.

The solution here is to write the result in each command attempt context.
In the previous implementation, we used one `GetConvertResult` for all command attempts.
Now there is one (`GetConvertResult` -> `CtxResultWriter`) for each attempt.

### Type of change
- Bug fix

### How risky is the change?
- High

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
