### PR TITLE
RavenDB-7070: Remove Debug.Assert due to floating-point encoding. In the case of big numbers (like Ticks), it can lead to having different numbers.

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -643,7 +643,6 @@ namespace Corax
 
             public void Write(int fieldId, string path, ReadOnlySpan<byte> value, long longValue, double dblValue)
             {
-                Debug.Assert(longValue == (long)dblValue);
                 var field = GetField(fieldId, path);
 
                 if (field.ShouldStore)


### PR DESCRIPTION

### Additional description

: Remove Debug.Assert due to floating-point encoding. In the case of big numbers (like Ticks), it can lead to having different numbers.

### Type of change

- Regression bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
