### PR TITLE
RavenDB-20547 - SlowTests.Client.TimeSeries.Replication.TimeSeriesRep…

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Replication/TimeSeriesReplicationTests.cs
@@ -131,7 +131,7 @@ namespace SlowTests.Client.TimeSeries.Replication
                     session.SaveChanges();
                 }
 
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 Validate1(storeA, baseline);
                 Validate1(storeB, baseline);
@@ -150,7 +150,7 @@ namespace SlowTests.Client.TimeSeries.Replication
                     session.SaveChanges();
                 }
 
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 await Validate2(storeA, baseline);
                 await Validate2(storeB, baseline);


### PR DESCRIPTION
…licationTests.TimeSeriesShouldBeCaseInsensitiveAndKeepOriginalCasing(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20547/SlowTests.Client.TimeSeries.Replication.TimeSeriesReplicationTests.TimeSeriesShouldBeCaseInsensitiveAndKeepOriginalCasingoptions


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
