### PR TITLE
RavenDB-20839 - fix failing test - CanImportRevisions1

### DIFF
--- a/test/SlowTests/Smuggler/LegacySmugglerTests.cs
+++ b/test/SlowTests/Smuggler/LegacySmugglerTests.cs
@@ -188,7 +188,7 @@ namespace SlowTests.Smuggler
                     Assert.NotEqual(DateTime.MinValue.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite), metadata.GetString(Constants.Documents.Metadata.LastModified));
 
                     var changeVector = session.Advanced.GetChangeVectorFor(user);
-                    Assert.StartsWith("RV:", changeVector);
+                    Assert.Contains("RV:", changeVector);
 
                     var revisions = session.Advanced.Revisions.GetFor<User>("users/1");
                     Assert.Equal(4, revisions.Count);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20839/SlowTests.Smuggler.LegacySmugglerTests.CanImportRevisions2file-SlowTests.Smuggler.Data.DocumentWithRevisions.rave...

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
