### PR TITLE
RavenDB-20974 Add word-break to index name in modal

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexStalenessReasons.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexStalenessReasons.html
@@ -5,10 +5,10 @@
                 <i class="icon-cancel"></i>
             </button>
             <h4 class="modal-title text-warning" data-bind="visible: reasons().IsStale">
-                    Index <span data-bind="text: $root.indexName"></span> is stale.
+                    Index <span data-bind="text: $root.indexName" class="word-break"></span> is stale.
             </h4>
             <h4 class="modal-title text-success" data-bind="visible: !reasons().IsStale">
-                Index <span data-bind="text: $root.indexName"></span> is up to date.
+                Index <span data-bind="text: $root.indexName" class="word-break"></span> is up to date.
             </h4>
         </div>
         <div class="modal-body" data-bind="with: reasons">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20974

### Additional description
Added word-break class to index name

### Type of change
- Optimization

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
