### PR TITLE
RavenDB-21089 - Fixing Import creates revisions

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -299,8 +299,15 @@ namespace Raven.Server.Documents.Revisions
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByTimeSeriesUpdate))
                     return false;
 
-                if (docConfiguration == ConflictConfiguration.Default || docConfiguration.Disabled)
+                if (docConfiguration == ConflictConfiguration.Default || docConfiguration == _emptyConfiguration || docConfiguration.Disabled)
                     return false;
+
+                // if (docConfiguration.MinimumRevisionsToKeep == 0)
+                //     return false;
+                //
+                // if (docConfiguration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue &&
+                //     _database.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > docConfiguration.MinimumRevisionAgeToKeep.Value.Ticks)
+                //     return false;
             }
 
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
@@ -641,8 +648,8 @@ namespace Raven.Server.Documents.Revisions
             var result = new DeleteOldRevisionsResult();
             result.PreviousCount = GetRevisionsCount(context, prefixSlice);
 
-            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler))
-                return result;
+            // if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler))
+            //     return result;
 
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))
                 return result;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -301,13 +301,6 @@ namespace Raven.Server.Documents.Revisions
 
                 if (docConfiguration == ConflictConfiguration.Default || docConfiguration == _emptyConfiguration || docConfiguration.Disabled)
                     return false;
-
-                // if (docConfiguration.MinimumRevisionsToKeep == 0)
-                //     return false;
-                //
-                // if (docConfiguration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue &&
-                //     _database.Time.GetUtcNow().Ticks - lastModifiedTicks.Value > docConfiguration.MinimumRevisionAgeToKeep.Value.Ticks)
-                //     return false;
             }
 
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.Resolved))
@@ -647,9 +640,6 @@ namespace Raven.Server.Documents.Revisions
         {
             var result = new DeleteOldRevisionsResult();
             result.PreviousCount = GetRevisionsCount(context, prefixSlice);
-
-            // if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler))
-            //     return result;
 
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication))
                 return result;

--- a/test/SlowTests/Issues/RavenDB-21089.cs
+++ b/test/SlowTests/Issues/RavenDB-21089.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
+using Sparrow;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.RavenDB_20425;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21089 : RavenTestBase
+{
+    public RavenDB_21089(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task ImportedDocumentShouldNotHaveRevisions()
+    {
+        string file = "SlowTests.Smuggler.Data.Northwind_3.5.35168.ravendbdump";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        await using var stream = GetType().Assembly.GetManifestResourceStream(file);
+        using var store = GetDocumentStore();
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 0
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        Assert.NotNull(stream);
+        var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), stream, cts.Token);
+        await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+        var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation(), cts.Token);
+        var collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation(), cts.Token);
+        AssertImport(stats, collectionStats);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var order = await session.LoadAsync<Order>("orders/1", cts.Token);
+            Assert.NotNull(order);
+
+            var metadata = session.Advanced.GetMetadataFor(order);
+            Assert.False(metadata.ContainsKey("Raven-Entity-Name"));
+            Assert.False(metadata.ContainsKey("Raven-Last-Modified"));
+            Assert.False(metadata.ContainsKey("Last-Modified"));
+
+            var order1RevCount = await session.Advanced.Revisions.GetCountForAsync("orders/1");
+            Assert.Equal(0, order1RevCount); // got 1
+        }
+    }
+
+    [Fact]
+    public async Task MinToKeep0ShouldNotCreateRevisions()
+    {
+        using var store = GetDocumentStore();
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 0
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Order() { Id = "orders/1", Company = "A" });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Order() { Id = "orders/1", Company = "B" });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var order = await session.LoadAsync<Order>("orders/1");
+            Assert.NotNull(order);
+
+            var order1RevCount = await session.Advanced.Revisions.GetCountForAsync("orders/1");
+            Assert.Equal(0, order1RevCount); // EnforceConfig: 0
+        }
+    }
+
+    private void AssertImport(DatabaseStatistics stats, CollectionStatistics collectionStats)
+    {
+        Assert.Equal(1059, stats.CountOfDocuments);
+        Assert.Equal(3, stats.CountOfIndexes); // there are 4 in ravendbdump, but Raven/DocumentsByEntityName is skipped
+        Assert.Equal(1059, collectionStats.CountOfDocuments);
+        Assert.Equal(9, collectionStats.Collections.Count);
+        Assert.Equal(8, collectionStats.Collections["Categories"]);
+        Assert.Equal(91, collectionStats.Collections["Companies"]);
+        Assert.Equal(9, collectionStats.Collections["Employees"]);
+        Assert.Equal(830, collectionStats.Collections["Orders"]);
+        Assert.Equal(77, collectionStats.Collections["Products"]);
+        Assert.Equal(4, collectionStats.Collections["Regions"]);
+        Assert.Equal(3, collectionStats.Collections["Shippers"]);
+        Assert.Equal(29, collectionStats.Collections["Suppliers"]);
+        Assert.Equal(8, collectionStats.Collections["@hilo"]);
+    }
+}
+

--- a/test/SlowTests/Smuggler/LegacySmugglerTests.cs
+++ b/test/SlowTests/Smuggler/LegacySmugglerTests.cs
@@ -283,7 +283,7 @@ namespace SlowTests.Smuggler
                 Assert.Equal(6, stats.CountOfRevisionDocuments); // 1 of the doc "Raven/Versioning/DefaultConfiguration", and 5 revisions of the deleted doc "test" 
                                                                                 // (which had originally 6 revisions, but the last was deleted in the import because default configuration has 'MinimumRevisionsToKeep=5')
                 Assert.Equal(2, stats.LastDocEtag);
-
+                
                 var collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
                 Assert.Equal(1, collectionStats.CountOfDocuments);
                 Assert.Equal(2, collectionStats.Collections.Count);
@@ -296,16 +296,16 @@ namespace SlowTests.Smuggler
                     Assert.Null(test);
 
                     var revisions = session.Advanced.Revisions.GetFor<User>("test");
-                    Assert.Equal(5, revisions.Count);  // the number of the revisions shrinked to be 5 in the import because the default revisions config
+                    Assert.Equal(5, revisions.Count);  // the number of the revisions shrinked to be 5 in the import because the default revisions config (the oldest revision with the name "..." was deleted during the import).
 
                     var metadata = session.Advanced.GetMetadataFor(revisions[0]);
                     Assert.Equal($"{DocumentFlags.HasRevisions}, {DocumentFlags.DeleteRevision}", metadata.GetString(Constants.Documents.Metadata.Flags));
 
+                    Assert.Equal(null, revisions[0].Name);
                     Assert.Equal("4", revisions[1].Name);
                     Assert.Equal("3", revisions[2].Name);
                     Assert.Equal("2", revisions[3].Name);
                     Assert.Equal("1", revisions[4].Name);
-                    Assert.Equal("...", revisions[5].Name);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21089/Import-creates-revisions

### Additional description

Fixing Import creates revisions, when you trying to import to a database which has revisions configuration with 'MinToKeep' 0.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
