### PR TITLE
RavenDB-21143: Fixed sized cache and improved codegen 

### DIFF
--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -139,7 +139,7 @@ namespace Corax.Queries
                 _itBuffer = (long*)bs.Ptr;
                 _containerItemsScope = _allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
                 _containerItems = (UnmanagedSpan*)bs.Ptr;
-                _pageLocator = new PageLocator(searcher._transaction.LowLevelTransaction, BufferSize);
+                _pageLocator = new PageLocator(searcher._transaction.LowLevelTransaction);
             }
 
             public void Reset(ref MultiTermMatch<TTermProvider> match)

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -272,7 +272,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             _itBuffer = (long*)bs.Ptr;
             _containerItemsScope = llt.Allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
             _containerItems = (UnmanagedSpan*)bs.Ptr;
-            _pageLocator = new PageLocator(llt, BufferSize);
+            _pageLocator = new PageLocator(llt);
         }
 
 
@@ -533,7 +533,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         TEntryComparer entryComparer = new();
         entryComparer.Init(ref match);
             
-        var pageCache = new PageLocator(llt, 1024);
+        var pageCache = new PageLocator(llt);
         
         entryComparer.SortBatch(ref match, llt, pageCache, batchResults, batchTermIds, termsPtr);
 

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
@@ -168,7 +168,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         // Initialize the important infrastructure for the sorting.
         TComparer1 entryComparer = new();
         entryComparer.Init(ref match, default, 0);
-        var pageCache = new PageLocator(llt, 1024);
+        var pageCache = new PageLocator(llt);
         fixed (long* ptrBatchResults = batchResults)
         {
             var resultsPtr = new UnmanagedSpan<long>(ptrBatchResults, sizeof(long)* batchResults.Length);

--- a/src/Voron/TransactionPersistentContext.cs
+++ b/src/Voron/TransactionPersistentContext.cs
@@ -8,7 +8,6 @@ namespace Voron
     public sealed class TransactionPersistentContext
     {
         private bool _longLivedTransaction;
-        private int _cacheSize;
 
         public bool LongLivedTransactions
         {
@@ -16,7 +15,6 @@ namespace Voron
             set
             {
                 _longLivedTransaction = value;
-                _cacheSize = _longLivedTransaction ? 512 : 256;
             }
         }
 
@@ -34,14 +32,13 @@ namespace Voron
             if (_pageLocators.Count != 0)
             {
                 locator = _pageLocators.Pop();
-                locator.Renew(tx, _cacheSize);
+                locator.Renew(tx);
             }
             else
             {
-                locator = new PageLocator(tx, _cacheSize);
+                locator = new PageLocator(tx);
             }
             return locator;
-
         }
 
         public void FreePageLocator(PageLocator locator)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21143

### Additional description

PageLocator was introduced during the 4.0 timeframe and was never reviewed. Since memory access is stressed in Corax queries and indexing, there are improvements that can be done based on new knowledge about actual behavior, improvements in the hardware being used and exploiting code generation in the newer framework versions.

For example, instead of allowing to change the size of the page locator cache up to 1Kb we would just default to it and forgo the necessity to store the mask. This causes optimizations by the JIT compiler at the moment of calculating the bucket. 

Usage of `ref` accesses allow us to emit more predictable code that the JIT can optimize avoiding excess referencing when multiple accesses are involved. 

### Type of change
- Optimization


### How risky is the change?
- Moderate 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No