### PR TITLE
RavenDB-21028 : Error during export operation causes WaitForCompletion to hang 

### DIFF
--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -266,15 +266,8 @@ namespace Raven.Client.Documents.Operations
                         StopProcessing();
                         if (_afterOperationCompleted.IsFaulted)
                         {
-                            try
-                            {
-                                // we want the exception itself and not AggregateException 
-                                _afterOperationCompleted.GetAwaiter().GetResult();
-                            }
-                            catch (Exception e)
-                            {
-                                _result.TrySetException(e);
-                            }
+                            // we want the exception itself and not AggregateException
+                            _result.TrySetException(_afterOperationCompleted.Exception.ExtractSingleInnerException());
                             break;
                         }
 

--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -315,14 +315,14 @@ namespace Raven.Client.Documents.Operations
             return WaitForCompletionAsync<IOperationResult>(timeout);
         }
 
-        public Task<TResult> WaitForCompletionAsync<TResult>(TimeSpan? timeout = null)
+        public async Task<TResult> WaitForCompletionAsync<TResult>(TimeSpan? timeout = null)
             where TResult : IOperationResult
         {
             if (timeout == null)
-                return WaitForCompletionAsync<TResult>(CancellationToken.None);
+                return await WaitForCompletionAsync<TResult>(CancellationToken.None).ConfigureAwait(false);
 
             using (var cts = new CancellationTokenSource(timeout.Value))
-                return WaitForCompletionAsync<TResult>(cts.Token);
+                return await WaitForCompletionAsync<TResult>(cts.Token).ConfigureAwait(false);
         }
 
         public Task<IOperationResult> WaitForCompletionAsync(CancellationToken token)

--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Operations
         private readonly RequestExecutor _requestExecutor;
         private readonly Func<IDatabaseChanges> _changes;
         private readonly DocumentConventions _conventions;
-        private readonly Task _additionalTask;
+        private Task _additionalTask;
         private readonly long _id;
         private TaskCompletionSource<IOperationResult> _result = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
@@ -355,6 +355,7 @@ namespace Raven.Client.Documents.Operations
                 catch (Exception e)
                 {
                     await StopProcessingUnderLock(e).ConfigureAwait(false);
+                    _additionalTask = Task.CompletedTask; // don't await the additional task if we had an error
                 }
 
                 await _additionalTask.ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -277,7 +277,7 @@ namespace Raven.Client.Documents.Smuggler
                 }
 
                 return new Operation(_requestExecutor, () => _store.Changes(_databaseName, getOperationIdCommand.NodeTag), _requestExecutor.Conventions, operationId,
-                    nodeTag: getOperationIdCommand.NodeTag, additionalTask: task);
+                    nodeTag: getOperationIdCommand.NodeTag, afterOperationCompleted: task);
 
             }
             catch (Exception e)

--- a/test/SlowTests/Issues/RavenDB-21028.cs
+++ b/test/SlowTests/Issues/RavenDB-21028.cs
@@ -2,8 +2,11 @@
 using Xunit.Abstractions;
 using System;
 using FastTests;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Server.Documents.PeriodicBackup;
+using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -27,6 +30,44 @@ namespace SlowTests.Issues
 
             await Assert.ThrowsAsync<RavenException>(async () => await op.WaitForCompletionAsync(TimeSpan.FromSeconds(10)));
 
+        }
+
+        [RavenFact(RavenTestCategory.Smuggler)]
+        public async Task WaitForCompletionShouldRespectTimeout()
+        {
+            using var store = GetDocumentStore();
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    await session.StoreAsync(new User());
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            var path = NewDataPath();
+            var config = new BackupConfiguration
+            {
+                BackupType = BackupType.Backup,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = path
+                }
+            };
+
+            var db = await GetDatabase(store.Database);
+
+            // hold backup execution 
+            var tcs = new TaskCompletionSource<object>();
+            db.PeriodicBackupRunner._forTestingPurposes ??= new PeriodicBackupRunner.TestingStuff();
+            db.PeriodicBackupRunner._forTestingPurposes.OnBackupTaskRunHoldBackupExecution = tcs;
+
+            // wait for completion should not hang
+            var operation = await store.Maintenance.SendAsync(new BackupOperation(config));
+            await Assert.ThrowsAsync<TimeoutException>(async () => await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)));
+
+            tcs.TrySetResult(null);
         }
 
     }

--- a/test/SlowTests/Issues/RavenDB-21028.cs
+++ b/test/SlowTests/Issues/RavenDB-21028.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Xunit.Abstractions;
+using System;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21028 : RavenTestBase
+    {
+        
+        public RavenDB_21028(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Smuggler)]
+        public async Task WaitForCompletionShouldNotHangOnFailureDuringExport()
+        {
+            using var store = GetDocumentStore();
+            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+            var file = GetTempFileName();
+            var op = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions { EncryptionKey = "fakeKey" }, file);
+
+            await Assert.ThrowsAsync<RavenException>(async () => await op.WaitForCompletionAsync(TimeSpan.FromSeconds(10)));
+
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21028/Jenkins-hangs-on-InterversionTests.SmugglerTests.CanExportFrom54XAndImportToCurrent

### Additional description

- `Operation.WaitForCompletion` : don't await the `additionalTask` if we had an error during processing, since it can cause us to hang
- e.g. in Export operation the additional task is set as completed only after we finish handling the stream response, which will never happen if we had an error during the export process - so awaiting the additional task in this case will hang

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
