### PR TITLE
RavenDB-20979  Use` PulsedTransactionEnumerator` during the dictionary …

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -837,43 +837,7 @@ namespace Raven.Server.Documents
         {
             public ManualResetEventSlim DelayDocumentLoad;
         }
-
-        public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, string collection, long take, DocumentFields fields = DocumentFields.All)
-        {
-            var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
-            if (collectionName == null)
-                yield break;
-
-            var table = context.Transaction.InnerTransaction.OpenTable(DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
-            if (table == null)
-                yield break;
-
-            long skip = table.NumberOfEntries < take ? 1 : table.NumberOfEntries / take;
-
-            foreach (var result in table.IterateUniformly(DocsSchema.FixedSizeIndexes[CollectionEtagsSlice], skip))
-            {
-                if (take-- <= 0)
-                    yield break;
-
-                yield return TableValueToDocument(context, ref result.Reader, fields);
-            }
-        }
-
-        public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, long take, DocumentFields fields = DocumentFields.All)
-        {
-            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
-
-            long skip = table.NumberOfEntries < take ? 1 : table.NumberOfEntries / take;
-
-            foreach (var result in table.IterateUniformly(DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice], skip))
-            {
-                if (take-- <= 0)
-                    yield break;
-
-                yield return TableValueToDocument(context, ref result.Reader, fields);
-            }
-        }
-
+        
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils.Enumerators;
+using Sparrow;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax;
+
+public class CoraxDocumentTrainSourceEnumerator
+{
+    private readonly DocumentsStorage _documentsStorage;
+
+    public CoraxDocumentTrainSourceEnumerator(DocumentsStorage documentsStorage)
+    {
+        _documentsStorage = documentsStorage;
+    }
+    
+    public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, string collection, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
+    {
+        var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
+        if (collectionName == null)
+            yield break;
+
+        var table = context.Transaction.InnerTransaction.OpenTable(_documentsStorage.DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
+        if (table == null)
+            yield break;
+        
+        state.InitializeState(table);
+        
+        foreach (var (key, result) in table.IterateUniformly(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.CollectionEtagsSlice], state.DocumentSkip, seek: state.CurrentKey))
+        {
+            //Update inner key in order to seek after transaction refresh
+            state.CurrentKey = key;
+            
+            if (state.Take <= 0)
+                yield break;
+
+            
+            yield return _documentsStorage.TableValueToDocument(context, ref result.Reader, fields);
+        }
+    }
+
+    public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
+    {
+        var table = new Table(_documentsStorage.DocsSchema, context.Transaction.InnerTransaction);
+        state.InitializeState(table);
+        foreach (var (key, result) in table.IterateUniformly(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice], state.DocumentSkip, state.CurrentKey))
+        {
+            state.CurrentKey = key;
+            
+            if (state.Take <= 0)
+                yield break;
+
+            yield return _documentsStorage.TableValueToDocument(context, ref result.Reader, fields);
+        }
+    }
+}
+
+public class CoraxDocumentTrainSourceState : PulsedEnumerationState<Document>
+{
+    private readonly long _takeLimit;
+    public long Take;
+    private bool _initialized;
+    public long CurrentKey = 0;
+    
+    // Creates cycle when we've to return a document.
+    public long DocumentSkip;
+    public CoraxDocumentTrainSourceState(DocumentsOperationContext context, Size pulseLimit, long takeLimit, int numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded = DefaultNumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded) : base(context, pulseLimit, numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded)
+    {
+        _takeLimit = takeLimit;
+    }
+
+    public void InitializeState(Table documentsTable)
+    {
+        if (_initialized)
+            return;
+        _initialized = true;
+        DocumentSkip = documentsTable.NumberOfEntries < _takeLimit ? 1 : documentsTable.NumberOfEntries / _takeLimit;
+        Take = _takeLimit;
+    }
+    
+    
+    public override void OnMoveNext(Document current)
+    {
+        ReadCount++;
+        Take--;
+    }
+}

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1684,7 +1684,7 @@ namespace Voron.Data.Tables
             }
         }
 
-        public IEnumerable<TableValueHolder> IterateUniformly(FixedSizeKeyIndexDef index, long skip = 1)
+        public IEnumerable<(long Key, TableValueHolder TableValueHolder)> IterateUniformly(FixedSizeKeyIndexDef index, long skip = 1, long seek = 0)
         {
             if (skip < 1)
                 throw new ArgumentOutOfRangeException(nameof(skip), "The skip must be positive and non zero.");
@@ -1693,7 +1693,7 @@ namespace Voron.Data.Tables
 
             long count = -1;
             using var it = fst.Iterate();
-            if (it.Seek(0) == false)
+            if (it.Seek(seek) == false)
                 yield break;
 
             var result = new TableValueHolder();
@@ -1703,7 +1703,7 @@ namespace Voron.Data.Tables
                 if (count % skip == 0)
                 {
                     GetTableValueReader(it, out result.Reader);
-                    yield return result;
+                    yield return (it.CurrentKey, result);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-20979.cs
+++ b/test/SlowTests/Issues/RavenDB-20979.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using FastTests;
+using FastTests.Client;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20979 : RavenTestBase
+{
+    public RavenDB_20979(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CanUsePulsedEnumeratorInDictionaryTrainingPhase(Options parameters)
+    {
+        Encryption.EncryptedServer(out var certificates, out string dbName);
+        using var store = GetDocumentStore(new Options
+        {
+            Encrypted = true,
+            AdminCertificate = certificates.ServerCertificate.Value,
+            ClientCertificate = certificates.ServerCertificate.Value,
+            ModifyDatabaseName = s => dbName,
+            ModifyDatabaseRecord = record =>
+            {
+                parameters.ModifyDatabaseRecord(record);
+                record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
+                record.Encrypted = true;
+            }
+        });
+
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < 1024*5; ++i)
+            {
+                bulkInsert.Store(new Query.Order() {Employee = i.ToString()});
+            }
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var autoIndex = session.Query<Query.Order>()
+                .Customize(i => i.WaitForNonStaleResults(waitTimeout: TimeSpan.FromMinutes(1)))
+                .Statistics(out var statistics)
+                .Count(i => i.Employee.StartsWith("1"));
+            Assert.True(autoIndex > 0);
+            
+            var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {statistics.IndexName}));
+            Assert.Empty(indexErrors.First(i=> i.Name == statistics.IndexName).Errors);
+        }
+    }
+}


### PR DESCRIPTION
…training phase to avoid allocating too much memory.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-20979 
### Additional description

In the case of encrypted DB, we can use `PulsedTransactionEnumerator ` during the dictionary training phase to avoid allocating too much memory.

### Type of change


- Optimization
- New feature

### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
