### PR TITLE
RavenDB-20733 Databases view: Offline / Online confusion

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Toggles.scss
+++ b/src/Raven.Studio/typescript/components/common/Toggles.scss
@@ -259,6 +259,8 @@ $separator-color: colors.$border-color-light-var;
         .vr {
             margin: $separator-margin 4px $separator-margin 0;
             background-color: colors.$border-color-var;
+            width: 2px;
+            opacity: 0.5;
         }
 
         .multi-toggle-item {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
@@ -1,5 +1,5 @@
 ﻿import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ComponentMeta, ComponentStory, StoryObj } from "@storybook/react";
 import clusterTopologyManager from "common/shell/clusterTopologyManager";
 import React from "react";
 import { DatabasesPage } from "./DatabasesPage";
@@ -157,4 +157,21 @@ export const DifferentNodeStates: ComponentStory<typeof DatabasesPage> = () => {
     mockServices.databasesService.withGetDatabasesState(() => [clusterDb.name, ...shardedDb.shards.map((x) => x.name)]);
 
     return <DatabasesPage />;
+};
+
+export const WithOfflineNodes: StoryObj = {
+    render: ({ offlineNodes }: { offlineNodes: string[] }) => {
+        commonInit();
+
+        const value = mockStore.databases.with_Cluster();
+
+        mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value), {
+            offlineNodes: offlineNodes,
+        });
+
+        return <DatabasesPage />;
+    },
+    args: {
+        offlineNodes: ["A"],
+    },
 };

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseDistribution.tsx
@@ -9,13 +9,10 @@ import { DatabaseLoadError } from "components/pages/resources/databases/partials
 import { Icon } from "components/common/Icon";
 import { selectDatabaseState } from "components/pages/resources/databases/store/databasesViewSelectors";
 import { DatabaseNodeSetItem } from "components/pages/resources/databases/partials/DatabaseNodeSetItem";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 interface DatabaseDistributionProps {
     db: DatabaseSharedInfo;
-}
-
-function formatUptime(uptime: string) {
-    return uptime ?? "Offline";
 }
 
 export function DatabaseDistribution(props: DatabaseDistributionProps) {
@@ -76,7 +73,7 @@ export function DatabaseDistribution(props: DatabaseDistributionProps) {
 
                 const node = nodesToUse.find((x) => x.tag === localState.location.nodeTag);
 
-                const uptime = localState.data ? formatUptime(localState.data.upTime) : "";
+                const uptime = localState.data ? DatabaseUtils.formatUptime(localState.data.upTime) : "";
 
                 return (
                     <DistributionItem
@@ -91,7 +88,7 @@ export function DatabaseDistribution(props: DatabaseDistributionProps) {
                     >
                         {sharded && shard}
                         <div className={classNames("node", { top: !sharded })}>
-                            <DatabaseNodeSetItem node={node} />
+                            <DatabaseNodeSetItem node={node} isOffline={uptime === "Offline"} />
                         </div>
                         <div className="entries">
                             {localState.data?.loadError ? (

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseNodeSetItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseNodeSetItem.tsx
@@ -3,13 +3,13 @@ import { NodeSetItem } from "components/common/NodeSet";
 import React from "react";
 import assertUnreachable from "components/utils/assertUnreachable";
 
-export function DatabaseNodeSetItem(props: { node: NodeInfo }) {
-    const { node } = props;
+export function DatabaseNodeSetItem(props: { node: NodeInfo; isOffline?: boolean }) {
+    const { node, isOffline } = props;
     return (
         <NodeSetItem
             key={node.tag}
             icon={iconForNodeType(node.type)}
-            color={colorForNodeType(node.type)}
+            color={colorForNodeType(node.type, isOffline)}
             title={node.type}
         >
             {node.tag}
@@ -17,7 +17,11 @@ export function DatabaseNodeSetItem(props: { node: NodeInfo }) {
     );
 }
 
-function colorForNodeType(type: databaseGroupNodeType) {
+function colorForNodeType(type: databaseGroupNodeType, isOffline?: boolean) {
+    if (isOffline) {
+        return "muted";
+    }
+
     switch (type) {
         case "Member":
             return "node";

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseNodeSetItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseNodeSetItem.tsx
@@ -5,6 +5,7 @@ import assertUnreachable from "components/utils/assertUnreachable";
 
 export function DatabaseNodeSetItem(props: { node: NodeInfo; isOffline?: boolean }) {
     const { node, isOffline } = props;
+
     return (
         <NodeSetItem
             key={node.tag}
@@ -18,13 +19,9 @@ export function DatabaseNodeSetItem(props: { node: NodeInfo; isOffline?: boolean
 }
 
 function colorForNodeType(type: databaseGroupNodeType, isOffline?: boolean) {
-    if (isOffline) {
-        return "muted";
-    }
-
     switch (type) {
         case "Member":
-            return "node";
+            return isOffline ? "muted" : "node";
         case "Rehab":
             return "danger";
         case "Promotable":

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -472,7 +472,11 @@ export function DatabasePanel(props: DatabasePanelProps) {
                             <DatabaseDistribution db={db} />
                         </Collapse>
                         <Collapse isOpen={panelCollapsed}>
-                            <DatabaseTopology db={db} dbState={dbState} togglePanelCollapsed={togglePanelCollapsed} />
+                            <DatabaseTopology
+                                db={db}
+                                localInfos={dbState}
+                                togglePanelCollapsed={togglePanelCollapsed}
+                            />
                         </Collapse>
                     </div>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -472,7 +472,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                             <DatabaseDistribution db={db} />
                         </Collapse>
                         <Collapse isOpen={panelCollapsed}>
-                            <DatabaseTopology db={db} togglePanelCollapsed={togglePanelCollapsed} />
+                            <DatabaseTopology db={db} dbState={dbState} togglePanelCollapsed={togglePanelCollapsed} />
                         </Collapse>
                     </div>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopology.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopology.tsx
@@ -7,12 +7,12 @@ import { locationAwareLoadableData } from "components/models/common";
 
 interface DatabaseTopologyProps {
     db: DatabaseSharedInfo;
-    dbState: locationAwareLoadableData<DatabaseLocalInfo>[];
+    localInfos: locationAwareLoadableData<DatabaseLocalInfo>[];
     togglePanelCollapsed: () => void;
 }
 
 export function DatabaseTopology(props: DatabaseTopologyProps) {
-    const { db, dbState, togglePanelCollapsed } = props;
+    const { db, localInfos, togglePanelCollapsed } = props;
 
     if (db.sharded) {
         const shardedDb = db as ShardedDatabaseSharedInfo;
@@ -28,7 +28,7 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                         Orchestrators
                     </NodeSetLabel>
                     {db.nodes.map((node) => (
-                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} dbState={dbState} />
+                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} localInfos={localInfos} />
                     ))}
                 </NodeSet>
 
@@ -49,7 +49,7 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                                     <DatabaseTopologyNodeSetItem
                                         key={node.tag}
                                         node={node}
-                                        dbState={dbState}
+                                        localInfos={localInfos}
                                         shardNumber={shardNumber}
                                     />
                                 ))}
@@ -82,7 +82,7 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                 >
                     <NodeSetLabel icon="database">Nodes</NodeSetLabel>
                     {db.nodes.map((node) => (
-                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} dbState={dbState} />
+                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} localInfos={localInfos} />
                     ))}
                     {db.deletionInProgress.map((node) => {
                         return (

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopology.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopology.tsx
@@ -1,16 +1,18 @@
-﻿import { DatabaseSharedInfo, ShardedDatabaseSharedInfo } from "components/models/databases";
+﻿import { DatabaseLocalInfo, DatabaseSharedInfo, ShardedDatabaseSharedInfo } from "components/models/databases";
 import { NodeSet, NodeSetItem, NodeSetLabel } from "components/common/NodeSet";
-import { DatabaseNodeSetItem } from "components/pages/resources/databases/partials/DatabaseNodeSetItem";
 import React from "react";
 import DatabaseUtils from "components/utils/DatabaseUtils";
+import DatabaseTopologyNodeSetItem from "./DatabaseTopologyNodeSetItem";
+import { locationAwareLoadableData } from "components/models/common";
 
 interface DatabaseTopologyProps {
     db: DatabaseSharedInfo;
+    dbState: locationAwareLoadableData<DatabaseLocalInfo>[];
     togglePanelCollapsed: () => void;
 }
 
 export function DatabaseTopology(props: DatabaseTopologyProps) {
-    const { db, togglePanelCollapsed } = props;
+    const { db, dbState, togglePanelCollapsed } = props;
 
     if (db.sharded) {
         const shardedDb = db as ShardedDatabaseSharedInfo;
@@ -26,11 +28,12 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                         Orchestrators
                     </NodeSetLabel>
                     {db.nodes.map((node) => (
-                        <DatabaseNodeSetItem key={node.tag} node={node} />
+                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} dbState={dbState} />
                     ))}
                 </NodeSet>
 
                 {shardedDb.shards.map((shard) => {
+                    const shardNumber = DatabaseUtils.shardNumber(shard.name);
                     return (
                         <React.Fragment key={shard.name}>
                             <NodeSet
@@ -40,10 +43,15 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                                 title="Expand distribution details"
                             >
                                 <NodeSetLabel color="shard" icon="shard">
-                                    #{DatabaseUtils.shardNumber(shard.name)}
+                                    #{shardNumber}
                                 </NodeSetLabel>
-                                {shard.nodes.map((node) => (
-                                    <DatabaseNodeSetItem key={node.tag} node={node} />
+                                {db.nodes.map((node) => (
+                                    <DatabaseTopologyNodeSetItem
+                                        key={node.tag}
+                                        node={node}
+                                        dbState={dbState}
+                                        shardNumber={shardNumber}
+                                    />
                                 ))}
                                 {shard.deletionInProgress.map((node) => {
                                     return (
@@ -73,9 +81,9 @@ export function DatabaseTopology(props: DatabaseTopologyProps) {
                     title="Expand distribution details"
                 >
                     <NodeSetLabel icon="database">Nodes</NodeSetLabel>
-                    {db.nodes.map((node) => {
-                        return <DatabaseNodeSetItem key={node.tag} node={node} />;
-                    })}
+                    {db.nodes.map((node) => (
+                        <DatabaseTopologyNodeSetItem key={node.tag} node={node} dbState={dbState} />
+                    ))}
                     {db.deletionInProgress.map((node) => {
                         return (
                             <NodeSetItem

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopologyNodeSetItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopologyNodeSetItem.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { locationAwareLoadableData } from "components/models/common";
+import { NodeInfo, DatabaseLocalInfo } from "components/models/databases";
+import DatabaseUtils from "components/utils/DatabaseUtils";
+import { databaseLocationComparator } from "components/utils/common";
+import { DatabaseNodeSetItem } from "./DatabaseNodeSetItem";
+
+interface DatabaseTopologyNodeSetItemProps {
+    node: NodeInfo;
+    dbState: locationAwareLoadableData<DatabaseLocalInfo>[];
+    shardNumber?: number;
+}
+
+export default function DatabaseTopologyNodeSetItem({ node, dbState, shardNumber }: DatabaseTopologyNodeSetItemProps) {
+    const localInfo = dbState.find((x) =>
+        databaseLocationComparator(x.location, {
+            nodeTag: node.tag,
+            shardNumber,
+        })
+    );
+
+    const isOffline = DatabaseUtils.formatUptime(localInfo?.data?.upTime) === "Offline";
+
+    return <DatabaseNodeSetItem node={node} isOffline={isOffline} />;
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopologyNodeSetItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabaseTopologyNodeSetItem.tsx
@@ -7,19 +7,29 @@ import { DatabaseNodeSetItem } from "./DatabaseNodeSetItem";
 
 interface DatabaseTopologyNodeSetItemProps {
     node: NodeInfo;
-    dbState: locationAwareLoadableData<DatabaseLocalInfo>[];
+    localInfos: locationAwareLoadableData<DatabaseLocalInfo>[];
     shardNumber?: number;
 }
 
-export default function DatabaseTopologyNodeSetItem({ node, dbState, shardNumber }: DatabaseTopologyNodeSetItemProps) {
-    const localInfo = dbState.find((x) =>
-        databaseLocationComparator(x.location, {
-            nodeTag: node.tag,
-            shardNumber,
-        })
+export default function DatabaseTopologyNodeSetItem({
+    node,
+    localInfos,
+    shardNumber,
+}: DatabaseTopologyNodeSetItemProps) {
+    const localInfo = localInfos.find((x) =>
+        shardNumber != null
+            ? databaseLocationComparator(x.location, {
+                  nodeTag: node.tag,
+                  shardNumber,
+              })
+            : x.location.nodeTag === node.tag
     );
 
-    const isOffline = DatabaseUtils.formatUptime(localInfo?.data?.upTime) === "Offline";
+    if (!localInfo) {
+        return null;
+    }
+
+    const isOffline = localInfo.data ? DatabaseUtils.formatUptime(localInfo.data.upTime) === "Offline" : false;
 
     return <DatabaseNodeSetItem node={node} isOffline={isOffline} />;
 }

--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
@@ -122,6 +122,10 @@ export default class DatabaseUtils {
             color: durationInSeconds > dayAsSeconds ? "warning" : "success",
         };
     }
+
+    static formatUptime(uptime: string): "Offline" | (string & NonNullable<unknown>) {
+        return uptime ?? "Offline";
+    }
 }
 
 const dayAsSeconds = 60 * 60 * 24;

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -6,12 +6,20 @@ import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 import StudioDatabaseState = Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabasesState.StudioDatabaseState;
 import RefreshConfiguration = Raven.Client.Documents.Operations.Refresh.RefreshConfiguration;
 
+interface WithGetDatabasesStateOptions {
+    loadError?: string[];
+    offlineNodes?: string[];
+}
+
 export default class MockDatabasesService extends AutoMockService<DatabasesService> {
     constructor() {
         super(new DatabasesService());
     }
 
-    withGetDatabasesState(databaseListProvider: (nodeTag: string) => string[], options: { loadError?: string[] } = {}) {
+    withGetDatabasesState(
+        databaseListProvider: (nodeTag: string) => string[],
+        options: WithGetDatabasesStateOptions = {}
+    ) {
         this.mocks.getDatabasesState.mockImplementation(async (tag) => {
             const dbs = databaseListProvider(tag);
 
@@ -23,6 +31,10 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
                         Name: db,
                         LoadError: "This is some load error!",
                     } as StudioDatabaseState;
+                }
+
+                if ((options.offlineNodes || []).includes(tag)) {
+                    state.UpTime = null;
                 }
 
                 return state;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20733/Databases-view-Offline-Online-confusion

### Additional description

For example now local + offline shows databases that are offline on the local node. Previously it shows offline that exist locally.
Now node icon is grey out if is offline.
vr seprator for filter by state is more visible

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/d3da1de2-1997-4dea-ba77-274b83587fa3)
![image](https://github.com/ravendb/ravendb/assets/47967925/609e65ea-03a1-4f7c-919a-9be75766f77b)

