### PR TITLE
RavenDB-20846 - EnforceConfiguration for single collection

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -140,11 +140,13 @@ namespace Raven.Server.Documents.Handlers
                 configuration = JsonDeserializationServer.EnforceRevisionsConfiguration(json);
             }
 
+            HashSet<string> collections = configuration.Collections?.Length > 0 ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
+
             var t = Database.Operations.AddOperation(
                 Database,
                 $"Enforce revision configuration in database '{Database.Name}'.",
                 Operations.Operations.OperationType.EnforceRevisionConfiguration,
-                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, configuration.IncludeForceCreated, configuration.Collection, token),
+                onProgress => Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, configuration.IncludeForceCreated, collections, token),
                 operationId,
                 token: token);
 

--- a/src/Raven.Server/Documents/Revisions/EnforceRevisionsConfigurationRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/EnforceRevisionsConfigurationRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.Revisions
+{
+    public class EnforceRevisionsConfigurationRequest
+    {
+        public bool IncludeForceCreated { get; set; } = false;
+        public string Collection { get; set; } = null;
+    }
+}

--- a/src/Raven.Server/Documents/Revisions/EnforceRevisionsConfigurationRequest.cs
+++ b/src/Raven.Server/Documents/Revisions/EnforceRevisionsConfigurationRequest.cs
@@ -9,6 +9,6 @@ namespace Raven.Server.Documents.Revisions
     public class EnforceRevisionsConfigurationRequest
     {
         public bool IncludeForceCreated { get; set; } = false;
-        public string Collection { get; set; } = null;
+        public string[] Collections { get; set; } = null;
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -136,6 +136,8 @@ namespace Raven.Server.Json
         
         public static readonly Func<BlittableJsonReaderObject, RevertRevisionsRequest> RevertRevisions = GenerateJsonDeserializationRoutine<RevertRevisionsRequest>();
 
+        public static readonly Func<BlittableJsonReaderObject, EnforceRevisionsConfigurationRequest> EnforceRevisionsConfiguration = GenerateJsonDeserializationRoutine<EnforceRevisionsConfigurationRequest>();
+
         public static readonly Func<BlittableJsonReaderObject, LicenseSupportInfo> LicenseSupportInfo = GenerateJsonDeserializationRoutine<LicenseSupportInfo>();
 
         public static readonly Func<BlittableJsonReaderObject, UserRegistrationInfo> UserRegistrationInfo = GenerateJsonDeserializationRoutine<UserRegistrationInfo>();

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -622,7 +622,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -643,7 +643,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -706,7 +706,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -722,7 +722,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -771,7 +771,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1238,7 +1238,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests/Issues/RavenDB-16961.cs
+++ b/test/SlowTests/Issues/RavenDB-16961.cs
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store, store.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
                 }
 
 
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
                 db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    enforceResult = await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
                 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1, store1.Database);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests/Issues/RavenDB-20846.cs
+++ b/test/SlowTests/Issues/RavenDB-20846.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Corax;
+using FastTests.Utils;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20846 : ClusterTestBase
+{
+    public RavenDB_20846(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    class Company
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public async Task EnforceConfigurationForSingleCollection()
+    {
+        using var store = GetDocumentStore();
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        var company = new Company()
+        {
+            Id = "Companies/1-A",
+            Name = ""
+        };
+        var user = new User()
+        {
+            Id = "Users/1-A",
+            Name = ""
+        };
+
+
+        for (int i = 0; i < 10; i++)
+        {
+            using var session = store.OpenAsyncSession();
+            company.Name = user.Name = $"revision{i}";
+            await session.StoreAsync(company);
+            await session.StoreAsync(user);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var companyRevCount = await session.Advanced.Revisions.GetCountForAsync(company.Id);
+            Assert.Equal(10, companyRevCount);
+            var userRevCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(10, userRevCount);
+        }
+
+        configuration.Default.MinimumRevisionsToKeep = 5;
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+        var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collection: "Users", token: token);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var companyRevCount = await session.Advanced.Revisions.GetCountForAsync(company.Id);
+            Assert.Equal(10, companyRevCount);
+            var userRevCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(5, userRevCount);
+        }
+    }
+}
+

--- a/test/SlowTests/Issues/RravenDB-16949.cs
+++ b/test/SlowTests/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -68,7 +68,7 @@ namespace SlowTests
         {
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated, token);
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated, token: token);
         }
 
         private async Task UpdateDoc(DocumentStore store, string docId)

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -298,7 +298,7 @@ namespace SlowTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
 
                 WaitForMarker(store1, store2);
 
@@ -952,7 +952,7 @@ namespace SlowTests.Server.Documents.Revisions
                 EnforceConfigurationResult result;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(onProgress: null, token: token);
+                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, token: token);
                 }
 
                 Assert.Equal(11, result.ScannedRevisions);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -458,7 +458,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await Databases.GetDocumentDatabaseInstanceFor(store1);
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationIncludeForceCreatedAsync(onProgress: null, token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20846/Allow-to-enforce-revisions-configuration-for-a-single-collection

### Additional description

Allow to enforce revisions configuration for a single collection

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Breaks backward compatibility.
  The EP is now getting a json (configuration..).

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Yes.
  EnforceRevisionsConfiguration ep 
([RavenAction("/databases/*/admin/revisions/config/enforce", "POST", AuthorizationStatus.DatabaseAdmin)])
is now getting a json with the fields: IncludeForceCreated and Collections.