### PR TITLE
RavenDB-20999 Fixing overflow of buffer that led to corruption of nea…

### DIFF
--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -135,7 +135,7 @@ namespace Voron.Debugging
                                     if (lookup.State.DictionaryId < 0)
                                     {
                                         var nestedReport = GetReport(lookup, input.IncludeDetails);
-                                        nestedReport.Name = treeReport.Name + "/" + nestedReport.Name;
+                                        nestedReport.Name = treeReport.Name + "/" + nestedReport.Name + " (Lookup)";
                                         trees.Add(nestedReport);
                                     }
                                     else
@@ -143,9 +143,10 @@ namespace Voron.Debugging
                                         tree.Forget(it.CurrentKey);
                                         var textLookup = tree.LookupFor<CompactTree.CompactKeyLookup>(it.CurrentKey);
                                         var nestedReport = GetReport(textLookup, input.IncludeDetails);
-                                        nestedReport.Name = treeReport.Name + "/" + nestedReport.Name;
+                                        string nestedReportName = treeReport.Name + "/" + nestedReport.Name;
+                                        nestedReport.Name = nestedReportName +" (CompactTree)";
                                         trees.Add(nestedReport);
-                                        trees.Add(GetContainerReport(nestedReport.Name, textLookup.State.TermsContainerId, input.IncludeDetails));
+                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", textLookup.State.TermsContainerId, input.IncludeDetails));
                                     }
                                     break;
                                 case RootObjectType.EmbeddedFixedSizeTree:
@@ -153,9 +154,9 @@ namespace Voron.Debugging
                                 case RootObjectType.FixedSizeTree:
                                     var header = (FixedSizeTreeHeader.Large*)readResult.Reader.Base;
                                     var set = tree.FixedTreeFor(it.CurrentKey, (byte)header->ValueSize);
-                                    var nesteSetReport = GetReport(set, input.IncludeDetails);
-                                    nesteSetReport.Name = treeReport.Name + "/" + nesteSetReport.Name;
-                                    trees.Add(nesteSetReport);
+                                    var nestedSetReport = GetReport(set, input.IncludeDetails);
+                                    nestedSetReport.Name = treeReport.Name + "/" + nestedSetReport.Name +", FixedSizeTree";
+                                    trees.Add(nestedSetReport);
                                     break;
                                 default:
                                     throw new ArgumentOutOfRangeException(rootObjectType.ToString());

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -20,7 +20,7 @@ public unsafe struct FastPForDecoder : IDisposable
     private byte* _metadata;
     private byte* _end;
     private uint* _exceptions;
-    private fixed int _exceptionOffsets[32];
+    private fixed int _exceptionOffsets[33];
     private int _prefixShiftAmount;
     private ushort _sharedPrefix;
     private ByteStringContext<ByteStringMemoryCache>.InternalScope _exceptionsScope;


### PR DESCRIPTION
…rby field

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20999 

The problem was that we are using `1..32` indexes, but the buffer was `32` _elements_