### PR TITLE
RavenDB-20960 SlowTests.Issues.RavenDB_20783.NullTimerInRecordFastest

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -1381,5 +1381,20 @@ namespace Raven.Client.Documents.Conventions
                 throw new InvalidOperationException(
                     $"Conventions has frozen after '{nameof(DocumentStore)}.{nameof(DocumentStore.Initialize)}()' and no changes can be applied to them.");
         }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal Action<RequestExecutor> OnBeforeTopologyUpdate;
+        }
     }
 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -366,6 +366,7 @@ namespace Raven.Client.Http
         public static RequestExecutor Create(string[] initialUrls, string databaseName, X509Certificate2 certificate, DocumentConventions conventions)
         {
             var executor = new RequestExecutor(databaseName, certificate, conventions, initialUrls);
+            conventions.ForTestingPurposes?.OnBeforeTopologyUpdate?.Invoke(executor);
             executor._firstTopologyUpdate = executor.FirstTopologyUpdate(initialUrls, GlobalApplicationIdentifier);
             return executor;
         }

--- a/test/SlowTests/Issues/RavenDB-20783.cs
+++ b/test/SlowTests/Issues/RavenDB-20783.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Http;
-using SlowTests.MailingList;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,29 +23,32 @@ namespace SlowTests.Issues
             var (servers, leader) = await CreateRaftCluster(3, watcherCluster: true);
             var mre = new ManualResetEventSlim(false);
             var mre2 = new ManualResetEventSlim(false);
+            NodeSelector node = null;
             using (var store = GetDocumentStore(new Options
                    {
                        Server = servers[0],
                        ModifyDatabaseName = s => $"{s}_1",
                        ReplicationFactor = 3,
-                       ModifyDocumentStore = s => s.Conventions.ReadBalanceBehavior = Raven.Client.Http.ReadBalanceBehavior.FastestNode
+                       ModifyDocumentStore = s =>
+                       {
+                           s.Conventions.ReadBalanceBehavior = ReadBalanceBehavior.FastestNode;
+                           //We need to block TopologyUpdate until SelectFastest is running
+                           s.Conventions.ForTestingPurposesOnly().OnBeforeTopologyUpdate = (ex) =>
+                           {
+                               ex.ForTestingPurposesOnly().OnBeforeScheduleSpeedTest = (n) =>
+                               {
+                                   node = n;
+                                   mre2.Set();
+                                   Assert.True(mre.Wait(_reasonableWaitTime), "Waited too long for RecordFastest");
+                               };
+                           };
+                       }
                    }))
             {
                 var requestExecutor = store.GetRequestExecutor();
-                NodeSelector node = null;
-                requestExecutor.ForTestingPurposesOnly().OnBeforeScheduleSpeedTest = (n) =>
-                {
-                    node = n;
-                    mre2.Set();
-                    Assert.True(mre.Wait(_reasonableWaitTime), "Waited too long");
-                };
-                _ = requestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(new ServerNode { Url = servers[0].WebUrl, Database = store.Database })
-                {
-                    TimeoutInMs = Timeout.Infinite,
-                    ForceUpdate = true,
-                    DebugTag = "first-topology-update",
-                });
-                Assert.True(mre2.Wait(_reasonableWaitTime), "Waited too long");
+
+                Assert.True(mre2.Wait(_reasonableWaitTime), "Waited too long for OnBeforeScheduleSpeedTest");
+
                 for (int i = 0; i < 10; i++)
                 {
                     node.RecordFastest(0, node.Topology.Nodes[0]);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20960

### Additional description

We had a race in the test. the problem was when we called UpdateTopologyAsync from GetRequestExecutor before setting  OnBeforeScheduleSpeedTest.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
