### PR TITLE
RavenDB-21185: Simplified and added extra diagnostics to the PageLocator

### DIFF
--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -1005,7 +1005,7 @@ namespace Voron.Data.Containers
                 if (pageCache.TryGetReadOnlyPage(pageNum, out var page) == false)
                 {
                     page = llt.GetPage(pageNum);
-                    pageCache.SetReadable(pageNum, page);
+                    pageCache.SetReadable(page);
                 }
 
                 var container = new Container(page);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -546,7 +546,7 @@ namespace Voron.Impl
 
             TrackWritablePage(newPage);
 
-            _pageLocator.SetWritable(num, newPage);
+            _pageLocator.SetWritable(newPage);
 
             return newPage;
         }
@@ -593,7 +593,7 @@ namespace Voron.Impl
 
             var p = GetPageInternal(pageNumber);
 
-            _pageLocator.SetReadable(p.PageNumber, p);
+            _pageLocator.SetReadable(p);
 
             return p;
         }
@@ -825,7 +825,7 @@ namespace Voron.Impl
                     Flags = PageFlags.Single
                 };
 
-                _pageLocator.SetWritable(pageNumber, newPage);
+                _pageLocator.SetWritable(newPage);
 
                 TrackWritablePage(newPage);
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21183
https://issues.hibernatingrhinos.com/issue/RavenDB-21182
https://issues.hibernatingrhinos.com/issue/RavenDB-21185

### Additional description

All those stack traces are uninformative and could not reproduce the errors themselves, therefore the most likely case is that they appear because of a crash. 

Since `PageLocator` is a pretty important piece of code, I implemented extra debug checks (therefore we should run the slow tests in debug too) and also simplified much more the code itself to have less complexity and hopefully less branches in .Net 8.0.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change