### PR TITLE
RavenDB-20909 - Proxy command loops forever when the targeted node is down

### DIFF
--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -1014,7 +1014,8 @@ namespace RachisTests
                 }, true);
                 
                 var error = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new GetStatisticsOperation("test", dbNode.ServerStore.NodeTag)));
-                Assert.Contains("No connection could be made because the target machine actively refused it", error.Message);
+                Assert.True(error.Message.Contains("No connection could be made because the target machine actively refused it") ||
+                            error.Message.Contains("Connection refused"));
             }
         }
 

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -252,7 +252,8 @@ namespace RachisTests.DatabaseCluster
                 }, true);
 
                 var error = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new GetIndexesProgressOperation(dbNode.ServerStore.NodeTag)));
-                Assert.Contains("No connection could be made because the target machine actively refused it", error.Message);
+                Assert.True(error.Message.Contains("No connection could be made because the target machine actively refused it") ||
+                            error.Message.Contains("Connection refused"));
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20909

### Additional description

This is a test for a v6.0 bug that was fixed in 5.4
https://issues.hibernatingrhinos.com/issue/RavenDB-20954/SelectedNodeTag-operations-reach-a-different-node-when-node-is-in-rehab-or-when-topology-updates-are-disabled

### Type of change

- Bug fix
