### PR TITLE
RavenDB-20901 properly counting number of returned items, we now are iterating one item more to check if we haven't encountered e.g. counter group where all the items contain same etag

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Test/TestIndexRun.cs
+++ b/src/Raven.Server/Documents/Indexes/Test/TestIndexRun.cs
@@ -42,6 +42,17 @@ public class TestIndexRun
         return new TestIndexWriteOperation(writer, index);
     }
 
+    public void HandleCanContinueBatch(Index.CanContinueBatchResult result, string collection)
+    {
+        Debug.Assert(result is Index.CanContinueBatchResult.False or Index.CanContinueBatchResult.RenewTransaction, $"{result} is Index.CanContinueBatchResult.False or Index.CanContinueBatchResult.RenewTransaction");
+
+        if (_collectionTracker.TryGetValue(collection, out var stats) == false)
+            return;
+
+        stats.CountOfReturnedItems--;
+        stats.Completed = stats.CountOfReturnedItems > _docsToProcessPerCollection;
+    }
+
     public IEnumerable<IndexItem> CreateEnumeratorWrapper(IEnumerable<IndexItem> enumerator, string collection)
     {
         if (_collectionTracker.TryGetValue(collection, out var stats) == false)

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -104,12 +104,20 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     {
                                         if (batchContinuationResult == Index.CanContinueBatchResult.False)
                                         {
+                                            if (_index.TestRun != null)
+                                                _index.TestRun.HandleCanContinueBatch(batchContinuationResult, collection);
+
                                             keepRunning = false;
                                             break;
                                         }
 
                                         if (batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction)
+                                        {
+                                            if (_index.TestRun != null)
+                                                _index.TestRun.HandleCanContinueBatch(batchContinuationResult, collection);
+
                                             break;
+                                        }
 
                                         if (totalProcessedCount >= pageSize)
                                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20901

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
