### PR TITLE
RavenDB-21072 Ongoing tasks view doesn't work in mixed cluster

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/tasks/getOngoingTasksCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getOngoingTasksCommand.ts
@@ -21,7 +21,15 @@ class getOngoingTasksCommand extends commandBase {
             ...this.location
         };
 
-        return this.query<Raven.Server.Web.System.OngoingTasksResult>(url, args, this.db);
+        return this.query<Raven.Server.Web.System.OngoingTasksResult>(url, args, this.db, result => {
+            // since in 6.0 property OngoingTasksList was renamed to OngoingTasks
+            // we unify format here to support mixed clusters
+            if ("OngoingTasksList" in result) {
+                result.OngoingTasks = result.OngoingTasksList;
+            }
+            
+            return result;
+        });
     }
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21072 

### Additional description

Ongoing task view for mixed cluster.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### 