### PR TITLE
RavenDB-20794 throw load error immediately to distinguish between partial errors used by SQL ETL and commit errors

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -493,7 +493,7 @@ namespace Raven.Server.Documents.ETL
 
                         EnterFallbackMode();
 
-                        Statistics.RecordLoadError(e.ToString(), documentId: null, count: stats.NumberOfExtractedItems.Sum(x => x.Value));
+                        Statistics.ThrowLoadError(e.ToString(), count: stats.NumberOfExtractedItems.Sum(x => x.Value));
                     }
 
                     return false;

--- a/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
@@ -98,7 +98,7 @@ namespace Raven.Server.Documents.ETL
             throw new InvalidOperationException($"{message}. Current stats: {this}");
         }
 
-        public void RecordLoadError(string error, string documentId, int count = 1)
+        public void RecordPartialLoadError(string error, string documentId, int count = 1)
         {
             WasLatestLoadSuccessful = false;
 
@@ -125,6 +125,15 @@ namespace Raven.Server.Documents.ETL
             CreateAlertIfAnyLoadErrors(message);
 
             throw new InvalidOperationException($"{message}. Current stats: {this}. Error: {error}");
+        }
+
+        public void ThrowLoadError(string error, int count)
+        {
+            var message = $"Current ETL batch with '{count}' items was stopped. Error: {error}";
+
+            CreateAlertIfAnyLoadErrors(message);
+
+            throw new InvalidOperationException($"{message}. Current stats: {this}");
         }
 
         public void RecordSlowSql(SlowSqlStatementInfo slowSql)

--- a/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
@@ -104,11 +104,13 @@ namespace Raven.Server.Documents.ETL
 
             LoadErrors += count;
 
-            LastLoadErrorTime = SystemTime.UtcNow;
+            var now = SystemTime.UtcNow;
+            
+            LastLoadErrorTime = now;
 
             LastLoadErrorsInCurrentBatch.Add(new EtlErrorInfo
             {
-                Date = SystemTime.UtcNow,
+                Date = now,
                 DocumentId = documentId,
                 Error = error
             });
@@ -129,7 +131,17 @@ namespace Raven.Server.Documents.ETL
 
         public void ThrowLoadError(string error, int count)
         {
-            var message = $"Current ETL batch with '{count}' items was stopped. Error: {error}";
+            var now = SystemTime.UtcNow;
+            
+            LastLoadErrorTime = now;
+
+            LastLoadErrorsInCurrentBatch.Add(new EtlErrorInfo
+            {
+                Date = now,
+                Error = error
+            });
+
+            var message = $"Current ETL batch with '{count}' items was stopped. ";
 
             CreateAlertIfAnyLoadErrors(message);
 

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                                 $"(doc: {itemToReplicate.DocumentId}), will continue trying. {Environment.NewLine}{cmd.CommandText}", e);
                         }
 
-                        _etl.Statistics.RecordLoadError($"Insert statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}. Error:{Environment.NewLine}{e}",
+                        _etl.Statistics.RecordPartialLoadError($"Insert statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}. Error:{Environment.NewLine}{e}",
                             itemToReplicate.DocumentId);
                     }
                     finally
@@ -350,7 +350,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             _logger.Info($"Failure to replicate deletions to relational database for: {_etl.Name}, " +
                                          "will continue trying." + Environment.NewLine + cmd.CommandText, e);
 
-                        _etl.Statistics.RecordLoadError($"Delete statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}Error:{Environment.NewLine}{e}", null);
+                        _etl.Statistics.RecordPartialLoadError($"Delete statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}Error:{Environment.NewLine}{e}", null);
                     }
                     finally
                     {

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlEtl.cs
@@ -157,7 +157,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
                 }
                 catch (Exception e)
                 {
-                    Statistics.RecordLoadError(e.ToString(), documentId: null, count: 1);
+                    Statistics.RecordPartialLoadError(e.ToString(), documentId: null, count: 1);
                 }
             }
             else

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertRaised.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertRaised.cs
@@ -1,11 +1,14 @@
-﻿using Raven.Server.NotificationCenter.Notifications.Details;
+﻿using System;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications
 {
     public sealed class AlertRaised : Notification
     {
-        private AlertRaised(string database) : base(NotificationType.AlertRaised, database)
+        private AlertRaised(string database, DateTime? createdAt = null) 
+            : base(NotificationType.AlertRaised, database, createdAt)
         {
         }
         
@@ -26,6 +29,27 @@ namespace Raven.Server.NotificationCenter.Notifications
             json[nameof(Details)] = Details?.ToJson();
 
             return json;
+        }
+
+        public static AlertRaised FromJson(string key, BlittableJsonReaderObject json, INotificationDetails details = null)
+        {
+            json.TryGet(nameof(Database), out string database);
+            json.TryGet(nameof(AlertType), out AlertType alertType);
+            json.TryGet(nameof(CreatedAt), out DateTime createdAt);
+            json.TryGet(nameof(Message), out string message);
+            json.TryGet(nameof(Severity), out NotificationSeverity notificationSeverity);
+            json.TryGet(nameof(Title), out string title);
+
+            return new AlertRaised(database, createdAt)
+            {
+                IsPersistent = true,
+                Title = title,
+                Message = message,
+                AlertType = alertType,
+                Severity = notificationSeverity,
+                Key = key,
+                Details = details
+            };
         }
 
         public static AlertRaised Create(string database, string title, string msg, AlertType type, NotificationSeverity severity, string key = null, INotificationDetails details = null)

--- a/src/Raven.Server/NotificationCenter/Notifications/Notification.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Notification.cs
@@ -10,9 +10,9 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         public const string AllDatabases = "*";
 
-        protected Notification(NotificationType type, string database)
+        protected Notification(NotificationType type, string database, DateTime? createdAt = null)
         {
-            CreatedAt = SystemTime.UtcNow;
+            CreatedAt = createdAt ?? SystemTime.UtcNow;
             Type = type;
             Database = database;
         }

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -253,9 +253,11 @@ namespace FastTests
 
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_LoadError);
 
-                if (loadAlert.Errors.Count != 0)
+                var details = (EtlErrorsDetails)loadAlert.Details;
+
+                if (details.Errors.Count != 0)
                 {
-                    error = loadAlert.Errors.First();
+                    error = details.Errors.First();
 
                     return true;
                 }
@@ -285,9 +287,11 @@ namespace FastTests
 
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_TransformationError);
 
-                if (loadAlert.Errors.Count != 0)
+                var details = (EtlErrorsDetails)loadAlert.Details;
+
+                if (details.Errors.Count != 0)
                 {
-                    error = loadAlert.Errors.First();
+                    error = details.Errors.First();
 
                     return true;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20794

### Additional description

We need to distinguish between partial load errors that are used in SQL ETL and for example commit errors that can happen during load. If we will not, ETL will not retry and just move forward.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- TODO

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
