### PR TITLE
RavenDB-19967: Notification/warning about tombstone cleaner subscribers disabled

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
@@ -6,18 +6,16 @@
 
 using System.Diagnostics;
 using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
-    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible, ITombstoneDeletionBlocker
+    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible
     {
         public string Name { get; set; }
         public long TaskId { get; set; }
         public bool Disabled { get; set; }
-        public string BlockingSourceName => $"{BackupType} '{Name}'";
         public string MentorNode { get; set; }
         public bool PinToMentorNode { get; set; }
         public RetentionPolicy RetentionPolicy { get; set; }

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
@@ -23,8 +23,6 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
 
         public override EtlType EtlType => EtlType.ElasticSearch;
 
-        public override string BlockingSourceName => $"ElasticSearch ETL task '{Name}'";
-
         public override bool UsingEncryptedCommunicationChannel()
         {
             foreach (var url in Connection.Nodes)

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -5,13 +5,12 @@ using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
-    public abstract class EtlConfiguration<T> : IDynamicJsonValueConvertible, IDatabaseTask, ITombstoneDeletionBlocker where T : ConnectionString
+    public abstract class EtlConfiguration<T> : IDynamicJsonValueConvertible, IDatabaseTask where T : ConnectionString
     {
         private bool _initialized;
 
@@ -42,9 +41,7 @@ namespace Raven.Client.Documents.Operations.ETL
         public List<Transformation> Transforms { get; set; } = new List<Transformation>();
 
         public bool Disabled { get; set; }
-
-        public abstract string BlockingSourceName { get; }
-
+        
         public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
         {
             if (validateConnection && _initialized == false)

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
@@ -27,8 +27,6 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
         public override EtlType EtlType => EtlType.Olap;
 
-        public override string BlockingSourceName => $"OLAP ETL task '{Name}'";
-
         public override bool UsingEncryptedCommunicationChannel()
         {
             if (Connection.FtpSettings == null)

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -35,8 +35,6 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
         }
 
         public override EtlType EtlType => EtlType.Queue;
-
-        public override string BlockingSourceName => $"Queue ETL task '{Name}'";
         
         public override bool UsingEncryptedCommunicationChannel()
         {

--- a/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
@@ -11,8 +11,6 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public override EtlType EtlType => EtlType.Raven;
 
-        public override string BlockingSourceName => $"RavenDB ETL task '{Name}'";
-
         public override string GetDestination()
         {
             return _destination ?? (_destination = $"{Connection.Database}@{string.Join(",",Connection.TopologyDiscoveryUrls)}");

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -26,8 +26,6 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override EtlType EtlType => EtlType.Sql;
 
-        public override string BlockingSourceName => $"SQL ETL task '{Name}'";
-
         public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
         {
             base.Validate(out errors, validateName, validateConnection);

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public class ExternalReplication : ExternalReplicationBase, IExternalReplication, ITombstoneDeletionBlocker
+    public class ExternalReplication : ExternalReplicationBase, IExternalReplication
     {
         public ExternalReplication()
         {

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -152,7 +152,5 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             return PinToMentorNode;
         }
-
-        public override string BlockingSourceName => $"External Replication '{Name}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -41,7 +41,5 @@ namespace Raven.Client.Documents.Operations.Replication
                 return hashCode;
             }
         }
-
-        public override string BlockingSourceName => $"Internal Replication '{FromString()}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -95,7 +95,5 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             return $"Replication Sink for {HubName}";
         }
-
-        public override string BlockingSourceName => $"Replication Sink task '{Name}'";
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Replication.Messages;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public class PullReplicationDefinition : IDynamicJsonValueConvertible, ITombstoneDeletionBlocker
+    public class PullReplicationDefinition : IDynamicJsonValueConvertible
     {
         [Obsolete("You cannot use Certificates on the PullReplicationDefinition any more, please use the dedicated commands: RegisterReplicationHubAccessOperation and UnregisterReplicationHubAccessOperation")]
         public Dictionary<string, string> Certificates; // <thumbprint, base64 cert>
 
         public TimeSpan DelayReplicationFor;
-        public bool Disabled { get; set; }
+        public bool Disabled;
 
         public string MentorNode;
 
@@ -113,8 +112,6 @@ namespace Raven.Client.Documents.Operations.Replication
                 TaskId = taskId
             };
         }
-
-        public string BlockingSourceName => $"Replication Hub task '{Name}'";
     }
 
     [Flags]

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -5,7 +5,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Sparrow;
 using Sparrow.Json.Parsing;
 
@@ -14,7 +13,7 @@ namespace Raven.Client.Documents.Replication
     /// <summary>
     /// Data class for replication destination
     /// </summary>
-    public abstract class ReplicationNode : IEquatable<ReplicationNode>, ITombstoneDeletionBlocker
+    public abstract class ReplicationNode : IEquatable<ReplicationNode>
     {
         /// <summary>
         /// The name of the connection string specified in the 
@@ -49,8 +48,6 @@ namespace Raven.Client.Documents.Replication
         /// Used to indicate whether external replication is disabled.
         /// </summary>
         public bool Disabled { get; set; }
-
-        public abstract string BlockingSourceName { get; } 
 
         public bool Equals(ReplicationNode other) => IsEqualTo(other);
 

--- a/src/Raven.Client/ServerWide/Operations/OngoingTasks/ITombstoneDeletionBlocker.cs
+++ b/src/Raven.Client/ServerWide/Operations/OngoingTasks/ITombstoneDeletionBlocker.cs
@@ -1,7 +1,0 @@
-﻿namespace Raven.Client.ServerWide.Operations.OngoingTasks;
-
-public interface ITombstoneDeletionBlocker
-{
-    string BlockingSourceName { get; }
-    bool Disabled { get; set; }
-}

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1354,7 +1354,7 @@ namespace Raven.Server.Documents
         public long TombstonesSizeForCollectionInBytes(DocumentsOperationContext context, string collection)
         {
             var table = GetTombstoneTableForCollection(context, collection);
-            return table?.GetReport(includeDetails: false).DataSizeInBytes ?? 0;
+            return table?.GetReport(includeDetails: false).AllocatedSpaceInBytes ?? 0;
         }
 
         public IEnumerable<Tombstone> GetTombstonesFrom(

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1351,7 +1351,7 @@ namespace Raven.Server.Documents
             return table?.NumberOfEntries ?? 0;
         }
 
-        public long TombstonesSizeForCollection(DocumentsOperationContext context, string collection)
+        public long TombstonesSizeForCollectionInBytes(DocumentsOperationContext context, string collection)
         {
             var table = GetTombstoneTableForCollection(context, collection);
             return table?.GetReport(includeDetails: false).DataSizeInBytes ?? 0;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -27,6 +27,7 @@ using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Extensions;
 using Raven.Server.Json;
+using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -1916,18 +1917,40 @@ namespace Raven.Server.Documents.Replication
             return result;
         }
 
-        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        public Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
-            var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            var dict = new Dictionary<TombstoneDeletionBlockageSource, HashSet<string>>();
 
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
+                foreach (var _ in Destinations.Where(config => config.Disabled))
+                {
+                    var source = new TombstoneDeletionBlockageSource(ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication);
+                    dict[source] = tombstoneCollections;
+                }
+                
                 var rawDatabase = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name);
-                TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, Destinations, tombstoneCollections);
-                TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, rawDatabase?.ExternalReplications, tombstoneCollections);
-                TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, rawDatabase?.HubPullReplications, tombstoneCollections);
-                TombstoneCleaner.AssignTombstonesToDisabledConfigs(dict, rawDatabase?.SinkPullReplications, tombstoneCollections);
+                if (rawDatabase == null)
+                    return dict;
+
+                foreach (var config in rawDatabase.ExternalReplications.Where(config => config.Disabled))
+                {
+                    var source = new TombstoneDeletionBlockageSource(ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication, config.Name, config.TaskId);
+                    dict[source] = tombstoneCollections;
+                }
+
+                foreach (var config in rawDatabase.HubPullReplications.Where(config => config.Disabled))
+                {
+                    var source = new TombstoneDeletionBlockageSource(ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub, config.Name, config.TaskId);
+                    dict[source] = tombstoneCollections;
+                }
+
+                foreach (var config in rawDatabase.SinkPullReplications.Where(config => config.Disabled))
+                {
+                    var source = new TombstoneDeletionBlockageSource(ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink, config.Name, config.TaskId);
+                    dict[source] = tombstoneCollections;
+                }
             }
 
             return dict;

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -151,7 +151,7 @@ namespace Raven.Server.Documents
                 detailsSet.AddRange(
                     from collectionName in collections
                     let tombstonesCount = GetTombstoneDataForCollection(tombstonesCountsPerCollection, collectionName, context, _documentDatabase.DocumentsStorage.TombstonesCountForCollection)
-                    let tombstonesSize = GetTombstoneDataForCollection(tombstonesSizePerCollection, collectionName, context, _documentDatabase.DocumentsStorage.TombstonesSizeForCollection)
+                    let tombstonesSizeInBytes = GetTombstoneDataForCollection(tombstonesSizePerCollection, collectionName, context, _documentDatabase.DocumentsStorage.TombstonesSizeForCollectionInBytes)
                     where tombstonesCount > 0
                     select new BlockingTombstoneDetails
                     {
@@ -160,7 +160,7 @@ namespace Raven.Server.Documents
                         BlockerTaskId = source.TaskId,
                         Collection = collectionName,
                         NumberOfTombstones = tombstonesCount,
-                        SizeOfTombstones = tombstonesSize
+                        SizeOfTombstonesInBytes = tombstonesSizeInBytes
                     });
             }
         }

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -8,10 +8,10 @@ using Raven.Client;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Client.Util;
 using Raven.Server.Background;
