### PR TITLE
RavenDB-21190 Track all updates when updating term references for EntryTermReader

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1912,19 +1912,8 @@ namespace Corax
         private void UpdateEntriesForTerm(ref NativeList<TermInEntryModification> entriesForTerm, in EntriesModifications entries)
         {
             entriesForTerm.ResetAndEnsureCapacity(_entriesAllocator, entries.Additions.Count + entries.Updates.Count);
-
-            int i = 0;
-            var additions = entries.Additions.RawItems;
-            for (; i < entries.Additions.Count; i++)
-            {
-                entriesForTerm.PushUnsafe(additions[i]);
-            }
-
-            var updates = entries.Updates.RawItems;
-            for (; i < entries.Updates.Count; i++)
-            {
-                entriesForTerm.PushUnsafe(updates[i]);
-            }
+            entriesForTerm.AddRangeUnsafe(entries.Additions.RawItems, entries.Additions.Count);
+            entriesForTerm.AddRangeUnsafe(entries.Updates.RawItems, entries.Updates.Count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21190

### Additional description
The updated document can lose its reference to a term when it's the same as one already stored, and a new document with exactly the same term is inserted in the same batch.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
