### PR TITLE
RavenDB-20339 Shrading - Tests - Move replication slow tests to use sharded database

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -28,7 +26,6 @@ using Raven.Server.Documents;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -59,18 +56,18 @@ namespace SlowTests.Cluster
             return base.GetNewServer(options, caller);
         }
 
-        [Fact]
-        public async Task ThrowOnTooLargeClusterTransactionRequest()
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ThrowOnTooLargeClusterTransactionRequest(Options options)
         {
             var (_, leader) = await CreateRaftCluster(3, customSettings: new Dictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Cluster.MaxSizeOfSingleRaftCommand)] = "1"
             });
-            using (var leaderStore = GetDocumentStore(new Options
+            using (var leaderStore = GetDocumentStore(new Options(options)
             {
                 Server = leader,
                 ReplicationFactor = 3,
-
             }))
             {
                 var user1 = new User()
@@ -110,7 +107,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanCreateClusterTransactionRequest(Options options)
         {
@@ -174,7 +171,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster)]
         [RavenData(1, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(3, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(5, DatabaseMode = RavenDatabaseMode.All)]
@@ -249,7 +246,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster)]
         [RavenData(1, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(5, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(10, DatabaseMode = RavenDatabaseMode.All)]
@@ -286,7 +283,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster | RavenTestCategory.BackupExportImport)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanImportExportAndBackupWithClusterTransactions(Options options, bool disableGuards)
@@ -380,7 +377,7 @@ namespace SlowTests.Cluster
                     session.Advanced.SetTransactionMode(TransactionMode.ClusterWide);
                     var user = (await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<User>("usernames/ayende")).Value;
                     Assert.Equal(user2.Name, user.Name);
-                    WaitForUserToContinueTheTest(store);
+                  
                     user = await session.LoadAsync<User>("foo/bar");
                     Assert.Equal(user3.Name, user.Name);
                 }
@@ -655,7 +652,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CreateUniqueUser(Options options)
         {
@@ -698,7 +695,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.CompareExchange)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task SessionCompareExchangeCommands(Options options)
         {
@@ -731,7 +728,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Counters)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ClusterTxWithCounters(Options options)
         {
@@ -763,7 +760,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Counters)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void ThrowOnClusterTransactionWithCounters(Options options)
         {
@@ -789,7 +786,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Attachments)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void ThrowOnClusterTransactionWithAttachments(Options options)
         {
@@ -822,7 +819,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.TimeSeries)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void ThrowOnClusterTransactionWithTimeSeries(Options options)
         {
@@ -848,7 +845,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Revisions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ModifyDocumentWithRevision(Options options)
         {
@@ -904,7 +901,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Revisions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task PutDocumentInDifferentCollectionWithRevision(Options options)
         {
@@ -977,7 +974,7 @@ namespace SlowTests.Cluster
         /// - Wait for the raft index on the SUT to catch-up and verify that we still have one document with one revision.
         /// </summary>
         /// <returns></returns>
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Revisions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ClusterTransactionRequestWithRevisions(Options options)
         {
@@ -1223,7 +1220,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.CompareExchange)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanAddNullValueToCompareExchange(Options options)
         {
@@ -1244,7 +1241,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.CompareExchange)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanGetListCompareExchange(Options options)
         {
@@ -1266,7 +1263,7 @@ namespace SlowTests.Cluster
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Replication)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ClusterTransactionConflict(Options options)
         {
@@ -1440,10 +1437,11 @@ namespace SlowTests.Cluster
             return new string(str);
         }
 
-        [Fact]
-        public async Task BlockWorkingWithAtomicGuardBySession()
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task BlockWorkingWithAtomicGuardBySession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -1480,10 +1478,11 @@ namespace SlowTests.Cluster
             public bool Locked;
         }
 
-        [Fact]
-        public async Task CanModifyingAtomicGuardViaOperations()
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.CompareExchange)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanModifyingAtomicGuardViaOperations(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 const string docId = "users/1";
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -34,7 +33,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Seasame_st()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -107,11 +106,12 @@ namespace SlowTests.Issues
 
         }
 
-        [Fact]
-        public async Task Counters_and_force_revisions()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Counters | RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Counters_and_force_revisions(Options options)
         {
-            using var storeA = GetDocumentStore();
-            using var storeB = GetDocumentStore();
+            using var storeA = GetDocumentStore(options);
+            using var storeB = GetDocumentStore(options);
 
             using (var s = storeA.OpenAsyncSession())
             {
@@ -161,7 +161,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument(storeB, "users/pheobe"));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Can_Setup_Filtered_Replication()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -191,7 +191,7 @@ namespace SlowTests.Issues
                 }));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Cannot_setup_partial_filtered_replication()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -237,7 +237,7 @@ namespace SlowTests.Issues
             [TimeSeriesValue(0)] public double HeartRate;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task WhenDeletingHubReplicationWillRemoveAllAccess()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -295,7 +295,7 @@ namespace SlowTests.Issues
             Assert.NotEmpty(accesses);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Can_pull_via_filtered_replication()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -407,8 +407,6 @@ namespace SlowTests.Issues
                     Assert.Null(attachment);
                 }
 
