### PR TITLE
RavenDB-21106: Optimize the training for locality.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
@@ -16,7 +16,7 @@ public class CoraxDocumentTrainSourceEnumerator
         _documentsStorage = documentsStorage;
     }
     
-    public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, string collection, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
+    public IEnumerable<Document> GetDocumentsForDictionaryTraining(DocumentsOperationContext context, string collection, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
     {
         var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
         if (collectionName == null)
@@ -28,7 +28,7 @@ public class CoraxDocumentTrainSourceEnumerator
         
         state.InitializeState(table);
         
-        foreach (var (key, result) in table.IterateUniformly(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.CollectionEtagsSlice], state.DocumentSkip, seek: state.CurrentKey))
+        foreach (var (key, result) in table.IterateForDictionaryTraining(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.CollectionEtagsSlice], state.DocumentSkip, seek: state.CurrentKey))
         {
             //Update inner key in order to seek after transaction refresh
             state.CurrentKey = key;
@@ -41,11 +41,11 @@ public class CoraxDocumentTrainSourceEnumerator
         }
     }
 
-    public IEnumerable<Document> GetUniformlyDistributedDocumentsFrom(DocumentsOperationContext context, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
+    public IEnumerable<Document> GetDocumentsForDictionaryTraining(DocumentsOperationContext context, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
     {
         var table = new Table(_documentsStorage.DocsSchema, context.Transaction.InnerTransaction);
         state.InitializeState(table);
-        foreach (var (key, result) in table.IterateUniformly(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice], state.DocumentSkip, state.CurrentKey))
+        foreach (var (key, result) in table.IterateForDictionaryTraining(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice], state.DocumentSkip, state.CurrentKey))
         {
             state.CurrentKey = key;
             

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -473,6 +473,12 @@ namespace Sparrow.Server
         {
             return new Span<byte>(Ptr, Length);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly Span<T> ToSpan<T>() where T : unmanaged
+        {
+            return new Span<T>(Ptr, Length / Unsafe.SizeOf<T>());
+        }
     }
 
     public sealed unsafe class UnmanagedGlobalSegment : PooledItem

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1579,7 +1579,7 @@ namespace Voron.Data.Fixed
             return Slice.External(_tx.Allocator, ptr, size, out slice);
         }
 
-        public IFixedSizeIterator Iterate()
+        public IFixedSizeIterator Iterate(bool prefetch = false)
         {
             switch (Type)
             {
@@ -1588,7 +1588,7 @@ namespace Voron.Data.Fixed
                 case RootObjectType.EmbeddedFixedSizeTree:
                     return new EmbeddedIterator(this);
                 case RootObjectType.FixedSizeTree:
-                    return new LargeIterator(this);
+                    return new LargeIterator(this, prefetch);
                 default:
                     throw new ArgumentOutOfRangeException(Type?.ToString());
             }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21106

### Additional description
IO deprived setups would incur high cost in dictionary pretraining. We are looking into optimizing it as much as possible with the objective of having to avoid configuration knobs to deal with it.

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change