### PR TITLE
RavenDB-21137 Adding a configurable limit to the amount of memory we …

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.BinaryMatches.cs
@@ -17,22 +17,22 @@ public partial class IndexSearcher
         // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
         if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldAnd(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldAnd(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldAnd(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldAnd(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldAnd(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldAnd(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldAnd(Allocator, in set1, in set2, token));
+        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldAnd(this, in set1, in set2, token));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -48,22 +48,22 @@ public partial class IndexSearcher
         // do all the work to figure out what to emit. The cost is in instantiation not on execution. 
         if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldOr(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldOr(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldOr(Allocator, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldOr(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
         else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
         {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldOr(Allocator, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
+            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldOr(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
         }
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(Allocator, in set1, in set2, token));
+        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(this, in set1, in set2, token));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/IndexSearcher/IndexSearcher.Memoization.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.Memoization.cs
@@ -8,6 +8,6 @@ partial class IndexSearcher
     public MemoizationMatchProvider<TInner> Memoize<TInner>(TInner inner)
         where TInner : IQueryMatch
     {
-        return new MemoizationMatchProvider<TInner>(Allocator, inner);
+        return new MemoizationMatchProvider<TInner>(this, inner);
     }
 }

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -65,7 +65,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private Lookup<Int64LookupKey> _entryIdToLocation;
     public FieldsCache FieldCache;
 
-    public long MaxMemoizationSize = 128 * 1024 * 1024;
+    public long MaxMemoizationSizeInBytes = 128 * 1024 * 1024;
 
     public bool DocumentsAreBoosted => GetDocumentBoostTree().NumberOfEntries > 0;
 

--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -65,6 +65,8 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private Lookup<Int64LookupKey> _entryIdToLocation;
     public FieldsCache FieldCache;
 
+    public long MaxMemoizationSize = 128 * 1024 * 1024;
+
     public bool DocumentsAreBoosted => GetDocumentBoostTree().NumberOfEntries > 0;
 
     

--- a/src/Corax/Queries/BinaryMatch.Boolean.cs
+++ b/src/Corax/Queries/BinaryMatch.Boolean.cs
@@ -14,7 +14,7 @@ namespace Corax.Queries
     unsafe partial struct BinaryMatch<TInner, TOuter>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BinaryMatch<TInner, TOuter> YieldAnd(ByteStringContext ctx, in TInner inner, in TOuter outer, in CancellationToken token)
+        public static BinaryMatch<TInner, TOuter> YieldAnd(IndexSearcher searcher, in TInner inner, in TOuter outer, in CancellationToken token)
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static int FillFunc(ref BinaryMatch<TInner, TOuter> match, Span<long> matches)
@@ -70,7 +70,7 @@ namespace Corax.Queries
                     // which can be really expensive, instead, let's memoize the outer and remember that 
                     if (resultsSpan.Length == 0 && match._memoizedOuter is null)
                     {
-                        match._memoizedOuter = new MemoizationMatchProvider<TOuter>(match._ctx, match._outer);
+                        match._memoizedOuter = new MemoizationMatchProvider<TOuter>(match._indexSearcher, match._outer);
                         match._memoizedOuter.SortingRequired();
                     }
 
@@ -123,10 +123,10 @@ namespace Corax.Queries
             else
                 confidence = inner.Confidence.Min(outer.Confidence);
 
-            return new BinaryMatch<TInner, TOuter>(ctx, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, Math.Min(inner.Count, outer.Count), confidence, token);
+            return new BinaryMatch<TInner, TOuter>(searcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, Math.Min(inner.Count, outer.Count), confidence, token);
         }
 
-        public static BinaryMatch<TInner, TOuter> YieldOr(ByteStringContext ctx, in TInner inner, in TOuter outer, in CancellationToken token)
+        public static BinaryMatch<TInner, TOuter> YieldOr(IndexSearcher indexSearcher, in TInner inner, in TOuter outer, in CancellationToken token)
         {
 #if !DEBUG
             [SkipLocalsInit]
@@ -322,7 +322,7 @@ namespace Corax.Queries
             else
                 confidence = inner.Confidence.Min(outer.Confidence);
 
-            return new BinaryMatch<TInner, TOuter>(ctx, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, inner.Count + outer.Count, confidence, token);
+            return new BinaryMatch<TInner, TOuter>(indexSearcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, inner.Count + outer.Count, confidence, token);
         }
     }
 }

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -18,7 +18,8 @@ namespace Corax.Queries
         private TInner _inner;
         private TOuter _outer;
         private MemoizationMatchProvider<TOuter> _memoizedOuter;
-        private ByteStringContext _ctx;
+        private readonly ByteStringContext _ctx;
+        private readonly IndexSearcher _indexSearcher;
         private readonly long _totalResults;
         private readonly QueryCountConfidence _confidence;
         private readonly CancellationToken _token;
@@ -40,7 +41,7 @@ namespace Corax.Queries
         public QueryCountConfidence Confidence => _confidence;
 
         private BinaryMatch(
-            ByteStringContext ctx,
+            IndexSearcher indexSearcher,
             in TInner inner, in TOuter outer,
             delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> fillFunc,
             delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> andWithFunc,
@@ -49,6 +50,7 @@ namespace Corax.Queries
             QueryCountConfidence confidence,
             in CancellationToken token)
         {
+            _indexSearcher = indexSearcher;
             _totalResults = totalResults;
 
             _fillFunc = fillFunc;
@@ -59,7 +61,7 @@ namespace Corax.Queries
             _outer = outer;
             _confidence = confidence;
             _token = token;
-            _ctx = ctx;
+            _ctx = indexSearcher.Allocator;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Queries/MemoizationMatch.Provider.cs
+++ b/src/Corax/Queries/MemoizationMatch.Provider.cs
@@ -144,7 +144,7 @@ namespace Corax.Queries
 
             var sizeInBytes = size * sizeof(long);
 
-            if (sizeInBytes > _indexSearcher.MaxMemoizationSize) ThrowExceededMemoizationSize();
+            if (sizeInBytes > _indexSearcher.MaxMemoizationSizeInBytes) ThrowExceededMemoizationSize();
 
             // Allocate the new buffer
             var newBufferScope = _ctx.Allocate(sizeInBytes, out var newBufferHolder);
@@ -169,7 +169,7 @@ namespace Corax.Queries
                 }
                 
                 throw new InvalidOperationException(
-                    $"Memoization clause need to allocation {new Size(sizeInBytes, SizeUnit.Bytes)} but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {new Size(_indexSearcher.MaxMemoizationSize, SizeUnit.Bytes)}, in query: {inner}");
+                    $"Memoization clause need to allocation {new Size(sizeInBytes, SizeUnit.Bytes)} but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {new Size(_indexSearcher.MaxMemoizationSizeInBytes, SizeUnit.Bytes)}, in query: {inner}");
             }
         }
 

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -493,6 +493,13 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
         public bool CoraxIncludeSpatialDistance { get; set; }
+        
+        [Description("The maximum amount of memory that Corax can use for a memoization clause during query processing")]
+        [DefaultValue(128)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.Corax.MaxMemoizationSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public Size MaxMemoizationLengthSize { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -497,9 +497,9 @@ namespace Raven.Server.Config.Categories
         [Description("The maximum amount of memory that Corax can use for a memoization clause during query processing")]
         [DefaultValue(128)]
         [SizeUnit(SizeUnit.Megabytes)]
-        [IndexUpdateType(IndexUpdateType.None)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Corax.MaxMemoizationSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
-        public Size MaxMemoizationLengthSize { get; set; }
+        public Size MaxMemoizationSize { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -39,7 +39,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         _fieldMappings = fieldsMapping;
         _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
         {
-            MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+            MaxMemoizationSizeInBytes = index.Configuration.MaxMemoizationSize.GetValue(SizeUnit.Bytes) 
         };
         _fieldNameCache = new();
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -37,7 +37,10 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         _fieldMappings = fieldsMapping;
         _allocator = readTransaction.Allocator;
         _fieldMappings = fieldsMapping;
-        _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings);
+        _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
+        {
+            MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+        };
         _fieldNameCache = new();
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -95,7 +95,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         {
             _allocator = readTransaction.Allocator;
             _fieldMappings = fieldsMapping;
-            IndexSearcher = new IndexSearcher(readTransaction, _fieldMappings);
+            IndexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
+            {
+                MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+            };
             if (index.Type.IsMap())
             {
                 _documentIdReader = IndexSearcher.TermsReaderFor(Constants.Documents.Indexing.Fields.DocumentIdFieldName);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -97,7 +97,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             _fieldMappings = fieldsMapping;
             IndexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
             {
-                MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+                MaxMemoizationSizeInBytes = index.Configuration.MaxMemoizationSize.GetValue(SizeUnit.Bytes) 
             };
             if (index.Type.IsMap())
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
@@ -30,7 +30,7 @@ public class CoraxSuggestionReader : SuggestionIndexReaderBase
         _binding = binding;
         _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
         {
-            MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+            MaxMemoizationSizeInBytes = index.Configuration.MaxMemoizationSize.GetValue(SizeUnit.Bytes) 
         };
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
@@ -10,6 +10,7 @@ using Corax.Pipeline;
 using Raven.Client.Documents.Queries.Suggestions;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Suggestions;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Voron.Impl;
@@ -27,7 +28,10 @@ public class CoraxSuggestionReader : SuggestionIndexReaderBase
     {
         _fieldMappings = fieldsMapping;
         _binding = binding;
-        _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings);
+        _indexSearcher = new IndexSearcher(readTransaction, _fieldMappings)
+        {
+            MaxMemoizationSize = index.Configuration.MaxMemoizationLengthSize.GetValue(SizeUnit.Bytes) 
+        };
     }
 
     public override SuggestionResult Suggestions(IndexQueryServerSide query, SuggestionField field, JsonOperationContext documentsContext, CancellationToken token)

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -40,7 +40,8 @@ class configurationItem {
         "Query.RegexTimeoutInMs",
         "Indexing.Lucene.ReaderTermsIndexDivisor",
         "Indexing.Corax.IncludeDocumentScore",
-        "Indexing.Corax.IncludeSpatialDistance"
+        "Indexing.Corax.IncludeSpatialDistance",
+        "Indexing.Corax.MaxMemoizationSizeInMb",
 
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -84,6 +84,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.DocumentsLimitForCompressionDictionaryCreation",
                 "Indexing.Corax.IncludeDocumentScore",
                 "Indexing.Corax.IncludeSpatialDistance",
+                "Indexing.Corax.MaxMemoizationSizeInMb",
                 
                 
                 //Obsolete studio keys:


### PR DESCRIPTION
…can use during memoization, better handling of allocation of invalid amounts

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21137 
https://issues.hibernatingrhinos.com/issue/RavenDB-19567

### Additional description

During memoization of query clause, we need to remember all the entries that match, that means that we allocate an array for those entries.
In some cases, a query clause can be _huge_ (hundreds of millions or billions of entries). In those cases, we will try to hold the entire query results in memory, leading to result sizes that are > 2B and exceed `Span<long>` size.

Added a limit that would catch this far earlier, preventing us from needing to actually memoize such queries is a separate task.