### PR TITLE
RavenDB-21179 - Reduce the memory allocations when getting a DoNotChange

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -397,7 +397,7 @@ namespace Raven.Server.ServerWide
                     case nameof(IncrementClusterIdentityCommand):
                         if (ValidatePropertyExistence(cmd, nameof(IncrementClusterIdentityCommand), nameof(IncrementClusterIdentityCommand.Prefix), out errorMessage) == false)
                             throw new RachisApplyException(errorMessage);
-                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out result);
+                        SetValueForTypedDatabaseCommand(context, type, cmd, index, out result);
                         leader?.SetStateOf(index, result);
                         SetIndexForBackup(context, UpdateValueForDatabaseCommand.GetDatabaseNameFromJson(cmd), index, type);
                         break;
@@ -405,7 +405,7 @@ namespace Raven.Server.ServerWide
                     case nameof(IncrementClusterIdentitiesBatchCommand):
                         if (ValidatePropertyExistence(cmd, nameof(IncrementClusterIdentitiesBatchCommand), nameof(IncrementClusterIdentitiesBatchCommand.DatabaseName), out errorMessage) == false)
                             throw new RachisApplyException(errorMessage);
-                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out result);
+                        SetValueForTypedDatabaseCommand(context, type, cmd, index, out result);
                         leader?.SetStateOf(index, result);
                         SetIndexForBackup(context, UpdateValueForDatabaseCommand.GetDatabaseNameFromJson(cmd), index, type);
                         break;
@@ -413,7 +413,7 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdateClusterIdentityCommand):
                         if (ValidatePropertyExistence(cmd, nameof(UpdateClusterIdentityCommand), nameof(UpdateClusterIdentityCommand.Identities), out errorMessage) == false)
                             throw new RachisApplyException(errorMessage);
-                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out result);
+                        SetValueForTypedDatabaseCommand(context, type, cmd, index, out result);
                         leader?.SetStateOf(index, result);
                         SetIndexForBackup(context, UpdateValueForDatabaseCommand.GetDatabaseNameFromJson(cmd), index, type);
                         break;
@@ -490,7 +490,7 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdateSnmpDatabaseIndexesMappingCommand):
                     case nameof(RemoveEtlProcessStateCommand):
                     case nameof(DelayBackupCommand):
-                        SetValueForTypedDatabaseCommand(context, type, cmd, index, leader, out _);
+                        SetValueForTypedDatabaseCommand(context, type, cmd, index, out _);
                         break;
 
                     case nameof(AddOrUpdateCompareExchangeCommand):
@@ -1411,9 +1411,8 @@ namespace Raven.Server.ServerWide
             return true;
         }
 
-        private void SetValueForTypedDatabaseCommand(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, Leader leader, out object result)
+        private void SetValueForTypedDatabaseCommand(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, out object result)
         {
-            result = null;
             UpdateValueForDatabaseCommand updateCommand = null;
             Exception exception = null;
             try

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -42,12 +42,8 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
                 [nameof(DelayUntil)] = DelayUntil,
                 [nameof(OriginalBackupTime)] = OriginalBackupTime
             };
-            
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(existingValue, GetItemId())
-            };
+
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(existingValue, GetItemId()));
         }
 
         var status = new PeriodicBackupStatus
@@ -56,11 +52,7 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
             OriginalBackupTime = OriginalBackupTime
         };
 
-        return new UpdatedValue
-        {
-            Action = Action.Update,
-            Value = context.ReadObject(status.ToJson(), GetItemId())
-        };
+        return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(status.ToJson(), GetItemId()));
     }
 
     public override object GetState()

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -33,7 +33,7 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
         json[nameof(OriginalBackupTime)] = OriginalBackupTime;
     }
 
-    protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+    protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
     {
         if (existingValue != null)
         {
@@ -42,7 +42,12 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
                 [nameof(DelayUntil)] = DelayUntil,
                 [nameof(OriginalBackupTime)] = OriginalBackupTime
             };
-            return context.ReadObject(existingValue, GetItemId());
+            
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(existingValue, GetItemId())
+            };
         }
 
         var status = new PeriodicBackupStatus
@@ -50,7 +55,12 @@ public class DelayBackupCommand : UpdateValueForDatabaseCommand
             DelayUntil = DelayUntil,
             OriginalBackupTime = OriginalBackupTime
         };
