### PR TITLE
RavenDB-20931 - SlowTests.Sharding.Replication.ShardedExternalReplica…

### DIFF
--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -499,7 +499,7 @@ namespace SlowTests.Sharding.Replication
                     TimeSpan.FromSeconds(60)));
             }
         }
-        
+
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
         [RavenExternalReplication(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
         [RavenExternalReplication(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
@@ -552,7 +552,7 @@ namespace SlowTests.Sharding.Replication
                     }
 
                     return taskStatus?.DestinationUrl;
-                    
+
                     MaintenanceOperationExecutor GetExecutor(MaintenanceOperationExecutor executor)
                     {
                         if (source.DatabaseMode == RavenDatabaseMode.Sharded)
@@ -618,6 +618,7 @@ namespace SlowTests.Sharding.Replication
 
                 using (var session = dst.OpenSession())
                 {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), replicas: clusterSize - 1);
                     session.Store(new User { Name = "Karmel" }, "users/2$users/1");
                     session.SaveChanges();
                 }
@@ -658,7 +659,7 @@ namespace SlowTests.Sharding.Replication
                 {
                     await Replication.EnsureNoReplicationLoopAsync(source.DatabaseMode, server, src.Database);
                 }
-                
+
                 foreach (var server in dstNodes)
                 {
                     await Replication.EnsureNoReplicationLoopAsync(destination.DatabaseMode, server, dst.Database);


### PR DESCRIPTION
…tionTests.BidirectionalReplicationWithReshardingShouldWork(source:  DatabaseMode = Sharded, destination:  DatabaseMode = Sharded)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20931/SlowTests.Sharding.Replication.ShardedExternalReplicationTests.BidirectionalReplicationWithReshardingShouldWorksource

### Additional description

Couldn't reproduce the failure (waiting to see if will fail after those changes).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
