### PR TITLE
RavenDB-20839 - SlowTests.Smuggler.LegacySmugglerTests.CanImportRevis…

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -706,6 +706,7 @@ namespace Raven.Server.Smuggler.Documents
                             // in v3.x: rev1, rev2, document, rev3
                             parentDocument = _database.DocumentsStorage.Get(context, newId);
                             _missingDocumentsForRevisions.TryRemove(newId, out _);
+                            documentChangeVector = documentChangeVector.MergeWith(parentDocument.ChangeVector, context);
                         }
 
                         document.Flags |= DocumentFlags.HasRevisions;
@@ -721,7 +722,7 @@ namespace Raven.Server.Smuggler.Documents
                                 parentDocument.Data = parentDocument.Data.Clone(context);
 
                             _database.DocumentsStorage.Put(context, parentDocument.Id, null,
-                                parentDocument.Data, parentDocument.LastModified.Ticks, document.ChangeVector, null,
+                                parentDocument.Data, parentDocument.LastModified.Ticks, documentChangeVector, null,
                                 parentDocument.Flags, parentDocument.NonPersistentFlags);
                         }
 

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -280,8 +280,11 @@ namespace Raven.Server.Smuggler.Documents
                     };
                 }
 
-                document.Data = context.ReadObject(document.Data, document.Id);
-
+                using (var old = document.Data)
+                {
+                    document.Data = context.ReadObject(document.Data, document.Id);
+                }
+                
                 return DatabaseContext.GetShardNumberFor(_allocator, id);
             }
 


### PR DESCRIPTION
…ions2(file: "SlowTests.Smuggler.Data.DocumentWithRevisions.rave"...)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20839/SlowTests.Smuggler.LegacySmugglerTests.CanImportRevisions2file-SlowTests.Smuggler.Data.DocumentWithRevisions.rave...

### Additional description

Although the test fails only in 32bit - the problem exists for 64bit as well. 
When importing from v3.5 (with revisions) to v4.X+, we expect the following result:
Revision 'test/revisions/1' - change vector: RV:1-XXXX...
Revision 'test/revisions/2' - change vector: RV:2-XXXX...
Revision 'test/revisions/3' - change vector: RV:3-XXXX, A:1-YYYY...
Document 'test' - change vector: RV:3-XXXX, A:1-YYYY...

before those changes, the change vectors of the last revision ('test/revisions/3', LegacyRevision) and the document ('test', LegacyHasRevisions) both were RV:3-XXXX...; so for `UpdateGlobalReplicationInfoBeforeCommit.SetDatabaseChangeVector()` `ConflictStatus == Conflict ` and we throw `InvalidOperationException`.

In addition, we also detected and fix a bug for Sharding (missing `NonPersistentDocumentFlags.LegacyRevision`, `NonPersistentDocumentFlags.LegacyHasRevisions` flags). 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
