### PR TITLE
RavenDB-20962: On StartShardSubscriptionWorkers connect worker to responsible node

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -194,6 +194,8 @@ namespace Raven.Client.Documents.Subscriptions
 
             var requestExecutor = GetRequestExecutor();
 
+            await TrySetRedirectNodeOnConnectToServerAsync().ConfigureAwait(false);
+
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 TcpConnectionInfo tcpInfo;
@@ -1017,6 +1019,8 @@ namespace Raven.Client.Documents.Subscriptions
         protected abstract void SetLocalRequestExecutor(string url, X509Certificate2 cert);
 
         protected abstract TBatch CreateEmptyBatch();
+
+        protected abstract Task TrySetRedirectNodeOnConnectToServerAsync();
 
         public event Action<AbstractSubscriptionWorker<TBatch, TType>> OnDisposed = delegate { };
 

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorker.cs
@@ -13,6 +13,7 @@
 #endif
 
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 
@@ -44,5 +45,11 @@ namespace Raven.Client.Documents.Subscriptions
         }
 
         protected override SubscriptionBatch<T> CreateEmptyBatch() => new SubscriptionBatch<T>(_subscriptionLocalRequestExecutor, _store, _dbName, _logger);
+
+        protected override Task TrySetRedirectNodeOnConnectToServerAsync()
+        {
+            // no-op
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -12,6 +12,7 @@ using Xunit;
 using Voron.Impl.Backup;
 using Voron.Util.Settings;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Voron.Backups
 {
@@ -20,8 +21,7 @@ namespace FastTests.Voron.Backups
         public BackupToOneZipFile(ITestOutputHelper output) : base(output)
         {
         }
-
-        [Fact(Skip = "Should add database record to backup and restore")]
+        [RavenFact(RavenTestCategory.Subscriptions | RavenTestCategory.BackupExportImport, Skip = "Should add database record to backup and restore")]
         public async Task FullBackupToOneZipFile()
         {
             var tempFileName = NewDataPath(forceCreateDir: true);

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -1302,17 +1302,16 @@ namespace SlowTests.Sharding.Cluster
                     }
                 });
 
-
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User(), "foo$users/1-A");
+                    session.Store(new User() {Age = 0}, "foo$users/1-A");
 
                     for (int i = 0; i < 20; i++)
                     {
-                        session.Store(new User(), NextId);
+                        session.Store(new User() { Age = 0 }, NextId);
                     }
 
-                    session.Store(new User(), "foo$users/8-A");
+                    session.Store(new User() { Age = 0 }, "foo$users/8-A");
 
                     session.SaveChanges();
                 }
@@ -1347,16 +1346,16 @@ namespace SlowTests.Sharding.Cluster
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User(), "bar$users/1-A");
-                    session.Store(new User(), "users/1-A");
+                    session.Store(new User() { Age = 1 }, "bar$users/1-A");
+                    session.Store(new User() { Age = 1 }, "users/1-A");
 
                     for (int i = 0; i < 20; i++)
                     {
-                        session.Store(new User(), NextId);
+                        session.Store(new User() { Age = 1 }, NextId);
                     }
 
-                    session.Store(new User(), "bar$users/8-A");
-                    session.Store(new User(), "users/8-A");
+                    session.Store(new User() { Age = 1 }, "bar$users/8-A");
+                    session.Store(new User() { Age = 1 }, "users/8-A");
 
                     session.SaveChanges();
                 }
@@ -1371,16 +1370,16 @@ namespace SlowTests.Sharding.Cluster
 
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new User(), "baz$users/1-A");
-                    session.Store(new User(), "users/1-A");
+                    session.Store(new User() { Age = 2 }, "baz$users/1-A");
+                    session.Store(new User() { Age = 2 }, "users/1-A");
 
                     for (int i = 0; i < 20; i++)
                     {
-                        session.Store(new User(), NextId);
+                        session.Store(new User() { Age = 2 }, NextId);
                     }
 
-                    session.Store(new User(), "baz$users/8-A");
-                    session.Store(new User(), "users/8-A");
+                    session.Store(new User() { Age = 2 }, "baz$users/8-A");
+                    session.Store(new User() { Age = 2 }, "users/8-A");
 
 
                     session.SaveChanges();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20962

### Additional description

Try to connect the sharded worker to the responsible node.

The test was failing because we might connect to server which still doesn't have the subscription task, since when we are creating the task we wait to the index only on responsible nodes

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
