### PR TITLE
RavenDB-20965 - Can't recover from entire shard being in Rehab

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -223,6 +223,10 @@ namespace Raven.Server.ServerWide.Maintenance
                             }
 
                             UpdateReshardingStatus(context, rawRecord, newStats, ref confirmCommands);
+
+                            //if orchestrator topology was changed, we skip the checks for the shard topologies to avoid concurrency exception
+                            if (updateReason != null)
+                                continue;
                         }
 
                         var mergedState = new MergedDatabaseObservationState(rawRecord);
@@ -248,6 +252,8 @@ namespace Raven.Server.ServerWide.Maintenance
                                 };
 
                                 updateCommands.Add((cmd, updateReason));
+                                //breaking here to only change the db record once in order to avoid concurrency exception
+                                break;
                             }
                         }
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -35,10 +35,10 @@ public static class Program
             {
                 TryRemoveDatabasesFolder();
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new SubscriptionsWithReshardingTests(testOutputHelper))
+                using (var test = new ShardedClusterObserverTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.GetDocumentsWithFilteringAndModifications3();
+                    await test.ClusterObserverWillSkipCommandIfChangingTheSameDatabaseRecordTwiceInOneIteration();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20965

### Additional description

Cluster observer would try to `UpdateTopologyCommand` multiple times for the same database record with the same raft id.
This caused concurrency exceptions which prevented topology updates and prevented the database from recovering nodes in the topology.
Now making sure to only issue one `UpdateTopologyCommand` for every record in each iteration.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
