### PR TITLE
RavenDB-20953 Set overflow pages as free in case of deletion to avoid losing storage memory.

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1863,11 +1863,20 @@ namespace Corax
             if (numberOfEntries == 0)
             {
                 llt.FreePage(postingListState.RootPage);
+                
                 Container.Delete(llt, _postingListContainerId, containerId);
+                RemovePostingListFromLargePostingListsSet(containerId);
                 return AddEntriesToTermResult.RemoveTermId;
             }
 
             return AddEntriesToTermResult.NothingToDo;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void RemovePostingListFromLargePostingListsSet(long containerId)
+        {
+            _largePostingListSet ??= _transaction.OpenPostingList(Constants.IndexWriter.LargePostingListsSetSlice);
+            _largePostingListSet.Remove(containerId);
         }
 
         private void InsertNumericFieldLongs(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf)

--- a/src/Voron/Data/CompactTrees/PersistentDictionary.cs
+++ b/src/Voron/Data/CompactTrees/PersistentDictionary.cs
@@ -144,7 +144,22 @@ namespace Voron.Data.CompactTrees
                 return previousDictionary;
 
             if (previousDictionary != null)
-                llt.FreePage(previousDictionary.DictionaryId);
+            {
+                var previousDictionaryPage = llt.GetPage(previousDictionary.DictionaryId);
+                if (previousDictionaryPage.IsOverflow == false)
+                {
+                    llt.FreePage(previousDictionary.DictionaryId);
+                }
+                else
+                {
+                    var overflowPageNumber = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(previousDictionaryPage.OverflowSize);
+                    for (long pageToRelease = previousDictionary.DictionaryId; pageToRelease < previousDictionary.DictionaryId + overflowPageNumber; ++pageToRelease)
+                    {
+                        llt.FreePage(pageToRelease);
+                    }
+                }
+                
+            }
 
             int requiredSize = Encoder3Gram<AdaptiveMemoryEncoderState>.GetDictionarySize(encoderState);
             int requiredTotalSize = requiredSize + PersistentDictionaryHeader.SizeOf;

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -693,9 +693,13 @@ namespace Voron.Data.Containers
 
             if (page.IsOverflow)
             {
-               rootContainer.Header.NumberOfOverflowPages -= VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);
+                var numberOfOverflowPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);
+                rootContainer.Header.NumberOfOverflowPages -= numberOfOverflowPages;
                 ModifyMetadataList(llt, rootContainer, ContainerPageHeader.AllPagesOffset, add: false, pageNum);
-                llt.FreePage(pageNum);
+                
+                for (var pageToRelease = pageNum; pageToRelease < pageNum + numberOfOverflowPages; ++pageToRelease)
+                    llt.FreePage(pageToRelease);
+                
                 return;
             }
 

--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -338,6 +338,9 @@ namespace Voron.Data.Tables
             var fst = _parentTree.FixedTreeFor(AllocationStorage, valSize: BitmapSize);
 
             var results = new List<long>();
+
+            if (fst.PageCount == 0)
+                return results;
             
             using (var it = fst.Iterate())
             {

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1275,13 +1275,22 @@ namespace Voron
 
             void RegisterContainer(long container, string name)
             {
+                var overflowName = $"{name}/OverflowPage";
                 var (allPages, freePages) = Container.GetPagesFor(tx.LowLevelTransaction, container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");
                 RegisterPages(freePages.AllPages(), name + "/FreePagesSet");
                 var iterator = Container.GetAllPagesSet(tx.LowLevelTransaction, container);
                 while (iterator.TryMoveNext(out var page))
                 {
+                    var pageObject = tx.LowLevelTransaction.GetPage(page);
                     r.Add(page, name);
+                    if (pageObject.IsOverflow == false)
+                        continue;
+                    
+
+                    var numberOfOverflowPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(pageObject.OverflowSize);
+                    for (int overflowPage = 1; overflowPage < numberOfOverflowPages; ++overflowPage)
+                        r.Add(page + overflowPage, overflowName);
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20953 

### Additional description

1) In case of deletion overflow item, we've to free overflow pages too.
2) In case of posting list removal we've to also remove reference to it from LargePostingList array
3) Include overflow pages in storage report (to avoid erroneous gaps report)
4) Track overflow pages removal in debug mode to detect leaks in future
5) Remove overflow pages during dictionary replacement.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