-        return context.ReadObject(status.ToJson(), GetItemId());
+
+        return new UpdatedValue
+        {
+            Action = Action.Update,
+            Value = context.ReadObject(status.ToJson(), GetItemId())
+        };
     }
 
     public override object GetState()

--- a/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
@@ -27,10 +27,13 @@ namespace Raven.Server.ServerWide.Commands.ETL
             return EtlProcessState.GenerateItemName(DatabaseName, ConfigurationName, TransformationName);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context,
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context,
             BlittableJsonReaderObject existingValue)
         {
-            return null; // it's going to delete the value
+            return new UpdatedValue
+            {
+                Action = Action.Delete
+            };
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/DeleteEtlProcessStateCommand.cs
@@ -30,10 +30,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
         protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context,
             BlittableJsonReaderObject existingValue)
         {
-            return new UpdatedValue
-            {
-                Action = Action.Delete
-            };
+            return new UpdatedValue(UpdatedValueActionType.Delete, value: null);
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -160,11 +160,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
             etlState.SkippedTimeSeriesDocs = SkippedTimeSeriesDocs;
             etlState.LastBatchTime = LastBatchTime;
 
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(etlState.ToJson(), GetItemId())
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(etlState.ToJson(), GetItemId()));
         }
 
         public static Func<string> GetLastResponsibleNode(

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -120,7 +120,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
             return null;
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             EtlProcessState etlState;
 
@@ -160,8 +160,11 @@ namespace Raven.Server.ServerWide.Commands.ETL
             etlState.SkippedTimeSeriesDocs = SkippedTimeSeriesDocs;
             etlState.LastBatchTime = LastBatchTime;
 
-
-            return context.ReadObject(etlState.ToJson(), GetItemId());
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(etlState.ToJson(), GetItemId())
+            };
         }
 
         public static Func<string> GetLastResponsibleNode(

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentitiesBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentitiesBatchCommand.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.ServerWide.Commands
             json[nameof(Identities)] = new DynamicJsonArray(Identities);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/IncrementClusterIdentityCommand.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.ServerWide.Commands
             return $"{databaseName.ToLowerInvariant()}/{prefix?.ToLowerInvariant()}";
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
@@ -51,27 +51,16 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
 
                 if (previousValue.Modifications.Properties.Count == 0)
                 {
-                    return new UpdatedValue
-                    {
-                        Action = Action.Noop
-                    };
+                    return new UpdatedValue(UpdatedValueActionType.Noop, value: null);
                 }
 
-                return new UpdatedValue
-                {
-                    Action = Action.Update,
-                    Value = context.ReadObject(previousValue, GetItemId())
-                };
+                return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(previousValue, GetItemId()));
             }
 
             var djv = new DynamicJsonValue();
             AddIndexesIfNecessary(djv, null, Indexes);
 
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(djv, GetItemId())
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(djv, GetItemId()));
         }
 
         private static void AddIndexesIfNecessary(DynamicJsonValue djv, BlittableJsonReaderObject previousValue, List<string> indexes)

--- a/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Monitoring/Snmp/UpdateSnmpDatabaseIndexesMappingCommand.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
             json[nameof(Indexes)] = new DynamicJsonArray(Indexes);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject previousValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject previousValue)
         {
             if (previousValue != null)
             {
@@ -50,15 +50,28 @@ namespace Raven.Server.ServerWide.Commands.Monitoring.Snmp
                 AddIndexesIfNecessary(previousValue.Modifications, previousValue, Indexes);
 
                 if (previousValue.Modifications.Properties.Count == 0)
-                    return previousValue;
+                {
+                    return new UpdatedValue
+                    {
+                        Action = Action.Noop
+                    };
+                }
 
-                return context.ReadObject(previousValue, GetItemId());
+                return new UpdatedValue
+                {
+                    Action = Action.Update,
+                    Value = context.ReadObject(previousValue, GetItemId())
+                };
             }
 
             var djv = new DynamicJsonValue();
             AddIndexesIfNecessary(djv, null, Indexes);
 
-            return context.ReadObject(djv, GetItemId());
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(djv, GetItemId())
+            };
         }
 
         private static void AddIndexesIfNecessary(DynamicJsonValue djv, BlittableJsonReaderObject previousValue, List<string> indexes)

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -24,9 +24,13 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             return PeriodicBackupStatus.GenerateItemName(DatabaseName, PeriodicBackupStatus.TaskId);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
-            return context.ReadObject(PeriodicBackupStatus.ToJson(), GetItemId());
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(PeriodicBackupStatus.ToJson(), GetItemId())
+            };
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -26,11 +26,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 
         protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(PeriodicBackupStatus.ToJson(), GetItemId())
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(PeriodicBackupStatus.ToJson(), GetItemId()));
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -55,10 +55,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 var subscriptionTask = new SubscriptionTask(existingValue);
                 AssertSubscriptionState(record, subscriptionTask, subscriptionName);
 
