### PR TITLE
RavenDB-21019 - External Interversion 6.0 scenarios (between _cluster…

### DIFF
--- a/test/InterversionTests/EtlTests.cs
+++ b/test/InterversionTests/EtlTests.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orders;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class EtlTests : InterversionTestBase
+    {
+        public EtlTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class OrderWithLinesCount
+        {
+            public int OrderLinesCount { get; set; }
+            public decimal TotalCost { get; set; }
+        }
+
+        private class LineItemWithTotalCost
+        {
+            public string ProductName { get; set; }
+            public decimal Cost { get; set; }
+            public int Quantity { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
+        public async Task RavenEtlFromShardedCurrentTo54X()
+        {
+            using (var srcCurrent = Sharding.GetDocumentStore())
+            using (var dest54 = await GetDocumentStoreAsync(Server54Version))
+            {
+                Etl.AddEtl(srcCurrent, dest54, "Users", script: @"this.Name = 'James Doe';
+                                       loadToUsers(this);");
+
+                var etlDone = Etl.WaitForEtlToComplete(srcCurrent);
+
+                using (var session = srcCurrent.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe Doe" });
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest54.OpenSession())
+                {
+                    var user = session.Load<User>("users/1-A");
+
+                    Assert.NotNull(user);
+                    Assert.Equal("James Doe", user.Name);
+                }
+
+                etlDone.Reset();
+
+                using (var session = srcCurrent.OpenSession())
+                {
+                    session.Delete("users/1-A");
+                    session.SaveChanges();
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest54.OpenSession())
+                {
+                    var user = session.Load<User>("users/1-A");
+
+                    Assert.Null(user);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
+        public async Task RavenEtlFrom54XToShardedCurrent()
+        {
+            using (var src54 = await GetDocumentStoreAsync(Server54Version))
+            using (var destCurrent = Sharding.GetDocumentStore())
+            {
+                Etl.AddEtl(src54, destCurrent, "Users", script: @"this.Name = 'James Doe';
+                                       loadToUsers(this);");
+
+                using (var session = src54.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe Doe" });
+                    session.SaveChanges();
+                }
+
+                await Etl.AssertEtlReachedDestination(() =>
+                {
+                    using (var session = destCurrent.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1-A");
+
+                        Assert.NotNull(user);
+                        Assert.Equal("James Doe", user.Name);
+                    }
+                }, 60_000, 333);
+
+                using (var session = src54.OpenSession())
+                {
+                    session.Delete("users/1-A");
+
+                    session.SaveChanges();
+                }
+
+                await Etl.AssertEtlReachedDestination(() =>
+                {
+                    using (var session = destCurrent.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1-A");
+
+                        Assert.Null(user);
+                    }
+                }, 60_000, 333);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
+        public async Task RavenEtlBetween54XAndCurrent()
+        {
+            using (var store54 = await GetDocumentStoreAsync(Server54Version))
+            using (var storeCurrent = Sharding.GetDocumentStore())
+            {
+                Etl.AddEtl(store54, storeCurrent, "Users", script: @"this.Name = 'James Doe';
+                                       loadToUsers(this);"
+                );
+
+                Etl.AddEtl(storeCurrent, store54, "Orders", @"
+var orderData = {
+    OrderLinesCount: this.Lines.length,
+    TotalCost: 0
+};
+
+for (var i = 0; i < this.Lines.length; i++) {
+    var line = this.Lines[i];
+    var cost = (line.Quantity * line.PricePerUnit) *  ( 1 - line.Discount);
+
+    orderData.TotalCost += cost;
+
+    loadToOrderLines({
+        Quantity: line.Quantity,
+        ProductName: line.ProductName,
+        Cost: cost
+    });
+}
+
+loadToOrders(orderData);
+");
+
+                using (var session = store54.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe Doe" });
+                    session.SaveChanges();
+                }
+
+                using (var session = storeCurrent.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Lines = new List<OrderLine>
+                        {
+                            new OrderLine
+                            {
+                                ProductName = "a",
+                                PricePerUnit = 10,
+                                Quantity = 1
+                            },
+                            new OrderLine
+                            {
+                                ProductName = "b",
+                                PricePerUnit = 10,
+                                Quantity = 2
+                            }
+                        }
+                    });
+
+                    session.SaveChanges();
+                }
+
+
+                await Etl.AssertEtlReachedDestination(() =>
+                {
+                    using (var session = storeCurrent.OpenSession())
+                    {
+                        var user = session.Load<User>("users/1-A");
+
+                        Assert.NotNull(user);
+                        Assert.Equal("James Doe", user.Name);
+                    }
+                }, 60_000, 333);
+
+                await Etl.AssertEtlReachedDestination(() =>
+                {
+                    using (var session = store54.OpenSession())
+                    {
+                        var order = session.Load<OrderWithLinesCount>("orders/1-A");
+
+                        Assert.Equal(2, order.OrderLinesCount);
+                        Assert.Equal(30, order.TotalCost);
+
+                        var lines = session.Advanced.LoadStartingWith<LineItemWithTotalCost>("orders/1-A/OrderLines/").OrderBy(x => x.ProductName).ToList();
+
+                        Assert.Equal(2, lines.Count);
+
+                        Assert.Equal(10, lines[0].Cost);
+                        Assert.Equal("a", lines[0].ProductName);
+                        Assert.Equal(1, lines[0].Quantity);
+
+                        Assert.Equal(20, lines[1].Cost);
+                        Assert.Equal("b", lines[1].ProductName);
+                        Assert.Equal(2, lines[1].Quantity);
+                    }
+                }, 60_000, 333);
+            }
+        }
+    }
+}

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -8,7 +8,6 @@ using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using static InterversionTests.ReplicationTests;
 
 namespace InterversionTests
 {
@@ -44,7 +43,7 @@ namespace InterversionTests
                     await session.SaveChangesAsync();
                 }
 
-                await SetupReplication(store, oldStore);
+                await SetupReplicationAsync(store, oldStore);
 
                 var replicationLoader = (await Databases.GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
                 Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);
@@ -54,7 +53,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows| RavenTestCategory.Counters)]
         public async Task ShouldNotReplicateTimeSeriesToOldServer()
         {
             const string docId = "users/1";
@@ -80,7 +79,7 @@ namespace InterversionTests
                     await session.SaveChangesAsync();
                 }
 
-                await SetupReplication(store, oldStore);
+                await SetupReplicationAsync(store, oldStore);
 
                 var replicationLoader = (await Databases.GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
                 Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);
@@ -107,7 +106,7 @@ namespace InterversionTests
                     await session.SaveChangesAsync();
                 }
 
-                await SetupReplication(store, oldStore);
+                await SetupReplicationAsync(store, oldStore);
                 await EnsureReplicatingAsync(store, oldStore);
 
                 using (var session = store.OpenAsyncSession())
@@ -179,7 +178,7 @@ namespace InterversionTests
                     await session.SaveChangesAsync();
                 }
 
-                await SetupReplication(store, oldStore);
+                await SetupReplicationAsync(store, oldStore);
 
                 var replicationLoader = (await Databases.GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
                 Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -53,7 +53,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows| RavenTestCategory.Counters)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows)]
         public async Task ShouldNotReplicateTimeSeriesToOldServer()
         {
             const string docId = "users/1";

--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -148,7 +148,6 @@ namespace InterversionTests
             }
         }
 
-
         [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Smuggler, RavenPlatform.Windows)]
         [InlineData(ExcludeOn.Non)]
         [InlineData(ExcludeOn.Export)]
