### PR TITLE
RavenDB-7070 - fix debugging info

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -195,7 +195,7 @@ class trafficWatch extends viewModelBase {
     private columnPreview = new columnPreviewPlugin<Raven.Client.Documents.Changes.TrafficWatchChangeBase>();
 
     private readonly allTypeDataHttp: Raven.Client.Documents.Changes.TrafficWatchChangeType[] =
-        ["BulkDocs", "Counters", "Documents", "Hilo", "Index", "MultiGet", "None", "Operations", "Queries", "Streams", "Subscriptions", "TimeSeries"];
+        ["BulkDocs", "ClusterCommands", "Counters", "Documents", "Hilo", "Index", "MultiGet", "None", "Notifications", "Operations", "Queries", "Streams", "Subscriptions", "TimeSeries"];
     private readonly allTypeDataTcp: Raven.Client.ServerWide.Tcp.TcpConnectionHeaderMessage.OperationTypes[] =
         ["Cluster", "Drop", "Heartbeats", "None", "Ping", "Replication", "Subscription", "TestConnection"];
 

--- a/src/Sparrow/Utils/MemoryUtils.cs
+++ b/src/Sparrow/Utils/MemoryUtils.cs
@@ -10,6 +10,7 @@ public static class MemoryUtils
     private const string GenericOutMemoryException = "Failed to generate an out of memory exception";
     private static readonly InvertedComparer InvertedComparerInstance = new InvertedComparer();
     private const int MinAllocatedThresholdInBytes = 10 * 1024 * 1024;
+
     public static string GetExtendedMemoryInfo(MemoryInfoResult memoryInfo)
     {
         try
@@ -21,8 +22,8 @@ public static class MemoryUtils
             TryAppend(() => sb.Append("Dirty memory: ").Append(memoryInfo.TotalScratchDirtyMemory).Append(", "));
             TryAppend(() => sb.Append("Managed memory: ").Append(new Size(AbstractLowMemoryMonitor.GetManagedMemoryInBytes(), SizeUnit.Bytes)).Append(", "));
             TryAppend(() => sb.Append("Unmanaged allocations: ").Append(new Size(AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes(), SizeUnit.Bytes)).Append(", "));
-            TryAppend(() => sb.Append("Lucene managed allocations for term cache: ").Append(new Size(NativeMemory.TotalLuceneManagedAllocationsForTermCache, SizeUnit.Bytes)));
-            TryAppend(() => sb.Append("Lucene unmanaged allocations for sorting: ").Append(new Size(NativeMemory.TotalLuceneUnmanagedAllocationsForSorting, SizeUnit.Bytes)));
+            TryAppend(() => sb.Append("Lucene managed: ").Append(new Size(NativeMemory.TotalLuceneManagedAllocationsForTermCache, SizeUnit.Bytes)).Append(", "));
+            TryAppend(() => sb.Append("Lucene unmanaged: ").Append(new Size(NativeMemory.TotalLuceneUnmanagedAllocationsForSorting, SizeUnit.Bytes)));
 
             try
             {


### PR DESCRIPTION
### Additional description

- Add missing traffic watch categories (cannot filter the new categories).
- Simplify the low-memory notification message.