-                return new UpdatedValue
-                {
-                    Action = Action.Noop
-                };
+                return new UpdatedValue(UpdatedValueActionType.Noop, value: null);
             }
 
             var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
@@ -75,11 +72,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             subscription.NodeTag = NodeTag;
             subscription.LastBatchAckTime = LastTimeServerMadeProgressWithDocuments;
 
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(subscription.ToJson(), subscriptionName)
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(subscription.ToJson(), subscriptionName));
         }
 
         private void AssertSubscriptionState(RawDatabaseRecord record, IDatabaseTask subscription, string subscriptionName)

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/DeleteSubscriptionCommand.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             throw new NotImplementedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             SubscriptionConnection.ParseSubscriptionQuery(query);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -184,7 +184,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 json[nameof(Deleted)] = new DynamicJsonArray(Deleted);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/ToggleSubscriptionStateCommand.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             throw new NotImplementedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotImplementedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
         public override string GetItemId() => SubscriptionState.GenerateSubscriptionItemKeyName(DatabaseName, SubscriptionName);
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             var itemId = GetItemId();
             if (existingValue == null)
@@ -49,7 +49,11 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             subscription.LastClientConnectionTime = LastClientConnectionTime;
             subscription.NodeTag = NodeTag;
 
-            return context.ReadObject(subscription.ToJson(), itemId);
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(subscription.ToJson(), itemId)
+            };
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -49,11 +49,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             subscription.LastClientConnectionTime = LastClientConnectionTime;
             subscription.NodeTag = NodeTag;
 
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(subscription.ToJson(), itemId)
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(subscription.ToJson(), itemId));
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateClusterIdentityCommand.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.ServerWide.Commands
             throw new NotSupportedException();
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
             throw new NotSupportedException();
         }

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
@@ -23,9 +23,13 @@ namespace Raven.Server.ServerWide.Commands
             return ExternalReplicationState.GenerateItemName(DatabaseName, ExternalReplicationState.TaskId);
         }
 
-        protected override BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
+        protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
-            return context.ReadObject(ExternalReplicationState.ToJson(), GetItemId());
+            return new UpdatedValue
+            {
+                Action = Action.Update,
+                Value = context.ReadObject(ExternalReplicationState.ToJson(), GetItemId())
+            };
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationStateCommand.cs
@@ -25,11 +25,7 @@ namespace Raven.Server.ServerWide.Commands
 
         protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
         {
-            return new UpdatedValue
-            {
-                Action = Action.Update,
-                Value = context.ReadObject(ExternalReplicationState.ToJson(), GetItemId())
-            };
+            return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(ExternalReplicationState.ToJson(), GetItemId()));
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client;
+﻿using System.Diagnostics;
+using Raven.Client;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -15,26 +16,30 @@ namespace Raven.Server.ServerWide.Commands
 
         public abstract void FillJson(DynamicJsonValue json);
 
-        protected abstract BlittableJsonReaderObject GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context,
-            BlittableJsonReaderObject existingValue);
+        protected abstract UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue);
 
         public virtual unsafe void Execute(ClusterOperationContext context, Table items, long index, RawDatabaseRecord record, RachisState state, out object result)
         {
-            BlittableJsonReaderObject itemBlittable = null;
             var itemKey = GetItemId();
+            UpdatedValue updatedValue;
 
             using (Slice.From(context.Allocator, itemKey.ToLowerInvariant(), out Slice valueNameLowered))
             {
+                BlittableJsonReaderObject itemBlittable = null;
                 if (items.ReadByKey(valueNameLowered, out TableValueReader reader))
                 {
                     var ptr = reader.Read(2, out int size);
                     itemBlittable = new BlittableJsonReaderObject(ptr, size, context);
                 }
 
-                itemBlittable = GetUpdatedValue(index, record, context, itemBlittable);
+                updatedValue = GetUpdatedValue(index, record, context, itemBlittable);
+                if (updatedValue.Action == Action.Noop)
+                {
+                    result = null;
+                    return;
+                }
 
-                // if returned null, means, there is nothing to update and we just wanted to delete the value
-                if (itemBlittable == null)
+                if (updatedValue.Action == Action.Delete)
                 {
                     items.DeleteByKey(valueNameLowered);
                     result = GetResult();
@@ -45,10 +50,12 @@ namespace Raven.Server.ServerWide.Commands
                 itemKey = GetItemId();
             }
 
+            Debug.Assert(updatedValue.Action == Action.Update && updatedValue.Value != null);
+
             using (Slice.From(context.Allocator, itemKey, out Slice valueName))
             using (Slice.From(context.Allocator, itemKey.ToLowerInvariant(), out Slice valueNameLowered))
             {
-                ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, itemBlittable);
+                ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, updatedValue.Value);
                 result = GetResult();
             }
         }
