### PR TITLE
RavenDB-20865 - RachisTests.AddNodeToClusterTests.AddingNodeToClusterUpdatesClusterRequestExecutorTopology_RavenDB_20702

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -535,11 +535,11 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public bool ShouldUpdateTopology(long newRecordIndex, long currentIndex, out string url)
+        public bool ShouldUpdateTopology(long newRecordIndex, long currentIndex, out string url, ClusterTopology clusterTopology = null)
         {
             if (currentIndex < newRecordIndex)
             {
-                var clusterTopology = GetClusterTopology();
+                clusterTopology ??= GetClusterTopology();
                 url = clusterTopology.GetUrlFromTag(NodeTag);
                 if (url != null)
                     return true;
@@ -1213,7 +1213,7 @@ namespace Raven.Server.ServerWide
         {
             var topology = leaderClusterTopology ?? localClusterTopology;
             
-            if (ShouldUpdateTopology(topology.Etag, _lastClusterTopologyIndex, out _))
+            if (ShouldUpdateTopology(topology.Etag, _lastClusterTopologyIndex, out _, localClusterTopology))
             {
                 _ = ClusterRequestExecutor.UpdateTopologyAsync(
                     new RequestExecutor.UpdateTopologyParameters(topologyNode)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1221,6 +1221,8 @@ namespace Raven.Server.ServerWide
                         DebugTag = "cluster-topology-update"
                     });
 
+                // We only want to fire a notification if the follower's persistent cluster topology is caught up to leader
+                // Or if we are leader and our own cluster topology has changed
                 if (leaderClusterTopology == null || localClusterTopology.Etag == leaderClusterTopology.Etag)
                     NotificationCenter.Add(ClusterTopologyChanged.Create(topology, LeaderTag, NodeTag, _engine.CurrentTerm, _engine.CurrentState,
                         status ?? GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20865

### Additional description

We are deciding whether to update the follower's cluster request executor's topology according to the leader's topology index.
But then in `UpdateTopologyAsync()` we fetch the new topology from the local node instead of the leader.
This sometimes causes the executor's topology to be updated to an old topology because our local node's persistent cluster topology might not be caught up to leader yet.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Test exists

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
