### PR TITLE
RavenDB-21069 compare Exchange includes should not override already tracked compare exchange values in the session

### DIFF
--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -102,6 +102,7 @@ namespace Raven.Client.Documents.Session
         {
             _state.Clear();
             _compareExchangeIncludes.Clear();
+            _missingDocumentsToAtomicGuardIndex?.Clear();
         }
 
         protected async Task<CompareExchangeValue<T>> GetCompareExchangeValueAsyncInternal<T>(string key, CancellationToken token = default)

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -224,7 +224,7 @@ namespace Raven.Client.Documents.Session.Operations
             if (_compareExchangeValuesToInclude != null || includingMissingAtomicGuards)
             {
                 var clusterSession = _session.GetClusterSession();
-                clusterSession.RegisterCompareExchangeValues(result.CompareExchangeValueIncludes, includingMissingAtomicGuards);
+                clusterSession.RegisterCompareExchangeIncludes(result.CompareExchangeValueIncludes, includingMissingAtomicGuards);
             }
 
             foreach (var document in GetDocumentsFromResult(result))

--- a/src/Raven.Client/Documents/Session/Operations/QueryOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/QueryOperation.cs
@@ -172,8 +172,12 @@ namespace Raven.Client.Documents.Session.Operations
                     _session.RegisterTimeSeries(
                         queryResult.TimeSeriesIncludes);
                 }
+
                 if (queryResult.CompareExchangeValueIncludes != null)
-                    _session.GetClusterSession().RegisterCompareExchangeValues(queryResult.CompareExchangeValueIncludes, includingMissingAtomicGuards: false);
+                {
+                    var clusterSession = _session.GetClusterSession();
+                    clusterSession.RegisterCompareExchangeIncludes(queryResult.CompareExchangeValueIncludes, includingMissingAtomicGuards: false);
+                }
 
                 if (queryResult.RevisionIncludes != null) 
                     _session.RegisterRevisionIncludes(queryResult.RevisionIncludes);

--- a/test/SlowTests/Issues/RavenDB_14006.cs
+++ b/test/SlowTests/Issues/RavenDB_14006.cs
@@ -410,6 +410,11 @@ namespace SlowTests.Issues
                     Assert.NotEqual(resultEtag, stats.ResultEtag);
 
                     value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
+                    Assert.Equal("Torun", value1.Value.City);
+
+                    session.Advanced.Clear();
+
+                    value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
                     Assert.Equal("Bydgoszcz", value1.Value.City);
                 }
             }
@@ -507,7 +512,7 @@ select incl(c)"
                     Assert.NotEqual(resultEtag, stats.ResultEtag);
 
                     value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
-                    Assert.Equal("Bydgoszcz", value1.Value.City);
+                    Assert.Equal("Torun", value1.Value.City);
                 }
             }
         }
@@ -583,6 +588,11 @@ select incl(c)"
                     Assert.Equal(1, companies.Count);
                     Assert.True(stats.DurationInMs >= 0); // not from cache
                     Assert.NotEqual(resultEtag, stats.ResultEtag);
+
+                    value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
+                    Assert.Equal("Torun", value1.Value.City);
+
+                    session.Advanced.Clear();
 
                     value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
                     Assert.Equal("Bydgoszcz", value1.Value.City);
@@ -661,6 +671,11 @@ select incl(c)"
                     Assert.Equal(1, companies.Count);
                     Assert.True(stats.DurationInMs >= 0); // not from cache
                     Assert.NotEqual(resultEtag, stats.ResultEtag);
+
+                    value1 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<Address>(companies[0].ExternalId);
+                    Assert.Equal("Torun", value1.Value.City);
+
+                    session.Advanced.Clear();
 
                     value1 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<Address>(companies[0].ExternalId);
                     Assert.Equal("Bydgoszcz", value1.Value.City);
@@ -763,6 +778,11 @@ select incl(c)"
                     Assert.Equal(1, companies.Count);
                     Assert.True(stats.DurationInMs >= 0); // not from cache
                     Assert.NotEqual(resultEtag, stats.ResultEtag);
+
+                    value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
+                    Assert.Equal("Torun", value1.Value.City);
+
+                    session.Advanced.Clear();
 
                     value1 = session.Advanced.ClusterTransaction.GetCompareExchangeValue<Address>(companies[0].ExternalId);
                     Assert.Equal("Bydgoszcz", value1.Value.City);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21069

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Written in the YT issue description.

### UI work

- No UI work is needed
