### PR TITLE
RavenDB-20697 Adding node to database group causes loading error in index panel

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -101,20 +101,22 @@ export function IndexDistribution(props: IndexDistributionProps) {
 
     const items = (
         <>
-            {index.nodesInfo.map((nodeInfo) => {
-                const key = indexNodeInfoKey(nodeInfo);
-                return (
-                    <ItemWithTooltip
-                        key={key}
-                        nodeInfo={nodeInfo}
-                        sharded={sharded}
-                        index={index}
-                        globalIndexingStatus={globalIndexingStatus}
-                        showStaleReason={showStaleReason}
-                        openFaulty={openFaulty}
-                    />
-                );
-            })}
+            {[...index.nodesInfo]
+                .sort((l, r) => l.location.shardNumber - r.location.shardNumber)
+                .map((nodeInfo) => {
+                    const key = indexNodeInfoKey(nodeInfo);
+                    return (
+                        <ItemWithTooltip
+                            key={key}
+                            nodeInfo={nodeInfo}
+                            sharded={sharded}
+                            index={index}
+                            globalIndexingStatus={globalIndexingStatus}
+                            showStaleReason={showStaleReason}
+                            openFaulty={openFaulty}
+                        />
+                    );
+                })}
         </>
     );
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -194,7 +194,7 @@ export const indexesStatsReducer: Reducer<IndexesStatsState, IndexesStatsReducer
         case "ProgressLoaded": {
             const incomingLocation = action.location;
             const progress = action.progress;
-            
+
             return produce(state, (draft) => {
                 draft.indexes.forEach((index) => {
                     const itemToUpdate = index.nodesInfo.find((x) =>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -199,7 +199,7 @@ export function useIndexesPage(database: database, stale: boolean) {
                 watchAllDatabaseChanges.off();
             };
         }
-    }, [database, databaseChangesApi, handleDatabaseChanges, serverNotifications]);
+    }, [databaseChangesApi, handleDatabaseChanges, serverNotifications]);
 
     const highlightUsed = useRef<boolean>(false);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20697/Adding-node-to-database-group-causes-loading-error-in-index-panel

### Additional description

Added watch on database changes and update the view if ChangeType equals "Update" or "RemoveNode".
Sort index distribution items by shard number.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

https://issues.hibernatingrhinos.com/issue/RavenDB-20697/Adding-node-to-database-group-causes-loading-error-in-index-panel#focus=Comments-67-688682.0-0