### PR TITLE
RavenDB-19962: Community License (item 1&2)

### DIFF
--- a/src/Raven.Server/Commercial/DetailsPerNode.cs
+++ b/src/Raven.Server/Commercial/DetailsPerNode.cs
@@ -42,11 +42,14 @@ namespace Raven.Server.Commercial
             };
         }
 
-        public int GetMaxCoresToUtilize(int requestedCores)
+        public int GetMaxCoresToUtilize(int requestedCores, int? maxCoresPerNode)
         {
             var coresToUtilize = Math.Min(requestedCores, NumberOfCores);
             if (MaxUtilizedCores != null)
                 coresToUtilize = Math.Min(coresToUtilize, MaxUtilizedCores.Value);
+
+            if (maxCoresPerNode is > 0)
+                coresToUtilize = Math.Min(coresToUtilize, maxCoresPerNode.Value);
 
             return coresToUtilize;
         }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -174,7 +174,7 @@ namespace Raven.Server.Commercial
                     OsInfo = nodeInfo.OsInfo
                 };
 
-                await _serverStore.PutNodeLicenseLimitsAsync(_serverStore.NodeTag, detailsPerNode, LicenseStatus.MaxCores);
+                await _serverStore.PutNodeLicenseLimitsAsync(_serverStore.NodeTag, detailsPerNode, LicenseStatus);
             }
             catch (Exception e)
             {
@@ -287,7 +287,7 @@ namespace Raven.Server.Commercial
             if (licenseLimits?.NodeLicenseDetails != null &&
                 licenseLimits.NodeLicenseDetails.TryGetValue(_serverStore.NodeTag, out var detailsPerNode))
             {
-                return Math.Min(detailsPerNode.UtilizedCores, LicenseStatus.MaxCores);
+                return Math.Min(detailsPerNode.UtilizedCores, LicenseStatus.MaxCoresPerNode ?? LicenseStatus.MaxCores);
             }
 
             // we don't have any license limits for this node, let's put our info to update it
@@ -353,7 +353,7 @@ namespace Raven.Server.Commercial
                 detailsPerNode.MaxUtilizedCores = maxUtilizedCores;
             }
 
-            await _serverStore.PutNodeLicenseLimitsAsync(nodeTag, detailsPerNode, LicenseStatus.MaxCores, raftRequestId);
+            await _serverStore.PutNodeLicenseLimitsAsync(nodeTag, detailsPerNode, LicenseStatus, raftRequestId);
         }
 
         private async Task<Client.ServerWide.Commands.NodeInfo> GetNodeInfo(string nodeUrl, TransactionOperationContext ctx)

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -731,7 +731,8 @@ namespace Raven.Server.Commercial
             if (license == null)
                 throw new InvalidOperationException("License not found");
 
-            var response = await ApiHttpClient.Instance.PostAsync("/api/v2/license/renew",
+            var requestUri = $"/api/v2/license/renew?&build={ServerVersion.Build}";
+            var response = await ApiHttpClient.Instance.PostAsync(requestUri,
                     new StringContent(JsonConvert.SerializeObject(license), Encoding.UTF8, "application/json"))
                 .ConfigureAwait(false);
 

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -94,6 +94,8 @@ namespace Raven.Server.Commercial
 
         public int MaxCores => GetValue<int?>("cores") ?? 3;
 
+        public int? MaxCoresPerNode { get; set; }
+
         public bool IsIsv => GetValue<bool>("redist");
 
         public bool HasEncryption => GetValue<bool>("encryption");
@@ -200,6 +202,7 @@ namespace Raven.Server.Commercial
                 [nameof(Expiration)] = Expiration,
                 [nameof(MaxMemory)] = MaxMemory,
                 [nameof(MaxCores)] = MaxCores,
+                [nameof(MaxCoresPerNode)] = MaxCoresPerNode,
                 [nameof(IsIsv)] = IsIsv,
                 [nameof(HasEncryption)] = HasEncryption,
                 [nameof(HasSnmpMonitoring)] = HasSnmpMonitoring,

--- a/src/Raven.Server/Commercial/LicenseValidator.cs
+++ b/src/Raven.Server/Commercial/LicenseValidator.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Commercial
             "documentsCompression", "timeSeriesRollupsAndRetention", "additionalAssembliesNuget",
             "monitoringEndpoints", "olapEtl", "readOnlyCertificates",
             "tcpDataCompression", "concurrentSubscriptions", "elasticSearchEtl", "powerBI", "postgreSqlIntegration",
-            "canBeActivatedUntil", "queueEtl"
+            "canBeActivatedUntil", "queueEtl", "maxCoresPerNode"
         };
 
         private enum ValueType : byte

--- a/src/Raven.Server/Commercial/NodeLicenseLimits.cs
+++ b/src/Raven.Server/Commercial/NodeLicenseLimits.cs
@@ -11,6 +11,8 @@ namespace Raven.Server.Commercial
 
         public int LicensedCores { get; set; }
 
+        public int? MaxCoresPerNode { get; set; }
+
         public List<string> AllNodes { get; set; }
 
         public DynamicJsonValue ToJson()
@@ -20,6 +22,7 @@ namespace Raven.Server.Commercial
                 [nameof(NodeTag)] = NodeTag,
                 [nameof(DetailsPerNode)] = DetailsPerNode.ToJson(),
                 [nameof(LicensedCores)] = LicensedCores,
