### PR TITLE
RavenDB-21047 - Ensure revision tombstone ids don't excced the maximu…

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -786,6 +785,9 @@ namespace Raven.Server.Documents.Revisions
 
             foreach (var revision in revisionsToRemove)
             {
+                if (revision.ChangeVector.Length > DocumentIdWorker.MaxIdSize)
+                    DocumentIdWorker.ThrowDocumentIdTooBig(changeVector);
+
                 using (DocumentIdWorker.GetSliceFromId(context, revision.LowerId, out var prefixSlice))
                 using (CreateRevisionTombstoneKeySlice(context, prefixSlice, revision.ChangeVector, out var changeVectorSlice, out var keySlice))
                 {


### PR DESCRIPTION
…m id length V6.0

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21047/Ensure-revision-tombstone-ids-dont-excced-the-maximum-id-length

### Additional description

In continuation of https://github.com/ravendb/ravendb/pull/17100
For v6.0 - Check the id for 512 bytes and the change vector for 512 bytes (we already check the id in `DocumentIdWorker.GetSliceFromId` so I added a check for the change vector).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
