### PR TITLE
RavenDB-20339 Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/test/SlowTests/Issues/RavenDB-18916.cs
+++ b/test/SlowTests/Issues/RavenDB-18916.cs
@@ -1,36 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using FastTests;
-using FastTests.Server.Replication;
-using FastTests.Utils;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Operations.Attachments;
-using Raven.Client.Documents.Operations.Revisions;
-using Raven.Client.Documents.Queries;
-using Raven.Client.Documents.Replication;
-using Raven.Client.Exceptions.Documents;
-using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
-using Raven.Server.Documents;
-using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
-using Raven.Server.NotificationCenter;
-using Raven.Server.Utils;
-using Xunit;
-using Constants = Raven.Client.Constants;
-using Raven.Server.Documents.Replication;
-using Raven.Server.ServerWide.Context;
-using Xunit.Abstractions;
+﻿using System.IO;
 using System.Threading;
-using Amazon.Runtime;
-using System.Security.Cryptography;
-using Nito.AsyncEx;
+using System.Threading.Tasks;
 using Tests.Infrastructure;
-using static Raven.Server.Documents.Replication.ReplicationOperation;
+using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
@@ -40,15 +12,16 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task DeadLockTest()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DeadLockTest(Options options)
         {
             var server = GetNewServer();
 
-            using var store1 = GetDocumentStore(new Options { Server = server, ReplicationFactor = 1 });
-            using var store2 = GetDocumentStore(new Options { Server = server, ReplicationFactor = 1 });
+            using var store1 = GetDocumentStore(new Options(options) { Server = server, ReplicationFactor = 1 });
+            using var store2 = GetDocumentStore(new Options(options) { Server = server, ReplicationFactor = 1 });
 
-            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store2.Database);
+            var database = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, "Users/2-A", server);
             var replicationLoader = database.ReplicationLoader;
 
             var handlersMre = new ManualResetEvent(false);

--- a/test/SlowTests/Issues/RavenDB-4997.cs
+++ b/test/SlowTests/Issues/RavenDB-4997.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Replication;
 using Raven.Client.Exceptions.Documents;
-using Raven.Client.ServerWide;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,31 +18,13 @@ namespace SlowTests.Issues
             public string Name { get; set; }
         }
 
