### PR TITLE
RavenDB-21052 In case of border element we've to swap "arrays" to check if there is a gap | apply mask to value in array to avoid "fake" gap

### DIFF
--- a/src/Corax/Queries/Meta/SortHelper.cs
+++ b/src/Corax/Queries/Meta/SortHelper.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 
-namespace Corax.Queries;
+namespace Corax.Queries.Meta;
 
 internal sealed unsafe class SortHelper
 {
@@ -39,8 +36,17 @@ internal sealed unsafe class SortHelper
         long* leftEndPtr = leftPtr + leftLength;
         long* rightEndPtr = rightPtr + rightLength;
 
-        if (*leftPtr > *(rightEndPtr - 1))
-            return 0; // there is no overlap in the range
+        //We've to assert in good order, so lets check which array is "first" (lowest first item)
+        var cmp = (*leftPtr & long.MaxValue) - (*rightPtr & long.MaxValue);
+        switch (cmp)
+        {
+            //[a,....,b] [c,...,d]
+            case < 0 when (*(leftEndPtr - 1)  & long.MaxValue) < (*rightPtr & long.MaxValue):
+            //[c,...,d] [a,...,b]
+            case > 0 when (*(rightEndPtr - 1)  & long.MaxValue ) < (*leftPtr & long.MaxValue):
+                return 0;
+        }
+
 
         if (leftLength * 2 > rightLength)
         {

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Corax.Queries.SortingMatches.Meta;
 using System.Threading;
+using Corax.Queries.Meta;
 using Corax.Utils;
 using Corax.Utils.Spatial;
 using Sparrow;

--- a/test/FastTests/Corax/Bugs/RavenDB-21052.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21052.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Corax.Queries;
+using Corax.Queries.Meta;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_21052 : NoDisposalNeeded
+{
+    public RavenDB_21052(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanDetectGapBetweenArrays()
+    {
+        var right = new long[] {10, 11, 13, 15};
+        var left = new long[] {8, 9};
+        var dst = new long[2];
+
+        //LEFT [RIGHT]
+        //[8, 9] [10,..]
+        var read = SortHelper.FindMatches(dst, left, right);
+        Assert.Equal(0, read);
+
+        left = new long[] {16, 17};
+
+        //[RIGHT] [LEFT]
+        //[10,..,15] [16,17]
+        read = SortHelper.FindMatches(dst, left, right);
+        Assert.Equal(0, read);
+    }
+    
+    [Fact]
+    public void CanPerformIntersectionWhenLastElementIsMarkedAsUsed()
+    {
+        var right = new long[] {10, 11, 13, 15};
+        var left = new long[] {9, 15};
+        var dst = new long[10];
+
+        var read = SortHelper.FindMatches(dst.AsSpan(0, left.Length), left, right);
+        Assert.Equal(1, read);
+        left = new long[] {9, 11, 13};
+
+        read = SortHelper.FindMatches(dst.AsSpan(0, left.Length), left, right);
+        Assert.Equal(2, read);
+    }
+    
+    [Fact]
+    public void CanPerformIntersectionWhenFirstElementIsMarkedAsUsed()
+    {
+        var right = new long[] {10, 11, 13, 15};
+        var left = new long[] {9, 10};
+        var dst = new long[10];
+
+        var read = SortHelper.FindMatches(dst.AsSpan(0, left.Length), left, right);
+        Assert.Equal(1, read);
+        left = new long[] {13, 15, 16}; // force order [right] [left]
+
+        read = SortHelper.FindMatches(dst.AsSpan(0, left.Length), left, right);
+        Assert.Equal(2, read);
+        
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21052

### Additional description

We try to detect if we could have common values in arrays via checking the "space" between them (since arrays are sorted), but we also mark elements as USED via sign bit which can lead to having a negative value (and there always will be a gap). 


### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
