### PR TITLE
RavenDB-21132: Marvin fails when pointer is null.  (v6.0)

### DIFF
--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -998,7 +998,7 @@ namespace Sparrow
         {
             public static uint Calculate(byte[] buffer, ulong seed = 0x5D70D359C498B3F8ul)
             {
-                fixed ( byte* ptr = buffer )
+                fixed (byte* ptr = buffer)
                     return CalculateInline(ptr, buffer.Length, seed);
             }
 
@@ -1087,6 +1087,10 @@ namespace Sparrow
             {
                 uint high = (uint)(seed >> 32);
                 uint low = (uint)seed;
+                uint final = 0x80;
+
+                if (len == 0)
+                    goto Tail;
 
                 byte* ptr = buffer;
                 byte* bEnd = ptr + len;
@@ -1098,7 +1102,6 @@ namespace Sparrow
                     ptr += sizeof(uint);
                 }
 
-                uint final = 0x80;
                 int rest = (int)(bEnd - ptr);
                 if (rest == 3)
                     final = (final << 8) | ptr[2];
@@ -1107,6 +1110,7 @@ namespace Sparrow
                 if (rest >= 1)
                     final = (final << 8) | ptr[0];
 
+                Tail:
                 MarvinMix(ref high, ref low, final);
                 MarvinMix(ref high, ref low, 0);
 

--- a/test/FastTests/Sparrow/Hashing.cs
+++ b/test/FastTests/Sparrow/Hashing.cs
@@ -267,6 +267,39 @@ namespace FastTests.Sparrow
             Assert.NotEqual(expected, result);
         }
 
+        [Fact]
+        public unsafe void EnsureZeroLengthStringIsAValidHash()
+        {
+            byte[] zeroLength = Array.Empty<byte>();
+            byte[] nonZeroLength = "abcd"u8.ToArray();
+
+            fixed (byte* zeroPtr = zeroLength)
+            fixed (byte* nonZeroPtr = nonZeroLength)
+            {
+                uint zeroHash = Hashing.XXHash32.Calculate(zeroLength);
+                Assert.Equal(zeroHash, Hashing.XXHash32.Calculate(zeroPtr, 0));
+                Assert.Equal(zeroHash, Hashing.XXHash32.Calculate(nonZeroLength, 0));
+                Assert.Equal(zeroHash, Hashing.XXHash32.Calculate(nonZeroPtr, 0));
+
+                ulong zeroHashLong = Hashing.XXHash64.Calculate(zeroLength);
+                Assert.Equal(zeroHashLong, Hashing.XXHash64.Calculate(zeroPtr, 0));
+                Assert.Equal(zeroHashLong, Hashing.XXHash64.Calculate(nonZeroLength, 0));
+                Assert.Equal(zeroHashLong, Hashing.XXHash64.Calculate(nonZeroPtr, 0));
+
+                var zeroHash128 = Hashing.Metro128.Calculate(zeroLength);
+                Assert.Equal(zeroHash128, Hashing.Metro128.Calculate(zeroPtr, 0));
+                Assert.Equal(zeroHash128, Hashing.Metro128.Calculate(nonZeroLength, 0));
+                Assert.Equal(zeroHash128, Hashing.Metro128.Calculate(nonZeroPtr, 0));
+
+                var marvinHash = Hashing.Marvin32.Calculate(zeroLength);
+                Assert.Equal(marvinHash, Hashing.Marvin32.CalculateInline(zeroPtr, 0));
+                Assert.Equal(marvinHash, Hashing.Marvin32.CalculateInline(nonZeroPtr, 0));
+                Assert.Equal(marvinHash, Hashing.Marvin32.CalculateInline(new List<int>()));
+            }
+        }
+
+
+
 
         public static IEnumerable<object[]> BufferSize
         {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21132

### Additional description
Null pointer causes an access violation when it gets substracted and ends up in the high parts of the memory. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No
