### PR TITLE
RavenDB-21040 Implemented test indexes for sharded databases (indexing only on one shard)

### DIFF
--- a/src/Raven.Server/Documents/Commands/Indexes/TestIndexCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Indexes/TestIndexCommand.cs
@@ -46,7 +46,5 @@ internal sealed class TestIndexCommand : RavenCommand<BlittableJsonReaderObject>
         }
 
         Result = response.Clone(context);
-        
-        //Result = _documentConventions.Serialization.DefaultConverter.FromBlittable<TestIndexResult>(response);
     }
 }

--- a/src/Raven.Server/Documents/Commands/Indexes/TestIndexCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Indexes/TestIndexCommand.cs
@@ -1,0 +1,52 @@
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Documents.Indexes.Test;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Commands.Indexes;
+
+internal sealed class TestIndexCommand : RavenCommand<BlittableJsonReaderObject>
+{
+    private readonly TestIndexParameters _parameters;
+    private readonly DocumentConventions _documentConventions;
+    
+    public override bool IsReadRequest => true;
+    
+    public TestIndexCommand(DocumentConventions documentConventions, string nodeTag, TestIndexParameters parameters)
+    {
+        _documentConventions = documentConventions;
+        SelectedNodeTag = nodeTag;
+        _parameters = parameters;
+    }
+    
+    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+    {
+        url = $"{node.Url}/databases/{node.Database}/indexes/test";
+        
+        var parametersJson = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx);
+        
+        return new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            Content = new BlittableJsonContent(async stream =>
+            {
+                await ctx.WriteAsync(stream, parametersJson);
+            }, _documentConventions)
+        };
+    }
+    
+    public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+    {
+        if (response == null)
+        {
+            ThrowInvalidResponse();
+            return; // never hit
+        }
+
+        Result = response.Clone(context);
+        
+        //Result = _documentConventions.Serialization.DefaultConverter.FromBlittable<TestIndexResult>(response);
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForTestIndex.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Documents.Indexes.Test;
+using Raven.Server.Json;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
+
+internal abstract class AbstractAdminIndexHandlerProcessorForTestIndex<TRequestHandler, TOperationContext> : AbstractHandlerProxyReadProcessor<BlittableJsonReaderObject, TRequestHandler, TOperationContext>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+    protected AbstractAdminIndexHandlerProcessorForTestIndex([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+    
+    protected async Task<TestIndexParameters> GetTestIndexParametersAsync(JsonOperationContext context)
+    {
+        var requestBodyStream = RequestHandler.RequestBodyStream();
+        
+        var input = await context.ReadForMemoryAsync(requestBodyStream, "Input");
+
+        var testIndexParameters = JsonDeserializationServer.TestIndexParameters(input);
+
+        return testIndexParameters;
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Test;
+using Raven.Server.Documents.Queries;
+using Raven.Server.NotificationCenter;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
+
+internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminIndexHandlerProcessorForTestIndex<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public AdminIndexHandlerProcessorForTestIndex([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override bool SupportsCurrentNode => true;
+    
+    protected override async ValueTask HandleCurrentNodeAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var testIndexParameters = await GetTestIndexParametersAsync(context);
+            
+            var testIndexDefinition = testIndexParameters.IndexDefinition;
+            var query = testIndexParameters.Query;
+            var queryParameters = testIndexParameters.QueryParameters;
+            int maxDocumentsPerIndex = testIndexParameters.MaxDocumentsToProcess ?? 100;
+            int waitForNonStaleResultsTimeoutInSec = testIndexParameters.WaitForNonStaleResultsTimeoutInSec ?? 15;
+
+            const int documentsPerIndexUpperLimit = 10_000;
+            const int documentsPerIndexLowerLimit = 1;
+
+            const string testIndexName = "<TestIndexName>";
+                
+            if (testIndexParameters.IndexDefinition is null)
+                throw new BadRequestException($"Index must have an {nameof(TestIndexParameters.IndexDefinition)} field");
+
+            if (maxDocumentsPerIndex > documentsPerIndexUpperLimit || maxDocumentsPerIndex < documentsPerIndexLowerLimit)
+                throw new BadRequestException($"Number of documents to process cannot be bigger than {documentsPerIndexUpperLimit} or less than {documentsPerIndexLowerLimit}.");
+
+            if (testIndexDefinition.Type.IsJavaScript() == false)
+            {
+                // C# index without admin authorization
+                if (HttpContext.Features.Get<IHttpAuthenticationFeature>() is RavenServer.AuthenticateConnection feature && feature.CanAccess(RequestHandler.Database.Name, requireAdmin: true, requireWrite: true) == false)
+                    throw new UnauthorizedAccessException($"Testing C# indexes requires admin privileges.");
+            }
+
+            var temporaryIndexName = Guid.NewGuid().ToString("N");
+                
+            testIndexDefinition.Name = temporaryIndexName;
+
+            query ??= $"from index '{testIndexName}'";
+                
+            query = query.Replace(testIndexName, temporaryIndexName);
+                
+            var djv = new DynamicJsonValue() { [nameof(IndexQueryServerSide.Query)] = query, [nameof(IndexQueryServerSide.QueryParameters)] = queryParameters };
+
+            var queryAsBlittable = context.ReadObject(djv, "test-index-query");
+
+            using var tracker = new RequestTimeTracker(HttpContext, Logger, RequestHandler.Database.NotificationCenter, RequestHandler.Database.Configuration, "Query");
+                
+            var indexQueryServerSide = IndexQueryServerSide.Create(HttpContext, queryAsBlittable, RequestHandler.Database.QueryMetadataCache, tracker);
+
+            if (indexQueryServerSide.Metadata.IndexName != temporaryIndexName)
+                throw new BadRequestException($"Expected '{testIndexName}' as index name in query, but could not find it.");
+                
+            using (var index = RequestHandler.Database.IndexStore.CreateTestIndexFromDefinition(testIndexDefinition, context.DocumentDatabase, context, maxDocumentsPerIndex))
+            {
+                index.Start();
+
+                var timespanToWaitForProcessing = TimeSpan.FromSeconds(waitForNonStaleResultsTimeoutInSec);
+                index.TestRun.WaitForProcessingOfSampleDocs(timespanToWaitForProcessing);
+                    
+                using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
+                using (var queryContext = QueryOperationContext.Allocate(RequestHandler.Database))
+                {
+                    indexQueryServerSide.WaitForNonStaleResults = false;
+
+                    var entries = await index.IndexEntries(indexQueryServerSide, queryContext, ignoreLimit: false, token);
+                    var mapResults = index.TestRun.MapResults;
+                    var reduceResults = index.TestRun.ReduceResults;
+                    var queryResults = await index.Query(indexQueryServerSide, queryContext, token);
+                    var hasDynamicFields = index.Definition.HasDynamicFields;
+
+                    var result = new TestIndexResult()
+                    {
+                        IndexEntries = entries.Results,
+                        QueryResults = queryResults.Results,
+                        MapResults = mapResults,
+                        HasDynamicFields = hasDynamicFields,
+                        ReduceResults = reduceResults,
+                        IsStale = queryResults.IsStale,
+                        IndexType = testIndexDefinition.Type
+                    };
+
+                    await result.WriteTestIndexResultAsync(RequestHandler.ResponseBodyStream(), context);
+                }
+            }
+        }
+    }
+
+    protected override Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+}

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -1981,8 +1981,9 @@ namespace Raven.Server.Documents.Indexes
             {
                 _didWork = true;
                 _firstBatchTimeout = null;
-                TestRun?.BatchCompleted.Set();
             }
+            
+            TestRun?.BatchCompleted.Set();
 
             var batchCompletedAction = DocumentDatabase.IndexStore.IndexBatchCompleted;
             batchCompletedAction?.Invoke((Name, didWork));

--- a/src/Raven.Server/Documents/Indexes/Test/TestIndexParameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Test/TestIndexParameters.cs
@@ -1,5 +1,4 @@
 using Raven.Client.Documents.Indexes;
-using Sparrow.Json;
 
 namespace Raven.Server.Documents.Indexes.Test;
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminIndexHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Indexes;
-using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Indexes;
 using Raven.Server.Routing;
 
@@ -26,7 +25,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin
         [RavenShardedAction("/databases/*/indexes/test", "POST")]
         public async Task TestIndex()
         {
-            using (var processor = new NotSupportedInShardingProcessor(this, $"$Database '{DatabaseName}' is a sharded database and does not support Test Indexes."))
+            using (var processor = new ShardedIndexHandlerProcessorForTestIndex(this))
                 await processor.ExecuteAsync();
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForTestIndex.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Indexes;
+using Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Indexes;
+
+internal sealed class ShardedIndexHandlerProcessorForTestIndex : AbstractAdminIndexHandlerProcessorForTestIndex<ShardedDatabaseRequestHandler, TransactionOperationContext>
+{
+    public ShardedIndexHandlerProcessorForTestIndex([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override bool SupportsCurrentNode => false;
+    
+    protected override ValueTask HandleCurrentNodeAsync()
+    {
+        throw new NotSupportedException();
+    }
+    
+    protected override RavenCommand<BlittableJsonReaderObject> CreateCommandForNode(string nodeTag)
+    {
+        using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        {
+            var parameters = GetTestIndexParametersAsync(context).Result;
+
+            var documentConventions = RequestHandler.ShardExecutor.Conventions;
+            
+            return new TestIndexCommand(documentConventions, nodeTag, parameters);
+        }
+    }
+    
+    protected override async Task HandleRemoteNodeAsync(ProxyCommand<BlittableJsonReaderObject> command, OperationCancelToken token)
+    {
+        var shardNumber = GetShardNumber();
+
+        await RequestHandler.DatabaseContext.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21040/Implement-test-indexes-for-single-database-shard

### Additional description

Implemented and enabled test indexes for sharded databases, they work on documents from single shard (picked by user)

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
