### PR TITLE
RavenDB-21066 - Can't toggle dynamic node distribution for shard database

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
@@ -10,7 +10,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Sharding
 {
-    internal sealed class AddDatabaseShardOperation : IServerOperation<AddDatabaseShardResult>
+    public sealed class AddDatabaseShardOperation : IServerOperation<AddDatabaseShardResult>
     {
         private readonly string _databaseName;
         private readonly int? _shardNumber;

--- a/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/AddDatabaseShardOperation.cs
@@ -16,27 +16,29 @@ namespace Raven.Client.ServerWide.Sharding
         private readonly int? _shardNumber;
         private readonly string[] _nodes;
         private readonly int? _replicationFactor;
+        private readonly bool? _dynamicNodeDistribution;
 
-        public AddDatabaseShardOperation(string databaseName, int? shardNumber = null)
+        public AddDatabaseShardOperation(string databaseName, int? shardNumber = null, bool? dynamicNodeDistribution = null)
         {
             ResourceNameValidator.AssertValidDatabaseName(databaseName);
             _databaseName = databaseName;
             _shardNumber = shardNumber;
+            _dynamicNodeDistribution = dynamicNodeDistribution;
         }
 
-        public AddDatabaseShardOperation(string databaseName, string[] nodes, int? shardNumber = null) : this(databaseName, shardNumber)
+        public AddDatabaseShardOperation(string databaseName, string[] nodes, int? shardNumber = null, bool? dynamicNodeDistribution = null) : this(databaseName, shardNumber, dynamicNodeDistribution)
         {
             _nodes = nodes;
         }
 
-        public AddDatabaseShardOperation(string databaseName, int? replicationFactor, int? shardNumber = null) : this(databaseName, shardNumber)
+        public AddDatabaseShardOperation(string databaseName, int? replicationFactor, int? shardNumber = null, bool? dynamicNodeDistribution = null) : this(databaseName, shardNumber, dynamicNodeDistribution)
         {
             _replicationFactor = replicationFactor;
         }
 
         public RavenCommand<AddDatabaseShardResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new AddDatabaseShardCommand(_databaseName, _shardNumber, _nodes, _replicationFactor);
+            return new AddDatabaseShardCommand(_databaseName, _shardNumber, _nodes, _replicationFactor, _dynamicNodeDistribution);
         }
 
         internal sealed class AddDatabaseShardCommand : RavenCommand<AddDatabaseShardResult>, IRaftCommand
@@ -45,13 +47,15 @@ namespace Raven.Client.ServerWide.Sharding
             private readonly int? _shardNumber;
             private readonly string[] _nodes;
             private readonly int? _replicationFactor;
+            private readonly bool? _dynamicNodeDistribution;
 
-            public AddDatabaseShardCommand(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null)
+            public AddDatabaseShardCommand(string databaseName, int? shardNumber = null, string[] nodes = null, int? replicationFactor = null, bool? dynamicNodeDistribution = null)
             {
                 _databaseName = databaseName;
                 _shardNumber = shardNumber;
                 _nodes = nodes;
                 _replicationFactor = replicationFactor;
+                _dynamicNodeDistribution = dynamicNodeDistribution;
             }
 
             public override bool IsReadRequest => false;
@@ -65,6 +69,9 @@ namespace Raven.Client.ServerWide.Sharding
 
                 if (_replicationFactor.HasValue)
                     sb.Append($"&replicationFactor={_replicationFactor}");
+
+                if( _dynamicNodeDistribution.HasValue)
+                    sb.Append($"&dynamicNodeDistribution={_dynamicNodeDistribution.Value}");
 
                 if (_nodes?.Length > 0)
                 {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -827,13 +827,10 @@ namespace Raven.Server.Web.System
                 throw licenseLimit;
             }
 
-            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            {
-                var (index, _) = await ServerStore.ToggleDatabasesStateAsync(ToggleDatabasesStateCommand.Parameters.ToggleType.DynamicDatabaseDistribution, new[] { name }, enable == false, $"{raftRequestId}");
-                await ServerStore.Cluster.WaitForIndexNotification(index);
+            var (index, _) = await ServerStore.ToggleDatabasesStateAsync(ToggleDatabasesStateCommand.Parameters.ToggleType.DynamicDatabaseDistribution, new[] { name }, enable == false, $"{raftRequestId}");
+            await ServerStore.Cluster.WaitForIndexNotification(index);
 
-                NoContentStatus();
-            }
+            NoContentStatus();
         }
 
         private async Task ToggleDisableDatabases(bool disable)

--- a/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/ShardedAdminDatabaseHandler.cs
@@ -219,6 +219,7 @@ namespace Raven.Server.Web.System
             var shardNumber = GetIntValueQueryString("shardNumber", required: false);
             var nodes = GetStringValuesQueryString("node", required: false);
             var replicationFactor = GetIntValueQueryString("replicationFactor", required: false);
+            var dynamicNodeDistribution = GetBoolValueQueryString("dynamicNodeDistribution", required: false);
             var raftRequestId = GetRaftRequestIdFromQuery();
             
             if (ShardHelper.IsShardName(database))
@@ -307,6 +308,7 @@ namespace Raven.Server.Web.System
                     throw new InvalidOperationException($"Replication factor {replicationFactor.Value} cannot exceed the number of nodes in the cluster {clusterTopology.AllNodes.Count}.");
 
                 newShardTopology.ReplicationFactor = replicationFactor ?? (nodesList.Count > 0 ? nodesList.Count : databaseRecord.Sharding.Shards.ElementAt(0).Value.ReplicationFactor);
+                newShardTopology.DynamicNodesDistribution = dynamicNodeDistribution ?? databaseRecord.Sharding.Shards.ElementAt(0).Value.DynamicNodesDistribution;
 
                 var nodeToInstanceCount = new Dictionary<string, int>();
                 foreach (var node in clusterTopology.AllNodes.Keys)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21066

### Additional description

Can now toggle an existing shard database's dynamic-node-distribution.
Also added dynamic-node-distribution parameter to shard creation operation.
If not provided, will use the setting of the first shard in shard's list (as we do with replication factor).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio - Add this option when creating a new shard?
