### PR TITLE
RavenDB-21005 "Start indexing" on an errored index doesn't start it

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -307,15 +307,11 @@ export function useIndexesPage(database: database, stale: boolean) {
                         const indexStatus = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details
                             ?.status;
 
-                        if (indexStatus !== "Disabled" && indexStatus !== "Paused") {
-                            continue;
-                        }
-
-                        if (indexStatus === "Disabled") {
+                        if (indexStatus === "Paused") {
                             startRequests.push(
-                                indexesService.enable(index, database, location).then(() => {
+                                indexesService.resume(index, database, location).then(() => {
                                     dispatch({
-                                        type: "EnableIndexing",
+                                        type: "ResumeIndexing",
                                         indexName: index.name,
                                         location,
                                     });
@@ -323,9 +319,9 @@ export function useIndexesPage(database: database, stale: boolean) {
                             );
                         } else {
                             startRequests.push(
-                                indexesService.resume(index, database, location).then(() => {
+                                indexesService.enable(index, database, location).then(() => {
                                     dispatch({
-                                        type: "ResumeIndexing",
+                                        type: "EnableIndexing",
                                         indexName: index.name,
                                         location,
                                     });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21005/Start-indexing-on-an-errored-index-doesnt-start-it

### Additional description

Now we enable index regardless of current running state

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/d8ea5a81-0800-4746-a569-278948e83a5f)
