### PR TITLE
RavenDB-21159 : flaky test adjustments

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -319,6 +319,8 @@ namespace FastTests
                 foreach (var documentDatabase in databases)
                 {
                     var performanceStats = GetEtlPerformanceStatsForDatabase(documentDatabase);
+                    if (performanceStats == null)
+                        continue;
                     sb.AppendLine($"database '{documentDatabase.Name}' stats : {performanceStats}");
                 }
 
@@ -327,7 +329,9 @@ namespace FastTests
 
             public string GetEtlPerformanceStatsForDatabase(DocumentDatabase database)
             {
-                var process = database.EtlLoader.Processes.First();
+                var process = database.EtlLoader.Processes.FirstOrDefault();
+                if (process == null)
+                    return null;
                 var stats = process.GetPerformanceStats();
                 return string.Join(Environment.NewLine, stats.Select(JsonConvert.SerializeObject));
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21159/SlowTests.Sharding.ETL.FailoverEtlTests.OlapTaskShouldBeHighlyAvailable

### Additional description

- use a singe store with orchestrator on all 3 nodes
- wait for etl on all shard nodes (instead of a single node) and use the same MRE instance for all shard replicas (for each shard, only one of its nodes will be responsible for the etl)
- dispose a node instead of removing from cluster
- choose an actual responsible node to remove instead of a random node
- after disposing node, wait for it to be removed from orchestrators members in db record

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 