-                WaitForUserToContinueTheTest(storeA);
-
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende/dogs/arava"));
                 Assert.NotNull(await s.LoadAsync<object>("users/ayende"));
                 Assert.NotNull(await s.Advanced.Revisions.GetAsync<object>("users/ayende", RavenTestHelper.UtcToday.AddDays(1)));
@@ -420,7 +418,6 @@ namespace SlowTests.Issues
                 {
                     Assert.NotNull(attachment);
                 }
-
             }
 
             using (var s = storeA.OpenAsyncSession())
@@ -448,7 +445,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Can_push_via_filtered_replication()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -599,7 +596,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Can_pull_and_push_and_filter_at_dest_and_source()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -692,7 +689,6 @@ namespace SlowTests.Issues
             WaitForDocument(storeB, "users/ayende");
             WaitForDocument(storeA, "users/ayende/config");
 
-            WaitForUserToContinueTheTest(storeA);
             using (var s = storeB.OpenAsyncSession())
             {
                 Assert.Null(await s.LoadAsync<object>("users/ayende/office"));
@@ -721,7 +717,7 @@ namespace SlowTests.Issues
             public string Source;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task PickupConfigurationChangesOnTheFly()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -800,7 +796,7 @@ namespace SlowTests.Issues
             EnsureReplicating(sinkStore1, hubStore);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Sinks_should_not_update_hubs_change_vector()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -948,7 +944,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Sinks_should_not_update_hubs_change_vector2()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1113,7 +1109,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Sinks_should_not_update_hubs_change_vector3()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1355,7 +1351,7 @@ namespace SlowTests.Issues
             Assert.Equal(0, r.Count);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates | RavenTestCategory.BackupExportImport)]
         public async Task Can_import_export_replication_certs()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1427,7 +1423,7 @@ namespace SlowTests.Issues
             Assert.Equal("Arava", accessResults[0].Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Cannot_use_access_paths_if_filtering_is_not_set()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1462,7 +1458,7 @@ namespace SlowTests.Issues
             Assert.Contains("Filtering replication is not set for this Replication Hub task. AllowedSinkToHubPaths and AllowedHubToSinkPaths cannot have a value.", ex.InnerException.Message);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Must_use_access_paths_if_filtering_is_set()
         {
             var certificates = Certificates.SetupServerAuthentication();

--- a/test/SlowTests/Issues/RavenDB-13595.cs
+++ b/test/SlowTests/Issues/RavenDB-13595.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,11 +12,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ShouldCloneTheConflictedHiLoDocumentOnReplication()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldCloneTheConflictedHiLoDocumentOnReplication(Options options)
         {
-            using (var store1 = GetDocumentStore(new Options { ModifyDatabaseName = s => s + "_foo1" }))
-            using (var store2 = GetDocumentStore(new Options { ModifyDatabaseName = s => s + "_foo2" }))
+            using (var store1 = GetDocumentStore(new Options(options) { ModifyDatabaseName = s => s + "_foo1" }))
+            using (var store2 = GetDocumentStore(new Options(options) { ModifyDatabaseName = s => s + "_foo2" }))
             {
                 using (var s1 = store1.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-15224.cs
+++ b/test/SlowTests/Issues/RavenDB-15224.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using FastTests.Server.Replication;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,11 +12,12 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ShouldReplicateCounterDelete()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Counters)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldReplicateCounterDelete(Options options)
         {
-            using (var storeA = GetDocumentStore())
-            using (var storeB = GetDocumentStore())
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
             {
                 await SetupReplicationAsync(storeA, storeB);
                 await SetupReplicationAsync(storeB, storeA);
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                EnsureReplicating(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
 
                 // delete counter on B
                 using (var session = storeB.OpenAsyncSession())
@@ -46,7 +46,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                EnsureReplicating(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
 
                 // counter should be deleted on A
                 using (var session = storeA.OpenAsyncSession())

--- a/test/SlowTests/Issues/RavenDB-16510.cs
+++ b/test/SlowTests/Issues/RavenDB-16510.cs
@@ -2,16 +2,15 @@
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
-using System.Threading.Tasks;
-using Xunit;
-using Xunit.Abstractions;
 using System.Threading;
-using FastTests.Server.Replication;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Extensions;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
@@ -21,13 +20,14 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task CheckTcpTrafficWatch()
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CheckTcpTrafficWatch(Options options)
         {
             DoNotReuseServer();
 
-            using (var store1 = GetDocumentStore())
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 var cts = new CancellationTokenSource();
 
@@ -84,15 +84,15 @@ namespace SlowTests.Issues
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task CheckTcpTrafficWatchExceptionMessage(bool exceptionType)
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CheckTcpTrafficWatchExceptionMessage(Options options, bool exceptionType)
         {
             DoNotReuseServer();
 
-            using (var store1 = GetDocumentStore())
-            using (var store2 = GetDocumentStore())
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
             {
                 var cts = new CancellationTokenSource();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20339/Shrading-Tests-Move-replication-slow-tests-to-use-sharded-database

### Additional description

Files:
- `RavenDB_16510.cs`
- `RavenDB_15224.cs`
- `RavenDB_13595.cs`
- `RavenDB_13510.cs`
- `RavenDB_13341.cs`
- `FilteredReplicationTests.cs`
- `ClusterTransactionTests.cs`

### Type of change

- Tests

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
