### PR TITLE
RavenDB-20821 Reducing memory usage when skipping huge number of compressed docs / revisions during replication

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -952,7 +952,7 @@ namespace Raven.Server.Documents
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice], etag, 0))
             {
-                yield return DocumentReplicationItem.From(TableValueToDocument(context, ref result.Reader, fields));
+                yield return DocumentReplicationItem.From(TableValueToDocument(context, ref result.Reader, fields), context);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                     initialState.Skip = new Reference<long>();
                 }
 
-                var documentsEnumerator = new PulsedTransactionEnumerator<Document, DocsStreamingIterationState>(context, state =>
+                var documentsEnumerator = new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document, DocsStreamingIterationState>(context, state =>
                     {
                         if (string.IsNullOrEmpty(state.StartsWith) == false)
                         {
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
 
                         return Database.DocumentsStorage.GetDocumentsInReverseEtagOrder(context, state.Start, state.Take);
                     },
-                    initialState);
+                    initialState), context);
 
                 using (var token = CreateHttpRequestBoundOperationToken())
                 await using (var writer = GetLoadDocumentsResultsWriter(format, context, ResponseBodyStream()))

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -155,7 +155,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }
                 else
                 {
-                    enumerator = new PulsedTransactionEnumerator<Document, CollectionQueryResultsIterationState>(context.Documents,
+                    enumerator = new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document, CollectionQueryResultsIterationState>(context.Documents,
                         state =>
                         {
                             query.Start = state.Start;
@@ -170,7 +170,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         {
                             Start = query.Start,
                             Take = query.PageSize
-                        });
+                        }), context.Documents);
                 }
 
                 IncludeCountersCommand includeCountersCommand = null;

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Replication
             var tombs = database.DocumentsStorage.GetTombstonesFrom(ctx, etag + 1);
             var conflicts = database.DocumentsStorage.ConflictsStorage.GetConflictsFrom(ctx, etag + 1).Select(DocumentReplicationItem.From);
             var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
-            var revisions = revisionsStorage.GetRevisionsFrom(ctx, etag + 1, long.MaxValue, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data).Select(DocumentReplicationItem.From);
+            var revisions = revisionsStorage.GetRevisionsFrom(ctx, etag + 1, long.MaxValue, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data).Select(x => DocumentReplicationItem.From(x, ctx));
             var attachments = database.DocumentsStorage.AttachmentsStorage.GetAttachmentsFrom(ctx, etag + 1);
             var counters = database.DocumentsStorage.CountersStorage.GetCountersFrom(ctx, etag + 1, caseInsensitiveCounters);
             var timeSeries = database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(ctx, etag + 1);
@@ -499,12 +499,22 @@ namespace Raven.Server.Documents.Replication
 
                     return true;
                 }
-                finally
+                catch
                 {
                     foreach (var item in _orderedReplicaItems)
                     {
                         item.Value.Dispose();
                     }
+
+                    foreach (var item in _replicaAttachmentStreams)
+                    {
+                        item.Value.Dispose();
+                    }
+
+                    throw;
+                }
+                finally
+                {
                     _orderedReplicaItems.Clear();
                     _replicaAttachmentStreams.Clear();
                 }
