### PR TITLE
RavenDB-20628 - Handling getting null as 'Clus…

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -51,6 +51,7 @@ using Sparrow.Server;
 using Sparrow.Server.Meters;
 using Sparrow.Server.Utils;
 using Sparrow.Threading;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Exceptions;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -45,6 +45,7 @@ namespace Raven.Server.Documents
         public static readonly Slice CollectionsSlice;
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
+        private static readonly Slice LastCompletedClusterTransactionIndexSlice;
         private static readonly Slice LastEtagSlice;
         private static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
@@ -107,6 +108,7 @@ namespace Raven.Server.Documents
             {
                 Slice.From(ctx, "AllTombstonesEtags", ByteStringType.Immutable, out AllTombstonesEtagsSlice);
                 Slice.From(ctx, "Etags", ByteStringType.Immutable, out EtagsSlice);
+                Slice.From(ctx, "LastCompletedClusterTransactionIndex", ByteStringType.Immutable, out LastCompletedClusterTransactionIndexSlice);
                 Slice.From(ctx, "LastEtag", ByteStringType.Immutable, out LastEtagSlice);
                 Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
                 Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
@@ -676,6 +678,31 @@ namespace Raven.Server.Documents
             }
 
             return 0;
+        }
+
+        public static long ReadLastCompletedClusterTransactionIndex(Transaction tx)
+        {
+            if (tx == null)
+                throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
+            var tree = tx.ReadTree(GlobalTreeSlice);
+            if (tree == null)
+            {
+                return 0;
+            }
+            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
+            if (readResult == null)
+            {
+                return 0;
+            }
+
+            return readResult.Reader.ReadLittleEndianInt64();
+        }
+
+        public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
+        {
+            var tree = context.Transaction.InnerTransaction.CreateTree(GlobalTreeSlice);
+            using (Slice.External(context.Allocator, (byte*)&index, sizeof(long), out Slice indexSlice))
+                tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
         }
 
         public static long ReadLastEtag(Transaction tx)

--- a/src/Raven.Server/Rachis/RachisLogHistory.cs
+++ b/src/Raven.Server/Rachis/RachisLogHistory.cs
@@ -493,5 +493,42 @@ namespace Raven.Server.Rachis
                 return true;
             }
         }
+
+
+        public unsafe bool TryGetResultByGuid<T>(ClusterOperationContext context, string guid, out T result)
+        {
+            result = default(T);
+
+            var table = context.Transaction.InnerTransaction.OpenTable(LogHistoryTable, LogHistorySlice);
+            using (Slice.From(context.Allocator, guid, out var guidSlice))
+            {
+                if (table.ReadByKey(guidSlice, out var reader) == false)
+                    return false;
+
+                var bytes = reader.Read((int)LogHistoryColumn.Result, out int size);
+                if (size == 0)
+                    return false;
+
+                var cmd = new BlittableJsonReaderObject(bytes, size, context);
+
+                if (typeof(T) == typeof(ClusterTransactionResult))
+                {
+                    if (cmd.TryGet(nameof(LogHistoryColumn.Result), out BlittableJsonReaderObject resultAsBlt) == false)
+                        // Should never happen! (we are getting here after the command is completed int the db, so it ha been applied and should have results).
+                        throw new InvalidOperationException($"'Results' field is inaccessible in '{cmd}' for type {typeof(T).FullName}");
+
+                    result = (T)(object)JsonDeserializationCluster.ClusterTransactionResult(resultAsBlt);
+                }
+                else
+                {
+                    if (cmd.TryGet(nameof(LogHistoryColumn.Result), out result) == false)
+                        // Should never happen! (we are getting here after the command is completed int the db, so it ha been applied and should have results).
+                        throw new InvalidOperationException($"'Results' field is inaccessible in '{cmd}' for type {typeof(T).FullName}");
+                }
+
+                return result != null;
+            }
+        }
+
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
+++ b/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nest;
+using Newtonsoft.Json;
+using Raven.Server.ServerWide.Commands;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide;
+public class ClusterTransactionResult : IDynamicJsonValueConvertible
+{
+    public long? Count { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Count)] = Count
+        };
+    }
+}
+

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -136,6 +136,7 @@ namespace Raven.Server.ServerWide
         public static Func<BlittableJsonReaderObject, SorterDefinition> SorterDefinition = GenerateJsonDeserializationRoutine<SorterDefinition>();
 
         public static Func<BlittableJsonReaderObject, PostgreSqlConfiguration> PostgreSqlConfiguration = GenerateJsonDeserializationRoutine<PostgreSqlConfiguration>();
