### PR TITLE
RavenDB-21103 - Resharding - Delete document from the wrong shard

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1548,6 +1548,9 @@ namespace Raven.Server.Documents
             CollectionName collectionName = null, NonPersistentDocumentFlags nonPersistentFlags = NonPersistentDocumentFlags.None,
             DocumentFlags newFlags = DocumentFlags.None)
         {
+            if (newFlags.HasFlag(DocumentFlags.FromResharding) == false)
+                ValidateId(lowerId, operationType: DocumentChangeTypes.Delete);
+
             var local = GetDocumentOrTombstone(context, lowerId, throwOnConflict: false);
             var modifiedTicks = GetOrCreateLastModifiedTicks(lastModifiedTicks);
 
@@ -1769,6 +1772,11 @@ namespace Raven.Server.Documents
                     Etag = etag
                 };
             }
+        }
+
+        public virtual void ValidateId(Slice lowerId, DocumentChangeTypes operationType)
+        {
+
         }
 
         [DoesNotReturn]

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1549,7 +1549,7 @@ namespace Raven.Server.Documents
             DocumentFlags newFlags = DocumentFlags.None)
         {
             if (newFlags.HasFlag(DocumentFlags.FromResharding) == false)
-                ValidateId(lowerId, operationType: DocumentChangeTypes.Delete);
+                ValidateId(context, lowerId, type: DocumentChangeTypes.Delete, newFlags);
 
             var local = GetDocumentOrTombstone(context, lowerId, throwOnConflict: false);
             var modifiedTicks = GetOrCreateLastModifiedTicks(lastModifiedTicks);
@@ -1774,7 +1774,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public virtual void ValidateId(Slice lowerId, DocumentChangeTypes operationType)
+        public virtual void ValidateId(DocumentsOperationContext context, Slice lowerId, DocumentChangeTypes type, DocumentFlags documentFlags = DocumentFlags.None)
         {
 
         }

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Jint;
 using Raven.Client;
+using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
@@ -67,7 +68,7 @@ namespace Raven.Server.Documents.Patch
 
             using (DocumentIdWorker.GetLower(context.Allocator, id, out Slice lowerId))
             {
-                _database.DocumentsStorage.DocumentPut.ValidateId(context, lowerId);
+                _database.DocumentsStorage.ValidateId(context, lowerId, type: DocumentChangeTypes.Put);
             }
 
             var originalDocument = GetCurrentDocument(context, id);

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.ServerWide.Commands.Sharding;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Logging;
@@ -31,7 +33,6 @@ namespace Raven.Server.Documents.Sharding.Background
 
                 int bucket = -1;
                 int moveToShard = -1;
-                bool found = false;
                 using (_database.ShardedDocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
@@ -50,47 +51,12 @@ namespace Raven.Server.Documents.Sharding.Background
 
                         var bucketStatistics = ShardedDocumentsStorage.GetBucketStatistics(context, start, end);
 
-                        foreach (var bucketStats in bucketStatistics)
-                        {
-                            _token.ThrowIfCancellationRequested();
-
-                            if (bucketStats.Size == 0)
-                                continue;
-
-                            bucket = bucketStats.Bucket;
-
-                            // this bucket already been migrated
-                            if (configuration.BucketMigrations.ContainsKey(bucket))
-                                continue;
-
-                            if (bucketStats.NumberOfDocuments == 0)
-                            {
-                                var foundTombstone = false;
-                                foreach (var tombstone in _database.ShardedDocumentsStorage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
-                                {
-                                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "handle DeletedTimeSeriesRange?");
-
-                                    if (tombstone.Flags.Contain(DocumentFlags.Artificial))
-                                        continue;
-
-                                    foundTombstone = true;
-                                }
-
-                                if (foundTombstone == false)
-                                    continue;
-                            }
-
-                            moveToShard = range.ShardNumber;
-                            found = true;
-                            break;
-                        }
-
-                        if (found)
+                        if (TryFindWrongBucket(context, configuration, range, bucketStatistics, out bucket, out moveToShard))
                             break;
                     }
                 }
 
-                if (found)
+                if (bucket != -1)
                     await MoveDocumentsToShardAsync(bucket, moveToShard);
             }
             catch (Exception e)
@@ -103,6 +69,45 @@ namespace Raven.Server.Documents.Sharding.Background
 
                 throw;
             }
