### PR TITLE
RavenDB-19967: Notification/warning about tombstone cleaner subscribers disabled (failing test fix)

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -307,7 +307,7 @@ namespace SlowTests.Issues
                 switch (etlType)
                 {
                     case EtlType.Raven:
-                        var ravenConnectionString = new RavenConnectionString { Name = store.Identifier };
+                        var ravenConnectionString = new RavenConnectionString { Name = store.Identifier, Database = store.Database, TopologyDiscoveryUrls = store.Urls };
                         var ravenConfiguration = new RavenEtlConfiguration { Name = _customTaskName, ConnectionStringName = ravenConnectionString.Name, Transforms = { transforms } };
                         await AddEtlDisableItAndSetTaskName(store, ravenConnectionString, ravenConfiguration, OngoingTaskType.RavenEtl);
                         expectedSource = $"RavenDB ETL task '{_customTaskName}'";
@@ -325,14 +325,14 @@ namespace SlowTests.Issues
                         expectedSource = $"OLAP ETL task '{_customTaskName}'";
                         break;
                     case EtlType.ElasticSearch:
-                        var elasticConnectionString = new ElasticSearchConnectionString { Name = store.Identifier };
+                        var elasticConnectionString = new ElasticSearchConnectionString { Name = store.Identifier, Nodes = new[] { "http://127.0.0.1:8080"} };
                         var elasticConfiguration = new ElasticSearchEtlConfiguration { Name = _customTaskName, ConnectionStringName = elasticConnectionString.Name, Transforms = { transforms } };
                         await AddEtlDisableItAndSetTaskName(store, elasticConnectionString, elasticConfiguration, OngoingTaskType.ElasticSearchEtl);
                         expectedSource = $"ElasticSearch ETL task '{_customTaskName}'";
                         break;
                     case EtlType.Queue:
                         var queueConnectionString = new QueueConnectionString { Name = store.Identifier, BrokerType = QueueBrokerType.RabbitMq, RabbitMqConnectionSettings = new RabbitMqConnectionSettings { ConnectionString = "test" } };
-                        var queueConfiguration = new QueueEtlConfiguration { Name = _customTaskName, ConnectionStringName = queueConnectionString.Name, Transforms = { transforms } };
+                        var queueConfiguration = new QueueEtlConfiguration { Name = _customTaskName, ConnectionStringName = queueConnectionString.Name, Transforms = { transforms }, BrokerType = QueueBrokerType.RabbitMq};
                         await AddEtlDisableItAndSetTaskName(store, queueConnectionString, queueConfiguration, OngoingTaskType.QueueEtl);
                         expectedSource = $"Queue ETL task '{_customTaskName}'";
                         break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.

### Additional description

1. Reworded notification's title and message.
2. Clarified the source name of the `Tombstones` blockage.
3. Extended test coverage to assert valid display of `Tombstones` blockage source.
4. Added handling for the case of `Tombstones` blockage when disabling hub/sink replication and all types of `Etl`s.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio.