### PR TITLE
RavenDB-21028: skip 4.x Interversion tests on linux, categorize and fix Interversion smuggler tests

### DIFF
--- a/test/InterversionTests/BasicTests.cs
+++ b/test/InterversionTests/BasicTests.cs
@@ -16,7 +16,7 @@ namespace InterversionTests
         {
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         public async Task Test()
         {
             var getStoreTask407 = GetDocumentStoreAsync("4.0.7");
@@ -29,7 +29,7 @@ namespace InterversionTests
             AssertStore(GetDocumentStore());
         }
 
-        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
         [InlineData("5.2.3")]
         [InlineData("5.3.0-nightly-20211107-0402")]
         public async Task SubscriptionTest(string version)

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -38,7 +38,7 @@ namespace InterversionTests
         {
         }
 
-        [Theory]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         [InlineData("4.1.7", "4.1.7", "4.1.7")]
         [InlineData("4.1.6", "4.1.6", "4.1.6")]
         [InlineData("4.1.5", "4.1.5", "4.1.5")]
@@ -52,7 +52,7 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
         }
 
-        [Theory]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         [InlineData("4.1.4", "4.1.4", "4.1.4")]
         [InlineData("4.1.3", "4.1.3", "4.1.3")]
         [InlineData("4.1.2", "4.1.2", "4.1.2")]
@@ -78,7 +78,7 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo, before, before, v41X);
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         public async Task IncrementalUpgrade()
         {
             var initialVersions = new[] { "4.0.11", "4.0.11", "4.0.11" };
@@ -94,7 +94,7 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo41X, v40, v40, v41);
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         public async Task UpgradeFromLatest40()
         {
             var initialVersions = new[] { "4.0.11", "4.0.11", "4.0.11" };
@@ -108,7 +108,7 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo, before, before, after);
         }
 
-        [Theory]
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         [InlineData("4.2.0", "4.2.0", "4.2.0")]
         [InlineData("4.2.1", "4.2.1", "4.2.1")]
         public async Task UpgradeDirectlyFrom42X(params string[] initialVersions)
@@ -121,7 +121,7 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows)]
         public async Task UpgradeToLatest()
         {
             var latest = "4.2.119";
@@ -134,10 +134,24 @@ namespace InterversionTests
             await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
         }
 
-        [Fact]
-        public async Task UpgradeDirectlyFrom54X()
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData("5.4.5")]
+        [InlineData("5.4.109")]
+        public async Task UpgradeDirectlyFrom54X(string latest)
         {
-            var latest = "5.4.101";
+            var initialVersions = new[] { latest, latest, latest };
+            var upgradeTo = new List<string>
+            {
+                "current"
+            };
+            var suit = new Version54X(this);
+            await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData("5.2.116")]
+        public async Task UpgradeDirectlyFrom52X(string latest)
+        {
             var initialVersions = new[] { latest, latest, latest };
             var upgradeTo = new List<string>
             {
@@ -218,8 +232,7 @@ namespace InterversionTests
             }
         }
 
-
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows, Skip = "WIP")]
         public async Task ReplicationInMixedCluster_40Leader_with_two_41_nodes()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -281,8 +294,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows, Skip = "WIP")]
         public async Task ReplicationInMixedCluster_40Leader_with_one_41_node_and_two_40_nodes()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -320,8 +332,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows, Skip = "WIP")]
         public async Task ReplicationInMixedCluster_41Leader_with_two_406()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -357,8 +368,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows, Skip = "WIP")]
         public async Task MixedCluster_OutgoingReplicationFrom41To40_ShouldStopAfterUsingCounters()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -454,7 +464,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ReplicationInMixedCluster_60Leader_with_two_54()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -490,7 +500,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task SingleSubscriptionMixedClusterEnsureDocumentResend54()
         {
             var proccess526List = await CreateCluster(new string[] { "5.4.101", "5.4.101" });
@@ -568,7 +578,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task SingleSubscriptionMixedClusterStartAgainFromSpecificChangeVector()
         {
             var proccess526List = await CreateCluster(new string[] { "5.4.101", "5.4.101" });
@@ -639,7 +649,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task SingleSubscriptionMixedClusterV54StartAgainFromSpecificChangeVector()
         {
             var proccess541List = await CreateCluster(new string[] { "5.4.101", "5.4.101" });
@@ -710,8 +720,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.ClientApi, RavenPlatform.Windows, Skip = "WIP")]
         public async Task ClientFailoverInMixedCluster_V41Store()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -770,8 +779,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.ClientApi, RavenPlatform.Windows, Skip = "WIP")]
         public async Task ClientFailoverInMixedCluster_V40Store()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -831,8 +839,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows, Skip = "WIP")]
         public async Task SubscriptionsInMixedCluster_FailoverFrom41To40()
         {
             var batchSize = 5;
@@ -880,8 +887,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows, Skip = "WIP")]
         public async Task SubscriptionsInMixedCluster_FailoverFrom410To41()
         {
             var batchSize = 5;
@@ -933,7 +939,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows, Skip = "WIP")]
         public async Task V40Cluster_V41Client_BasicReplication()
         {
             var nodeA = await GetServerAsync("4.0.7");
@@ -988,7 +994,7 @@ namespace InterversionTests
 
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Cluster, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ClusterTcpCompressionTest()
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
@@ -1002,7 +1008,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Counters, RavenPlatform.Windows, Skip = "WIP")]
         public async Task V40Cluster_V41Client_Counters()
         {
             var nodeA = await GetServerAsync("4.0.7");
@@ -1073,7 +1079,7 @@ namespace InterversionTests
 
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.ClusterTransactions, RavenPlatform.Windows, Skip = "WIP")]
         public async Task V40Cluster_V41Client_ClusterTransactions()
         {
             var nodeA = await GetServerAsync("4.0.7");
@@ -1131,7 +1137,7 @@ namespace InterversionTests
 
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Revisions, RavenPlatform.Windows, Skip = "WIP")]
         public async Task RevisionsInMixedCluster()
         {
             var company = new Company { Name = "Company Name" };
@@ -1187,7 +1193,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows, Skip = "WIP")]
         public async Task MixedCluster_ClusterWideIdentity()
         {
 
@@ -1223,7 +1229,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact(Skip = "WIP")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Cluster, RavenPlatform.Windows, Skip = "WIP")]
         public async Task MixedCluster_CanReorderDatabaseNodes()
         {
             var (leader, peers, local) = await CreateMixedCluster(new[]
@@ -1247,8 +1253,7 @@ namespace InterversionTests
 
         }
 
-        [RavenFact(RavenTestCategory.Subscriptions | RavenTestCategory.Revisions, Skip = "WIP")]
-
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions | RavenTestCategory.Revisions, RavenPlatform.Windows, Skip = "WIP")]
         public async Task MixedCluster_DistributedRevisionsSubscription()
         {
             var uniqueRevisions = new HashSet<string>();

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -18,7 +18,7 @@ namespace InterversionTests
         {
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.Counters, RavenPlatform.Windows)]
         public async Task ShouldNotReplicateCountersToOldServer()
         {
             const string docId = "users/1";
@@ -54,7 +54,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows)]
         public async Task ShouldNotReplicateTimeSeriesToOldServer()
         {
             const string docId = "users/1";
@@ -90,7 +90,7 @@ namespace InterversionTests
             }
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.Counters, RavenPlatform.Windows)]
         public async Task ShouldNotReplicateCounterTombstonesToOldServer()
         {
             const string docId = "users/1";
@@ -149,8 +149,7 @@ namespace InterversionTests
             }
         }
 
-
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ShouldNotReplicateIncrementalTimeSeriesToOldServer2()
         {
             const string version = "5.2.3";

--- a/test/InterversionTests/RavenDB-17556.cs
+++ b/test/InterversionTests/RavenDB-17556.cs
@@ -15,7 +15,7 @@ namespace InterversionTests
         {
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task IncomingReplicationShouldRejectIncrementalTimeSeriesFromOldServer()
         {
             const string version = "5.2.3";

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -31,7 +31,7 @@ namespace InterversionTests
         {
         }
 
-        [Theory(Skip = "TODO: Add compatible version of v4.2 when released")]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows, Skip = "TODO: Add compatible version of v4.2 when released")]
         public async Task CannotReplicateTimeSeriesToV42()
         {
             var version = "4.2.101"; // todo:Add compatible version of v4.2 when released
@@ -62,13 +62,25 @@ namespace InterversionTests
             Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("TimeSeries"))));
         }
 
-        [Theory]
-        [InlineData("4.2.117")]
-        [InlineData("5.2.3")]
-        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion(string version)
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows)]
+        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersionV42()
         {
             // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
+            string version = "4.2.117";
+            await CanReplicateToOldServerWithLowerReplicationProtocolVersion(version);
+        }
 
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersionV52()
+        {
+            // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
+            string version = "5.2.3";
+            await CanReplicateToOldServerWithLowerReplicationProtocolVersion(version);
+        }
+
+
+        private async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion(string version)
+        {
             using var oldStore = await GetDocumentStoreAsync(version);
             using var store = GetDocumentStore();
             {
@@ -90,7 +102,8 @@ namespace InterversionTests
             Assert.True(WaitForDocument<User>(oldStore, "users/1", u => u.Name == "Egor"));
         }
 
-        [Fact]
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ShouldNotReplicateIncrementalTimeSeriesToOldServer()
         {
             const string version = "5.2.3";
@@ -120,7 +133,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ExternalReplicationShouldWork_NonShardedAndV54()
         {
             var processNode = await GetServerAsync("5.4.5");
@@ -167,7 +180,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Sharding | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ReplicationWithReshardingShouldWorkFromShardedToOldServer()
         {
             var processNode = await GetServerAsync("5.4.5");
@@ -242,7 +255,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Sharding)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Sharding, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ExternalReplicationWithRevisionTombstones_ShardedToOldServer()
         {
             var processNode = await GetServerAsync("5.4.5");
@@ -310,7 +323,7 @@ namespace InterversionTests
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.Revisions, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ExternalReplicationWithRevisionTombstones_NonShardedToOldServer()
         {
             var processNode = await GetServerAsync("5.4.5");

--- a/test/Tests.Infrastructure/InterversionTest/ServerBuildRetriever.cs
+++ b/test/Tests.Infrastructure/InterversionTest/ServerBuildRetriever.cs
@@ -101,8 +101,13 @@ namespace Tests.Infrastructure.InterversionTest
             if (PlatformDetails.RunningOnPosix)
             {
                 Directory.CreateDirectory(targetDirectory);
-                var extractTarBall = Process.Start(
-                    "tar", $"xjf \"{packagePath}\" -C \"{targetDirectory}\" --strip-components=1");
+                var extractTarBall = new Process();
+                extractTarBall.StartInfo.RedirectStandardOutput = true;
+                extractTarBall.StartInfo.RedirectStandardError = true;
+                extractTarBall.StartInfo.FileName = "tar";
+                extractTarBall.StartInfo.Arguments = $"xjf \"{packagePath}\" -C \"{targetDirectory}\" --strip-components=1";
+                extractTarBall.Start();
+
                 extractTarBall.WaitForExit();
 
                 if (extractTarBall.ExitCode != 0)

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -56,5 +56,6 @@ public enum RavenTestCategory : long
     Smuggler = 1L << 41,
     Lucene = 1L << 42,
     [Description("Changes API")]
-    ChangesApi = 1L << 43
+    ChangesApi = 1L << 43,
+    Interversion = 1L << 44
 }


### PR DESCRIPTION
fix interversion tests
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21028