### PR TITLE
RavenDB-21124 Improve performance of SortUsingIndex in deep paging sc…

### DIFF
--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -442,6 +442,8 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 }
                 break;
             }
+
+            totalRead += read;
             var sortedIds = sortedIdBuffer[..read];
             var indexes = indexesBuffer[..read];
             // we effectively permute the indexes as well as the sortedIds to get a sorted list to compare

--- a/src/Sparrow/UnmanagedPointer.cs
+++ b/src/Sparrow/UnmanagedPointer.cs
@@ -114,6 +114,9 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(UnmanagedSpan item)
         {
+            if (item.Length == 0)
+                return 0;
+            
             return (int)Hashing.Marvin32.CalculateInline(item.Address, item.Length);
         }
     }


### PR DESCRIPTION
…enarios

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21124 

### Additional description

When we do deep queries, we need to consider whatever there is a big mismatch between the amount of the results in the query and how much we need to read from the index to match.
After a while, we'll detect that we are spending too much time here and fallback to just sorting the results directly without an index.