### PR TITLE
RavenDB-16659 Deleting the database during a restore will throw an ex…

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -334,7 +334,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         databaseRecord.DatabaseState = DatabaseStateStatus.RestoreInProgress;
 
                         await SaveDatabaseRecordAsync(databaseName, databaseRecord, restoreSettings.DatabaseValues, result, onProgress);
-                        _serverStore.ForTestingPurposesOnly()?.RestoreDatabaseAfterSavingDatabaseRecord.Invoke();
+                        _serverStore.ForTestingPurposes?.RestoreDatabaseAfterSavingDatabaseRecord?.Invoke();
                         database.ClusterTransactionId = databaseRecord.Topology.ClusterTransactionIdBase64;
                         database.DatabaseGroupId = databaseRecord.Topology.DatabaseTopologyIdBase64;
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -334,7 +334,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         databaseRecord.DatabaseState = DatabaseStateStatus.RestoreInProgress;
 
                         await SaveDatabaseRecordAsync(databaseName, databaseRecord, restoreSettings.DatabaseValues, result, onProgress);
-                        _serverStore.ForTestingPurposesOnly()?.AfterSavingDatabaseRecored.Invoke();
+                        _serverStore.ForTestingPurposesOnly()?.RestoreDatabaseAfterSavingDatabaseRecord.Invoke();
                         database.ClusterTransactionId = databaseRecord.Topology.ClusterTransactionIdBase64;
                         database.DatabaseGroupId = databaseRecord.Topology.DatabaseTopologyIdBase64;
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -334,6 +334,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         databaseRecord.DatabaseState = DatabaseStateStatus.RestoreInProgress;
 
                         await SaveDatabaseRecordAsync(databaseName, databaseRecord, restoreSettings.DatabaseValues, result, onProgress);
+                        _serverStore.ForTestingPurposesOnly()?.AfterSavingDatabaseRecored.Invoke();
                         database.ClusterTransactionId = databaseRecord.Topology.ClusterTransactionIdBase64;
                         database.DatabaseGroupId = databaseRecord.Topology.DatabaseTopologyIdBase64;
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3547,6 +3547,7 @@ namespace Raven.Server.ServerWide
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
+            internal Action AfterSavingDatabaseRecored;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3547,7 +3547,7 @@ namespace Raven.Server.ServerWide
             internal Action BeforePutLicenseCommandHandledInOnValueChanged;
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
-            internal Action AfterSavingDatabaseRecored;
+            internal Action RestoreDatabaseAfterSavingDatabaseRecord;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -714,7 +714,7 @@ namespace Raven.Server.Web.System
                             if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
                                 throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
                                                                     $"process is in progress. In order to delete the database, " +
-                                                                    $"you can cancel it from node {rawRecord.Topology.Members[0]}");
+                                                                    $"you can cancel the restore task from node {rawRecord.Topology.Members[0]}");
 
                             switch (rawRecord.LockMode)
                             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -712,7 +712,9 @@ namespace Raven.Server.Web.System
                                 continue;
 
                             if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
-                                throw new InvalidOperationException($"Can't delete database {databaseName} while restore is in progress.");
+                                throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                                    $"process is in progress. In order to delete the database, " +
+                                                                    $"you can cancel it from node {rawRecord.Topology.Members[0]}");
 
                             switch (rawRecord.LockMode)
                             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -711,6 +711,9 @@ namespace Raven.Server.Web.System
                             if (rawRecord == null)
                                 continue;
 
+                            if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
+                                throw new InvalidOperationException($"Can't delete database {databaseName} while restore is in progress.");
+
                             switch (rawRecord.LockMode)
                             {
                                 case DatabaseLockMode.Unlock:

--- a/test/SlowTests/Issues/RavenDB-16659.cs
+++ b/test/SlowTests/Issues/RavenDB-16659.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_16659 :RavenTestBase
+    {
+        private readonly int _reasonableTimeout = Debugger.IsAttached ? 60000 : 30000;
+
+        public RavenDB_16659(ITestOutputHelper output) : base(output)
+        {
+        }
+        [Fact]
+        public async Task DeleteDatabaseDuringRestore()
+        {
+            var mre = new ManualResetEventSlim();
+            var backupPath = NewDataPath();
+            
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" },"users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+
+                var result = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                var databaseName = $"{store}_Restore";
+                try
+                {
+                    RestoreBackupOperation restoreOperation =
+                        new RestoreBackupOperation(new RestoreBackupConfiguration
+                            {BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+                    Server.ServerStore.ForTestingPurposesOnly().AfterSavingDatabaseRecored += () => mre.Set();
+                    
+                    var op  = await store.Maintenance.Server.SendAsync(restoreOperation);
+                    mre.Wait();
+                    
+                    var e = Assert.Throws<RavenException>(() => store.Maintenance.Server.Send(new DeleteDatabasesOperation(databaseName, hardDelete: true)));
+                    Assert.Contains($"Can't delete database {databaseName} while restore is in progress.", e.Message);
+                    await op.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                }
+                finally
+                {
+                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-16659.cs
+++ b/test/SlowTests/Issues/RavenDB-16659.cs
@@ -54,8 +54,8 @@ namespace SlowTests.Issues
                     Server.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () => mre.Set();
                     
                     var op  = await store.Maintenance.Server.SendAsync(restoreOperation);
-                    mre.Wait();
-                    
+                    var res = mre.Wait(TimeSpan.FromSeconds(30));
+                    Assert.True(res);
                     var e = Assert.Throws<RavenException>(() => store.Maintenance.Server.Send(new DeleteDatabasesOperation(databaseName, hardDelete: true)));
                     Assert.Contains($"Can't delete database '{databaseName}' while the restore process is in progress.", e.Message);
                     await op.WaitForCompletionAsync(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
…ception

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16659

### Additional description

We don't want to delete a database during a restore due to https://issues.hibernatingrhinos.com/issue/RDBCL-1827/Database-stuck-deleting-when-deleted-during-restore. 
We will throw an exception instead 

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update


- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