@@ -103,6 +110,20 @@ namespace Raven.Server.ServerWide.Commands
             string databaseName = null;
             cmd?.TryGet(nameof(DatabaseName), out databaseName);
             return databaseName;
+        }
+
+        protected enum Action
+        {
+            Noop,
+            Update,
+            Delete
+        }
+
+        protected struct UpdatedValue
+        {
+            public Action Action;
+
+            public BlittableJsonReaderObject Value;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -1,5 +1,5 @@
-﻿using System.Diagnostics;
-using Raven.Client;
+﻿using System;
+using System.Diagnostics;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -20,6 +20,8 @@ namespace Raven.Server.ServerWide.Commands
 
         public virtual unsafe void Execute(ClusterOperationContext context, Table items, long index, RawDatabaseRecord record, RachisState state, out object result)
         {
+            result = null;
+
             var itemKey = GetItemId();
             UpdatedValue updatedValue;
 
@@ -33,39 +35,31 @@ namespace Raven.Server.ServerWide.Commands
                 }
 
                 updatedValue = GetUpdatedValue(index, record, context, itemBlittable);
-                if (updatedValue.Action == Action.Noop)
+                switch (updatedValue.ActionType)
                 {
-                    result = null;
-                    return;
+                    case UpdatedValueActionType.Noop:
+                        return;
+                    case UpdatedValueActionType.Delete:
+                        items.DeleteByKey(valueNameLowered);
+                        return;
+                    default:
+                        // here we get the item key again, in case it was changed (a new entity, etc)
+                        itemKey = GetItemId();
+                        break;
                 }
-
-                if (updatedValue.Action == Action.Delete)
-                {
-                    items.DeleteByKey(valueNameLowered);
-                    result = GetResult();
-                    return;
-                }
-
-                // here we get the item key again, in case it was changed (a new entity, etc)
-                itemKey = GetItemId();
             }
 
-            Debug.Assert(updatedValue.Action == Action.Update && updatedValue.Value != null);
+            Debug.Assert(updatedValue.ActionType == UpdatedValueActionType.Update && updatedValue.Value != null);
 
             using (Slice.From(context.Allocator, itemKey, out Slice valueName))
             using (Slice.From(context.Allocator, itemKey.ToLowerInvariant(), out Slice valueNameLowered))
+            using (updatedValue)
             {
                 ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, updatedValue.Value);
-                result = GetResult();
             }
         }
 
         public virtual object GetState()
-        {
-            return null;
-        }
-
-        public virtual object GetResult()
         {
             return null;
         }
@@ -112,18 +106,29 @@ namespace Raven.Server.ServerWide.Commands
             return databaseName;
         }
 
-        protected enum Action
+        protected enum UpdatedValueActionType
         {
             Noop,
             Update,
             Delete
         }
 
-        protected struct UpdatedValue
+        protected readonly struct UpdatedValue : IDisposable
         {
-            public Action Action;
+            public readonly UpdatedValueActionType ActionType;
 
-            public BlittableJsonReaderObject Value;
+            public readonly BlittableJsonReaderObject Value;
+
+            public UpdatedValue(UpdatedValueActionType actionType, BlittableJsonReaderObject value)
+            {
+                ActionType = actionType;
+                Value = value;
+            }
+
+            public void Dispose()
+            {
+                Value?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21179

### Additional description

When we get a `DoNotChange`, we just verify if the the node that we expect to be responsible for the task is still the same one.
We can reduce the amount of data that we commit (we don't need to commit anything) and reduce the memory allocations.

The command with `DoNotChange` can be executed on the leader only and we can skip writing it to the log. Since we need to keep backward compatibility, it must continue going to all nodes.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Ensured.
- 
### Testing by Contributor

- It has been verified by manual testing