### PR TITLE
RavenDB-20878: fix docs skipped when subscription send only from resend list

### DIFF
--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.ServerWide.Context;
@@ -82,7 +81,7 @@ namespace Raven.Server.Documents.Replication
                         };
                         conflicts.AddRange(_database.DocumentsStorage.ConflictsStorage.GetConflictsFor(documentsContext, id));
 
-                        var localDocumentTuple = _database.DocumentsStorage.GetDocumentOrTombstone(documentsContext, id, false);
+                        var localDocumentTuple = _database.DocumentsStorage.GetDocumentOrTombstone(documentsContext, id, throwOnConflict: false);
                         var local = DocumentConflict.From(documentsContext, localDocumentTuple.Document) ?? DocumentConflict.From(localDocumentTuple.Tombstone);
                         if (local != null)
                             conflicts.Add(local);
@@ -113,7 +112,7 @@ namespace Raven.Server.Documents.Replication
             }
             if (existing.Tombstone != null)
             {
-                if (string.Equals(existing.Tombstone.Collection,collection, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(existing.Tombstone.Collection, collection, StringComparison.OrdinalIgnoreCase))
                     return true;
                 if (existing.Tombstone.Collection == null)
                     return string.Equals(collection, Client.Constants.Documents.Collections.EmptyCollection, StringComparison.OrdinalIgnoreCase);
@@ -178,8 +177,8 @@ namespace Raven.Server.Documents.Replication
                 conflictedDocs,
                 documentsContext.GetLazyString(collection), out var resolved))
             {
-                 _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, incoming: conflict);
-                 return true;
+                _conflictResolver.PutResolvedDocument(documentsContext, resolved, resolvedToLatest: false, incoming: conflict);
+                return true;
             }
 
             return false;
@@ -262,7 +261,7 @@ namespace Raven.Server.Documents.Replication
                     nonPersistentFlags |= NonPersistentDocumentFlags.ResolveTimeSeriesConflict;
 
                 _database.DocumentsStorage.Put(context, id, null, incomingDoc, lastModifiedTicks, mergedChangeVector,
-                    flags: existingDoc.Flags | DocumentFlags.Resolved, 
+                    flags: existingDoc.Flags | DocumentFlags.Resolved,
                     nonPersistentFlags: nonPersistentFlags);
                 return true;
             }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -162,10 +162,10 @@ public class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDatabaseSu
         return false;
     }
 
-    protected override bool ShouldFetchFromResend(DocumentsOperationContext context, string id, DocumentsStorage.DocumentOrTombstone item, string currentChangeVector, out string reason)
+    protected override bool ShouldFetchFromResend(DocumentsOperationContext context, string id, Document item, string currentChangeVector, out string reason)
     {
         reason = null;
-        if (item.Document == null)
+        if (item == null)
         {
             // the document was delete while it was processed by the client
             ItemsToRemoveFromResend.Add(id);
@@ -173,11 +173,11 @@ public class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDatabaseSu
             return false;
         }
 
-        var cv = context.GetChangeVector(item.Document.ChangeVector);
+        var cv = context.GetChangeVector(item.ChangeVector);
         if (cv.IsSingle)
             return base.ShouldFetchFromResend(context, id, item, currentChangeVector, out reason);
 
-        item.Document.ChangeVector = context.GetChangeVector(cv.Version, cv.Order.RemoveId(_sharding.DatabaseId, context));
+        item.ChangeVector = context.GetChangeVector(cv.Version, cv.Order.RemoveId(_sharding.DatabaseId, context));
 
         return base.ShouldFetchFromResend(context, id, item, currentChangeVector, out reason);
     }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Includes.Sharding;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.Processor;
+using Raven.Server.Documents.Subscriptions.Sharding;
 using Raven.Server.Documents.Subscriptions.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide;
