### PR TITLE
RavenDB-20972 Projection does not return the @id metadata property

### DIFF
--- a/src/Raven.Server/Documents/Document.cs
+++ b/src/Raven.Server/Documents/Document.cs
@@ -51,6 +51,30 @@ namespace Raven.Server.Documents
         public bool TryGetMetadata(out BlittableJsonReaderObject metadata) =>
             Data.TryGet(Constants.Documents.Metadata.Key, out metadata);
 
+        
+        
+        public void EnsureDocumentId()
+        {
+            if (_metadataEnsured)
+                return;
+
+            _metadataEnsured = true;
+            DynamicJsonValue mutatedMetadata = null;
+            if (Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
+            {
+                if (metadata.Modifications == null)
+                    metadata.Modifications = new DynamicJsonValue(metadata);
+
+                mutatedMetadata = metadata.Modifications;
+            }
+            Data.Modifications = new DynamicJsonValue(Data)
+            {
+                [Constants.Documents.Metadata.Key] = (object)metadata ?? (mutatedMetadata = new DynamicJsonValue())
+            };
+            mutatedMetadata[Constants.Documents.Metadata.Id] = Id;
+            _hash = null;
+        }
+        
         public void EnsureMetadata()
         {
             if (_metadataEnsured)

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -465,14 +465,22 @@ namespace Raven.Server.Documents.Queries.Results
                 for (int i = 0; i < list.Count; i++)
                 {
                     if (list[i] is Document d)
+                    {
+                        d.EnsureDocumentId();
+
                         array.Add(d.Data);
+                    }
                     else
                         array.Add(list[i]);
                 }
                 fieldVal = array;
             }
+
             if (fieldVal is Document d2)
+            {
+                d2.EnsureDocumentId();
                 fieldVal = d2.Data;
+            }
 
             result[key] = fieldVal;
         }

--- a/test/SlowTests/Issues/RavenDB-20972.cs
+++ b/test/SlowTests/Issues/RavenDB-20972.cs
@@ -1,0 +1,46 @@
+﻿using FastTests;
+using Newtonsoft.Json.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20972 : RavenTestBase
+{
+    public RavenDB_20972(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private record Item(string Name, string Parent);
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void CanProjectIdInNestedDocuments()
+    {
+        using var store = GetDocumentStore();
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item("Box", null), "items/1");
+            s.Store(new Item("Bottle", "items/1"), "items/2");
+            s.SaveChanges();
+        }
+
+        using (var s = store.OpenSession())
+        {
+            var result = s.Advanced.RawQuery<JObject>("from Items as i where id(i) == 'items/2' load i.Parent as p select p, i")
+                .Single();
+            Assert.True(result.Value<JObject>("p").Value<JObject>("@metadata").ContainsKey("@id"));
+            Assert.True(result.Value<JObject>("i").Value<JObject>("@metadata").ContainsKey("@id"));
+        }
+        
+        using (var s = store.OpenSession())
+        {
+            var result = s.Advanced.RawQuery<JObject>("from Items as i where id(i) == 'items/2' load i.Parent as p select { p, i }")
+                .Single();
+            Assert.True(result.Value<JObject>("p").Value<JObject>("@metadata").ContainsKey("@id"));
+            Assert.True(result.Value<JObject>("i").Value<JObject>("@metadata").ContainsKey("@id"));
+        }
+    }
+    
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20972 

### Additional description

Ensuring that we get the `@id` property in the metadata for nested documents in complex projections

Matching the behavior of `select a,b,c` and `select {a,b,c}`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

