### PR TITLE
RavenDB-18224: add more details & fix NRE in GetSubscriptionResend endpoint

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2612,6 +2612,14 @@ namespace Raven.Server.Documents
             return result;
         }
 
+        public bool Exists(DocumentsOperationContext context, string id)
+        {
+            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerDocumentId))
+            {
+                return GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: false, tvr: out _);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TableValueToEtag(int index, ref TableValueReader tvr)
         {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -27,6 +27,8 @@ using Sparrow.Binary;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
+using Sparrow.Server;
+using Sparrow.Server.Utils;
 using Voron;
 
 namespace Raven.Server.Documents.Subscriptions
@@ -392,7 +394,7 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
-        public string GetSubscriptionNameById(TransactionOperationContext serverStoreContext, long id)
+        public string GetSubscriptionNameById<T>(TransactionOperationContext<T> serverStoreContext, long id) where T : RavenTransaction
         {
             foreach (var keyValue in ClusterStateMachine.ReadValuesStartingWith(serverStoreContext,
                 SubscriptionState.SubscriptionPrefix(_db.Name)))
@@ -417,6 +419,7 @@ namespace Raven.Server.Documents.Subscriptions
             public long Batch;
             public string ChangeVector;
             public SubscriptionType Type;
+            public long SubscriptionId;
 
             public DynamicJsonValue ToJson()
             {
@@ -430,22 +433,42 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
-        public static IEnumerable<ResendItem> GetResendItems(ClusterOperationContext context, string database, long id)
+        public static IEnumerable<ResendItem> GetResendItemsForSubscriptionId(ClusterOperationContext context, string database, long id)
         {
             var subscriptionState = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.SubscriptionStateSchema, ClusterStateMachine.SubscriptionState);
             using (SubscriptionConnectionsState.GetDatabaseAndSubscriptionPrefix(context, database, id, out var prefix))
             using (Slice.External(context.Allocator, prefix, out var prefixSlice))
             {
-                var resendItem = new ResendItem();
-
                 foreach (var item in subscriptionState.SeekByPrimaryKeyPrefix(prefixSlice, Slices.Empty, 0))
                 {
-                    resendItem.Type = (SubscriptionType)item.Key[prefixSlice.Size];
-                    resendItem.Id = item.Value.Reader.ReadStringWithPrefix((int)ClusterStateMachine.SubscriptionStateTable.Key, prefix.Length + 2);
-                    resendItem.ChangeVector = item.Value.Reader.ReadString((int)ClusterStateMachine.SubscriptionStateTable.ChangeVector);
-                    resendItem.Batch = Bits.SwapBytes(item.Value.Reader.ReadLong((int)ClusterStateMachine.SubscriptionStateTable.BatchId));
+                    yield return new ResendItem
+                    {
+                        Type = (SubscriptionType)item.Key[prefixSlice.Size],
+                        Id = item.Value.Reader.ReadStringWithPrefix((int)ClusterStateMachine.SubscriptionStateTable.Key, prefix.Length + 2),
+                        ChangeVector = item.Value.Reader.ReadString((int)ClusterStateMachine.SubscriptionStateTable.ChangeVector),
+                        Batch = Bits.SwapBytes(item.Value.Reader.ReadLong((int)ClusterStateMachine.SubscriptionStateTable.BatchId)),
+                        SubscriptionId = id
+                    };
+                }
+            }
+        }
 
-                    yield return resendItem;
+        public static IEnumerable<ResendItem> GetResendItemsForDatabase(ClusterOperationContext context, string database)
+        {
+            var subscriptionState = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.SubscriptionStateSchema, ClusterStateMachine.SubscriptionState);
+            using var _ = Slice.From(context.Allocator, database.ToLowerInvariant(), SpecialChars.RecordSeparator, ByteStringType.Immutable, out var dbNamePrefix);
+            {
+                foreach (var item in subscriptionState.SeekByPrimaryKeyPrefix(dbNamePrefix, Slices.Empty, 0))
+                {
+                    yield return new ResendItem
+                    {
+                        Type = (SubscriptionType)item.Key[dbNamePrefix.Size + sizeof(long) + sizeof(byte)],
+                        Id = item.Value.Reader.ReadStringWithPrefix((int)ClusterStateMachine.SubscriptionStateTable.Key,
+                            dbNamePrefix.Size + sizeof(long) + sizeof(byte) + sizeof(byte) + sizeof(byte)),
+                        ChangeVector = item.Value.Reader.ReadString((int)ClusterStateMachine.SubscriptionStateTable.ChangeVector),
+                        Batch = Bits.SwapBytes(item.Value.Reader.ReadLong((int)ClusterStateMachine.SubscriptionStateTable.BatchId)),
+                        SubscriptionId = item.Value.Reader.ReadLongWithPrefix((int)ClusterStateMachine.SubscriptionStateTable.Key, dbNamePrefix.Size)
+                    };
                 }
             }
         }

--- a/src/Voron/Data/Tables/TableValueReader.cs
+++ b/src/Voron/Data/Tables/TableValueReader.cs
@@ -68,6 +68,13 @@ namespace Voron.Data.Tables
             return Encoding.UTF8.GetString(read + bytesToSkip, size - bytesToSkip);
         }
 
