### PR TITLE
RavenDB-20927 Corax: can delete null/empty from stored values.

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1058,6 +1058,10 @@ namespace Corax
             reader.Reset();
             while (reader.MoveNextStoredField())
             {
+                //Null/empty is not stored in container, just exists as marker.
+                 if (reader.TermId == -1)
+                     continue;
+                
                 Container.Delete(llt, _storedFieldsContainerId, reader.TermId);
             }
             reader.Reset();

--- a/test/SlowTests/Issues/RavenDB_20927.cs
+++ b/test/SlowTests/Issues/RavenDB_20927.cs
@@ -1,0 +1,50 @@
+
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20927 : RavenTestBase
+{
+    public RavenDB_20927(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanStoreEmptyOrNullAndCanDeleteIt()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenSession())
+        {
+            new EmptyStoredIndex().Execute(store);
+            session.Store(new Document("", 1), "doc/1");
+            session.Advanced.WaitForIndexesAfterSaveChanges();
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            session.Delete("doc/1");
+            session.SaveChanges();
+            var errors = Indexes.WaitForIndexingErrors(store, new[] {new EmptyStoredIndex().IndexName}, errorsShouldExists: false);
+            Assert.Null(errors);
+        }
+    }
+    
+    private record Document(string Name, int Count);
+
+    private class EmptyStoredIndex : AbstractIndexCreationTask<Document>
+    {
+        public EmptyStoredIndex()
+        {
+            Map = docs => from doc in docs
+                select new {EmptyValue = new string[] { }, NullValue = (object)null};
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20927 

### Additional description

Corax: can delete null/empty from stored values.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
