### PR TITLE
RavenDB-21110 & RavenDB-21111 & RavenDB-21109 Clear native list to avoid accessing memory from already disposed allocator.

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1408,11 +1408,16 @@ namespace Corax
         {
             _pforDecoder.Dispose();
             _indexedEntries.Clear();
+
+            foreach (var entryTerms in _termsPerEntryId.Values)
+                entryTerms.Dispose(_entriesAllocator);
             _termsPerEntryId.Clear();
+            
             _deletedEntries.Clear();
             _entriesAlreadyAdded.Clear();
             _additionsForTerm.Clear();
             _removalsForTerm.Clear();
+            _tempListBuffer.Dispose();
 
             for (int i = 0; i < _knownFieldsTerms.Length; i++)
             {
@@ -1427,10 +1432,11 @@ namespace Corax
             }
             
             _entriesAllocator.Reset();
-
+            _entriesToTermsBuffer = new(_entriesAllocator);
             _entriesForTermsAdditionsBuffer = new NativeList<(long EntryId, long TermId)>();
             _entriesForTermsRemovalsBuffer = new NativeIntegersList(_entriesAllocator);
-            
+            _tempListBuffer = new NativeIntegersList(_entriesAllocator);
+
             _pforDecoder = new FastPForDecoder(_entriesAllocator);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21110 & 
https://issues.hibernatingrhinos.com/issue/RavenDB-21111 & 
https://issues.hibernatingrhinos.com/issue/RavenDB-21109

### Additional description

 Clear native list to avoid accessing memory from already disposed allocator.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