+using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Logging;
-using static Raven.Server.NotificationCenter.TombstoneNotifications;
 
 namespace Raven.Server.Documents
 {
@@ -124,6 +124,7 @@ namespace Raven.Server.Documents
         {
             var detailsSet = new List<BlockingTombstoneDetails>();
             var tombstonesCountsPerCollection = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+            var tombstonesSizePerCollection = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
             using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
@@ -131,7 +132,7 @@ namespace Raven.Server.Documents
                 foreach (var disabledSubscribers in _subscriptions
                              .Select(x => x.GetDisabledSubscribersCollections(tombstoneCollections.Tombstones.Keys.ToHashSet())))
                 {
-                    FillDetailsSet(detailsSet, disabledSubscribers, tombstonesCountsPerCollection, context);
+                    FillDetailsSet(detailsSet, disabledSubscribers, tombstonesCountsPerCollection, tombstonesSizePerCollection, context);
                 }
             }
 
@@ -140,34 +141,43 @@ namespace Raven.Server.Documents
 
         private void FillDetailsSet(
             List<BlockingTombstoneDetails> detailsSet,
-            Dictionary<string, HashSet<string>> disabledSubscribers,
+            Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> disabledSubscribers,
             IDictionary<string, long> tombstonesCountsPerCollection,
+            IDictionary<string, long> tombstonesSizePerCollection,
             DocumentsOperationContext context)
         {
-            foreach ((string source, HashSet<string> collections) in disabledSubscribers)
+            foreach ((TombstoneDeletionBlockageSource source, HashSet<string> collections) in disabledSubscribers)
             {
                 detailsSet.AddRange(
-                    from collectionName in collections 
-                    let tombstonesCount = GetTombstonesCountForCollection(tombstonesCountsPerCollection, collectionName, context) 
-                    where tombstonesCount > 0 
+                    from collectionName in collections
+                    let tombstonesCount = GetTombstoneDataForCollection(tombstonesCountsPerCollection, collectionName, context, _documentDatabase.DocumentsStorage.TombstonesCountForCollection)
+                    let tombstonesSize = GetTombstoneDataForCollection(tombstonesSizePerCollection, collectionName, context, _documentDatabase.DocumentsStorage.TombstonesSizeForCollection)
+                    where tombstonesCount > 0
                     select new BlockingTombstoneDetails
                     {
-                        Source = source, 
-                        Collection = collectionName, 
-                        NumberOfTombstones = tombstonesCount
+                        Source = source.Name,
+                        BlockerType = source.Type,
+                        BlockerTaskId = source.TaskId,
+                        Collection = collectionName,
+                        NumberOfTombstones = tombstonesCount,
+                        SizeOfTombstones = tombstonesSize
                     });
             }
         }
 
-        private long GetTombstonesCountForCollection(IDictionary<string, long> tombstonesCountsPerCollection, string collectionName, DocumentsOperationContext context)
+        private static long GetTombstoneDataForCollection(
+            IDictionary<string, long> dataPerCollection,
+            string collectionName,
+            DocumentsOperationContext context,
+            Func<DocumentsOperationContext, string, long> retrieveDataFunc)
         {
-            if (tombstonesCountsPerCollection.TryGetValue(collectionName, out var tombstonesCount)) 
-                return tombstonesCount;
+            if (dataPerCollection.TryGetValue(collectionName, out var data))
+                return data;
 
-            tombstonesCount = _documentDatabase.DocumentsStorage.TombstonesCountForCollection(context, collectionName);
-            tombstonesCountsPerCollection[collectionName] = tombstonesCount;
+            data = retrieveDataFunc(context, collectionName);
+            dataPerCollection[collectionName] = data;
 
-            return tombstonesCount;
+            return data;
         }
 
         private void UpdateNotifications(List<BlockingTombstoneDetails> detailsSet)
@@ -288,15 +298,6 @@ namespace Raven.Server.Documents
                     default:
                         throw new NotSupportedException($"Tombstone type '{type}' is not supported.");
                 }