-        [Fact]
-        public async Task Load_of_conflicted_document_with_tombstone_should_result_in_error()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Load_of_conflicted_document_with_tombstone_should_result_in_error(Options options)
         {
-            using (var storeA = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
-            using (var storeB = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
+            options = UpdateConflictSolverAndGetMergedOptions(options);
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -81,31 +60,13 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Load_of_conflicted_document_with_another_document_should_result_in_error()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Load_of_conflicted_document_with_another_document_should_result_in_error(Options options)
         {
-            using (var storeA = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
-            using (var storeB = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
+            options = UpdateConflictSolverAndGetMergedOptions(options);
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -135,31 +96,13 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task Delete_of_conflicted_document_should_resolve_conflict()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Delete_of_conflicted_document_should_resolve_conflict(Options options)
         {
-            using (var storeA = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
-            using (var storeB = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
+            options = UpdateConflictSolverAndGetMergedOptions(options);
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {
@@ -180,51 +123,23 @@ namespace SlowTests.Issues
 
                 using (var session = storeA.OpenSession())
                 {
-                    session.Delete("users/1"); 
+                    session.Delete("users/1");
                     session.SaveChanges();
                 }
 
                 var conflicts = storeA.Commands().GetConflictsFor("users/1");
-                Assert.Equal(0,conflicts.Length);
+                Assert.Equal(0, conflicts.Length);
             }
         }
 
-        [Fact]
-        public async Task Load_of_several_conflicted_document_should_result_in_error()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Load_of_several_conflicted_document_should_result_in_error(Options options)
         {
-            using (var storeA = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
-            using (var storeB = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
-            using (var storeC = GetDocumentStore(options: new Options
-            {
-                ModifyDatabaseRecord = record =>
-                {
-                    record.ConflictSolverConfig = new ConflictSolver
-                    {
-                        ResolveToLatest = false,
-                        ResolveByCollection = new Dictionary<string, ScriptResolver>()
-                    };
-                }
-            }))
+            options = UpdateConflictSolverAndGetMergedOptions(options);
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
+            using (var storeC = GetDocumentStore(options))
             {
                 using (var session = storeA.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB_13284.cs
+++ b/test/SlowTests/Issues/RavenDB_13284.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -16,8 +15,9 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ExternalReplicationCanReestablishAfterServerRestarts()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ExternalReplicationCanReestablishAfterServerRestarts(Options options)
         {
             var serverSrc = GetNewServer(new ServerCreationOptions
             {
@@ -27,12 +27,12 @@ namespace SlowTests.Issues
             {
                 RunInMemory = false
             });
-            using (var storeSrc = GetDocumentStore(new Options
+            using (var storeSrc = GetDocumentStore(new Options(options)
             {
                 Server = serverSrc,
                 Path = Path.Combine(serverSrc.Configuration.Core.DataDirectory.FullPath, "ExternalReplicationCanReestablishAfterServerRestarts")
             }))
-            using (var storeDst = GetDocumentStore(new Options
+            using (var storeDst = GetDocumentStore(new Options(options)
             {
                 Server = serverDst,
                 Path = Path.Combine(serverDst.Configuration.Core.DataDirectory.FullPath, "ExternalReplicationCanReestablishAfterServerRestarts")

--- a/test/SlowTests/Issues/RavenDB_15222.cs
+++ b/test/SlowTests/Issues/RavenDB_15222.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Client;
 using SlowTests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -15,11 +14,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ShouldNotHaveCounterSnapshotInMetadata()
+        [RavenTheory(RavenTestCategory.Counters | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldNotHaveCounterSnapshotInMetadata(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 // create a conflict
 
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
 
                 // conflict will be resolved to latest (incoming doc from A to B)
                 await SetupReplicationAsync(storeA, storeB);
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 using (var session = storeB.OpenAsyncSession())
                 {
@@ -53,7 +53,6 @@ namespace SlowTests.Issues
                     Assert.False(md.TryGet(Constants.Documents.Metadata.RevisionCounters, out object countersSnapshot));
                 }
             }
-
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_15437.cs
+++ b/test/SlowTests/Issues/RavenDB_15437.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client;
 using SlowTests.Core.Utils.Entities;
@@ -17,11 +16,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ShouldNotHaveCounterAndCountersSnapshotInMetadata()
+        [RavenTheory(RavenTestCategory.Counters | RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldNotHaveCounterAndCountersSnapshotInMetadata(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 await RevisionsHelper.SetupRevisionsAsync(storeA);
 
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
                 await SetupReplicationAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeA, storeB);
 
-                var dbA = await Databases.GetDocumentDatabaseInstanceFor(storeA);
+                var dbA = await GetDocumentDatabaseInstanceForAsync(storeA, options.DatabaseMode, "users/1");
                 dbA.Configuration.Replication.MaxItemsCount = 1;
                 dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce = new ManualResetEventSlim();
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -290,7 +290,7 @@ public partial class RavenTestBase
             return null;
         }
 
-        public async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null)
+        public async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
         {
             var shardingConfiguration = record != null ? record.Sharding : await GetShardingConfigurationAsync(store, database);
             DatabaseStatistics combined = new DatabaseStatistics();
@@ -308,7 +308,7 @@ public partial class RavenTestBase
             var uniqueAttachments = new HashSet<string>();
             foreach (var shardNumber in shardingConfiguration.Shards.Keys)
             {
-                var db = await GetAnyShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(database ?? store.Database, shardNumber));
+                var db = await GetAnyShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(database ?? store.Database, shardNumber), servers);
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -80,11 +80,11 @@ namespace FastTests
             return await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
         }
 
-        protected virtual async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null)
+        protected virtual async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
         {
             var dbRecord = record ?? await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));
             if (dbRecord.IsSharded)
-                return await Sharding.GetDatabaseStatisticsAsync(store, database ?? store.Database, dbRecord);
+                return await Sharding.GetDatabaseStatisticsAsync(store, database ?? store.Database, dbRecord, servers);
 
             return await store.Maintenance.SendAsync(new GetStatisticsOperation());
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:

- `RavenDB_16705.cs`
- `RavenDB-16614.cs`
- `RavenDB-16958.cs`
- `RavenDB-16961.cs`
- `RavenDB-17082.cs`
- `RavenDB-17382.cs`
- `RavenDB-17451.cs`
- `RavenDB-17702.cs`
- ` RavenDB-18512.cs`
- `RavenDB-18561.cs`
- `RavenDB-18916.cs`
- `RavenDB-19561.cs`
- `RavenDB-19699.cs`
- `RavenDB-4997.cs`
- `RavenDB-6259.cs`
- `RavenDB_10656.cs`
- `RavenDB_10955.cs`
- `RavenDB_13284.cs`
- `RavenDB_15222.cs`
- `RavenDB_15226.cs`
- `RavenDB_15437.cs`
- `RavenDB_15538.cs`
- `RavenDB_16156.cs`
- `RavenDB_16378_LastModifiedDate.cs`


### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
