### PR TITLE
RavenDB-21057 - Wrong collection at /databases/*/debug/replication/al…

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public override DynamicJsonValue ToDebugJson()
         {
             var djv = base.ToDebugJson();
-            djv[nameof(Collection)] = Collection?.ToString(CultureInfo.InvariantCulture) ?? Constants.Documents.Collections.EmptyCollection;
+            djv[nameof(Collection)] = Collection?.ToString(CultureInfo.InvariantCulture) ?? CollectionName.GetCollectionName(Data);
             djv[nameof(Id)] = Id.ToString(CultureInfo.InvariantCulture);
             djv[nameof(Flags)] = Flags;
             return djv;


### PR DESCRIPTION
…l-items

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21057/Wrong-collection-at-databases-debug-replication-all-items


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
