### PR TITLE
RavenDB-20954 - SelectedNodeTag operations reach a different node when node is in rehab or when topology updates are disabled

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -58,6 +58,8 @@ namespace Raven.Client.Http
                 _disableClientConfigurationUpdates = true,
                 _topologyHeaderName = Constants.Headers.ClusterTopologyEtag
             };
+            // This is just to fetch the cluster tag
+            executor._firstTopologyUpdate = executor.SingleTopologyUpdateAsync(initialUrls, null);
             return executor;
         }
 
@@ -108,26 +110,8 @@ namespace Raven.Client.Http
                         Nodes = nodes,
                         Etag = results.Etag
                     };
-
-                    TopologyEtag = results.Etag;
-
-                    if (_nodeSelector == null)
-                    {
-                        _nodeSelector = new NodeSelector(newTopology);
-                        if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
-                        {
-                            _nodeSelector.ScheduleSpeedTest();
-                        }
-                    }
-                    else if (_nodeSelector.OnUpdateTopology(newTopology, forceUpdate: parameters.ForceUpdate))
-                    {
-                        DisposeAllFailedNodesTimers();
-
-                        if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
-                        {
-                            _nodeSelector.ScheduleSpeedTest();
-                        }
-                    }
+                    
+                    UpdateNodeSelector(newTopology, parameters.ForceUpdate);
 
                     OnTopologyUpdatedInvoke(newTopology);
                 }

--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -52,8 +52,8 @@ namespace Raven.Client.Http
                 return ServerNode.Role.Member;
             if (Promotables.ContainsKey(nodeTag))
                 return ServerNode.Role.Promotable;
-
-            throw new InvalidOperationException($"The node tag {nodeTag} does not belong to the cluster");
+            
+            return ServerNode.Role.None;
         }
 
         public bool Contains(string node)

--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -46,6 +46,16 @@ namespace Raven.Client.Http
             
         }
 
+        internal ServerNode.Role GetServerRoleForTag(string nodeTag)
+        {
+            if (Members.ContainsKey(nodeTag) || Watchers.ContainsKey(nodeTag))
+                return ServerNode.Role.Member;
+            if (Promotables.ContainsKey(nodeTag))
+                return ServerNode.Role.Promotable;
+
+            throw new InvalidOperationException($"The node tag {nodeTag} does not belong to the cluster");
+        }
+
         public bool Contains(string node)
         {
             return Members.ContainsKey(node) || Promotables.ContainsKey(node) || Watchers.ContainsKey(node);

--- a/src/Raven.Client/Http/ClusterTopologyResponse.cs
+++ b/src/Raven.Client/Http/ClusterTopologyResponse.cs
@@ -6,6 +6,7 @@ namespace Raven.Client.Http
     {
         public string Leader;
         public string NodeTag;
+        public ServerNode.Role ServerRole;
         public ClusterTopology Topology;
         public long Etag;
         public Dictionary<string, NodeStatus> Status;

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -111,20 +111,13 @@ namespace Raven.Client.Http
             for (int i = 0; i < len; i++)
             {
                 Debug.Assert(string.IsNullOrEmpty(serverNodes[i].Url) == false, $"Expected serverNodes Url not null or empty but got: \'{serverNodes[i].Url}\'");
-                if (stateFailures[i] == 0)
+                if (stateFailures[i] == 0 && serverNodes[i].ServerRole == ServerNode.Role.Member)
                 {
                     return (i, serverNodes[i]);
                 }
             }
 
             return UnlikelyEveryoneFaultedChoice(state);
-        }
-
-        internal (int Index, ServerNode Node, long TopologyEtag) GetPreferredNodeWithTopology()
-        {
-            var state = _state;
-            var preferredNode = GetPreferredNodeInternal(state);
-            return (preferredNode.Index, preferredNode.Node, state.Topology?.Etag??-2);
         }
 
         internal int[] NodeSelectorFailures => _state.Failures;

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -129,6 +129,17 @@ namespace Raven.Client.Http
             if (state.Nodes.Count == 0)
                 throw new DatabaseDoesNotExistException("There are no nodes in the topology at all");
 
+            var stateFailures = state.Failures;
+            var serverNodes = state.Nodes;
+            var len = Math.Min(serverNodes.Count, stateFailures.Length);
+            for (int i = 0; i < len; i++)
+            {
+                if (stateFailures[i] == 0)
+                {
+                    return (i, serverNodes[i]);
+                }
+            }
+            
             return state.GetNodeWhenEveryoneMarkedAsFaulted();
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -405,7 +405,7 @@ namespace Raven.Client.Http
             return executor;
         }
 
