### PR TITLE
RavenDB-20079 Default DateTime value in IndexDefinition map is stored as default(DateTime)

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -855,6 +855,13 @@ namespace Raven.Client.Documents.Indexes
                 Out(')');
                 return node;
             }
+            if (node.Value is TimeSpan timeSpan && timeSpan.Equals(default))
+            {
+                Out("default(");
+                Out(typeof(TimeSpan).ToString());
+                Out(')');
+                return node;
+            }
 #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
             if (node.Value is DateOnly dateOnly && dateOnly.Equals(default))
             {

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -848,6 +848,13 @@ namespace Raven.Client.Documents.Indexes
                 Out(')');
                 return node;
             }
+            if (node.Value is DateTimeOffset dateTimeOffset && dateTimeOffset.Equals(default))
+            {
+                Out("default(");
+                Out(typeof(DateTimeOffset).ToString());
+                Out(')');
+                return node;
+            }
 #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
             if (node.Value is DateOnly dateOnly && dateOnly.Equals(default))
             {
@@ -860,13 +867,6 @@ namespace Raven.Client.Documents.Indexes
             {
                 Out("default(");
                 Out(typeof(TimeOnly).ToString());
-                Out(')');
-                return node;
-            }
-            if (node.Value is DateTimeOffset dateTimeOffset && dateTimeOffset.Equals(default))
-            {
-                Out("default(");
-                Out(typeof(DateTimeOffset).ToString());
                 Out(')');
                 return node;
             }

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -841,6 +841,13 @@ namespace Raven.Client.Documents.Indexes
                 Out('M');
                 return node;
             }
+            if (Equals(node.Value, default(DateTime)))
+            {
+                Out("default(");
+                Out(typeof(DateTime).ToString());
+                Out(')');
+                return node;
+            }
             Out(s);
             return node;
         }
@@ -852,8 +859,6 @@ namespace Raven.Client.Documents.Indexes
 
             StringExtensions.EscapeString(_out, value);
         }
-
-
 
         private void OutLiteral(char c)
         {

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -841,13 +841,36 @@ namespace Raven.Client.Documents.Indexes
                 Out('M');
                 return node;
             }
-            if (Equals(node.Value, default(DateTime)))
+            if (node.Value is DateTime dateTime && dateTime.Equals(default))
             {
                 Out("default(");
                 Out(typeof(DateTime).ToString());
                 Out(')');
                 return node;
             }
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            if (node.Value is DateOnly dateOnly && dateOnly.Equals(default))
+            {
+                Out("default(");
+                Out(typeof(DateOnly).ToString());
+                Out(')');
+                return node;
+            }
+            if (node.Value is TimeOnly timeOnly && timeOnly.Equals(default))
+            {
+                Out("default(");
+                Out(typeof(TimeOnly).ToString());
+                Out(')');
+                return node;
+            }
+            if (node.Value is DateTimeOffset dateTimeOffset && dateTimeOffset.Equals(default))
+            {
+                Out("default(");
+                Out(typeof(DateTimeOffset).ToString());
+                Out(')');
+                return node;
+            }
+#endif
             Out(s);
             return node;
         }

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -844,21 +844,21 @@ namespace Raven.Client.Documents.Indexes
             if (node.Value is DateTime dateTime && dateTime.Equals(default))
             {
                 Out("default(");
-                Out(typeof(DateTime).ToString());
+                Out(nameof(DateTime));
                 Out(')');
                 return node;
             }
             if (node.Value is DateTimeOffset dateTimeOffset && dateTimeOffset.Equals(default))
             {
                 Out("default(");
-                Out(typeof(DateTimeOffset).ToString());
+                Out(nameof(DateTimeOffset));
                 Out(')');
                 return node;
             }
             if (node.Value is TimeSpan timeSpan && timeSpan.Equals(default))
             {
                 Out("default(");
-                Out(typeof(TimeSpan).ToString());
+                Out(nameof(TimeSpan));
                 Out(')');
                 return node;
             }
@@ -866,14 +866,14 @@ namespace Raven.Client.Documents.Indexes
             if (node.Value is DateOnly dateOnly && dateOnly.Equals(default))
             {
                 Out("default(");
-                Out(typeof(DateOnly).ToString());
+                Out(nameof(DateOnly));
                 Out(')');
                 return node;
             }
             if (node.Value is TimeOnly timeOnly && timeOnly.Equals(default))
             {
                 Out("default(");
-                Out(typeof(TimeOnly).ToString());
+                Out(nameof(TimeOnly));
                 Out(')');
                 return node;
             }

--- a/test/SlowTests/Issues/RavenDB_20079.cs
+++ b/test/SlowTests/Issues/RavenDB_20079.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20079 : RavenTestBase
+{
+    public RavenDB_20079(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public void CanCreateIndexWithDateTime()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new TestIndex();
+            index.Execute(store);
+        }
+    }
+    
+    public class TestIndex : AbstractIndexCreationTask<Entity, TestIndex.Result>
+    {
+        public class Result
+        {
+            public DateTime DefaultDateTime { get; set; }
+            public DateTime DateTimeMinValue { get; set; }
+            public DateTime DateTime { get; set; }
+            public string DateTimeString { get; set; }
+        }
+        public TestIndex()
+        {
+            Map = collection => from c in collection
+                select new Result
+                {
+                    DefaultDateTime = default,
+                    DateTimeMinValue = DateTime.MinValue,
+                    DateTime = new DateTime(2023, 08, 16, 12,12,12),
+                    DateTimeString = "2012-09-17T22:02:51.4021600"
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_20079.cs
+++ b/test/SlowTests/Issues/RavenDB_20079.cs
@@ -28,9 +28,9 @@ public class RavenDB_20079 : RavenTestBase
         public class Result
         {
             public DateTime DefaultDateTime { get; set; }
-            public DateTime DateTimeMinValue { get; set; }
-            public DateTime DateTime { get; set; }
-            public string DateTimeString { get; set; }
+            public TimeOnly DefaultTimeOnly { get; set; }
+            public DateOnly DefaultDateOnly { get; set; }
+            public DateTimeOffset DefaultDateTimeOffset { get; set; }
         }
         public TestIndex()
         {
@@ -38,9 +38,9 @@ public class RavenDB_20079 : RavenTestBase
                 select new Result
                 {
                     DefaultDateTime = default,
-                    DateTimeMinValue = DateTime.MinValue,
-                    DateTime = new DateTime(2023, 08, 16, 12,12,12),
-                    DateTimeString = "2012-09-17T22:02:51.4021600"
+                    DefaultTimeOnly = default,
+                    DefaultDateOnly = default,
+                    DefaultDateTimeOffset = default
                 };
             
             StoreAllFields(FieldStorage.Yes);

--- a/test/SlowTests/Issues/RavenDB_20079.cs
+++ b/test/SlowTests/Issues/RavenDB_20079.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +15,7 @@ public class RavenDB_20079 : RavenTestBase
     {
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Indexes)]
     public void CanCreateIndexWithDefaultDateTime()
     {
         using (var store = GetDocumentStore())
@@ -38,7 +39,7 @@ public class RavenDB_20079 : RavenTestBase
         }
     }
     
-    public class TestIndex : AbstractIndexCreationTask<Entity, TestIndex.Result>
+    private class TestIndex : AbstractIndexCreationTask<Entity, TestIndex.Result>
     {
         public class Result
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20079/Cannot-use-default-for-DateTime-property-in-index-definition

### Additional description

Default DateTime value is converted to `default(DateTime)` instead of `01 / 01 / 0001 00: 00: 00`

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
