### PR TITLE
RavenDB-21087 Fixing few issues in SliceSmallSet:

### DIFF
--- a/src/Voron/Impl/SliceSmallSet.cs
+++ b/src/Voron/Impl/SliceSmallSet.cs
@@ -1,159 +1,25 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Server;
+// ReSharper disable StaticMemberInGenericType
 
 namespace Voron.Impl
 {
-    // The concept of the weak small set is about an optimized set that can lose elements when it gets filled.
-    // In a sense it behaves like a forgetful LRU cache, but will not track the read accesses. This version of the SmallSet
-    // is specially designed to deal with sequence values stored in byte pointers. The main difference with a
-    // dictionary is that the small set will calculate the hash ONLY if there are strong candidates that match already.
-    // IMPORTANT: This implementation is intended to be used where either identity semantics is irrelevant (doesn't matter)
-    // or the fallback method to acquire the object if it falls off the cache deals with that accordingly. If you need
-    // identity semantics use `SliceSmallSet<TValue>` instead.
-    public sealed class WeakSliceSmallSet<TValue> : IDisposable
-    {
-        private const int Invalid = -1;
-
-        private readonly int _length;
-        private readonly int[] _keySizes;
-        private readonly ulong[] _keyHashes;
-        private readonly Slice[] _keys;
-        private readonly TValue[] _values;
-        private int _currentIdx;
-
-        public WeakSliceSmallSet(int size = 0)
-        {
-            _length = size > Vector<long>.Count ? (size - size % Vector<long>.Count) : Vector<long>.Count;
-            _keySizes = ArrayPool<int>.Shared.Rent(_length);
-            _keyHashes = ArrayPool<ulong>.Shared.Rent(_length);
-            _keys = ArrayPool<Slice>.Shared.Rent(_length);
-            _values = ArrayPool<TValue>.Shared.Rent(_length);
-            _currentIdx = -1;
-        }
-
-        public unsafe void Add(Slice key, TValue value)
-        {
-            int idx = FindKey(key);
-            if (idx == Invalid)
-                idx = RequestWritableBucket();
-
-            _keys[idx] = key;
-            _keySizes[idx] = key.Size;
-            _keyHashes[idx] = Hashing.XXHash64.CalculateInline(key.Content.Ptr, (ulong)key.Size);
-            _values[idx] = value;
-
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe int FindKey(Slice key)
-        {
-            if (_currentIdx == Invalid)
-                return Invalid;
-
-            int keyLength = key.Size;
-            ulong keyHash = 0;
-            
-            Slice[] keys = _keys;
-            int[] keySizes = _keySizes;
-            ulong[] keyHashes = _keyHashes;
-            byte* keyPtr = key.Content.Ptr;
-
-            // PERF: It may seems strange to increase the size to decrement it as the first
-            // loop operation. The reason behind this is to be able to just jump back immediately
-            // to the top of the loop as soon as we know the item is not the item we are looking
-            // for. 
-            int elementIdx = Math.Min(_currentIdx, _length - 1);
-            while (elementIdx >= 0)
-            {
-                var currentIdx = elementIdx;
-                elementIdx--;
-
-                // First check, we are not going to look into any string that is not of the correct size
-                if (keySizes[currentIdx] != keyLength)
-                    continue;
-
-                // PERF: Assuming a uniformly random symbol distribution, the chance that first two symbols match
-                // (i.e.that S1[1] = S2[1]) is equal to 1/σ, the chance that both first and second symbol pairs
-                // match(i.e.that S1[1] = S2[1] and S1[2] = S2[2]) is equal to 1/σ^2, etc. More generally,
-                // the probability that there is a match between all characters up to a 1 - indexed position i
-                // is equal to 1 / σ^i. We are using that knowledge to quickly get rid of elements.
-                ref var candidateKey = ref keys[currentIdx];
-                
-                int midValue = (keyLength - 1) / 2;
-                if (key[0] != candidateKey[0] || key[midValue] != candidateKey[midValue] || key[keyLength - 1] != candidateKey[keyLength - 1])
-                    continue;
-                
-
-                // If there is a match, we will essentially want to quickly get rid of anything that looks 
-                // potentially wrong. For that we will use the hash, which will only get calculated if there
-                // are at least 1 strong candidate.
-                if (keyHash == 0)
-                    keyHash = Hashing.XXHash64.CalculateInline(keyPtr, (ulong)key.Size);
-
-                if (keyHashes[currentIdx] != keyHash)
-                    continue;
-
-                // We now know that we have an almost sure hit. We will do a final verification at this time.
-                // TODO: Implement a vectorized version of the Equals operation. 
-                if ( AdvMemory.CompareInline(keyPtr, keys[currentIdx].Content.Ptr, keyLength) != 0 )
-                    continue;
-
-                return currentIdx;
-            }
-
-            return Invalid;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int RequestWritableBucket()
-        {
-            _currentIdx++;
-            return _currentIdx % _length;
-        }
-
-        public bool TryGetValue(Slice key, out TValue value)
-        {
-            int idx = FindKey(key);
-            if (idx == Invalid)
-            {
-                Unsafe.SkipInit(out value);
-                return false;
-            }
-
-            value = _values[idx];
-            return true;
-        }
-
-        public void Clear()
-        {
-            Array.Fill(_keySizes, 0);
-            Array.Fill(_keys, default);
-            Array.Fill(_values, default);
-            _currentIdx = -1;
-        }
-
-        public void Dispose()
-        {
-            ArrayPool<int>.Shared.Return(_keySizes);
-            ArrayPool<ulong>.Shared.Return(_keyHashes);
-            ArrayPool<Slice>.Shared.Return(_keys);
-            ArrayPool<TValue>.Shared.Return(_values);
-        }
-    }
-
     // The concept of the small set is about a normal dictionary optimized for accessing recently accessed items. 
     // In a sense it behaves like a LRU cache over a dictionary, however, it will not use the backing dictionary unless it has to.
     // It is specially designed to deal with sequence values stored in byte pointers. The main difference with a
     // dictionary is that the small set will calculate the hash ONLY if there are strong candidates that match already. 
     public sealed class SliceSmallSet<TValue> : IDisposable
     {
+        private static readonly ArrayPool<int> KeySizesPool = ArrayPool<int>.Create();
+        private static readonly ArrayPool<ulong> KeyHashesPool = ArrayPool<ulong>.Create();
+        private static readonly ArrayPool<Slice> KeysPool = ArrayPool<Slice>.Create();
+        private static readonly ArrayPool<TValue> ValuesPool = ArrayPool<TValue>.Create();
+
         private const int Invalid = -1;
 
         private readonly int _length;
@@ -167,12 +33,12 @@ namespace Voron.Impl
         public SliceSmallSet(int size = 0)
         {
             _length = size > Vector<long>.Count ? (size - size % Vector<long>.Count) : Vector<long>.Count;
-            _keySizes = ArrayPool<int>.Shared.Rent(_length);
-            _keyHashes = ArrayPool<ulong>.Shared.Rent(_length);
-            _keys = ArrayPool<Slice>.Shared.Rent(_length);
-            _values = ArrayPool<TValue>.Shared.Rent(_length);
+            _keySizes = KeySizesPool.Rent(_length);
+            _keyHashes = KeyHashesPool.Rent(_length);
+            _keys = KeysPool.Rent(_length);
+            _values = ValuesPool.Rent(_length);
             _overflowStorage = null;
-            _currentIdx = -1;
+            _currentIdx = Invalid;
         }
 
         public IEnumerable<TValue> Values => ReturnValues();
@@ -270,9 +136,11 @@ namespace Voron.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int RequestWritableBucket()
         {
-            if (_currentIdx >= _length && _overflowStorage == null)
+            if (_currentIdx >= _length - 1 && _overflowStorage == null)
             {
-                var storage = new Dictionary<Slice, TValue>(_currentIdx * 2);
+                var storage = new Dictionary<Slice, TValue>(SliceComparer.Instance);
+                storage.EnsureCapacity(_currentIdx * 2);
+
                 for (int i = 0; i <= _currentIdx; i++)
                     storage[_keys[i]] = _values[i];
                 _overflowStorage = storage;
@@ -313,19 +181,20 @@ namespace Voron.Impl
 
         public void Clear()
         {
-            Array.Fill(_keySizes, 0);
+            Array.Fill(_keySizes, default);
+            Array.Fill(_keyHashes, default);
             Array.Fill(_keys, default);
             Array.Fill(_values, default);
             _overflowStorage?.Clear();
-            _currentIdx = -1;
+            _currentIdx = Invalid;
         }
 
         public void Dispose()
         {
-            ArrayPool<int>.Shared.Return(_keySizes);
-            ArrayPool<ulong>.Shared.Return(_keyHashes);
-            ArrayPool<Slice>.Shared.Return(_keys);
-            ArrayPool<TValue>.Shared.Return(_values);
+            KeySizesPool.Return(_keySizes, clearArray: true);
+            KeyHashesPool.Return(_keyHashes, clearArray: true);
+            KeysPool.Return(_keys, clearArray: true);
+            ValuesPool.Return(_values, clearArray: true);
         }
 
         public void Remove(Slice name)
@@ -338,7 +207,6 @@ namespace Voron.Impl
 
                 _overflowStorage.Remove(name);
             }
-            
             
             _keys[idx] = default;
             _keySizes[idx] = default;

--- a/test/FastTests/Corax/Bugs/RavenDB_21087.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_21087.cs
@@ -1,0 +1,71 @@
+﻿using System.Linq;
+using FastTests.Voron.FixedSize;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron.Impl;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_21087 : NoDisposalNeeded
+{
+    public RavenDB_21087(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(16)]
+    [InlineData(128)]
+    [InlineData(129)]
+    [InlineData(130)]
+    [InlineDataWithRandomSeed]
+    public void CanAddAndGetValues(int numberOfItems)
+    {
+        if (numberOfItems > 1025)
+            numberOfItems %= 1025;
+
+        using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+        using (var sut = new SliceSmallSet<object>(128))
+        {
+            var count = 0;
+
+            for (int i = 0; i < numberOfItems; i++)
+            {
+                Slice.From(allocator, "test" + i, ByteStringType.Immutable, out var key);
+
+                sut.Add(key, new object());
+
+                count++;
+            }
+
+            var values = sut.Values.ToArray();
+            Assert.Equal(count, values.Length);
+
+            foreach (object value in values)
+            {
+                Assert.NotNull(value);
+            }
+
+            for (int i = 0; i < numberOfItems; i++)
+            {
+                using var _ = Slice.From(allocator, "test" + i, ByteStringType.Immutable, out var key);
+
+                var result = sut.TryGetValue(key, out var value);
+
+                Assert.True(result);
+            }
+
+            sut.Clear();
+
+            Slice.From(allocator, "foo", ByteStringType.Immutable, out var keyFoo);
+
+            sut.Add(keyFoo, new object());
+
+            values = sut.Values.ToArray();
+            Assert.Equal(1, values.Length);
+        }
+    }
+}


### PR DESCRIPTION
- using dedicated array pools instead of shared one and clearing arrays when returning them
- fixed IndexOutOfRangeException on Add and Values
- using SliceComparer

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21087

### Additional description

Original PR introducing it - https://github.com/ravendb/ravendb/pull/15231

I believe that this caused the following strange errors in tests:

https://issues.hibernatingrhinos.com/issue/RavenDB-20948/FastTests.Corax.CompactTreeTests.CanHandlePageSplitsWithCompression

https://issues.hibernatingrhinos.com/issue/RavenDB-20947/FastTests.Corax.DeleteTest.CanDeleteOneElement

https://issues.hibernatingrhinos.com/issue/RavenDB-20984/FastTests.Corax.CoraxQueries.GreaterThanQuery

I couldn't reproduce exactly the same errors, I think it was somehow related to shared array pool and missing cleanup on returning buffers so we read trees from other (read) transactions

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable 

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