-            }
-        }
-
-        internal static void AssignTombstonesToDisabledConfigs<T>(Dictionary<string, HashSet<string>> dict, IEnumerable<T> destinations, HashSet<string> tombstoneCollections)
-            where T : ITombstoneDeletionBlocker
-        {
-            foreach (var config in destinations.Where(config => config.Disabled))
-            {
-                dict[config.BlockingSourceName] = tombstoneCollections;
             }
         }
 
@@ -513,13 +514,28 @@ namespace Raven.Server.Documents
 
         Dictionary<string, long> GetLastProcessedTombstonesPerCollection(TombstoneType type);
 
-        Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections);
+        Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections);
 
         public enum TombstoneType
         {
             Documents,
             TimeSeries,
             Counters
+        }
+
+        public enum TombstoneDeletionBlockerType
+        {
+            ExternalReplication,
+            InternalReplication,
+            RavenEtl,
+            SqlEtl,
+            OlapEtl,
+            ElasticSearchEtl,
+            QueueEtl,
+            Backup,
+            PullReplicationAsHub,
+            PullReplicationAsSink,
+            Index
         }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -51,6 +51,7 @@ using Sparrow.Json;
 using FacetSetup = Raven.Client.Documents.Queries.Facets.FacetSetup;
 using Raven.Server.Documents.ETL.Providers.OLAP.Test;
 using Raven.Server.Documents.ETL.Providers.Queue.Test;
