### PR TITLE
RavenDB-20423 - Attachments reference are missing in destination DB when recreating a document from revision due to replication

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20423.cs
+++ b/test/SlowTests/Issues/RavenDB-20423.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Graph;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_20423 : ReplicationTestBase
+{
+    public RavenDB_20423(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task RevisionsWithAttachmentOfDeletedDocAreReplicated()
+    {
+        using (var source = GetDocumentStore())
+        using (var destination = GetDocumentStore())
+        {
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MaximumRevisionsToDeleteUponDocumentUpdate = 1,
+                    MinimumRevisionsToKeep = 10,
+                    PurgeOnDelete = false
+                }
+            };
+            await RevisionsHelper.SetupRevisions(source, Server.ServerStore, configuration: configuration);
+
+            var id = "FoObAr/0";
+            using (var session = source.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Foo" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = source.OpenAsyncSession())
+            using (var fooStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+            {
+                session.Advanced.Attachments.Store(id, "foo.png", fooStream, "image/png");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = source.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<User>(id);
+                doc.Age = 30;
+                await session.SaveChangesAsync();
+            }
+
+            configuration.Default.Disabled = true;
+            await RevisionsHelper.SetupRevisions(source, Server.ServerStore, configuration: configuration);
+
+
+            using (var session = source.OpenAsyncSession())
+            {
+                session.Delete(id);
+                await session.SaveChangesAsync();
+            }
+
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(source.Database);
+            await database.TombstoneCleaner.ExecuteCleanup();
+
+            await SetupReplicationAsync(source, destination);
+            await EnsureReplicatingAsync(source, destination);
+            
+            // WaitForUserToContinueTheTest(destination, false);
+
+            using (var session = destination.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<User>(id);
+                Assert.Null(doc); // doc has been deleted, So it should load null (even its revisions exist in the revisions bin).
+
+                // Deleted doc has 4 revisions, the last is 'Delete Revision'
+                var revisionsCount = await session.Advanced.Revisions.GetCountForAsync(id);
+                Assert.Equal(4, revisionsCount);
+
+                var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                Assert.Equal(4, revisionsMetadata.Count);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata[0].GetString(Constants.Documents.Metadata.Flags));
+
+                var att1 = revisionsMetadata[1].GetObjects("@attachments");
+                var att2 = revisionsMetadata[2].GetObjects("@attachments");
+                Assert.Equal(1, att1.Length);
+                Assert.Equal("foo.png", att1[0]["Name"].ToString());
+                Assert.Equal(1, att2.Length);
+                Assert.Equal("foo.png", att2[0]["Name"].ToString());
+
+                Assert.False(revisionsMetadata[0].Keys.Contains("@attachments")); // the last revision ('Delete Revision') doesn't contain any attachments/counters/time-series.
+                Assert.False(revisionsMetadata[3].Keys.Contains("@attachments")); // the first revision was created before the attachment was stored, therefore it wont have any attachment.
+            }
+        }
+    }
+}
+

--- a/test/SlowTests/Issues/RavenDB-20423.cs
+++ b/test/SlowTests/Issues/RavenDB-20423.cs
@@ -9,8 +9,10 @@ using FastTests.Graph;
 using FastTests.Server.Replication;
 using FastTests.Utils;
 using Raven.Client;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -98,10 +100,35 @@ public class RavenDB_20423 : ReplicationTestBase
                 Assert.Equal(1, att2.Length);
                 Assert.Equal("foo.png", att2[0]["Name"].ToString());
 
-                Assert.False(revisionsMetadata[0].Keys.Contains("@attachments")); // the last revision ('Delete Revision') doesn't contain any attachments/counters/time-series.
-                Assert.False(revisionsMetadata[3].Keys.Contains("@attachments")); // the first revision was created before the attachment was stored, therefore it wont have any attachment.
+                var atKey = Raven.Client.Constants.Documents.Metadata.Attachments;
+                var cvKey = Raven.Client.Constants.Documents.Metadata.ChangeVector;
+
+                Assert.False(revisionsMetadata[0].Keys.Contains(atKey)); // the last revision ('Delete Revision') doesn't contain any attachments/counters/time-series.
+                Assert.False(revisionsMetadata[3].Keys.Contains(atKey)); // the first revision was created before the attachment was stored, therefore it wont have any attachment.
+                var db = await Databases.GetDocumentDatabaseInstanceFor(destination);
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    for (int i = 1; i <= 2; i++)
+                    {
+                        var cv = revisionsMetadata[i][cvKey].ToString();
+                        AssertAttachmntStream(context, db, id, cv);
+                    }
+                }
+
             }
         }
+    }
+
+    public void AssertAttachmntStream(DocumentsOperationContext context, DocumentDatabase db, string id, string revisionCv)
+    {
+        var lzv = context.GetLazyString(id.ToLowerInvariant());
+        var attachments = db.DocumentsStorage.AttachmentsStorage.GetAttachmentsForDocument(context, AttachmentType.Revision, lzv, revisionCv).ToList();
+        Assert.True(attachments.Count == 1);
+        var attachment = attachments[0];
+        Assert.True(attachment.Size == 3);
+        var stream = db.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(context, attachment.Base64Hash);
+        Assert.NotNull(stream);
     }
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20423/Attachments-reference-are-missing-in-destination-DB-when-recreating-a-document-from-revision-due-to-replication

### Additional description

Attachments reference are missing in destination DB when recreating a document from revision due to replication.
Attachment references are replicated, the 'delete revision' just doesn't have that, like it doesn't have the counters/time-series and the doc content.. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
