### PR TITLE
RavenDB-20918 Move dictionary training from initialization into indexing thread for better UX.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
@@ -44,6 +44,7 @@ namespace Raven.Client.Documents.Indexes
             public const string Prepare = "Corax/Prepare";
             public const string AddDocument = "Corax/AddDocument";
             public const string Commit = "Corax/Commit";
+            public const string DictionaryTraining = "Corax/DictionaryTraining";
         }
 
         internal static class Storage

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -896,8 +896,6 @@ namespace Raven.Server.Documents.Indexes
 
             IndexFieldsPersistence = new IndexFieldsPersistence(this);
             IndexFieldsPersistence.Initialize();
-
-            IndexPersistence.OnInitializeComplete();
         }
 
         protected virtual void OnInitialization()
@@ -1537,6 +1535,11 @@ namespace Raven.Server.Documents.Indexes
                         DocumentDatabase.IndexStore.ForTestingPurposes?.OnRollingIndexStart?.Invoke(this);
                     }
 
+                    {
+                        var onBeforeExecutionStats = _lastStats = new IndexingStatsAggregator(DocumentDatabase.IndexStore.Identities.GetNextIndexingStatsId(), _lastStats);
+                        IndexPersistence.OnBeforeExecuteIndexing(onBeforeExecutionStats);
+                    }
+                    
                     while (true)
                     {
                         lock (_disablingIndexLock)

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexPersistenceBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexPersistenceBase.cs
@@ -26,8 +26,8 @@ namespace Raven.Server.Documents.Indexes.Persistence
         public abstract void Clean(IndexCleanup mode);
 
         public abstract void Initialize(StorageEnvironment environment);
-
-        public abstract void OnInitializeComplete();
+        
+        public abstract void OnBeforeExecuteIndexing(IndexingStatsAggregator indexingStatsAggregator);
 
         public abstract void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -255,8 +255,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
             _initialized = true;
         }
-
-        public override void OnInitializeComplete()
+        
+        public override void OnBeforeExecuteIndexing(IndexingStatsAggregator indexingStatsAggregator)
         {
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20918 

### Additional description

-Move dictionary training from initialization into indexing thread for better UX.
-Expose dictionary phase in indexing performance view.

### Type of change

- Optimization

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

-We've to set the color for the dictionary training phase. Also, it disappears after refresh in PerformanceView (I assume it is configurable in studio code)