+                [nameof(MaxCoresPerNode)] = MaxCoresPerNode,
                 [nameof(AllNodes)] = AllNodes
             };
         }

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -498,11 +498,9 @@ namespace Raven.Server.Documents.Handlers.Admin
                             OsInfo = nodeInfo.OsInfo
                         };
 
-                        var maxCores = ServerStore.LicenseManager.LicenseStatus.MaxCores;
-
                         try
                         {
-                            await ServerStore.PutNodeLicenseLimitsAsync(nodeTag, detailsPerNode, maxCores, $"{raftRequestId}/put-license-limits");
+                            await ServerStore.PutNodeLicenseLimitsAsync(nodeTag, detailsPerNode, ServerStore.LicenseManager.LicenseStatus, $"{raftRequestId}/put-license-limits");
                         }
                         catch
                         {

--- a/src/Raven.Server/ServerWide/Commands/UpdateLicenseLimitsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateLicenseLimitsCommand.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.ServerWide.Commands
                     Value.DetailsPerNode.MaxUtilizedCores = currentDetailsPerNode.MaxUtilizedCores;
                 }
 
-                Value.DetailsPerNode.UtilizedCores = Value.DetailsPerNode.GetMaxCoresToUtilize(currentDetailsPerNode.UtilizedCores);
+                Value.DetailsPerNode.UtilizedCores = Value.DetailsPerNode.GetMaxCoresToUtilize(currentDetailsPerNode.UtilizedCores, Value.MaxCoresPerNode);
             }
             else
             {
@@ -79,7 +79,7 @@ namespace Raven.Server.ServerWide.Commands
                     throw new RachisApplyException($"Node {Value.NodeTag} isn't part of the cluster, all nodes are: {string.Join(", ", Value.AllNodes)}");
 
                 var coresPerNodeToDistribute = Math.Max(1, availableCoresToDistribute / unassignedNodesCount);
-                Value.DetailsPerNode.UtilizedCores = Value.DetailsPerNode.GetMaxCoresToUtilize(coresPerNodeToDistribute);
+                Value.DetailsPerNode.UtilizedCores = Value.DetailsPerNode.GetMaxCoresToUtilize(coresPerNodeToDistribute, Value.MaxCoresPerNode);
             }
 
             licenseLimits.NodeLicenseDetails[Value.NodeTag] = Value.DetailsPerNode;
@@ -92,7 +92,7 @@ namespace Raven.Server.ServerWide.Commands
                 // the number of licensed cores is less then the number of nodes
                 foreach (var detailsPerNode in licenseLimits.NodeLicenseDetails.Values)
                 {
-                    detailsPerNode.UtilizedCores = detailsPerNode.GetMaxCoresToUtilize(1);
+                    detailsPerNode.UtilizedCores = detailsPerNode.GetMaxCoresToUtilize(1, Value.MaxCoresPerNode);
                 }
 
                 return;
@@ -116,7 +116,7 @@ namespace Raven.Server.ServerWide.Commands
                 var nodeDetails = nodesToDistribute[i];
 
                 var coresToDistributePerNode = (int)Math.Ceiling((double)coresToDistribute / (nodesToDistribute.Count - i));
-                var utilizedCores = nodeDetails.GetMaxCoresToUtilize(coresToDistributePerNode);
+                var utilizedCores = nodeDetails.GetMaxCoresToUtilize(coresToDistributePerNode, Value.MaxCoresPerNode);
                 nodeDetails.UtilizedCores = utilizedCores;
                 coresToDistribute -= utilizedCores;
             }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3136,13 +3136,14 @@ namespace Raven.Server.ServerWide
             await Cluster.WaitForIndexNotification(result.Index);
         }
 
-        public async Task PutNodeLicenseLimitsAsync(string nodeTag, DetailsPerNode detailsPerNode, int maxLicensedCores, string raftRequestId = null)
+        public async Task PutNodeLicenseLimitsAsync(string nodeTag, DetailsPerNode detailsPerNode, LicenseStatus licenseStatus, string raftRequestId = null)
         {
             var nodeLicenseLimits = new NodeLicenseLimits
             {
                 NodeTag = nodeTag,
                 DetailsPerNode = detailsPerNode,
-                LicensedCores = maxLicensedCores,
+                LicensedCores = licenseStatus.MaxCores,
+                MaxCoresPerNode = licenseStatus.MaxCoresPerNode,
                 AllNodes = GetClusterTopology().AllNodes.Keys.ToList()
             };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19962/Community-License-changes

### Additional description

**Item 1**:
Reduce the maximum number of cores per node to 2, while the license will still have a maximum of 3 cores.
This will limit the user: a single node will have a maximum of 2 cores.

**Item 2**: 
- The POST request for license renewal now includes a build parameter. Depending on the build number and license type, the license renewal will either proceed as before (for builds before 60000) or according to the new procedure (see API-side changes).
- Changes for License status:
Implementation of the `UpgradeRequired` property. When its value is `true`, the studio's operation will be blocked with a requirement to upgrade to the latest stable version.
The `Version` property now contains the value up to which RavenDB needs to be updated for the studio to be unblocked.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. See description above

### UI work

- It requires further work in the Studio.