### PR TITLE
RavenDB-21088 - fix concurrent access to a Dictionary

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -412,9 +412,9 @@ namespace Voron.Impl.Scratch
             {
                 var pages = new List<PageFromScratchBuffer>();
 
-                foreach (var key in _parent._allocatedPages.Keys)
+                foreach (var keyValue in _parent._allocatedPages.ToArray())
                 {
-                    if (_parent._allocatedPages.TryGetValue(key, out var pageFromScratchBuffer) == false)
+                    if (_parent._allocatedPages.TryGetValue(keyValue.Key, out var pageFromScratchBuffer) == false)
                         continue;
 
                     if (pageFromScratchBuffer == null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21088/Failed-to-load-the-storage-report

### Additional description

Fix concurrent access to a `Dictionary` (for a debug endpoint).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change