### PR TITLE
RavenDB-20501 - SlowTests.Client.Attachments.AttachmentsReplication.D…

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -452,14 +452,14 @@ namespace SlowTests.Client.Attachments
                 await SetupAttachmentReplicationAsync(store1, store2);
                 await AssertAttachmentCount(store2, 2, 4);
 
-                store1.Commands().Delete("users/2", null);
-                await AssertDeleteAsync(store1, store2, "#1", 2, 3);
+                await store1.Commands().DeleteAsync("users/2", null);
+                await AssertDeleteAsync(store1, store2, "#1$users/2", 2, 3);
 
-                store1.Commands().Delete("users/1", null);
-                await AssertDeleteAsync(store1, store2, "#2", 1);
+                await store1.Commands().DeleteAsync("users/1", null);
+                await AssertDeleteAsync(store1, store2, "#2$users/1", 1);
 
-                store1.Commands().Delete("users/3", null);
-                await AssertDeleteAsync(store1, store2, "#3", 0);
+                await store1.Commands().DeleteAsync("users/3", null);
+                await AssertDeleteAsync(store1, store2, "#3$users/3", 0);
             }
         }
 


### PR DESCRIPTION
…eleteDocumentWithAttachmentsThatHaveTheSameStream(options: DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20501/SlowTests.Client.Attachments.AttachmentsReplication.DeleteDocumentWithAttachmentsThatHaveTheSameStreamoptions-DatabaseMode

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