@@ -215,7 +214,6 @@ namespace InterversionTests
                 Assert.Equal((0, 0, 0), import);
             }
         }
-
 
         [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Smuggler, RavenPlatform.Windows)]
         [InlineData(ExcludeOn.Non)]
@@ -287,7 +285,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenTheory(RavenTestCategory.BackupExportImport | RavenTestCategory.Smuggler)]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Smuggler, RavenPlatform.Windows | RavenPlatform.Linux)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanExportFromCurrentAndImportTo54X(Options options)
         {
@@ -298,7 +296,7 @@ namespace InterversionTests
             await GetStatsAndAssertAsync(storeCurrent, store54);
         }
 
-        [RavenTheory(RavenTestCategory.BackupExportImport | RavenTestCategory.Smuggler)]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Smuggler, RavenPlatform.Windows | RavenPlatform.Linux)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanExportFrom54XAndImportToCurrent(Options options)
         {

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -22,7 +22,7 @@ using Xunit.Abstractions;
 
 namespace Tests.Infrastructure
 {
-    public abstract class InterversionTestBase : ClusterTestBase
+    public abstract class InterversionTestBase : ReplicationTestBase
     {
         protected InterversionTestBase(ITestOutputHelper output) : base(output)
         {
@@ -42,6 +42,9 @@ namespace Tests.Infrastructure
         private readonly HashSet<Process> _testInstanceServerProcesses = new HashSet<Process>();
 
         private static readonly ServerBuildRetriever _serverBuildRetriever = new ServerBuildRetriever();
+
+        protected const string Server42Version = "4.2.124-nightly-20230112-0944";
+        protected const string Server54Version = "5.4.109";
 
         protected DocumentStore GetDocumentStore(
             string serverVersion,

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
@@ -43,7 +42,7 @@ namespace Tests.Infrastructure
 
         private static readonly ServerBuildRetriever _serverBuildRetriever = new ServerBuildRetriever();
 
-        protected const string Server42Version = "4.2.124-nightly-20230112-0944";
+        protected const string Server42Version = "4.2.124";
         protected const string Server54Version = "5.4.109";
 
         protected DocumentStore GetDocumentStore(


### PR DESCRIPTION
…s_ of different versions)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21019/External-Interversion-6.0-scenarios-between-clusters-of-different-versions


### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