+        public static Func<BlittableJsonReaderObject, ClusterTransactionResult> ClusterTransactionResult = GenerateJsonDeserializationRoutine<ClusterTransactionResult>();
         
         public static readonly Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>> Commands = new Dictionary<string, Func<BlittableJsonReaderObject, CommandBase>>
         {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -728,14 +728,16 @@ namespace Raven.Server.Smuggler.Documents
                     var parsedCommands = _clusterTransactionCommands.GetArraySegment();
 
                     var raftRequestId = RaftIdGenerator.NewId();
-                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(string.Empty, disableAtomicDocumentWrites: false,
+                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites: false,
                         ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
                     var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
 
                     var clusterTransactionCommand = new ClusterTransactionCommand(_database.Name, _database.IdentityPartsSeparator, topology, parsedCommands, options, raftRequestId);
                     clusterTransactionCommand.FromBackup = true;
 
+
                     var clusterTransactionResult = await _database.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+
                     for (int i = 0; i < _clusterTransactionCommands.Length; i++)
                     {
                         _clusterTransactionCommands[i].Document.Dispose();

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -41,7 +41,8 @@ namespace InterversionTests
             return base.GetNewServer(options, caller);
         }
 
-        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, IDictionary<string, string> customSettings = null, X509Certificate2 certificate = null)
+        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, X509Certificate2 certificate = null
+            , bool watcherCluster = false)
         {
             var processes = new List<ProcessNode>();
             foreach (var peer in peers)
@@ -49,28 +50,31 @@ namespace InterversionTests
                 processes.Add(await GetServerAsync(peer));
             }
 
-            var chosenOne = processes[0];
+            var leader = processes[0];
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(chosenOne.Url, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.Url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 foreach (var processNode in processes)
                 {
-                    if (processNode == chosenOne)
+                    if (processNode == leader)
                         continue;
 
-                    var addCommand = new AddClusterNodeCommand(processNode.Url);
+                    var addCommand = new AddClusterNodeCommand(processNode.Url, watcher: watcherCluster);
                     await requestExecutor.ExecuteAsync(addCommand, context);
                 }
 
+                var result = watcherCluster ? (1, peers.Length - 1) : (peers.Length, 0);
                 var clusterCreated = await WaitForValueAsync(async () =>
                 {
                     var clusterTopology = new GetClusterTopologyCommand();
                     await requestExecutor.ExecuteAsync(clusterTopology, context);
-                    return clusterTopology.Result.Topology.Members.Count;
-                }, peers.Length);
+                    var clusterTopology1 = clusterTopology.Result.Topology;
 
-                Assert.True(clusterCreated == peers.Length, "Failed to create initial cluster");
+                    return (clusterTopology1.Members.Count, clusterTopology1.Watchers.Count);
+                }, result);
+
+                Assert.True(clusterCreated == result, "Failed to create initial cluster");
             }
 
             return processes;
@@ -218,9 +222,9 @@ namespace InterversionTests
             }), stores);
         }
 