-        internal static RequestExecutor CreateForFixedTopologyForShortTermUse(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
+        internal static RequestExecutor CreateForShortTermUse(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
         {
             // This request executor doesn't call SingleTopologyUpdate so it won't attempt to reach the server of the url before it knows our certificate
             // It's topology will also not have cluster tags populated so it cannot be used long term for operations with SelectedNodeTag

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -724,6 +724,7 @@ namespace Raven.Client.Http
                         await ExecuteAsync(serverNode, null, context, command, shouldRetry: false, sessionInfo: null, token: CancellationToken.None)
                             .ConfigureAwait(false);
                         serverNode.ClusterTag = command.Result.NodeTag;
+                        serverNode.ServerRole = ServerNode.Role.Member;
                     }
                 }
                 catch (AuthorizationException)
@@ -806,6 +807,7 @@ namespace Raven.Client.Http
                 {
                     Url = url,
                     Database = _databaseName,
+                    ServerRole = ServerNode.Role.Member,
                     ClusterTag = "!"
                 }).ToList(),
                 Etag = TopologyEtag

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -536,6 +536,7 @@ namespace Raven.Client.Http
                 DisposeAllFailedNodesTimers();
                 if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                 {
+                    ForTestingPurposes.OnBeforeScheduleSpeedTest?.Invoke(_nodeSelector);
                     _nodeSelector.ScheduleSpeedTest();
                 }
             }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -536,7 +536,6 @@ namespace Raven.Client.Http
                 DisposeAllFailedNodesTimers();
                 if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                 {
-                    ForTestingPurposes.OnBeforeScheduleSpeedTest?.Invoke(_nodeSelector);
                     _nodeSelector.ScheduleSpeedTest();
                 }
             }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -527,7 +527,7 @@ namespace Raven.Client.Http
 
                 if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                 {
-                	ForTestingPurposes?.OnBeforeScheduleSpeedTest?.Invoke(_nodeSelector);
+                    ForTestingPurposes?.OnBeforeScheduleSpeedTest?.Invoke(_nodeSelector);
                     _nodeSelector.ScheduleSpeedTest();
                 }
             }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -748,7 +748,8 @@ namespace Raven.Client.Http
                 catch (Exception e)
                 {
                     serverNode.ClusterTag = "!";
-                    Logger.Info($"Error occurred while attempting to fetch the Cluster Tag for {url} in {nameof(SingleTopologyUpdateAsync)}", e);
+                    if(Logger.IsInfoEnabled)
+                        Logger.Info($"Error occurred while attempting to fetch the Cluster Tag for {url} in {nameof(SingleTopologyUpdateAsync)}", e);
                 }
 
                 topology.Nodes.Add(serverNode);

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -95,7 +95,8 @@ namespace Raven.Client.Http
                 nodes.Add(new ServerNode
                 {
                     Url = member.Value,
-                    ClusterTag = member.Key
+                    ClusterTag = member.Key,
+                    ServerRole = Role.Member
                 });
             }
 
@@ -104,7 +105,8 @@ namespace Raven.Client.Http
                 nodes.Add(new ServerNode
                 {
                     Url = watcher.Value,
-                    ClusterTag = watcher.Key
+                    ClusterTag = watcher.Key,
+                    ServerRole = Role.Member
                 });
             }
 

--- a/src/Raven.Client/ServerWide/Commands/GetNodeInfoCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetNodeInfoCommand.cs
@@ -21,6 +21,7 @@ namespace Raven.Client.ServerWide.Commands
         public OsInfo OsInfo;
         public Guid ServerId;
         public RachisState CurrentState;