+using Raven.Server.NotificationCenter;
 using BackupConfiguration = Raven.Client.Documents.Operations.Backups.BackupConfiguration;
 using MigrationConfiguration = Raven.Server.Smuggler.Migration.MigrationConfiguration;
 using StudioConfiguration = Raven.Client.Documents.Operations.Configuration.StudioConfiguration;
@@ -222,6 +223,8 @@ namespace Raven.Server.Json
         public static readonly Func<BlittableJsonReaderObject, PeriodicBackupConfiguration> GetPeriodicBackupConfiguration = GenerateJsonDeserializationRoutine<PeriodicBackupConfiguration>();
         
         internal static readonly Func<BlittableJsonReaderObject, AutoSpatialOptions> AutoSpatialOptions = GenerateJsonDeserializationRoutine<AutoSpatialOptions>();
+
+        public static readonly Func<BlittableJsonReaderObject, BlockingTombstoneDetails> BlockingTombstoneDetails = GenerateJsonDeserializationRoutine<BlockingTombstoneDetails>();
 
         public class Parameters
         {

--- a/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/TombstoneNotifications.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.NotificationCenter
                         [nameof(BlockingTombstoneDetails.BlockerTaskId)] = tombstoneDetails.BlockerTaskId,
                         [nameof(BlockingTombstoneDetails.Collection)] = tombstoneDetails.Collection,
                         [nameof(BlockingTombstoneDetails.NumberOfTombstones)] = tombstoneDetails.NumberOfTombstones,
-                        [nameof(BlockingTombstoneDetails.SizeOfTombstones)] = tombstoneDetails.SizeOfTombstones
+                        [nameof(BlockingTombstoneDetails.SizeOfTombstonesInBytes)] = tombstoneDetails.SizeOfTombstonesInBytes
                     });
                 }
 
