### PR TITLE
RavenDB-20752 - SlowTests.Client.Attachments.AttachmentsReplication.P…

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -335,6 +335,7 @@ namespace SlowTests.Client.Attachments
                     store1.Operations.Send(new PutAttachmentOperation("users/1", "big-file", stream2, "image/png"));
 
                 await SetupAttachmentReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
 
                 await AssertAttachmentCount(store2, 2, 4);
 


### PR DESCRIPTION
…utAndDeleteAttachmentsWithTheSameStream_AlsoTestBigStreams(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20752/SlowTests.Client.Attachments.AttachmentsReplication.PutAndDeleteAttachmentsWithTheSameStreamAlsoTestBigStreamsoptions

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
