### PR TITLE
RavenDB-19967: Notification/warning about tombstone cleaner subscribers disabled (Studio part)

### DIFF
--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -56,6 +56,8 @@ import studioSettings = require("common/settings/studioSettings");
 import optimizeIndexDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/optimizeIndexDetails");
 import mismatchedReferenceLoadDetails
     from "viewmodels/common/notificationCenter/detailViewer/alerts/mismatchedReferenceLoadDetails";
+import blockingTombstonesDetails
+    from "viewmodels/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails";
 
 interface detailsProvider {
     supportsDetailsFor(notification: abstractNotification): boolean;
@@ -175,6 +177,7 @@ class notificationCenter {
             newVersionAvailableDetails,
             etlTransformOrLoadErrorDetails,
             mismatchedReferenceLoadDetails,
+            blockingTombstonesDetails,
 
             genericAlertDetails  // leave it as last item on this list - this is fallback handler for all alert types
         );

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.ts
@@ -1,0 +1,85 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import alert = require("common/notifications/models/alert");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import abstractAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/abstractAlertDetails");
+import genUtils from "common/generalUtils";
+
+interface WarningItem {
+    source: string;
+    collection: string;
+    count: number;
+}
+
+class blockingTombstonesDetails extends abstractAlertDetails {
+    
+    view = require("views/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.html");
+
+    tableItems: WarningItem[] = [];
+    private gridController = ko.observable<virtualGridController<WarningItem>>();
+    private columnPreview = new columnPreviewPlugin<WarningItem>();
+
+    constructor(alert: alert, notificationCenter: notificationCenter) {
+        super(alert, notificationCenter);
+
+        const warning = this.alert.details() as any;
+        const detailsList = warning.BlockingTombstones as Raven.Server.NotificationCenter.TombstoneNotifications.BlockingTombstoneDetails[];
+        
+        this.tableItems = detailsList.map(x => ({
+            source: x.Source,
+            collection: x.Collection,
+            count: x.NumberOfTombstones
+        }));
+    }
+    
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(() => this.fetcher(), () => {
+            const sourceColumn = new textColumn<WarningItem>(grid, x => x.source, "Source", "35%", {
+                sortable: x => x.source
+            });
+            const collectionColumn = new textColumn<WarningItem>(grid, x => x.collection, "Collection", "40%", {
+                sortable: x => x.collection
+            });
+            const countColumn = new textColumn<WarningItem>(grid, x => x.count, "Tombstones count", "25%");
+
+            return [sourceColumn, collectionColumn, countColumn];
+        });
+        
+        
+        this.columnPreview.install(".blockingTombstonesDetails", ".js-blocking-tombstones-detials-tooltip",
+            (details: WarningItem,
+             column: textColumn<WarningItem>,
+             e: JQueryEventObject, onValue: (context: any, valueToCopy?: string) => void) => {
+                const value = column.getCellValue(details);
+                if (value) {
+                    onValue(genUtils.escapeHtml(value), value);
+                }
+            });
+    }
+    
+    private fetcher(): JQueryPromise<pagedResult<WarningItem>> {
+        return $.Deferred<pagedResult<WarningItem>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+    
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof alert) && notification.alertType() === "BlockingTombstones";
+    }
+
+    static showDetailsFor(alert: alert, center: notificationCenter) {
+        return app.showBootstrapDialog(new blockingTombstonesDetails(alert, center));
+    }
+}
+
+export = blockingTombstonesDetails;

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.html
@@ -1,0 +1,23 @@
+<div class="modal-dialog modal-lg blockingTombstonesDetails" id="js-blocking-tombstones-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: alert">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: alert.message"></h3>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-blocking-tombstones-detials-tooltip" style="opacity: 0">
+</div>

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -85,6 +85,7 @@ using Raven.Server.Documents.Studio;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Integrations.PostgreSQL.Handlers;
+using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.NotificationCenter.Notifications.Server;
@@ -240,6 +241,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(HugeDocumentsDetails));
             scripter.AddType(typeof(HugeDocumentInfo));
             scripter.AddType(typeof(MismatchedReferencesLoadWarning));
+            scripter.AddType(typeof(TombstoneNotifications.BlockingTombstoneDetails));
             scripter.AddType(typeof(RequestLatencyDetail));
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));
             scripter.AddType(typeof(IndexingReferenceLoadWarning));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.

### Additional description

1. Reworded notification's title and message.
2. Clarified the source name of the `Tombstones` blockage.
3. Extended test coverage to assert valid display of `Tombstones` blockage source.
4. Added handling for the case of `Tombstones` blockage when disabling hub/sink replication and all types of `Etl`s.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.