### PR TITLE
RavenDB-20975 - support ThenBy and ThenByDescending in a JS projection

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -639,11 +639,13 @@ namespace Raven.Client.Util
                             }
                         }
                     case "OrderBy":
+                    case "ThenBy":
                         {
                             OrderByToSort(context, methodCallExpression);
                             return;
                         }
                     case "OrderByDescending":
+                    case "ThenByDescending":
                         {
                             OrderByToSort(context, methodCallExpression, true);
                             return;

--- a/test/SlowTests/Issues/RavenDB-20975.cs
+++ b/test/SlowTests/Issues/RavenDB-20975.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20975 : RavenTestBase
+    {
+        public RavenDB_20975(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Support_ThenBy_ThenByDescending_In_Projection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Lines = new List<OrderLine>
+                        {
+                            new()
+                            {
+                                Discount = 10,
+                                ProductName = "A"
+                            },
+                            new()
+                            {
+                                Discount = 10,
+                                ProductName = "B"
+                            }
+                        }
+                    });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from doc in session.Query<Order>()
+                        let line = doc.Lines.OrderByDescending(x => x.Discount).ThenByDescending(x => x.ProductName).FirstOrDefault()
+                        select new
+                        {
+                            Line = line
+                        };
+
+                    var result = query.ToList();
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal(result[0].Line.ProductName, "B");
+
+                    query = from doc in session.Query<Order>()
+                        let line = doc.Lines.OrderByDescending(x => x.Discount).ThenBy(x => x.ProductName).FirstOrDefault()
+                        select new
+                        {
+                            Line = line
+                        };
+
+                    result = query.ToList();
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal(result[0].Line.ProductName, "A");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20975/ThenBy-and-ThenByDescending-isnt-supported-in-a-JS-projection

### Additional description

Support ThenBy and ThenByDescending in a JS projection.

### Type of change

- Bug fix
- 
### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
