### PR TITLE
RavenDB-20884 : Sharding - Deleting a database doesn't delete old notifications

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -147,9 +147,7 @@ namespace Raven.Server.Documents
                                 using (ShardedDatabasesCache.RemoveLockAndReturn(databaseName, (databaseContext) => databaseContext.Dispose(), out _))
                                 {
                                 }
-
-                                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += 
-                                    _ => _serverStore.NotificationCenter.Storage.DeleteStorageFor(databaseName);
+                                _serverStore.NotificationCenter.Storage.DeleteStorageFor(databaseName);
                             }
                         }
                         else

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -144,9 +144,12 @@ namespace Raven.Server.Documents
                             }
                             else
                             {
-                                using (ShardedDatabasesCache.RemoveLockAndReturn(databaseName, (databaseContext) => databaseContext.Dispose(), out var _))
+                                using (ShardedDatabasesCache.RemoveLockAndReturn(databaseName, (databaseContext) => databaseContext.Dispose(), out _))
                                 {
                                 }
+
+                                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += 
+                                    _ => _serverStore.NotificationCenter.Storage.DeleteStorageFor(databaseName);
                             }
                         }
                         else

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -238,6 +238,8 @@ namespace Raven.Server.Documents.Sharding
 
             exceptionAggregator.Execute(() => _databaseShutdown.Dispose());
 
+            exceptionAggregator.Execute(() => NotificationCenter.Dispose());
+
             exceptionAggregator.ThrowIfNeeded();
         }
     }

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -422,5 +422,14 @@ namespace Raven.Server.NotificationCenter
                 tx.Commit();
             }
         }
+
+        public void DeleteStorageFor<T>(TransactionOperationContext<T> ctx, string database) where T : RavenTransaction
+        {
+            if (database == null)
+                throw new ArgumentNullException(nameof(database));
+
+            var tableName = GetTableName(database);
+            ctx.Transaction.InnerTransaction.DeleteTable(tableName);
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1554,6 +1554,7 @@ namespace Raven.Server.ServerWide
 
                         if (databaseRecord.Sharding.Shards.Count == 0)
                         {
+                            serverStore.NotificationCenter.Storage.DeleteStorageFor(context, shardedDatabaseName);
                             DeleteDatabaseRecord(context, index, items, lowerKey, databaseRecord, serverStore);
                             NotifyDatabaseAboutChanged(context, shardedDatabaseName, index, nameof(RemoveNodeFromDatabaseCommand),
                                 DatabasesLandlord.ClusterDatabaseChangeType.RecordChanged, null);

--- a/test/SlowTests/Sharding/Issues/RavenDB_20884.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20884.cs
@@ -1,0 +1,102 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20884 : ReplicationTestBase
+    {
+        public RavenDB_20884(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        public void OnShardedDatabaseDeletion_ShouldDeleteNotificationsFromOrchestrator()
+        {
+            string databaseName;
+            AlertRaised alert;
+
+            using (var store = Sharding.GetDocumentStore())
+            {
+                databaseName = store.Database;
+
+                var shardedDbCtx = Sharding.GetOrchestrator(store.Database);
+
+                // store notification 
+                var alertMsg = $"you have low disk space on node '{Server.ServerStore.NodeTag}'";
+                alert = AlertRaised.Create(store.Database, "low disk space warning", alertMsg, AlertType.LowDiskSpace, NotificationSeverity.Warning);
+
+                shardedDbCtx.NotificationCenter.Add(alert);
+
+                using (shardedDbCtx.NotificationCenter.Storage.Read(alert.Id, out var ntv))
+                {
+                    Assert.NotNull(ntv);
+                    Assert.True(ntv.Json.TryGet(nameof(AlertRaised.Message), out string msg), "Unable to read stored notification");
+                    Assert.Equal(alertMsg, msg);
+                }
+            }
+
+            // recreate the sharded database
+            using (var store2 = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseName = _ => databaseName
+            }))
+            {
+                var shardedDbCtx = Sharding.GetOrchestrator(store2.Database);
+
+                // old notification should not be there
+                using (shardedDbCtx.NotificationCenter.Storage.Read(alert.Id, out var ntv))
+                {
+                    Assert.Null(ntv);
+                }
+            }
+
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        public async Task OnRemovingOrchestratorNode_ShouldDeleteShardedDatabaseNotificationsFromNode()
+        {
+            var cluster = await CreateRaftCluster(3);
+            var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                var server = cluster.Nodes.First(n => n != cluster.Leader);
+                var shardedDbCtx = Sharding.GetOrchestrator(store.Database, server);
+
+                // store notification 
+                var alertMsg = $"you have low disk space on node '{Server.ServerStore.NodeTag}'";
+                var alert = AlertRaised.Create(store.Database, "low disk space warning", alertMsg, AlertType.LowDiskSpace, NotificationSeverity.Warning);
+
+                shardedDbCtx.NotificationCenter.Add(alert);
+
+                using (shardedDbCtx.NotificationCenter.Storage.Read(alert.Id, out var ntv))
+                {
+                    Assert.NotNull(ntv);
+                    Assert.True(ntv.Json.TryGet(nameof(AlertRaised.Message), out string msg), "Unable to read stored notification");
+                    Assert.Equal(alertMsg, msg);
+                }
+
+                // remove one node from orchestrator topology
+                await store.Maintenance.Server.SendAsync(new RemoveNodeFromOrchestratorTopologyOperation(store.Database, server.ServerStore.NodeTag));
+                var shardingConfig = await Sharding.GetShardingConfigurationAsync(store);
+                Assert.Equal(2, shardingConfig.Orchestrator.Topology.Count);
+                Assert.DoesNotContain(server.ServerStore.NodeTag, shardingConfig.Orchestrator.Topology.AllNodes);
+
+                // verify that orchestrator notifications are removed from this node
+                using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var tableName = $"Notifications.{store.Database.ToLower()}";
+                    var table = ctx.Transaction.InnerTransaction.OpenTable(Raven.Server.Documents.Schemas.Notifications.Current, tableName);
+                    Assert.Null(table);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20884/Deleting-a-database-doesnt-delete-old-notifications

### Additional description

sharded database notifications are not deleted from orchestrator upon database deletion
same problem when removing a node from orchestrator's topology - notifications are not deleted on that node

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
