### PR TITLE
RavenDB-20754 - SlowTests.Server.Replication.AutomaticConflictResolut…

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
+++ b/test/SlowTests/Server/Replication/ReplicationAutomaticConflictResolution.cs
@@ -296,12 +296,12 @@ return out;
                     session.Store(new
                     {
                         Foo = "marker"
-                    }, "marker1");
+                    }, "marker1$users/2");
 
                     session.SaveChanges();
                 }
 
-                Assert.True(WaitForDocument(slave, "marker1"));
+                Assert.True(WaitForDocument(slave, "marker1$users/2"));
 
                 using (var session = slave.OpenSession())
                 {
@@ -323,12 +323,13 @@ return out;
                     session.Store(new
                     {
                         Foo = "marker"
-                    }, "marker2");
+                    }, "marker2$users/1");
 
                     session.SaveChanges();
                 }
 
-                Assert.True(WaitForDocument(slave, "marker2"));
+                Assert.True(WaitForDocument(slave, "marker2$users/1"));
+
                 using (var session = slave.OpenSession())
                 {
                     var user1 = session.Load<User>("users/1");


### PR DESCRIPTION
…ion.ShouldResolveDocumentConflictInFavorOfLatestVersion(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20754/SlowTests.Server.Replication.AutomaticConflictResolution.ShouldResolveDocumentConflictInFavorOfLatestVersionoptions-DatabaseMode


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