-        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null)
+        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null, DatabaseRecord record = null)
         {
-            var doc = new DatabaseRecord(dbName)
+            var doc = record ?? new DatabaseRecord(dbName)
             {
                 Settings =
                 {

--- a/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
+++ b/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Graph;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Tests.Infrastructure.InterversionTest;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class RavenDB_20628_backward_compatibility : MixedClusterTestBase
+    {
+        public RavenDB_20628_backward_compatibility(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task UpgradeLeaderToLatest()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var latest = "5.4.107";
+            var initialVersions = new[] { latest, latest };
+
+            var nodes = await CreateCluster(initialVersions, watcherCluster: true);
+            var database = GetDatabaseName();
+            var result = await GetStores(database, nodes);
+            var leaderUrl = await GetLeaderUrl(result.Stores[0]);
+            var leaderProc = nodes.Single(n => n.Url == leaderUrl);
+            var followerUrl = nodes.Single(n => n.Url != leaderUrl).Url;
+
+            using (result.Disposable)
+            {
+                var stores = result.Stores;
+                await CreateDatabase(stores[0], replicationFactor: nodes.Count, dbName: database, record: new DatabaseRecord(database));
+
+                await UpgradeServerAsync("current", leaderProc);
+
+                using var followerStore = new DocumentStore()
+                {
+                    Urls = new[] { followerUrl },
+                    Conventions =
+                    {
+                        DisableTopologyUpdates = true
+                    }
+                }.Initialize();
+
+                var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+
+                using (var session = followerStore.OpenAsyncSession(new SessionOptions
+                       {
+                           Database = database,
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    await session.StoreAsync(user1);
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        [MultiplatformFact(RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task UpgradeFollowerToLatest()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var latest = "5.4.107";
+            var initialVersions = new[] { latest, latest };
+
+            var nodes = await CreateCluster(initialVersions, watcherCluster: true);
+            var database = GetDatabaseName();
+            var result = await GetStores(database, nodes);
+            var leaderUrl = await GetLeaderUrl(result.Stores[0]);
+            var followerProc = nodes.Single(n => n.Url != leaderUrl);
+            var followerUrl = followerProc.Url;
+
+            using (result.Disposable)
+            {
+                var stores = result.Stores;
+                await CreateDatabase(stores[0], replicationFactor: nodes.Count, dbName: database, record: new DatabaseRecord(database));
+                await UpgradeServerAsync("current", followerProc);
+
+                using var followerStore = new DocumentStore()
+                {
+                    Urls = new[] { followerUrl },
+                    Conventions =
+                    {
+                        DisableTopologyUpdates = true
+                    }
+                }.Initialize();
+
+                var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+
+                using (var session = followerStore.OpenAsyncSession(new SessionOptions
+                       {
+                           Database = database,
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    await session.StoreAsync(user1);
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        private async Task<string> GetLeaderUrl(IDocumentStore store)
+        {
+            var clusterTopology = await store.Maintenance.Server.SendAsync(new GetClusterTopologyOperation());
+            var leaderTag = clusterTopology.Leader;
+            var leaderUrl = clusterTopology.Topology.Members[leaderTag];
+            return leaderUrl;
+        }
+
+        public class GetClusterTopologyOperation : IServerOperation<ClusterTopologyResponse>
+        {
+            public GetClusterTopologyOperation()
+            {
+            }
+
+            public RavenCommand<ClusterTopologyResponse> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetClusterTopologyCommand();
+            }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20628 : ClusterTestBase
+    {
+        public RavenDB_20628(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task ClusterTransaction_Should_Work_After_Commit_And_Failover()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
+
+            await ApplyFailoverAfterCommitAsync(nodes, store.Database);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Alice");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
+
+            await ApplyFailoverAfterCommitAsync(nodes, store.Database);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            var user2 = new User() { Id = "Users/2-A", Name = "Bob" };
+            var user3 = new User() { Id = "Users/3-A", Name = "Alice" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user3);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                (await session.LoadAsync<User>(user1.Id)).Name = "Bob";
+                await session.StoreAsync(user2);
+                session.Delete(user3.Id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Bob");
+
+                var users2onSession = await session.LoadAsync<User>(user2.Id);
+                Assert.Equal(users2onSession.Name, "Bob");
+
+                var users3onSession = await session.LoadAsync<User>(user3.Id);
+                Assert.Null(users3onSession);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover_UseResults()
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = nodes.Count
+            });
+
+            await ApplyFailoverAfterCommitAsync(nodes, store.Database);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            var user2 = new User() { Id = "Users/2-A", Name = "Bob" };
+            var user3 = new User() { Id = "Users/3-A", Name = "Alice" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user3);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                users1onSession.Name = "Bob";
+                await session.StoreAsync(user2);
+                session.Delete(user3.Id);
+                await session.SaveChangesAsync();
+
+                users1onSession.Name = "Shahar";
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Shahar");
+
+                var users2onSession = await session.LoadAsync<User>(user2.Id);
+                Assert.Equal(users2onSession.Name, "Bob");
+
+                var users3onSession = await session.LoadAsync<User>(user3.Id);
+                Assert.Null(users3onSession);
+            }
+        }
+
+        private async Task ApplyFailoverAfterCommitAsync(List<RavenServer> nodes, string database)
+        {
+            int failover = 0;
+            foreach (var n in nodes)
+            {
+                var server = n;
+                var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                db.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
+                {
+                    if (Interlocked.CompareExchange(ref failover, 1, 0) == 0)
+                        throw new TimeoutException("Fake server fail that cause failover"); // for failover in node A
+                };
+            }
+        }
+
+    }
+}
+
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20628/Cluster-wide-transaction-throw-TaskCanceledException-when-fails-on-timeout

### Additional description

Apparently, there's no backward compatibility for this issue.
Before the change the 'ClusterTransactionCommand' result was null or error array.
after the change the command result can also be a long (count)..
this count is required for generating the results for the client afterward because we are estimating
the change-vectors of the docs that were updated using it.
So in case you have an outdated leader, and you send the request (for doc update using cluster transaction) to an updated follower,
the follower will send 'ClusterTransactionCommand' to the leader (which isn't updated) by SendToLeaderAsync in the method 'HandleClusterTransaction(..)'.
The follower will get 'null' as a result from the leader, although the command is committed and succeeded,
so the follower will throw because it is not expected - you have 'DatabaseCommands' (like updating doc) inside the 'ClusterTransactionCommand' but you got null instead of count, so it cannot generate the results.

The solution:
We thought that it would be best if the result won't be null in any case (it will be a class that wraps the count and the array of errors - 'ClusterTransactionResult').
If you get a result that isn't 'ClusterTransactionResult' for the 'ClusterTransactionCommand' on the update follower, it means that the leader isn't updated,
so it first will check for the result on the follower's local history-log, and only if it isn't there (if it has been deleted from the log already), the follower will throw an exception about an outdated leader or something like that.
There's still a chance to throw when the leader is not updated and a cluster transaction is requested, but it's very small.
I also want to increase the size of the history to further reduce the chance of failure.

note:
We decided to try get the 'count' from the task in case of 'old leader', and only if you have an 'old leader' and you are in the EP (HandleClusterTransaction) after failover and the cluster transaction is already completed in the database, only then you will try to get the result from the local history log.

### Type of change

- Bug fix

### How risky is the change?

- High 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works
-  Tested manually: old leader and new follower, or new leader and old follower.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