+        public long ReadLongWithPrefix(int index, int bytesToSkip)
+        {
+            byte* read = Read(index, out var size1);
+            long l = *(long*)(read + bytesToSkip);
+            return l;
+        }
+
         public byte* Read(int index, out int size)
         {
             var hasNext = index + 1 < Count;

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -821,7 +821,7 @@ namespace RachisTests
                 using (server2.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    Assert.Single(SubscriptionStorage.GetResendItems(context, store.Database, state.SubscriptionId));
+                    Assert.Single(SubscriptionStorage.GetResendItemsForSubscriptionId(context, store.Database, state.SubscriptionId));
                 }
 
                 waitForBatch.Set();

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -19,6 +19,10 @@ using Sparrow.Json;
 using Sparrow.Server;
 using Xunit;
 using Xunit.Abstractions;
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable CollectionNeverUpdated.Local
+#pragma warning disable CS0649
+#pragma warning disable CS0169
 
 namespace SlowTests.Client.Subscriptions
 {
@@ -934,17 +938,13 @@ namespace SlowTests.Client.Subscriptions
                     var executor = store.GetRequestExecutor();
                     using var _ = executor.ContextPool.AllocateOperationContext(out var ctx);
                     var cmd = new GetSubscriptionResendListCommand(store.Database, id);
-                    executor.Execute(cmd, ctx);
-                    var res = cmd.Result;
-
-                    // the last batch may still not be cleared
-                    Assert.True(res.Results.Count is 0 or 40, "res.Results.Count is 0 or 40");
 
                     var finalRes = await WaitForValueAsync(() =>
                     {
                         executor.Execute(cmd, ctx);
-                        var res = cmd.Result;
-                        return res.Results.Count;
+                        var res = cmd.Result.Results.First();
+
+                        return res.ResendList.Count;
                     }, 0);
 
                     Assert.Equal(0, finalRes);
@@ -952,7 +952,7 @@ namespace SlowTests.Client.Subscriptions
             }
         }
 
-        private class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
+        private class GetSubscriptionResendListCommand : RavenCommand<ResendListResults>
         {
             private readonly string _database;
             private readonly string _name;
@@ -983,18 +983,24 @@ namespace SlowTests.Client.Subscriptions
                     return;
                 }
 
-                var deserialize = JsonDeserializationBase.GenerateJsonDeserializationRoutine<ResendListResult>();
+                var deserialize = JsonDeserializationBase.GenerateJsonDeserializationRoutine<ResendListResults>();
                 Result = deserialize.Invoke(response);
             }
 
             public override bool IsReadRequest => true;
         }
 
+        private class ResendListResults
+        {
+            public List<ResendListResult> Results;
+        }
+
         private class ResendListResult
         {
-#pragma warning disable CS0649
-            public List<SubscriptionStorage.ResendItem> Results;
-#pragma warning restore CS0649
+            public string SubscriptionName;
+            public long SubscriptionId;
+            public List<long> Active;
+            public List<SubscriptionStorage.ResendItem> ResendList;
         }
 
         private class User


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18224

### Additional description

- add more details to `GetSubscriptionResend` endpoint
- fix NRE in GetSubscriptionResend endpoint (`subscriptionConnections.GetActiveBatches()` can be null if there is no connection)

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
