### PR TITLE
RavenDB-21053 added 'Http.Http2.MaxStreamsPerConnection' configuration option and changed default from 100 to unlimited

### DIFF
--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -52,6 +52,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Http.Http2.KeepAlivePingDelayInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting? KeepAlivePingDelay { get; set; }
 
+        [Description("Set Kestrel's HTTP2 max streams per connection. This limits the number of concurrent request streams per HTTP/2 connection. Excess streams will be refused.")]
+        [DefaultValue(null)]
+        [ConfigurationEntry("Http.Http2.MaxStreamsPerConnection", ConfigurationEntryScope.ServerWideOnly)]
+        public int? MaxStreamsPerConnection { get; set; }
+
         [Description("Whether Raven's HTTP server should compress its responses")]
         [DefaultValue(true)]
         [ConfigurationEntry("Http.UseResponseCompression", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -190,6 +190,7 @@ namespace Raven.Server
                     options.Limits.MaxRequestBodySize = null; // no limit!
                     options.Limits.MinResponseDataRate = null; // no limit!
                     options.Limits.MinRequestBodyDataRate = null; // no limit!
+                    options.Limits.Http2.MaxStreamsPerConnection = int.MaxValue; // no limit!
 
                     if (Configuration.Http.MinDataRatePerSecond.HasValue && Configuration.Http.MinDataRateGracePeriod.HasValue)
                     {
@@ -207,6 +208,9 @@ namespace Raven.Server
 
                     if (Configuration.Http.KeepAlivePingTimeout.HasValue)
                         options.Limits.Http2.KeepAlivePingTimeout = Configuration.Http.KeepAlivePingTimeout.Value.AsTimeSpan;
+
+                    if (Configuration.Http.MaxStreamsPerConnection.HasValue)
+                        options.Limits.Http2.MaxStreamsPerConnection = Configuration.Http.MaxStreamsPerConnection.Value;
 
                     options.ConfigureEndpointDefaults(listenOptions => listenOptions.Protocols = Configuration.Http.Protocols);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21053

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
