### PR TITLE
RavenDB-20968 dereference shard & orchestrator executors

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/AbstractExecutor.cs
@@ -33,6 +33,12 @@ public abstract class AbstractExecutor : IDisposable
         ServerStore.Server.ServerCertificateChanged += OnCertificateChange;
     }
 
+    public void ForgetAbout()
+    {
+        // the event handler holds a strong reference to this object, so it will not be collected by the gc
+        ServerStore.Server.ServerCertificateChanged -= OnCertificateChange;
+    }
+
     public abstract RequestExecutor GetRequestExecutorAt(int position);
 
     protected abstract Memory<int> GetAllPositions();

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -120,6 +120,7 @@ namespace Raven.Server.Documents.Sharding
 
             if (DictionaryExtensions.KeysEqual(record.Sharding.Shards, _record.Sharding.Shards) == false)
             {
+                ShardExecutor.ForgetAbout();
                 ShardExecutor = new ShardExecutor(ServerStore, record, record.DatabaseName);
             }
             else
@@ -139,6 +140,7 @@ namespace Raven.Server.Documents.Sharding
 
             if (CheckForTopologyChangesAndRaiseNotification(record.Sharding.Orchestrator.Topology, _record.Sharding.Orchestrator.Topology))
             {
+                AllOrchestratorNodesExecutor.ForgetAbout();
                 AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, record);
             }
 
@@ -171,8 +173,10 @@ namespace Raven.Server.Documents.Sharding
             // we explicitly do not dispose the old executors here to avoid possible memory invalidation and since this is expected to be rare.
             // So we rely on the GC to dispose them via the finalizer
             
+            ShardExecutor.ForgetAbout();
             ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
 
+            AllOrchestratorNodesExecutor.ForgetAbout();
             AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20968

### Additional description

We rely on the GC to dispose the shard & orchestrator executors, to avoid invalidate a context that might be in use by ongoing requests. 

But those executors had a reference from the `ServerCertificateChanged` event handler, so they never collected by the GC.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
