### PR TITLE
RavenDB-20709 Dedicated thread for executing cluster transactions

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -6,7 +6,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Commercial;
@@ -15,7 +14,6 @@ using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
-using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.ETL;
@@ -50,11 +48,13 @@ using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Meters;
+using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
 using Voron.Exceptions;
 using Voron.Impl.Backup;
+using static Raven.Server.Monitoring.Snmp.SnmpOids;
 using Constants = Raven.Client.Constants;
 using DatabaseInfo = Raven.Client.ServerWide.Operations.DatabaseInfo;
 using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
@@ -175,7 +175,7 @@ namespace Raven.Server.Documents
                 {
                     serverStore.DatabasesLandlord.CatastrophicFailureHandler.Execute(name, e, environmentId, environmentPath, stacktrace);
                 });
-                _hasClusterTransaction = new AsyncManualResetEvent(DatabaseShutdown);
+                _hasClusterTransaction = new ManualResetEvent(false);
                 IdentityPartsSeparator = '/';
             }
             catch (Exception)
@@ -362,12 +362,13 @@ namespace Raven.Server.Documents
                     }
                 }, null);
 
-                _clusterTransactionsTask = Task.Run(async () =>
+                _clusterTransactionsThread = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
                 {
+                    ThreadHelper.TrySetThreadPriority(ThreadPriority.AboveNormal, "Cluster Transaction" , _logger);
                     try
                     {
                         _hasClusterTransaction.Set();
-                        await ExecuteClusterTransactionTask();
+                        ExecuteClusterTransaction();
                     }
                     catch (OperationCanceledException)
                     {
@@ -380,7 +381,11 @@ namespace Raven.Server.Documents
                             _logger.Info("An unhandled exception closed the cluster transaction task", e);
                         }
                     }
-                }, DatabaseShutdown);
+                }, null, ThreadNames.ForClusterTransactions("Cluster Transaction"));
+
+
+
+
                 _serverStore.LicenseManager.LicenseChanged += LoadTimeSeriesPolicyRunnerConfigurations;
                 IoChanges.OnIoChange += CheckWriteRateAndNotifyIfNecessary;
             }
@@ -413,7 +418,7 @@ namespace Raven.Server.Documents
             return new DatabaseDisabledException("The database " + Name + " is shutting down", e);
         }
 
-        private readonly AsyncManualResetEvent _hasClusterTransaction;
+        private readonly ManualResetEvent _hasClusterTransaction;
         public readonly DatabaseMetricCacher MetricCacher;
 
         public void NotifyOnPendingClusterTransaction(long index, DatabasesLandlord.ClusterDatabaseChangeType changeType)
@@ -432,7 +437,7 @@ namespace Raven.Server.Documents
         public long LastCompletedClusterTransaction => _lastCompletedClusterTransaction;
         public bool IsEncrypted => MasterKey != null;
 
-        private Task _clusterTransactionsTask;
+        private PoolOfThreads.LongRunningWork _clusterTransactionsThread;
         private int _clusterTransactionDelayOnFailure = 1000;
         private FileLocker _fileLocker;
 
@@ -450,18 +455,18 @@ namespace Raven.Server.Documents
             StorageEnvironmentWithType.StorageEnvironmentType.Configuration,
         };
 