@@ -868,6 +878,7 @@ namespace Raven.Server.Documents.Replication
 
             foreach (var item in _orderedReplicaItems)
             {
+                using (item.Value)
                 using (Slice.From(documentsContext.Allocator, item.Value.ChangeVector, out var cv))
                 {
                     item.Value.Write(cv, _stream, _tempBuffer, stats);
@@ -876,8 +887,11 @@ namespace Raven.Server.Documents.Replication
 
             foreach (var item in _replicaAttachmentStreams)
             {
-                item.Value.WriteStream(_stream, _tempBuffer);
-                stats.RecordAttachmentOutput(item.Value.Stream.Length);
+                using (item.Value)
+                {
+                    item.Value.WriteStream(_stream, _tempBuffer);
+                    stats.RecordAttachmentOutput(item.Value.Stream.Length);
+                }
             }
 
             // close the transaction as early as possible, and before we wait for reply

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using Raven.Client.Util;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
@@ -26,9 +27,9 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             return djv;
         }
 
-        public static DocumentReplicationItem From(Document doc)
+        public static DocumentReplicationItem From(Document doc, DocumentsOperationContext context)
         {
-            return new DocumentReplicationItem
+            var result = new DocumentReplicationItem
             {
                 Type = ReplicationItemType.Document,
                 Etag = doc.Etag,
@@ -37,8 +38,12 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 Id = doc.Id,
                 Flags = doc.Flags,
                 TransactionMarker = doc.TransactionMarker,
-                LastModifiedTicks = doc.LastModified.Ticks
+                LastModifiedTicks = doc.LastModified.Ticks,
             };
+
+            result.ToDispose(new ForgetAboutDecompressionBuffer(doc, context));
+
+            return result;
         }
 
         public static DocumentReplicationItem From(DocumentConflict doc)
@@ -204,6 +209,23 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             Data?.Dispose();
             Id?.Dispose();
             Collection?.Dispose();
+        }
+
+        private class ForgetAboutDecompressionBuffer : IDisposable
+        {
+            private readonly Document _doc;
+            private readonly DocumentsOperationContext _context;
+
+            public ForgetAboutDecompressionBuffer(Document doc, DocumentsOperationContext context)
+            {
+                _doc = doc;
+                _context = context;
+            }
+            
+            public void Dispose()
+            {
+                _context.Transaction.ForgetAbout(_doc);
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -9,6 +9,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
+using Sparrow.Threading;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.ReplicationItems
@@ -24,6 +25,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         protected Reader Reader;
 
         private List<IDisposable> _garbage;
+        private bool _disposed;
+
+        protected ReplicationBatchItem()
+        {
+        }
 
         public abstract long AssertChangeVectorSize();
 
@@ -175,6 +181,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public void Dispose()
         {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
             InnerDispose();
 
             if (_garbage == null)

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -167,7 +167,7 @@ namespace Raven.Server.Smuggler.Documents
         {
             Debug.Assert(_context != null);
 
-            var enumerator = new PulsedTransactionEnumerator<Document, DocumentsIterationState>(_context,
+            var enumerator = new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document, DocumentsIterationState>(_context,
                 state =>
                 {
                     if (state.StartEtagByCollection.Count != 0)
@@ -179,7 +179,7 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     StartEtag = _startDocumentEtag,
                     StartEtagByCollection = collectionsToExport.ToDictionary(x => x, x => _startDocumentEtag)
-                });
+                }), _context);
 
             while (enumerator.MoveNext())
             {
@@ -216,7 +216,7 @@ namespace Raven.Server.Smuggler.Documents
 
             var revisionsStorage = _database.DocumentsStorage.RevisionsStorage;
 
-            var enumerator = new PulsedTransactionEnumerator<Document, DocumentsIterationState>(_context,
+            var enumerator = new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document, DocumentsIterationState>(_context,
                 state =>
                 {
                     if (state.StartEtagByCollection.Count != 0)
@@ -228,7 +228,7 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     StartEtag = _startDocumentEtag,
                     StartEtagByCollection = collectionsToExport.ToDictionary(x => x, x => _startDocumentEtag)
-                });
+                }), _context);
 
             while (enumerator.MoveNext())
             {

--- a/src/Raven.Server/Utils/Enumerators/PulsedTransactionEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/PulsedTransactionEnumerator.cs
@@ -44,9 +44,6 @@ namespace Raven.Server.Utils.Enumerators
                 _innerEnumerator = _getEnumerator != null ? _getEnumerator(_state) : _getEnumerable(_state).GetEnumerator();
             }
 
-            if (Current is Document doc)
-                _context.Transaction.ForgetAbout(doc);
-
             if (_innerEnumerator.MoveNext() == false)
                 return false;
             

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Utils.Enumerators;
+
+public class TransactionForgetAboutDocumentEnumerator : IEnumerator<Document>
+{
+    private readonly IEnumerator<Document> _innerEnumerator;
+    private readonly DocumentsOperationContext _docsContext;
+
+    public TransactionForgetAboutDocumentEnumerator([NotNull] IEnumerator<Document> innerEnumerator, [NotNull] DocumentsOperationContext docsContext)
+    {
+        _innerEnumerator = innerEnumerator;
+        _docsContext = docsContext;
+    }
+
+    public bool MoveNext()
+    {
+        _docsContext.Transaction.ForgetAbout(Current);
+
+        if (_innerEnumerator.MoveNext() == false)
+            return false;
+
+        Current = _innerEnumerator.Current;
+
+        return true;
+    }
+
+    public void Reset()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Document Current { get; private set; }
+
+    object IEnumerator.Current => Current;
+
+    public void Dispose()
+    {
+        _innerEnumerator.Dispose();
+    }
+}

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -695,7 +695,10 @@ namespace Voron.Impl
                 return;
 
             if (_cachedDecompressedBuffersByStorageId.Remove(storageId, out var t))
+            {
                 Allocator.Release(ref t);
+                _lowLevelTransaction.DecompressedBufferBytes -= t.Length;
+            }
         }
     }
 }


### PR DESCRIPTION
Applying https://github.com/ravendb/ravendb/pull/16986 to release/v5.4