@@ -96,8 +96,8 @@ namespace Raven.Server.NotificationCenter
         public long BlockerTaskId { get; set; }
         public string Collection { get; set; }
         public long NumberOfTombstones { get; set; }
-        public long SizeOfTombstones { get; set; }
-        public string SizeOfTombstonesHumane => new Size(SizeOfTombstones, SizeUnit.Bytes).ToString();
+        public long SizeOfTombstonesInBytes { get; set; }
+        public string SizeOfTombstonesHumane => new Size(SizeOfTombstonesInBytes, SizeUnit.Bytes).ToString();
     }
 
     public class TombstoneDeletionBlockageSource : IEquatable<TombstoneDeletionBlockageSource>

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlEditModel.ts
@@ -110,8 +110,7 @@ class ongoingTaskElasticSearchEtlEditModel extends ongoingTaskEditModel {
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
-            ElasticIndexes: this.elasticIndexes().map(x => x.toDto()),
-            BlockingSourceName: this.blockingSourceName()
+            ElasticIndexes: this.elasticIndexes().map(x => x.toDto())
         };
         
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskModel.ts
@@ -15,8 +15,6 @@ abstract class ongoingTaskModel {
     
     taskConnectionStatus = ko.observable<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskConnectionStatus>();    
 
-    blockingSourceName = ko.observable<string>();
-
     badgeText: KnockoutComputed<string>;
     badgeClass: KnockoutComputed<string>;
     stateText: KnockoutComputed<string>;

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlEditModel.ts
@@ -133,8 +133,7 @@ class ongoingTaskOlapEtlEditModel extends ongoingTaskEditModel {
             CustomPartitionValue: this.customPartitionEnabled() ? this.customPartition() : null,
             RunFrequency: this.runFrequency(),
             OlapTables: this.olapTables().map(x => x.toDto()),
-            Format: undefined,
-            BlockingSourceName: this.blockingSourceName()
+            Format: undefined
         };
         
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlEditModel.ts
@@ -169,8 +169,7 @@ abstract class ongoingTaskQueueEtlEditModel extends ongoingTaskEditModel {
             TaskId: this.taskId,
             BrokerType: broker,
             SkipAutomaticQueueDeclaration: this.skipAutomaticQueueDeclaration(),
-            Queues: this.queueOptionsToDto(),
-            BlockingSourceName: this.blockingSourceName()
+            Queues: this.queueOptionsToDto()
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskRavenEtlEditModel.ts
@@ -121,8 +121,7 @@ class ongoingTaskRavenEtlEditModel extends ongoingTaskEditModel {
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
             TaskId: this.taskId,
-            LoadRequestTimeoutInSec: this.loadRequestTimeout() || null,
-            BlockingSourceName: this.blockingSourceName()
+            LoadRequestTimeoutInSec: this.loadRequestTimeout() || null
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
@@ -56,8 +56,7 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Url: undefined,
             Disabled: this.taskState() === "Disabled",
-            Database: undefined,
-            BlockingSourceName: this.blockingSourceName(),
+            Database: undefined
         };
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationHubEditModel.ts
@@ -8,7 +8,6 @@ class ongoingTaskReplicationHubEditModel {
     taskType = ko.observable<Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskType>();
 
     disabled = ko.observable<boolean>();
-    blockingSourceName = ko.observable<string>();
     stateText: KnockoutComputed<string>;
 
     responsibleNode = ko.observable<Raven.Client.ServerWide.Operations.NodeId>();
@@ -95,8 +94,7 @@ class ongoingTaskReplicationHubEditModel {
             Disabled: this.disabled(),
             PreventDeletionsMode: this.preventDeletions() ? "PreventSinkToHubDeletions" : "None",
             WithFiltering: this.withFiltering(),
-            Certificates: undefined,
-            BlockingSourceName: this.blockingSourceName()
+            Certificates: undefined
         };
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -132,8 +132,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             CommandTimeout: this.commandTimeout() || null,
             QuoteTables: this.tableQuotation(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
-            SqlTables: this.sqlTables().map(x => x.toDto()),
-            BlockingSourceName: this.blockingSourceName()
+            SqlTables: this.sqlTables().map(x => x.toDto())
         
         } as Raven.Client.Documents.Operations.ETL.SQL.SqlEtlConfiguration;
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -46,8 +46,6 @@ abstract class backupConfiguration {
     locationInfo = ko.observableArray<Raven.Server.Web.Studio.SingleNodeDataDirectoryResult>([]);
     folderPathOptions = ko.observableArray<string>([]);
 
-    blockingSourceName = ko.observable<string>();
-
     spinners = {
         locationInfoLoading: ko.observable<boolean>(false)
     };
@@ -207,7 +205,6 @@ abstract class backupConfiguration {
             BackupEncryptionSettings: null,
             SnapshotSettings: null,
             RetentionPolicy: null,
-            BlockingSourceName: null,
         }
     }
 }

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -163,8 +163,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             GlacierSettings: this.glacierSettings().toDto(),
             AzureSettings: this.azureSettings().toDto(),
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
-            FtpSettings: this.ftpSettings().toDto(),
-            BlockingSourceName: this.blockingSourceName()
+            FtpSettings: this.ftpSettings().toDto()
         };
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/blockingTombstonesDetails.ts
@@ -12,6 +12,8 @@ interface WarningItem {
     source: string;
     collection: string;
     count: number;
+    type: string;
+    size: number;
 }
 
 class blockingTombstonesDetails extends abstractAlertDetails {
@@ -26,12 +28,14 @@ class blockingTombstonesDetails extends abstractAlertDetails {
         super(alert, notificationCenter);
 
         const warning = this.alert.details() as any;
-        const detailsList = warning.BlockingTombstones as Raven.Server.NotificationCenter.TombstoneNotifications.BlockingTombstoneDetails[];
+        const detailsList = warning.BlockingTombstones as Raven.Server.NotificationCenter.BlockingTombstoneDetails[];
         
         this.tableItems = detailsList.map(x => ({
+            type: x.BlockerType,
             source: x.Source,
             collection: x.Collection,
-            count: x.NumberOfTombstones
+            count: x.NumberOfTombstones,
+            size: x.SizeOfTombstonesInBytes
         }));
     }
     
@@ -42,15 +46,22 @@ class blockingTombstonesDetails extends abstractAlertDetails {
         grid.headerVisible(true);
 
         grid.init(() => this.fetcher(), () => {
-            const sourceColumn = new textColumn<WarningItem>(grid, x => x.source, "Source", "35%", {
+            const typeColumn = new textColumn<WarningItem>(grid, x => x.type, "Type", "15%", {
+                sortable: x => x.type
+            });
+            const sourceColumn = new textColumn<WarningItem>(grid, x => x.source, "Source", "20%", {
                 sortable: x => x.source
             });
-            const collectionColumn = new textColumn<WarningItem>(grid, x => x.collection, "Collection", "40%", {
+            const collectionColumn = new textColumn<WarningItem>(grid, x => x.collection, "Collection", "20%", {
                 sortable: x => x.collection
             });
-            const countColumn = new textColumn<WarningItem>(grid, x => x.count, "Tombstones count", "25%");
+            const countColumn = new textColumn<WarningItem>(grid, x => x.count, "Tombstones count", "20%");
+            const sizeColumn = new textColumn<WarningItem>(grid, x => x.size, "Size", "20%", {
+                sortable: x => x.size,
+                transformValue: genUtils.formatBytesToSize
+            });
 
-            return [sourceColumn, collectionColumn, countColumn];
+            return [typeColumn, sourceColumn, collectionColumn, countColumn, sizeColumn];
         });
         
         

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/ongoingTasks.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/ongoingTasks.ts
@@ -33,6 +33,15 @@ class ongoingTasks extends viewModelBase {
     view = require("views/database/tasks/ongoingTasks.html");
     databaseGroupLegendView = require("views/partial/databaseGroupLegend.html");
     
+    private static tombstoneWarning = `<div class="margin-top margin-top-lg text-warning bg-warning padding padding-xs flex-horizontal">
+                <div class="flex-start">
+                    <small><i class="icon-warning"></i></small>
+                </div>
+                <div>
+                    <small>Warning: Please note that disabling this task will cause continuous tombstone accumulation until it is re-enabled or deleted, leading to increased disk space usage.</small>
+                </div>
+             </div>`
+    
     private clusterManager = clusterTopologyManager.default;
     myNodeTag = ko.observable<string>();
 
@@ -280,7 +289,7 @@ class ongoingTasks extends viewModelBase {
     
     private refresh() {
         if (!this.activeDatabase()) {
-            return;
+            return; 
         }
         return $.when<any>(this.fetchDatabaseInfo(), this.fetchOngoingTasks());
     }
@@ -549,18 +558,10 @@ class ongoingTasks extends viewModelBase {
     confirmDisableOngoingTask(model: ongoingTaskListModel | ongoingTaskReplicationHubDefinitionListModel) {
         const db = this.activeDatabase();
 
+        const extraHtml = model.taskType() !== "Subscription" ? ongoingTasks.tombstoneWarning : "";
+        
         this.confirmationMessage("Disable Task",
-            `You're disabling ${model.taskType()} task:<br><ul><li><strong>${generalUtils.escapeHtml(model.taskName())}</strong></li></ul>
-<div class="margin-top margin-top-lg text-warning bg-warning padding padding-xs flex-horizontal">
-                <div class="flex-start">
-                    <small><i class="icon-warning"></i></small>
-                </div>
-                <div>
-                    <small>Warning: Please note that disabling this task will cause continuous tombstone accumulation until it is re-enabled or deleted, leading to increased disk space usage.</small>
-                </div>
-             </div>
-
-`, {
+            `You're disabling ${model.taskType()} task:<br><ul><li><strong>${generalUtils.escapeHtml(model.taskName())}</strong></li></ul>${extraHtml}`, {
                 buttons: ["Cancel", "Disable"],
                 html: true
             })

--- a/test/FastTests/Server/Replication/ReplicationTestBase.cs
+++ b/test/FastTests/Server/Replication/ReplicationTestBase.cs
@@ -376,7 +376,7 @@ namespace FastTests.Server.Replication
         {
             await UpdateConflictResolver(store, null, conflictResolution == StraightforwardConflictResolution.ResolveToLatest);
         }
-        
+
         protected static async Task SetupReplicationWithCustomDestinations(DocumentStore fromStore, params ReplicationNode[] toNodes)
         {
             foreach (var node in toNodes)

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -113,8 +113,8 @@ namespace SlowTests.Issues
                 Assert.Equal(TombstonesCount, notificationDetails.First().NumberOfTombstones);
                 Assert.Equal(0, notificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.Index, notificationDetails.First().BlockerType);
-                Assert.True(notificationDetails.First().SizeOfTombstones > 0,
-                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstones}");
+                Assert.True(notificationDetails.First().SizeOfTombstonesInBytes > 0,
+                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstonesInBytes}");
             }
         }
 
@@ -175,8 +175,8 @@ namespace SlowTests.Issues
                 Assert.Equal(TombstonesCount, notificationDetails.First().NumberOfTombstones);
                 Assert.Equal(externalList.First().TaskId, notificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication, notificationDetails.First().BlockerType);
-                Assert.True(notificationDetails.First().SizeOfTombstones > 0,
-                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstones}");
+                Assert.True(notificationDetails.First().SizeOfTombstonesInBytes > 0,
+                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstonesInBytes}");
             }
         }
 
@@ -253,8 +253,8 @@ namespace SlowTests.Issues
                 Assert.Equal(sinkTombstonesCount, sinkNotificationDetails.First().NumberOfTombstones);
                 Assert.Equal(sinkCreationTaskId, sinkNotificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink, sinkNotificationDetails.First().BlockerType);
-                Assert.True(sinkNotificationDetails.First().SizeOfTombstones > 0,
-                    $"Expected the size of tombstones to be greater than 0, but it was {sinkNotificationDetails.First().SizeOfTombstones}");
+                Assert.True(sinkNotificationDetails.First().SizeOfTombstonesInBytes > 0,
+                    $"Expected the size of tombstones to be greater than 0, but it was {sinkNotificationDetails.First().SizeOfTombstonesInBytes}");
 
                 // Assert 'Hub' BlockingTombstones notification and its details.
                 var hubDatabase = await Databases.GetDocumentDatabaseInstanceFor(hub);
@@ -268,8 +268,8 @@ namespace SlowTests.Issues
                 Assert.Equal(hubTombstonesCount, hubNotificationDetails.First().NumberOfTombstones);
                 Assert.Equal(hubCreationTaskId, hubNotificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub, hubNotificationDetails.First().BlockerType);
-                Assert.True(hubNotificationDetails.First().SizeOfTombstones > 0,
-                    $"Expected the size of tombstones to be greater than 0, but it was {hubNotificationDetails.First().SizeOfTombstones}");
+                Assert.True(hubNotificationDetails.First().SizeOfTombstonesInBytes > 0,
+                    $"Expected the size of tombstones to be greater than 0, but it was {hubNotificationDetails.First().SizeOfTombstonesInBytes}");
             }
         }
 
@@ -380,8 +380,8 @@ namespace SlowTests.Issues
                 Assert.Equal(_customTaskName, notificationDetails.First().Source);
                 Assert.Equal(taskId, notificationDetails.First().BlockerTaskId);
                 Assert.Equal(blockerType, notificationDetails.First().BlockerType);
-                Assert.True(notificationDetails.First().SizeOfTombstones > 0, 
-                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstones}");
+                Assert.True(notificationDetails.First().SizeOfTombstonesInBytes > 0, 
+                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstonesInBytes}");
 
                 Assert.Equal(TombstonesCount, notificationDetails.First().NumberOfTombstones);
             }
@@ -451,8 +451,8 @@ namespace SlowTests.Issues
                 Assert.Equal(TombstonesCount, notificationDetails.First().NumberOfTombstones);
                 Assert.Equal(config.TaskId, notificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.Backup, notificationDetails.First().BlockerType);
-                Assert.True(notificationDetails.First().SizeOfTombstones > 0,
-                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstones}");
+                Assert.True(notificationDetails.First().SizeOfTombstonesInBytes > 0,
+                    $"Expected the size of tombstones to be greater than 0, but it was {notificationDetails.First().SizeOfTombstonesInBytes}");
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_10656.cs
+++ b/test/SlowTests/Issues/RavenDB_10656.cs
@@ -8,6 +8,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents;
+using Raven.Server.NotificationCenter;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -144,7 +145,7 @@ namespace SlowTests.Issues
             };
         }
 
-        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        public Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             throw new NotImplementedException();
         }

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -6,6 +6,7 @@ using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Documents;
+using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide.Context;
 using Xunit;
 using Xunit.Abstractions;
@@ -100,7 +101,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             };
         }
 
-        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        public Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             throw new NotImplementedException();
         }

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -23,6 +23,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Admin;
+using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -979,7 +980,7 @@ namespace SlowTests.Server.Documents.Revisions
             };
         }
 
-        public Dictionary<string, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
+        public Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections)
         {
             throw new NotImplementedException();
         }

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -241,7 +241,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(HugeDocumentsDetails));
             scripter.AddType(typeof(HugeDocumentInfo));
             scripter.AddType(typeof(MismatchedReferencesLoadWarning));
-            scripter.AddType(typeof(TombstoneNotifications.BlockingTombstoneDetails));
+            scripter.AddType(typeof(BlockingTombstoneDetails));
             scripter.AddType(typeof(RequestLatencyDetail));
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));
             scripter.AddType(typeof(IndexingReferenceLoadWarning));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19967/Notification-warning-about-tombstone-cleaner-subscribers-disabled.

### Additional description

The structure of the Notification's details about the presence of tombstone cleanup blocking has been modified:
1. The Source field now stores the name of the Task that, when disabled, leads to the blocking of tombstone cleanup.
2. Two new fields, TaskId and TombstoneDeletionBlockerType, have been added to provide the ability to generate a direct link to the task editing page of the task that, when disabled, results in tombstone cleanup blocking.
3. Additionally, information about the size of the tombstones whose cleanup is blocked has been included in the details of this Notification.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works.

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using Studio Required tag.