### PR TITLE
RavenDB-20926 Include query parameters in `IndexEntries` query.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1307,7 +1307,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 take = CoraxConstants.IndexSearcher.TakeAll;
 
             IQueryMatch queryMatch;
-            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, null, query, _index, null, null, _fieldMappings, null, null, -1, indexReadOperation: this, token: token);
+            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, null, query, _index, query.QueryParameters, QueryBuilderFactories, _fieldMappings, null, null, -1, indexReadOperation: this, token: token);
             if ((queryMatch = CoraxQueryBuilder.BuildQuery(builderParameters, out _)) is null)
                 yield break;
 

--- a/test/SlowTests/Issues/RavenDB_11097.cs
+++ b/test/SlowTests/Issues/RavenDB_11097.cs
@@ -147,11 +147,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    private void DocumentJsMapWithoutQueryAndIndexName()
+    private void DocumentJsMapWithoutQueryAndIndexName(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -309,11 +309,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    private void DocumentLinqMultimapReduce()
+    private void DocumentLinqMultimapReduce(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -807,10 +807,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void CheckIfOutputReduceToCollectionDoesNotStoreDocumentsForTestIndex()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CheckIfOutputReduceToCollectionDoesNotStoreDocumentsForTestIndex(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -854,10 +855,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void TestMaxDocumentsToProcessParameter()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TestMaxDocumentsToProcessParameter(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -922,8 +924,9 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void TestMaxDocumentsToProcessParameterWithMultipleBatches()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TestMaxDocumentsToProcessParameterWithMultipleBatches(Options options)
     {
         using (var server = GetNewServer(new ServerCreationOptions()
                {
@@ -933,7 +936,10 @@ public class RavenDB_11097 : RavenTestBase
                    }
                }))
         {
-            using (var store = GetDocumentStore(new Options(){ Server = server }))
+            using (var store = GetDocumentStore(new Options()
+                   {
+                       Server = server,
+                   }))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1011,10 +1017,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void MapWithLoadDocument()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MapWithLoadDocument(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -1083,10 +1090,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void TestQueryParametersParameter()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TestQueryParametersParameter(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -1139,10 +1147,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void TestDocumentsWithNestedProperty()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TestDocumentsWithNestedProperty(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
@@ -1183,10 +1192,11 @@ public class RavenDB_11097 : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes)]
-    public void InvalidIndexNameInQueryShouldThrow()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void InvalidIndexNameInQueryShouldThrow(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {

--- a/test/SlowTests/Issues/RavenDB_11097.cs
+++ b/test/SlowTests/Issues/RavenDB_11097.cs
@@ -405,7 +405,7 @@ public class RavenDB_11097 : RavenTestBase
     }
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void TimeSeriesLinqMap(Options options) => TestMapIndexOnTimeSeries(options,
         new TestIndexParameters()
         {
@@ -421,7 +421,7 @@ public class RavenDB_11097 : RavenTestBase
         });
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void TimeSeriesJsMap(Options options) => TestMapIndexOnTimeSeries(options,
         new TestIndexParameters()
         {
@@ -506,7 +506,7 @@ public class RavenDB_11097 : RavenTestBase
     }
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void TimeSeriesLinqMapReduce(Options options) => TestMapReduceIndexOnTimeSeries(options,
         new TestIndexParameters()
         {
@@ -523,7 +523,7 @@ public class RavenDB_11097 : RavenTestBase
         });
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void TimeSeriesJsMapReduce(Options options) => TestMapReduceIndexOnTimeSeries(options,
         new TestIndexParameters()
         {
@@ -611,7 +611,7 @@ public class RavenDB_11097 : RavenTestBase
     }
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void CountersLinqMap(Options options) => TestMapIndexOnCounters(options,
         new TestIndexParameters()
         {
@@ -626,7 +626,7 @@ public class RavenDB_11097 : RavenTestBase
         });
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void CountersJsMap(Options options) => TestMapIndexOnCounters(options,
         new TestIndexParameters()
         {
@@ -711,7 +711,7 @@ public class RavenDB_11097 : RavenTestBase
     }
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void CountersLinqMapReduce(Options options) => TestMapReduceIndexOnCounters(options,
         new TestIndexParameters()
         {
@@ -728,7 +728,7 @@ public class RavenDB_11097 : RavenTestBase
         });
     
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     private void CountersJsMapReduce(Options options) => TestMapReduceIndexOnCounters(options,
         new TestIndexParameters()
         {

--- a/test/SlowTests/Issues/RavenDB_72.cs
+++ b/test/SlowTests/Issues/RavenDB_72.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,10 +17,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public void CanWork()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanWork(Options options)
         {
-            using (var store = GetDocumentStore())
+            using var store = GetDocumentStore(options);
             {
                 const string searchQuery = "Doe";
 
@@ -49,10 +51,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public void CanWork2()
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanWork2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using var store = GetDocumentStore(options);
             {
                 const string searchQuery = "Doe";
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20926 

### Additional description

Pass parameters from query into query builder in case of `IndexEntries` query.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
