### PR TITLE
RavenDB-20481 Corax OR query: support for not equals | Test adjustment.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
@@ -49,6 +49,10 @@ public abstract class CoraxBooleanQueryBase : IQueryMatch
             (UnaryMatchOperation.GreaterThanOrEqual, long l) => IndexSearcher.GreatThanOrEqualsQuery(leftmostClause.Field, l),
             (UnaryMatchOperation.GreaterThanOrEqual, double d) => IndexSearcher.GreatThanOrEqualsQuery(leftmostClause.Field, d),
             (UnaryMatchOperation.GreaterThanOrEqual, string s) => IndexSearcher.GreatThanOrEqualsQuery(leftmostClause.Field, s),
+            
+            (UnaryMatchOperation.NotEquals, long l) => IndexSearcher.AndNot(IndexSearcher.ExistsQuery(leftmostClause.Field), IndexSearcher.TermQuery(leftmostClause.Field, l)),
+            (UnaryMatchOperation.NotEquals, double d) => IndexSearcher.AndNot(IndexSearcher.ExistsQuery(leftmostClause.Field), IndexSearcher.TermQuery(leftmostClause.Field, d)),
+            (UnaryMatchOperation.NotEquals, string s) => IndexSearcher.AndNot(IndexSearcher.ExistsQuery(leftmostClause.Field), IndexSearcher.TermQuery(leftmostClause.Field, s)),
             _ => throw new InvalidOperationException($"UnaryMatchOperation {leftmostClause.Operation} is not supported for type {leftmostClause.Term.GetType()}")
         };
     }

--- a/test/SlowTests/MailingList/Oregon.cs
+++ b/test/SlowTests/MailingList/Oregon.cs
@@ -1,5 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using FastTests;
+using Raven.Client.Documents.Indexes;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -30,7 +35,7 @@ namespace SlowTests.MailingList
 
         [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        public void Fails(Options options)
+        public void Fails_Lucene(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
@@ -44,7 +49,7 @@ namespace SlowTests.MailingList
                 }
                 using (var s = store.OpenSession())
                 {
-                    var objects = s.Query<Dummy>()
+                    var objects = s.Query<Dummy>()        
                         .Customize(x => x.WaitForNonStaleResults())
                         .Where(x => x.Boolean || x.Object != null)
                         .ToArray();
@@ -54,10 +59,47 @@ namespace SlowTests.MailingList
             }
         }
 
+        
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+        public void Fails_Corax(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var s = store.OpenSession())
+                {
+                    s.Store(new Dummy { Boolean = false, Object = null });
+                    s.Store(new Dummy { Boolean = true, Object = null });
+                    s.Store(new Dummy { Boolean = false, Object = new Dummy() });
+                    s.Store(new Dummy { Boolean = true, Object = new Dummy() });
+                    s.SaveChanges();
+                }
+                using (var s = store.OpenSession())
+                {
+                    new DummyCoraxIndex().Execute(store);
+                    var objects = s.Query<Dummy, DummyCoraxIndex>()        
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Where(x => x.Boolean || x.Object != null)
+                        .ToArray();
+                    WaitForUserToContinueTheTest(store);
+                    Assert.Equal(3, objects.Length); // objects.Length is 2
+                }
+            }
+        }
+
+        
         private class Dummy
         {
             public bool Boolean { get; set; }
             public Dummy Object { get; set; }
+        }
+
+        private class DummyCoraxIndex : AbstractIndexCreationTask<Dummy>
+        {
+            public DummyCoraxIndex()
+            {
+                Map = dummies => dummies.Select(n => new {Boolean = n.Boolean, Object = n.Object == null ? null : n.Object.ToString()});
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20481 
### Additional description

-Support for "not equals" in the OR clause.
-Test adjustment: We attempted to compare "not equals" to a complex object, which is not supported by Corax. The user has to `call .ToString()` to transform the object into a string. In the case of a null value, it has to be explicitly set as null.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
