### PR TITLE
RavenDB-16201 Delete topics from Kafka after tests. In RabbitMQ the queues are auto-deleted so no need to do it manually

### DIFF
--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -21,8 +21,6 @@ namespace SlowTests.Server.Documents.QueueSink
     [Trait("Category", "QueueSink")]
     public abstract class QueueSinkTestBase : RavenTestBase
     {
-        private DocumentStore _src;
-
         protected QueueSinkTestBase(ITestOutputHelper output) : base(output)
         {
             QueueSuffix = Guid.NewGuid().ToString("N");
@@ -118,33 +116,6 @@ namespace SlowTests.Server.Documents.QueueSink
                 //TryGetTransformationError(databaseName, config, out var transformationError);
 
                 //Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
-            }
-        }
-        
-        public override void Dispose()
-        {
-            try
-            {
-                if (_src == null)
-                    return;
-
-                if (Context.TestException == null || Context.TestOutput == null)
-                    return;
-
-                var notifications = GetQueueSinkErrorNotifications(_src).Result;
-                if (notifications.Any() == false)
-                    return;
-
-                string message = string.Join(",\n", notifications);
-                Context.TestOutput.WriteLine(message);
-            }
-            catch
-            {
-                // ignored
-            }
-            finally
-            {
-                base.Dispose();
             }
         }
 

--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -7,13 +7,10 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.QueueSink;
-using Raven.Server.Config;
-using Raven.Server.Config.Categories;
 using Raven.Server.Documents.QueueSink;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
-using Raven.Server.ServerWide;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,15 +23,6 @@ namespace SlowTests.Server.Documents.QueueSink
     {
         private DocumentStore _src;
 
-        protected static readonly BackupConfiguration DefaultBackupConfiguration;
-
-        static QueueSinkTestBase()
-        {
-            var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
-            configuration.Initialize();
-
-            DefaultBackupConfiguration = configuration.Backup;
-        }
         protected QueueSinkTestBase(ITestOutputHelper output) : base(output)
         {
             QueueSuffix = Guid.NewGuid().ToString("N");
@@ -158,6 +146,15 @@ namespace SlowTests.Server.Documents.QueueSink
             {
                 base.Dispose();
             }
+        }
+
+        protected class User
+        {
+            public string Id { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+
+            public string FullName { get; set; }
         }
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16201/Kafka-and-RabbitMQ-Sink-support

### Additional description

Test cleanup improvement

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