-        private async Task ExecuteClusterTransactionTask()
+        private void ExecuteClusterTransaction()
         {
             while (DatabaseShutdown.IsCancellationRequested == false)
             {
                 var topology = ServerStore.LoadDatabaseTopology(Name);
                 if (topology.Promotables.Contains(ServerStore.NodeTag))
                 {
-                    await Task.Delay(1000, DatabaseShutdown);
+                    DatabaseShutdown.WaitHandle.WaitOne(1000);
                     continue;
                 }
 
-                await _hasClusterTransaction.WaitAsync(DatabaseShutdown);
+                _hasClusterTransaction.WaitOne();
                 if (DatabaseShutdown.IsCancellationRequested)
                     return;
 
@@ -473,7 +478,7 @@ namespace Raven.Server.Documents
                     using (context.OpenReadTransaction())
                     {
                         var batchSize = Configuration.Cluster.MaxClusterTransactionsBatchSize;
-                        var executed = await ExecuteClusterTransaction(context, batchSize);
+                        var executed = ExecuteClusterTransaction(context, batchSize);
                         if (executed.Count == batchSize)
                         {
                             // we might have more to execute
@@ -491,7 +496,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async Task<List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> ExecuteClusterTransaction(TransactionOperationContext context, int batchSize)
+        public List<ClusterTransactionCommand.SingleClusterDatabaseCommand> ExecuteClusterTransaction(TransactionOperationContext context, int batchSize)
         {
             var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
                 ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: batchSize));
@@ -524,7 +529,7 @@ namespace Raven.Server.Documents
                 {
                     //If we get a database shutdown while we process a cluster tx command this
                     //will cause us to stop running and disposing the context while its memory is still been used by the merger execution
-                    await TxMerger.Enqueue(mergedCommands);
+                    TxMerger.Enqueue(mergedCommands).GetAwaiter().GetResult();
                 }
                 catch (Exception e) when (_databaseShutdown.IsCancellationRequested == false)
                 {
@@ -532,7 +537,7 @@ namespace Raven.Server.Documents
                     {
                         _logger.Info($"Failed to execute cluster transaction batch (count: {batch.Count}), will retry them one-by-one.", e);
                     }
-                    await ExecuteClusterTransactionOneByOne(batch);
+                    ExecuteClusterTransactionOneByOne(batch);
                     return batch;
                 }
 
@@ -566,7 +571,7 @@ namespace Raven.Server.Documents
             return batch;
         }
 
-        private async Task ExecuteClusterTransactionOneByOne(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch)
+        private void ExecuteClusterTransactionOneByOne(List<ClusterTransactionCommand.SingleClusterDatabaseCommand> batch)
         {
             foreach (var command in batch)
             {
@@ -577,7 +582,7 @@ namespace Raven.Server.Documents
                 var mergedCommand = new BatchHandler.ClusterTransactionMergedCommand(this, singleCommand);
                 try
                 {
-                    await TxMerger.Enqueue(mergedCommand);
+                    TxMerger.Enqueue(mergedCommand).GetAwaiter().GetResult();
                     OnClusterTransactionCompletion(command, mergedCommand);
 
                     _clusterTransactionDelayOnFailure = 1000;
@@ -597,7 +602,7 @@ namespace Raven.Server.Documents
                         $"{Name}/ClusterTransaction",
                         new ExceptionDetails(e)));
 
-                    await Task.Delay(_clusterTransactionDelayOnFailure, DatabaseShutdown);
+                    DatabaseShutdown.WaitHandle.WaitOne(_clusterTransactionDelayOnFailure);
                     _clusterTransactionDelayOnFailure = Math.Min(_clusterTransactionDelayOnFailure * 2, 15000);
 
                     return;
@@ -877,29 +882,16 @@ namespace Raven.Server.Documents
             });
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposed DocumentsStorage");
 
-            var clusterTransactionsTask = _clusterTransactionsTask;
-            if (clusterTransactionsTask != null)
+            ForTestingPurposes?.DisposeLog?.Invoke(Name, "Waiting for cluster transactions executor task to complete");
+            exceptionAggregator.Execute(() =>
             {
-                ForTestingPurposes?.DisposeLog?.Invoke(Name, "Waiting for cluster transactions executor task to complete");
-                exceptionAggregator.Execute(() =>
-                {
-                    try
-                    {
-                        clusterTransactionsTask.Wait();
-                    }
-                    catch (AggregateException e)
-                    {
-                        if (e.ExtractSingleInnerException() is TaskCanceledException)
-                        {
-                            // _clusterTransactionsTask might be TaskCanceled in case we dispose right after Initialize
-                            return;
-                        }
-
-                        throw;
-                    }
-                });
-                ForTestingPurposes?.DisposeLog?.Invoke(Name, "Finished waiting for cluster transactions executor task to complete");
-            }
+                var clusterTransactions = _clusterTransactionsThread;
+                _clusterTransactionsThread = null;
+                _hasClusterTransaction.Set();
+                if (clusterTransactions != null && PoolOfThreads.LongRunningWork.Current != clusterTransactions)
+                    clusterTransactions.Join(int.MaxValue);
+            });
+            ForTestingPurposes?.DisposeLog?.Invoke(Name, "Finished waiting for cluster transactions executor task to complete");
 
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing _databaseShutdown");
             exceptionAggregator.Execute(() =>

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -782,7 +782,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 using (serverContext.OpenReadTransaction())
                 {
                     // the commands are already batched (10k or 16MB), so we are executing only 1 at a time
-                    var executed = await database.ExecuteClusterTransaction(serverContext, batchSize: 1);
+                    var executed = database.ExecuteClusterTransaction(serverContext, batchSize: 1);
                     if (executed.Count == 0)
                         break;
 

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -141,6 +141,11 @@ namespace Raven.Server.Documents
             }
         }
 
+        public void EnqueueSync(MergedTransactionCommand cmd)
+        {
+            Enqueue(cmd).GetAwaiter().GetResult();
+        }
+
         private static void ThrowTxMergerWasDisposed()
         {
             throw new ObjectDisposedException("Transaction Merger");

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -200,11 +200,11 @@ public static class ThreadNames
         };
     }
 
-    public static ThreadInfo ForClusterTransactions(string threadName)
+    public static ThreadInfo ForClusterTransactions(string threadName, string databaseName)
     {
         return new ThreadInfo(threadName)
         {
-            Details = new ThreadDetails.ClusterTransaction()
+            Details = new ThreadDetails.ClusterTransaction(databaseName)
         };
     }
 
@@ -581,13 +581,15 @@ public static class ThreadNames
 
         public class ClusterTransaction : IThreadDetails
         {
-            public ClusterTransaction()
+            private readonly string _db;
+            public ClusterTransaction(string dbName)
             {
+                _db = dbName;
             }
 
             public string GetShortName()
             {
-                return "Cluster Transaction";
+                return $"{_db} CT Thread";
             }
         }
     }

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -589,7 +589,7 @@ public static class ThreadNames
 
             public string GetShortName()
             {
-                return $"{_db} CT Thread";
+                return $"ClstrTx {_db}";
             }
         }
     }

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -200,6 +200,14 @@ public static class ThreadNames
         };
     }
 
+    public static ThreadInfo ForClusterTransactions(string threadName)
+    {
+        return new ThreadInfo(threadName)
+        {
+            Details = new ThreadDetails.ClusterTransaction()
+        };
+    }
+
     public class ThreadDetails
     {
         public interface IThreadDetails
@@ -568,6 +576,18 @@ public static class ThreadNames
             public string GetShortName()
             {
                 return $"PllRepSnk {_destinationDatabase} at {_destinationUrl}";
+            }
+        }
+
+        public class ClusterTransaction : IThreadDetails
+        {
+            public ClusterTransaction()
+            {
+            }
+
+            public string GetShortName()
+            {
+                return "Cluster Transaction";
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20709

### Additional description

Dedicated thread for executing cluster transactions

_Please delete below the options that are not relevant_


### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
