### PR TITLE
RavenDB-21062 if result is blittable the user should be the owner of the context

### DIFF
--- a/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
+++ b/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
@@ -82,7 +82,7 @@ namespace Raven.Client.Documents.Operations
             return AsyncHelpers.RunSync(() => SendAsync(operation));
         }
 
-        public TResult Send<TResult>(JsonOperationContext context, IMaintenanceOperation<TResult> operation)
+        internal TResult Send<TResult>(JsonOperationContext context, IMaintenanceOperation<TResult> operation)
         {
             return AsyncHelpers.RunSync(() => SendAsync(context, operation));
         }
@@ -117,7 +117,7 @@ namespace Raven.Client.Documents.Operations
             }
         }
 
-        public async Task<TResult> SendAsync<TResult>(JsonOperationContext context, IMaintenanceOperation<TResult> operation, CancellationToken token = default)
+        internal async Task<TResult> SendAsync<TResult>(JsonOperationContext context, IMaintenanceOperation<TResult> operation, CancellationToken token = default)
         {
             var command = operation.GetCommand(RequestExecutor.Conventions, context);
 

--- a/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
+++ b/src/Raven.Server/Documents/Sharding/Executors/ShardExecutor.cs
@@ -12,6 +12,7 @@ using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Executors
 {

--- a/src/Sparrow/Utils/TypeUtils.cs
+++ b/src/Sparrow/Utils/TypeUtils.cs
@@ -8,7 +8,7 @@ using Sparrow.Json;
 
 namespace Sparrow.Utils
 {
-    public static class TypeUtils
+    internal static class TypeUtils
     {
         private struct VisitedResetBehavior : IResetSupport<HashSet<object>>
         {

--- a/src/Sparrow/Utils/TypeUtils.cs
+++ b/src/Sparrow/Utils/TypeUtils.cs
@@ -1,16 +1,13 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using CsvHelper;
-using Sparrow;
 using Sparrow.Json;
-using Sparrow.Utils;
 
-namespace Raven.Server.Utils
+namespace Sparrow.Utils
 {
-    
     public static class TypeUtils
     {
         private struct VisitedResetBehavior : IResetSupport<HashSet<object>>
@@ -22,7 +19,7 @@ namespace Raven.Server.Utils
         }
 
         private static readonly ObjectPool<HashSet<object>,VisitedResetBehavior> VisitedHashsets = 
-            new ObjectPool<HashSet<object>, VisitedResetBehavior>(() => new HashSet<object>(Sparrow.Utils.ReferenceEqualityComparer.Default));
+            new ObjectPool<HashSet<object>, VisitedResetBehavior>(() => new HashSet<object>(ReferenceEqualityComparer.Default));
 
         //detect if an object is a blittable or has any blittable objects somewhere in its object hierarchy
         public static bool ContainsBlittableObject(this object obj)
@@ -71,6 +68,7 @@ namespace Raven.Server.Utils
                 return false;
             }
 
+#if NETCOREAPP2_1_OR_GREATER
             if (obj is ITuple tuple)
             {
                 for (int i = 0; i < tuple.Length; i++)
@@ -83,6 +81,7 @@ namespace Raven.Server.Utils
 
                 return false;
             }
+#endif
 
             if (type.IsClass || type.IsUserDefinedStruct())
             {
@@ -109,6 +108,12 @@ namespace Raven.Server.Utils
             }
 
             return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsUserDefinedStruct(this Type type)
+        {
+            return type.IsValueType && !type.IsPrimitive && !type.IsEnum;
         }
     }
 }

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -61,11 +61,11 @@ namespace SlowTests.Server.Replication
                 }
 
                 Assert.True(WaitForDocument(store1, "foo/bar"));
-
-                var resolvedConflicts = (await store1.Maintenance.SendAsync(new GetResolvedRevisionsOperation())).Results.ToList();
+                using var ctx = JsonOperationContext.ShortTermSingleUse();
+                var resolvedConflicts = (await store1.Maintenance.SendAsync(ctx, new GetResolvedRevisionsOperation())).Results.ToList();
                 Assert.Equal(1, resolvedConflicts.Count);
 
-                var resolvedConflicts2 = (await store2.Maintenance.SendAsync(new GetResolvedRevisionsOperation())).Results.ToList();
+                var resolvedConflicts2 = (await store2.Maintenance.SendAsync(ctx, new GetResolvedRevisionsOperation())).Results.ToList();
                 Assert.Equal(1, resolvedConflicts2.Count);
 
                 Assert.Empty(store1.Commands().GetConflictsFor("foo/bar"));

--- a/test/SlowTests/Sharding/Client/Operations/GetDocumentConflictsTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetDocumentConflictsTests.cs
@@ -208,7 +208,8 @@ namespace SlowTests.Sharding.Client.Operations
                         var conflicts = db.DocumentsStorage.ConflictsStorage.GetConflictsFor(context, id).ToList();
                         Assert.Equal(2, conflicts.Count); // 2 conflicts per doc
 
-                        var documentConflicts = await store.Maintenance.SendAsync(new GetDocumentConflictsOperation(docId: id));
+                        using var ctx = JsonOperationContext.ShortTermSingleUse();
+                        var documentConflicts = await store.Maintenance.SendAsync(ctx, new GetDocumentConflictsOperation(docId: id));
                         Assert.Equal(2, documentConflicts.Results.Length);
                     }
                 }
