### PR TITLE
RavenDB-21167 we need to write metadata as is, if it goes through WriteMetadata extension method then it takes internal properties from the Document resulting in duplicate values in json with a lot of nulls

### DIFF
--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -161,7 +161,9 @@ public abstract class AbstractStudioCollectionsHandlerProcessorForPreviewCollect
 
     protected abstract void WriteResult(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, TResult document, PreviewState state);
 
-    protected static void WriteDocument(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, PreviewState state)
+    protected abstract void WriteMetadata(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, BlittableJsonReaderObject metadata);
+
+    protected void WriteDocument(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, PreviewState state)
     {
         using (document.Data)
         {
@@ -249,7 +251,8 @@ public abstract class AbstractStudioCollectionsHandlerProcessorForPreviewCollect
                 metadata = context.ReadObject(extraMetadataProperties, document.Id);
             }
 
-            writer.WriteMetadata(document, metadata);
+            WriteMetadata(writer, context, document, metadata);
+
             writer.WriteEndObject();
         }
     }

--- a/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Server.Documents;
+using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -104,8 +105,9 @@ public sealed class StudioCollectionsHandlerProcessorForPreviewCollection : Abst
         return ValueTask.FromResult(ExtractColumnNames(_documents, _context));
     }
 
-    protected override void WriteResult(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, PreviewState state) 
-        => WriteDocument(writer, context, document, state);
+    protected override void WriteResult(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, PreviewState state) => WriteDocument(writer, context, document, state);
+
+    protected override void WriteMetadata(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, BlittableJsonReaderObject metadata) => writer.WriteMetadata(document, metadata);
 
     public override void Dispose()
     {

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -75,14 +75,13 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
 
     private sealed class ShardedPreviewState : PreviewState
     {
-        private const string ShardNumberKey = "@shard-number";
         public int ShardNumber;
 
         public override DynamicJsonValue CreateMetadata(BlittableJsonReaderObject current)
         {
             return new DynamicJsonValue(current)
             {
-                [ShardNumberKey] = ShardNumber
+                [Constants.Documents.Metadata.Sharding.ShardNumber] = ShardNumber
             };
         }
     }
@@ -93,6 +92,12 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
     {
         ((ShardedPreviewState)state).ShardNumber = result.ShardNumber;
         WriteDocument(writer, context, result.Item, state);
+    }
+
+    protected override void WriteMetadata(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, Document document, BlittableJsonReaderObject metadata)
+    {
+        writer.WritePropertyName(Constants.Documents.Metadata.Key);
+        writer.WriteObject(metadata);
     }
 
     protected override async ValueTask<long> GetTotalResultsAsync()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21167 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
