### PR TITLE
RavenDB-20688: make sure we don't use disposed LazyStringValue and skip concurrent subscription test on sharding

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Subscriptions.Processor
         protected override SubscriptionBatchItem ShouldSend(Document item, out string reason)
         {
             reason = null;
-            var id = item.Id;
+            string id = item.Id; // we convert the Id to string since item might get disposed
             var result = new SubscriptionBatchItem
             {
                 Document = item,

--- a/test/StressTests/Rachis/SubscriptionsFailoverStress.cs
+++ b/test/StressTests/Rachis/SubscriptionsFailoverStress.cs
@@ -75,7 +75,7 @@ namespace StressTests.Rachis
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public async Task SubscriptionFailoverWhileModifying(Options options)
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;


### PR DESCRIPTION

### Issue link

[RavenDB-20688](https://issues.hibernatingrhinos.com/issue/RavenDB-20688) StressTests.Rachis.SubscriptionsFailoverStress.SubscriptionFailoverWhileModifying(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Additional description

- after the refactoring of the `ShouldSend` method, we might use disposed `LazyStringValue`, which would fail a `Debug.Assert`
- Skip that test StressTests.Rachis.SubscriptionsFailoverStress.SubscriptionFailoverWhileModifying on sharded DB, since this test uses concurrent subscriptions

### Type of change


- Regression bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
