### PR TITLE
RavenDB-7070: Use local context instead of static to avoid deadlocks in parallel test execution.

### DIFF
--- a/test/FastTests/Corax/Bugs/RavenDB-19283.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19283.cs
@@ -25,9 +25,8 @@ public class RavenDB_19283 : StorageTest
     {
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
         
-        using var _ = StorageEnvironment.GetStaticContext(out var ctx);
-        Slice.From(ctx, "Items", ByteStringType.Immutable, out Slice itemsSlice);
-        Slice.From(ctx, "id()", ByteStringType.Immutable, out Slice idSlice);
+        Slice.From(bsc, "Items", ByteStringType.Immutable, out Slice itemsSlice);
+        Slice.From(bsc, "id()", ByteStringType.Immutable, out Slice idSlice);
         
         // The idea is that GetField will return an struct we can use later on a loop (we just get it once).
         


### PR DESCRIPTION

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 
