### PR TITLE
RavenDB-20715 - SlowTests.Client.Attachments.AttachmentsReplication.A…

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -774,7 +774,7 @@ namespace SlowTests.Client.Attachments
                 Assert.True(WaitForDocumentDeletion(store2, "users/1"));
 
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2);
+                WaitForMarker(store1, store2, "marker1$users/1");
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -794,7 +794,7 @@ namespace SlowTests.Client.Attachments
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 2"));
 
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2);
+                WaitForMarker(store1, store2, "marker2$users/1");
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -813,7 +813,7 @@ namespace SlowTests.Client.Attachments
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 3"));
 
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2);
+                WaitForMarker(store1, store2, "marker3$users/1");
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -832,7 +832,7 @@ namespace SlowTests.Client.Attachments
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 4"));
 
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2);
+                WaitForMarker(store1, store2, "marker4$users/1");
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {
@@ -851,7 +851,7 @@ namespace SlowTests.Client.Attachments
                 Assert.True(WaitForDocument<User>(store2, "users/1", u => u.Name == "Fitzchak 5"));
 
                 await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
-                WaitForMarker(store1, store2);
+                WaitForMarker(store1, store2, "marker5$users/1");
 
                 await AssertRevisionsAsync(store2, names, (session, revisions) =>
                 {


### PR DESCRIPTION
…ttachmentsRevisionsReplication(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20715/SlowTests.Client.Attachments.AttachmentsReplication.AttachmentsRevisionsReplicationoptions-DatabaseMode-Sharded-SearchEngineMode

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