@@ -32,7 +33,7 @@ public class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDatabaseSu
     protected override SubscriptionFetcher<Document> CreateFetcher()
     {
         _sharding = _database.ShardingConfiguration;
-        return base.CreateFetcher();
+        return new ShardDocumentSubscriptionFetcher(Database, SubscriptionConnectionsState, Collection);
     }
 
     protected override ConflictStatus GetConflictStatus(string changeVector)

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Raven.Server.Documents.Subscriptions.Sharding;
+
+public class ShardDocumentSubscriptionFetcher : DocumentSubscriptionFetcher
+{
+    public ShardDocumentSubscriptionFetcher(DocumentDatabase database, SubscriptionConnectionsState subscriptionConnectionsState, string collection) :
+        base(database, subscriptionConnectionsState, collection)
+    {
+    }
+
+    protected override IEnumerable<Document> FetchFromResend()
+    {
+        var records = new SortedDictionary<long, Document>();
+        foreach (var document in base.FetchFromResend())
+        {
+            var current = Database.DocumentsStorage.GetDocumentOrTombstone(DocsContext, document.Id, throwOnConflict: false);
+            using (current.Document)
+            using (current.Tombstone)
+            {
+                if (current.Missing || current.Document == null)
+                {
+                    document.Dispose();
+                    // items from another shard or might be already deleted
+                    continue;
+                }
+
+                records.Add(current.Document.Etag, document);
+            }
+        }
+
+        foreach (var kvp in records)
+            yield return kvp.Value;
+    }
+}

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
@@ -14,18 +14,17 @@ public class ShardDocumentSubscriptionFetcher : DocumentSubscriptionFetcher
         var records = new SortedDictionary<long, Document>();
         foreach (var document in base.FetchFromResend())
         {
-            var current = Database.DocumentsStorage.GetDocumentOrTombstone(DocsContext, document.Id, throwOnConflict: false);
-            using (current.Document)
-            using (current.Tombstone)
+            var current = Database.DocumentsStorage.Get(DocsContext, document.Id, fields: DocumentFields.Default, throwOnConflict: false);
+            using (current)
             {
-                if (current.Missing || current.Document == null)
+                if (current == null)
                 {
                     document.Dispose();
                     // items from another shard or might be already deleted
                     continue;
                 }
 
-                records.Add(current.Document.Etag, document);
+                records.Add(current.Etag, document);
             }
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedSubscriptionTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedSubscriptionTestBase.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Server;
+using Raven.Server.Documents.Commands.Subscriptions;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Xunit;
 
 namespace FastTests;
@@ -47,6 +49,50 @@ public partial class RavenTestBase
                     Assert.True(result == 0, $"{string.Join(Environment.NewLine, AbstractSubscriptionConnectionsState.GetResendItems(ctx, store.Database, id).Select(x=>$"{x.Id}, {x.ChangeVector}, {x.Batch}"))}");
                 }
             }
+        }
+
+        public async Task AssertNumberOfItemsInTheResendQueueAsync(IDocumentStore store, string subscriptionId, long expected, List<RavenServer> servers = null,
+            List<ShardedDocumentDatabase> shards = null)
+        {
+            var id = long.Parse(subscriptionId);
+            shards ??= await _parent.Sharding.GetShardsDocumentDatabaseInstancesFor(store, servers).ToListAsync();
+            foreach (var shard in shards)
+            {
+                if (shard.DatabaseShutdown.IsCancellationRequested)
+                    continue;
+
+                long result = await WaitForValueAsync(() =>
+                {
+                    using (shard.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        return Task.FromResult(
+                            AbstractSubscriptionConnectionsState.GetNumberOfResendDocuments(shard.ServerStore, store.Database, SubscriptionType.Document, id));
+                    }
+                }, expected, timeout: 60_000);
+
+                using (shard.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    Assert.True(result == expected,
+                        $"{string.Join(Environment.NewLine, AbstractSubscriptionConnectionsState.GetResendItems(ctx, store.Database, id).Select(x => $"{x.Id}, {x.ChangeVector}, {x.Batch}"))}");
+                }
+            }
+        }
+
+        public async Task AssertNoOpenSubscriptionConnectionsAsync(IDocumentStore store, string subscriptionId, RavenServer server)
+        {
+            Assert.Equal(0, await WaitForValueAsync(async () =>
+            {
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var cmd = new GetSubscriptionConnectionsDetailsCommand(subscriptionId, server.ServerStore.NodeTag);
+                    await store.GetRequestExecutor().ExecuteAsync(cmd, context);
+
+                    var res = cmd.Result;
+                    return res.Results.Count;
+                }
+            }, 0, interval: 500));
         }
     }
 }


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-20878
- https://issues.hibernatingrhinos.com/issue/RavenDB-20906

### Additional description

- removed concurrency check in ack command (was leftover from previous code) since when we send from resend list we don't use current subscription cv
- ~~added order by local etag to resend list for shardind subscription~~
- decided to just order the resend list locally instead of ordering it in voron table, so we don't need schema upgrade

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