+        }
+
+        private bool TryFindWrongBucket(DocumentsOperationContext context, ShardingConfiguration configuration, ShardBucketRange range,
+            IEnumerable<BucketStats> bucketStatistics, out int bucket, out int shardNumber)
+        {
+            shardNumber = range.ShardNumber;
+            bucket = -1;
+
+            foreach (var bucketStats in bucketStatistics)
+            {
+                _token.ThrowIfCancellationRequested();
+
+                if (bucketStats.Size == 0)
+                    continue;
+
+                bucket = bucketStats.Bucket;
+
+                // this bucket already been migrated
+                if (configuration.BucketMigrations.ContainsKey(bucket))
+                    continue;
+
+                if (bucketStats.NumberOfDocuments == 0)
+                {
+                    foreach (var tombstone in _database.ShardedDocumentsStorage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                    {
+                        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Shiran, DevelopmentHelper.Severity.Normal, "handle DeletedTimeSeriesRange?");
+
+                        if (tombstone.Flags.Contain(DocumentFlags.Artificial) ||
+                            tombstone.Flags.Contain(DocumentFlags.FromResharding))
+                            continue;
+
+                        return true;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         private async Task MoveDocumentsToShardAsync(int bucket, int moveToShard)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentPutAction.cs
@@ -1,46 +1,12 @@
-﻿using Raven.Client.Exceptions.Sharding;
-using Raven.Server.ServerWide.Context;
+﻿using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
-using Sparrow.Utils;
-using Voron;
 
 namespace Raven.Server.Documents.Sharding;
 
 public sealed class ShardedDocumentPutAction : DocumentPutAction
 {
-    private readonly ShardedDocumentDatabase _documentDatabase;
-
     public ShardedDocumentPutAction(ShardedDocumentsStorage documentsStorage, ShardedDocumentDatabase documentDatabase) : base(documentsStorage, documentDatabase)
     {
-        _documentDatabase = documentDatabase;
-    }
-
-    // TODO need to make sure we check that for counters/TS/etc...
-    public override void ValidateId(DocumentsOperationContext context, Slice lowerId, DocumentFlags documentFlags = DocumentFlags.None)
-    {
-        if (documentFlags.Contain(DocumentFlags.FromResharding))
-            return;
-
-        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "Handle write documents to the wrong shard");
-        var config = _documentDatabase.ShardingConfiguration;
-        var bucket = ShardHelper.GetBucketFor(config, lowerId);
-        var shard = ShardHelper.GetShardNumberFor(config, bucket);
-        if (shard != _documentDatabase.ShardNumber)
-        {
-            if (_documentDatabase.ForTestingPurposes != null && _documentDatabase.ForTestingPurposes.EnableWritesToTheWrongShard)
-                return;
-
-            if (documentFlags.Contain(DocumentFlags.FromReplication))
-            {
-                // RavenDB-21104
-                // we allow writing the document to the wrong shard to avoid inconsistent data within the shard group
-                // and handle the leftovers at the end of the transaction 
-                context.Transaction.ExecuteDocumentsMigrationBeforeCommit();
-                return;
-            }
-
-            throw new ShardMismatchException($"Document '{lowerId}' belongs to bucket '{bucket}' on shard #{shard}, but PUT operation was performed on shard #{_documentDatabase.ShardNumber}.");
-        }
     }
 
     protected override unsafe void CalculateSuffixForIdentityPartsSeparator(string id, ref char* idSuffixPtr, ref int idSuffixLength, ref int idLength)
@@ -62,7 +28,7 @@ public sealed class ShardedDocumentPutAction : DocumentPutAction
 
     protected override unsafe void WriteSuffixForIdentityPartsSeparator(ref char* valueWritePosition, char* idSuffixPtr, int idSuffixLength)
     {
-        if (idSuffixLength <= 0) 
+        if (idSuffixLength <= 0)
             return;
 
         valueWritePosition -= idSuffixLength;

--- a/test/SlowTests/Sharding/Issues/RavenDB_21103.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_21103.cs
@@ -1,0 +1,241 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Documents.Replication.ReplicationItems.ReplicationBatchItem;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_21103 : ReplicationTestBase
+    {
+        public RavenDB_21103(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ShouldThrowOnDeleteDocumentFromWrongShardAfterResharding()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var id = "users/shiran";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                Assert.Throws<ShardMismatchException>(() =>
+                {
+                    using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, oldLocation)))
+                    {
+                        session.Delete(id);
+                        session.SaveChanges();
+                    }
+                });
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ShardedDocumentsMigratorShouldMoveBucketWithTombstones()
+        {
+            using (var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
+            }))
+            {
+                var id = "users/shiran";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var db1 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourceStore(ShardHelper.ToShardName(store.Database, oldLocation));
+                db1.ForTestingPurposesOnly().EnableWritesToTheWrongShard = true;
+
+                using (var session = store.OpenAsyncSession(db1.Name))
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(db1.Name))
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                await db1.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
+                var dbName2 = await Sharding.GetShardDatabaseNameForDocAsync(store, id);
+                Assert.True(WaitForValue(() =>
+                {
+                    using (var session = store.OpenSession(dbName2))
+                    {
+                        var user = session.Load<User>(id);
+                        return user == null;
+                    }
+                }, true, 30_000, 333));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Revisions)]
+        public async Task ShardedDocumentsMigratorShouldMoveBucketWithRevisionTombstones()
+        {
+            using (var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
+            }))
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store);
+                var id = "users/shiran";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var db1 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourceStore(ShardHelper.ToShardName(store.Database, oldLocation));
+
+                await db1.TombstoneCleaner.ExecuteCleanup();
+                db1.ForTestingPurposesOnly().EnableWritesToTheWrongShard = true;
+
+                using (var session = store.OpenAsyncSession(db1.Name))
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(db1.Name))
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (db1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstones = db1.DocumentsStorage.GetTombstonesFrom(context, 0).OrderBy(x => x.Etag).ToList();
+                    Assert.Equal(2, tombstones.Count);
+
+                    Assert.Equal(ReplicationItemType.DocumentTombstone, tombstones[0].Type);
+                    Assert.Equal(ReplicationItemType.RevisionTombstone, tombstones[1].Type);
+                }
+
+                await db1.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
+                var dbName2 = await Sharding.GetShardDatabaseNameForDocAsync(store, id);
+                Assert.True(WaitForValue(() =>
+                {
+                    using (var session = store.OpenSession(dbName2))
+                    {
+                        var user = session.Load<User>(id);
+                        return user == null;
+                    }
+                }, true, 30_000, 333));
+
+                var db2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourceStore(dbName2);
+
+                using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstones = db2.DocumentsStorage.GetTombstonesFrom(context, 0).OrderBy(x => x.Etag).ToList();
+                    Assert.Equal(3, tombstones.Count);
+
+                    Assert.Equal(ReplicationItemType.DocumentTombstone, tombstones[0].Type);
+                    Assert.Equal(ReplicationItemType.RevisionTombstone, tombstones[1].Type);
+                    Assert.Equal(ReplicationItemType.RevisionTombstone, tombstones[2].Type);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Attachments)]
+        public async Task ShardedDocumentsMigratorShouldMoveBucketWithAttachmentTombstones()
+        {
+            using (var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
+            }))
+            {
+                var id = "users/shiran";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Shiran" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var db1 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourceStore(ShardHelper.ToShardName(store.Database, oldLocation));
+
+                await db1.TombstoneCleaner.ExecuteCleanup();
+                db1.ForTestingPurposesOnly().EnableWritesToTheWrongShard = true;
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = store.OpenSession(db1.Name))
+                {
+                    session.Store(new User { Name = "Shiran2" }, id);
+                    session.Advanced.Attachments.Store(id, "profile.png", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(db1.Name))
+                {
+                    session.Delete(id);
+                    session.SaveChanges();
+                }
+
+                using (db1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstones = db1.DocumentsStorage.GetTombstonesFrom(context, 0).OrderBy(x => x.Etag).ToList();
+                    Assert.Equal(2, tombstones.Count);
+
+                    Assert.Equal(ReplicationItemType.DocumentTombstone, tombstones[0].Type);
+                    Assert.Equal(ReplicationItemType.AttachmentTombstone, tombstones[1].Type);
+                }
+
+                await db1.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
+                var dbName2 = await Sharding.GetShardDatabaseNameForDocAsync(store, id);
+                Assert.True(WaitForValue(() =>
+                {
+                    using (var session = store.OpenSession(dbName2))
+                    {
+                        var user = session.Load<User>(id);
+                        return user == null;
+                    }
+                }, true, 30_000, 333));
+
+                var db2 = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourceStore(dbName2);
+
+                using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstones = db2.DocumentsStorage.GetTombstonesFrom(context, 0).OrderBy(x => x.Etag).ToList();
+                    Assert.Equal(2, tombstones.Count);
+
+                    Assert.Equal(ReplicationItemType.DocumentTombstone, tombstones[0].Type);
+                    Assert.Equal(ReplicationItemType.AttachmentTombstone, tombstones[1].Type);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21103/Resharding-Delete-document-from-the-wrong-shard

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
