### PR TITLE
RavenDB-20823 - Deleted\missing 'Delete Revision' causes orphan revis…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1800,7 +1800,7 @@ namespace Raven.Server.Documents
                     var shouldVersion = DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionDocument(
                         collectionName, nonPersistentFlags, local.Document.Data, null, context, id, lastModifiedTicks, ref flags, out var configuration);
 
-                    if (shouldVersion)
+                    if (shouldVersion || flags.Contain(DocumentFlags.HasRevisions))
                     {
 
                         if (DocumentDatabase.DocumentsStorage.RevisionsStorage.ShouldVersionOldDocument(context, flags, local.Document.Data,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -904,7 +904,9 @@ namespace Raven.Server.Documents.Revisions
                 lastRevisionToDelete = revision;
             }
 
-
+            // If the last revision you got to remove is the last (newest) revision of the document and it is 'Delete Revision',
+            // and the doc still has revisions in addition to it,
+            // then don't delete it, so the previous revisions that remained wont become orphan.
             if (lastRevisionToDelete != null)
             {
                 var remained = revisionsPreviousCount - deleted;

--- a/test/SlowTests/Issues/RavenDB-20731.cs
+++ b/test/SlowTests/Issues/RavenDB-20731.cs
@@ -19,7 +19,7 @@ using Assert = Xunit.Assert;
 
 namespace SlowTests.Issues
 {
-    internal class RavenDB_20731 : ReplicationTestBase
+    public class RavenDB_20731 : ReplicationTestBase
     {
         public RavenDB_20731(ITestOutputHelper output) : base(output)
         {

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -683,7 +683,7 @@ return oldestDoc;"
 
         }
 
-        [Theory (Skip = "Until RavenDB-20823")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Include_ForceCreated_AlwaysOn_EnforceConfig_InCaseOf_PurgeOnDelete(bool deleteAlsoForceCreated)
@@ -1006,8 +1006,8 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Theory (Skip = "Until RavenDB-20823")]
-        [InlineData(false)]
+        [Theory]
+        [InlineData(false)] 
         [InlineData(true)]
         public async Task DocWithRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete(bool disableConfiguration)
         {
@@ -1087,7 +1087,7 @@ return oldestDoc;"
              */
         }
 
-        [Fact (Skip = "Until RavenDB-20823")]
+        [Fact]
         public async Task DocWithForceCreatedRevisionsAndNoConfig_ShouldCreateDeleteRevisionInDelete()
         {
             using var store = GetDocumentStore();
@@ -1127,7 +1127,7 @@ return oldestDoc;"
 
         //-----------------------------------------------------------------------------------------------------------------------------------------
 
-        [Fact (Skip = "Until RavenDB-20823")]
+        [Fact]
         public async Task RevivedDocumentShouldHaveTheRevisionsOfTheDeletedDoc()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20823/Deletedmissing-Delete-Revision-causes-orphan-revisions

### Additional description

Deleted\missing 'Delete Revision' causes orphan revisions:
1. DeleteOldRevisions delete the `delete revision` in some cases when we still have revisions for the documents, which causes those remaining revisions to be an orphan.
2. `delete revision` aren't created in some cases (in delete), which causes the remaining revisions to be an orphan after the delete.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