+        public ServerNode.Role ServerRole;
         public bool HasFixedPort;
         public int ServerSchemaVersion;
 
@@ -39,6 +40,7 @@ namespace Raven.Client.ServerWide.Commands
                 [nameof(OsInfo)] = OsInfo,
                 [nameof(ServerId)] = ServerId.ToString(),
                 [nameof(CurrentState)] = CurrentState,
+                [nameof(ServerRole)] = ServerRole,
                 [nameof(HasFixedPort)] = HasFixedPort,
                 [nameof(ServerSchemaVersion)] = ServerSchemaVersion,
             };

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -358,7 +358,7 @@ namespace Raven.Server.Commercial
 
         private async Task<Client.ServerWide.Commands.NodeInfo> GetNodeInfo(string nodeUrl, TransactionOperationContext ctx)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var infoCmd = new GetNodeInfoCommand(TimeSpan.FromSeconds(15));
 

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -90,6 +90,7 @@ namespace Raven.Server.Documents
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
             internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
             internal bool ShouldFetchIdleStateImmediately = false;
+            internal bool PreventNodePromotion = false;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object changeState)

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -182,7 +182,6 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/cluster/node-info", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetNodeInfo()
         {
-            await ServerStore.EnsureNotPassiveAsync();
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
@@ -324,7 +323,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             Client.ServerWide.Commands.NodeInfo nodeInfo;
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(nodeUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 requestExecutor.DefaultTimeout = ServerStore.Engine.OperationTimeout;
 
@@ -696,7 +695,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                         }
 
                         var cmd = new RemoveEntryFromRaftLogCommand(index);
-                        using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(node.Value, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                        using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(node.Value, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                         {
                             await requestExecutor.ExecuteAsync(cmd, context);
                             nodeList.AddRange(cmd.Result);

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             try
             {
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -143,7 +143,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         private async Task WriteDebugInfoPackageForNodeAsync(JsonOperationContext context, ZipArchive archive, string tag, string url, OperationCancelToken clusterOperationToken, int timeoutInSecPerNode, StringValues databases, DebugInfoPackageContentType contentType)
         {
             //note : theoretically GetDebugInfoFromNodeAsync() can throw, error handling is done at the level of WriteDebugInfoPackageForNodeAsync() calls
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nextOperationId = new GetNextServerOperationIdCommand();
                 await requestExecutor.ExecuteAsync(nextOperationId, context);

--- a/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
@@ -142,7 +142,7 @@ namespace Raven.Server.Documents.Handlers
 
         private static async Task SendKeyToNodeAsync(string name, string base64, JsonOperationContext ctx, ServerStore server, string node, string url)
         {
-            using (var shortLived = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, name, server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var shortLived = RequestExecutor.CreateForShortTermUse(new string[] { url }, name, server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var command = new PutSecretKeyCommand(name, base64);
                 try

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1574,7 +1574,7 @@ namespace Raven.Server.Documents.Replication
             {
                 string[] remoteDatabaseUrls;
                 // fetch hub cluster node urls
-                using (var requestExecutor = RequestExecutor.CreateForFixedTopology(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
+                using (var requestExecutor = RequestExecutor.CreateForFixedTopologyForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask);
@@ -1602,7 +1602,7 @@ namespace Raven.Server.Documents.Replication
                 }
 
                 // fetch tcp info for the hub nodes
-                using (var requestExecutor = RequestExecutor.CreateForFixedTopology(remoteDatabaseUrls,
+                using (var requestExecutor = RequestExecutor.CreateForFixedTopologyForShortTermUse(remoteDatabaseUrls,
                     pullReplicationAsSink.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetTcpInfoForRemoteTaskCommand(ExternalReplicationTag, database, remoteTask);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1574,7 +1574,7 @@ namespace Raven.Server.Documents.Replication
             {
                 string[] remoteDatabaseUrls;
                 // fetch hub cluster node urls
-                using (var requestExecutor = RequestExecutor.CreateForFixedTopologyForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
+                using (var requestExecutor = RequestExecutor.CreateForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask);
@@ -1602,7 +1602,7 @@ namespace Raven.Server.Documents.Replication
                 }
 
                 // fetch tcp info for the hub nodes
-                using (var requestExecutor = RequestExecutor.CreateForFixedTopologyForShortTermUse(remoteDatabaseUrls,
+                using (var requestExecutor = RequestExecutor.CreateForShortTermUse(remoteDatabaseUrls,
                     pullReplicationAsSink.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetTcpInfoForRemoteTaskCommand(ExternalReplicationTag, database, remoteTask);

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -518,7 +518,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                 {
                                     // check that the subscription exists on AppropriateNode
                                     var clusterTopology = server.GetClusterTopology(ctx);
-                                    using (var requester = ClusterRequestExecutor.CreateForSingleNode(
+                                    using (var requester = ClusterRequestExecutor.CreateForShortTermUse(
                                     clusterTopology.GetUrlFromTag(subscriptionDoesNotBelongException.AppropriateNode), server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                                     {
                                         await requester.ExecuteAsync(new WaitForRaftIndexCommand(subscriptionDoesNotBelongException.Index), ctx);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1299,6 +1299,9 @@ namespace Raven.Server.ServerWide.Maintenance
 
         private (bool Promote, string UpdateTopologyReason) TryPromote(DatabaseObservationState state, string mentorNode, string promotable)
         {
+            if (_server.DatabasesLandlord.ForTestingPurposes?.PreventNodePromotion == true)
+                return (false, "Preventing node promotion for testing purposes.");
+
             var dbName = state.Name;
             var topology = state.DatabaseTopology;
             var current = state.Current;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2924,10 +2924,11 @@ namespace Raven.Server.ServerWide
         public NodeInfo GetNodeInfo()
         {
             var memoryInformation = Server.MetricCacher.GetValue<MemoryInfoResult>(MetricCacher.Keys.Server.MemoryInfo);
+            var clusterTopology = GetClusterTopology();
             return new NodeInfo
             {
                 NodeTag = NodeTag,
-                TopologyId = GetClusterTopology().TopologyId,
+                TopologyId = clusterTopology.TopologyId,
                 Certificate = Server.Certificate.CertificateForClients,
                 NumberOfCores = ProcessorInfo.ProcessorCount,
                 InstalledMemoryInGb = memoryInformation.InstalledMemory.GetDoubleValue(SizeUnit.Gigabytes),
@@ -2936,6 +2937,7 @@ namespace Raven.Server.ServerWide
                 OsInfo = LicenseManager.OsInfo,
                 ServerId = GetServerId(),
                 CurrentState = CurrentRachisState,
+                ServerRole = clusterTopology.GetServerRoleForTag(NodeTag),
                 HasFixedPort = HasFixedPort,
                 ServerSchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion
             };

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Utils
 
         private static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, GetTcpInfoCommand getTcpInfoCommand, X509Certificate2 certificate, CancellationToken token)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))//TODO stav: createForFixed instead?
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 await requestExecutor.ExecuteAsync(getTcpInfoCommand, context, token: token);
@@ -52,7 +52,7 @@ namespace Raven.Server.Utils
 
         private static async Task<TcpConnectionInfo> GetTcpInfoForInternalReplicationAsync(string url, string databaseName, string databaseId, long etag, string tag, X509Certificate2 certificate, string localNodeTag, CancellationToken token)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 var getTcpInfoCommand = databaseId == null ? new GetTcpInfoForReplicationCommand(localNodeTag, tag, databaseName) : new GetTcpInfoForReplicationCommand(localNodeTag, tag, databaseName, databaseId, etag);

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -186,7 +186,7 @@ namespace Raven.Server.Web
         {
             await ServerStore.Cluster.WaitForIndexNotification(index); // first let see if we commit this in the leader
 
-            using (var requester = ClusterRequestExecutor.CreateForSingleNode(clusterTopology.GetUrlFromTag(node), ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requester = ClusterRequestExecutor.CreateForShortTermUse(clusterTopology.GetUrlFromTag(node), ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 await requester.ExecuteAsync(new WaitForRaftIndexCommand(index), context);
             }

--- a/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
+++ b/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
@@ -191,7 +191,7 @@ namespace Raven.Server.Web.Studio
             {
                 try
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(serverUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(serverUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                     using (_serverStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
                         var dataDirectoryInfo = new GetDataDirectoryInfoCommand(_path, _name, _isBackup);

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Web.System
                 // test the connection from the remote node to this one
                 if (bidirectional == true && result.Success)
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(url, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
                     {
                         result = await ServerStore.TestConnectionFromRemote(requestExecutor, context, url);
                     }

--- a/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
+++ b/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
@@ -75,7 +75,7 @@ namespace FastTests.Server.Basic
                 var t = Task.Run(() =>
                 {
                     using (var ctx = JsonOperationContext.ShortTermSingleUse())
-                    using (var requestExecutor = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, name, null, DocumentConventions.Default))
+                    using (var requestExecutor = RequestExecutor.CreateForShortTermUse(new string[] { url }, name, null, DocumentConventions.Default))
                     {
                         requestExecutor.Execute(
                             new CreateDatabaseOperation(doc).GetCommand(new DocumentConventions(), ctx), ctx);
@@ -85,7 +85,7 @@ namespace FastTests.Server.Basic
                 Assert.Throws<DatabaseLoadTimeoutException>(() =>
                 {
                     using (var ctx = JsonOperationContext.ShortTermSingleUse())
-                    using (var requestExecutor = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, name, null, DocumentConventions.Default))
+                    using (var requestExecutor = RequestExecutor.CreateForShortTermUse(new string[] { url }, name, null, DocumentConventions.Default))
                     {
                         mre.WaitOne();
                         requestExecutor.Execute(new GetDocumentsCommand("Raven/HiloPrefix", includes: null, metadataOnly: false), ctx);

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -51,7 +51,7 @@ namespace InterversionTests
 
             var chosenOne = processes[0];
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(chosenOne.Url, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(chosenOne.Url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 foreach (var processNode in processes)
@@ -98,7 +98,7 @@ namespace InterversionTests
             };
 
             using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderServer.WebUrl, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leaderServer.WebUrl, certificate, DocumentConventions.DefaultForServer))
             {
                 var local = new List<RavenServer>();
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -61,7 +61,7 @@ namespace RachisTests
 
             await ActionWithLeader((l) => l.ServerStore.RemoveFromClusterAsync(watcher.ServerStore.NodeTag));
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(watcher.WebUrl, watcher.ServerStore.NodeTag), ctx);
@@ -219,7 +219,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -249,7 +249,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -280,7 +280,7 @@ namespace RachisTests
 
             // here we pusblish a wrong PublicServerUrl, but connect to the ServerUrl, so the HTTP connection should be okay, but will when trying to the TCP connection.
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -310,7 +310,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -717,7 +717,7 @@ namespace RachisTests
             var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
             Servers.Add(server2);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 var ex = await Assert.ThrowsAsync<RavenException>(async () =>
@@ -755,7 +755,7 @@ namespace RachisTests
                 var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
                 Servers.Add(server2);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);
@@ -803,7 +803,7 @@ namespace RachisTests
                 var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
                 Servers.Add(server2);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);
@@ -849,7 +849,7 @@ namespace RachisTests
             var serverD = GetNewServer();
             var serverDUrl = serverD.ServerStore.GetNodeHttpServerUrl();
             Servers.Add(serverD);
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(serverDUrl, "D", watcher: true), ctx);
@@ -948,7 +948,7 @@ namespace RachisTests
             var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
             Servers.Add(server2);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -200,8 +200,6 @@ namespace RachisTests.DatabaseCluster
                     await session.SaveChangesAsync();
                 }
 
-                WaitForUserToContinueTheTest(store);
-
                 val = await WaitForValueAsync(async () => await GetMembersCount(store), 1);
                 Assert.Equal(1, val);
 

--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -164,7 +164,7 @@ namespace SlowTests.Cluster
                 await AddCompareExchangesWithExpire(count, compareExchanges, store, expiry);
                 await AssertCompareExchanges(compareExchanges, store, expiry);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(follower.WebUrl, watcher: true), ctx);
@@ -226,7 +226,7 @@ namespace SlowTests.Cluster
                     var follower = GetNewServer();
                     ServersForDisposal.Add(follower);
 
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                     using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                     {
                         await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(follower.WebUrl, watcher: true), ctx);
@@ -456,7 +456,7 @@ namespace SlowTests.Cluster
                 var server2Url = server2.ServerStore.GetNodeHttpServerUrl();
                 Servers.Add(server2);
 
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
                 using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
                 {
                     await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(server2Url, watcher: true), ctx);

--- a/test/SlowTests/Issues/RavenDB-11372.cs
+++ b/test/SlowTests/Issues/RavenDB-11372.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
             });
 
             var url = Server.WebUrl;
-            var reqExec = RequestExecutor.CreateForSingleNodeWithoutConfigurationUpdates(url, "Foo", null, DocumentConventions.Default);
+            var reqExec = RequestExecutor.CreateForShortTermUse(new string[] {url}, "Foo", null, DocumentConventions.Default);
             var op = new CreateDatabaseOperation(new Raven.Client.ServerWide.DatabaseRecord("Foo"));
             using (reqExec.ContextPool.AllocateOperationContext(out var ctx))
             {

--- a/test/SlowTests/Issues/RavenDB-16958.cs
+++ b/test/SlowTests/Issues/RavenDB-16958.cs
@@ -221,7 +221,7 @@ namespace SlowTests.Issues
             var cluster = await CreateRaftClusterWithSsl(1, watcherCluster: true);
             var serverB = CreateSecuredServer(cluster.Leader.ServerStore.GetNodeTcpServerUrl(), uniqueCerts: false);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(cluster.Leader.WebUrl, cluster.Leader.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(cluster.Leader.WebUrl, cluster.Leader.Certificate.Certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 string database = GetDatabaseName();

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -533,6 +533,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // new server should have only 0 backups
                 var server = GetNewServer();
+                await server.ServerStore.EnsureNotPassiveAsync();
 
                 using (Databases.EnsureDatabaseDeletion(databaseName, store))
                 using (var store2 = GetDocumentStore(new Options
@@ -713,6 +714,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 // new server should have only one backup
                 var server = GetNewServer();
+                await server.ServerStore.EnsureNotPassiveAsync();
                 using (var store3 = GetDocumentStore(new Options
                 {
                     CreateDatabase = false,

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -1033,7 +1033,7 @@ namespace Tests.Infrastructure
         private static async Task<string[]> GetClusterNodeUrlsAsync(string leadersUrl, IDocumentStore store)
         {
             string[] urls;
-            using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leadersUrl, store.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leadersUrl, store.Certificate, DocumentConventions.DefaultForServer))
             {
                 try
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -57,6 +57,7 @@ namespace FastTests
                 {
                     options ??= Options.Default;
                     var serverToUse = options.Server ?? Server;
+                    AsyncHelpers.RunSync(() => serverToUse.ServerStore.EnsureNotPassiveAsync());
 
                     var name = GetDatabaseName(caller);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20954

### Additional description

- operations with `SelectedNodeTag` (regardless of `disableTopologyUpdate`) did a failover to a preferred node which wasn't the *selected* node (thus we were succeeding when we expected to fail). Fix was: calling`ChooseNodeForRequest` on retry instead of `GetPreferredNode`
- operations that are waited on (patch etc) did not go to the correct node where the operation resides because `disableTopologyUpdate` skipped their `SelectedNodeTag`. Fix was: Remove `_disableTopologyUpdate` check and always respect `SelectedNodeTag`.

Since both of these are dependent on node tag, if we disabled the topology updates we never had the cluster tag of each url, and could never run those operations according to their `SelectedNodeTag`.
Added `SingleTopologyUpdate` that fetches the node tag for all the initial urls and happens once.

- Added a check for server role = Member in `GetPreferredNodeInternal`

These changes will also fix a bug in v6.0:
https://issues.hibernatingrhinos.com/issue/RavenDB-20909/Proxy-command-loops-forever-when-the-targeted-node-is-down

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Changed behavior when using `_disableTopologyUpdate=true` or when targeted node is in rehab - `SelectedNodeTag` operations that previously "worked" will now throw. 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
