### PR TITLE
RavenDB-20709 Dedicated thread for executing cluster transactions

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -342,7 +342,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var lastFilePath = RestoreSource.GetBackupPath(lastFileName);
             await ImportSingleBackupFileAsync(database, Progress, Result, lastFilePath, context, destination, options, isLastFile: true);
 
-            await ExecuteClusterTransactions(database);
+            ExecuteClusterTransactions(database);
         }
 
         protected Stream GetInputStream(Stream stream, byte[] databaseEncryptionKey)
@@ -552,7 +552,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 database.DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(smugglerDatabaseRecord);
         }
 
-        private async Task ExecuteClusterTransactions(DocumentDatabase database)
+        private void ExecuteClusterTransactions(DocumentDatabase database)
         {
             long totalExecutedCommands = 0;
 
@@ -565,7 +565,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 using (serverContext.OpenReadTransaction())
                 {
                     // the commands are already batched (10k or 16MB), so we are executing only 1 at a time
-                    var executed = await database.ExecuteClusterTransaction(serverContext, batchSize: 1);
+                    var executed = database.ExecuteClusterTransaction(serverContext, batchSize: 1);
                     if (executed.BatchSize == 0)
                         break;
 

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -135,6 +135,11 @@ namespace Raven.Server.Documents.TransactionMerger
             }
         }
 
+        public void EnqueueSync(MergedTransactionCommand<TOperationContext, TTransaction> cmd)
+        {
+            Enqueue(cmd).GetAwaiter().GetResult();
+        }
+
         [DoesNotReturn]
         private static void ThrowTxMergerWasDisposed()
         {

--- a/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
+++ b/src/Raven.Server/ServerWide/TransactionMerger/ClusterTransactionOperationsMerger.cs
@@ -29,11 +29,6 @@ public sealed class ClusterTransactionOperationsMerger : AbstractTransactionOper
     {
     }
 
-    public void EnqueueSync(MergedTransactionCommand<ClusterOperationContext, ClusterTransaction> cmd)
-    {
-        Enqueue(cmd).GetAwaiter().GetResult();
-    }
-
     public Task Enqueue(Func<ClusterOperationContext, long> executeFunc)
     {
         var cmd = new ExecutableMergedCommand(executeFunc);

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -614,7 +614,7 @@ public static class ThreadNames
 
             public string GetShortName()
             {
-                return $"{_db} CT Thread";
+                return $"ClstrTx {_db}";
             }
         }
     }

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -208,6 +208,14 @@ public static class ThreadNames
         };
     }
 
+    public static ThreadInfo ForClusterTransactions(string threadName, string databaseName)
+    {
+        return new ThreadInfo(threadName)
+        {
+            Details = new ThreadDetails.ClusterTransaction(databaseName)
+        };
+    }
+
     public sealed class ThreadDetails
     {
         public interface IThreadDetails
@@ -593,6 +601,20 @@ public static class ThreadNames
             public string GetShortName()
             {
                 return $"PllRepSnk {_destinationDatabase} at {_destinationUrl}";
+            }
+        }
+
+        public class ClusterTransaction : IThreadDetails
+        {
+            private readonly string _db;
+            public ClusterTransaction(string dbName)
+            {
+                _db = dbName;
+            }
+
+            public string GetShortName()
+            {
+                return $"{_db} CT Thread";
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20709

### Additional description
Dedicated thread for executing cluster transactions

_Please delete below the options that are not relevant_

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
