### PR TITLE
RavenDB-21142 TreeCursor: allocate FastStack via ObjectPool to avoid expensive Array.Resize calls

### DIFF
--- a/src/Voron/Data/BTrees/TreeCursor.cs
+++ b/src/Voron/Data/BTrees/TreeCursor.cs
@@ -9,7 +9,7 @@ namespace Voron.Data.BTrees
 {
     public sealed class TreeCursor : IDisposable
     {
-        private class TreeCursorState
+        private sealed class TreeCursorState
         {
             public readonly Dictionary<long, TreePage> PageByNum;
             public readonly FastStack<TreePage> Pages;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21142

### Additional description



### Type of change


- Optimization

### How risky is the change?


- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor



### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