@@ -242,8 +243,11 @@ namespace SlowTests.Sharding.Client.Operations
             for (int i = 0; i < 10; i++)
             {
                 var id = $"users/{i}${_suffix}";
-                var documentConflicts = await store.Maintenance.SendAsync(new GetDocumentConflictsOperation(docId: id));
-                Assert.Equal(2, documentConflicts.Results.Length);
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var documentConflicts = await store.Maintenance.SendAsync(ctx, new GetDocumentConflictsOperation(docId: id));
+                    Assert.Equal(2, documentConflicts.Results.Length);
+                }
             }
         }
 

--- a/test/SlowTests/Sharding/Client/Operations/GetSuggestConflictResolutionOperationTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetSuggestConflictResolutionOperationTests.cs
@@ -7,6 +7,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.Operations;
 using SlowTests.Core.Utils.Entities;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
@@ -47,10 +48,13 @@ namespace SlowTests.Sharding.Client.Operations
             for (int i = 0; i < 10; i++)
             {
                 var id = $"users/{i}${_suffix}";
-                var conflictsResolution = await store.Maintenance.SendAsync(new GetSuggestConflictResolutionOperation(id));
-                Assert.NotNull(conflictsResolution);
-                Assert.NotNull(conflictsResolution.Document);
-                Assert.NotNull(conflictsResolution.Metadata);
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var conflictsResolution = await store.Maintenance.SendAsync(ctx, new GetSuggestConflictResolutionOperation(id));
+                    Assert.NotNull(conflictsResolution);
+                    Assert.NotNull(conflictsResolution.Document);
+                    Assert.NotNull(conflictsResolution.Metadata);
+                }
             }
         }
 
@@ -81,10 +85,13 @@ namespace SlowTests.Sharding.Client.Operations
             for (int i = 0; i < 10; i++)
             {
                 var id = $"users/{i}${_suffix}";
-                var conflictsResolution = await store.Maintenance.SendAsync(new GetSuggestConflictResolutionOperation(id));
-                Assert.NotNull(conflictsResolution);
-                Assert.NotNull(conflictsResolution.Document);
-                Assert.NotNull(conflictsResolution.Metadata);
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var conflictsResolution = await store.Maintenance.SendAsync(ctx, new GetSuggestConflictResolutionOperation(id));
+                    Assert.NotNull(conflictsResolution);
+                    Assert.NotNull(conflictsResolution.Document);
+                    Assert.NotNull(conflictsResolution.Metadata);
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21062

### Additional description

Command that have a `Blittable` in the result must get an external context to use.
Otherwise the context can be returned and reused, and thus the result will be invalid.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Haven't tested it 
- 
### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
