### PR TITLE
RavenDB-21177 Decode entries during PostingListRead in SortingMatch  

### DIFF
--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -250,11 +250,11 @@ namespace Corax.Queries
 
             private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)
             {
-                if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false ||
-                    sortedIds[read - 1] > _max)
+                if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
                     _postListIt = default;
+                
                 EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx..], read);
-
+                
                 currentIdx += read;
             }
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -366,9 +366,10 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
         private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)
         {
-            if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || 
-                sortedIds[read-1] > _max)
+            if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
                 _postListIt = default;
+
+            EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds.Slice(currentIdx), read);
             currentIdx += read;
         }
 

--- a/test/SlowTests/Corax/RavenDB-21177.cs
+++ b/test/SlowTests/Corax/RavenDB-21177.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21177 : RavenTestBase
+{
+    public RavenDB_21177(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public void CoraxSortingPostingLists()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 63_000; ++i)
+            {
+                bulk.Store(new Dto($"{i % 5}"));
+            }
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var allDocsSortedByCorax = session.Advanced
+                .DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .OrderBy(nameof(Dto.Num), OrderingType.String)
+                .ToList();
+
+            var allDocsFromServer = session.Advanced.DocumentQuery<Dto>().ToList();
+           // WaitForUserToContinueTheTest(store);
+           Assert.Equal(63_000, allDocsSortedByCorax.Count); 
+           Assert.Equal(63_000, allDocsFromServer.Count); 
+
+           Assert.Equal(allDocsFromServer.Select(i => i.Num).OrderBy(i => i), allDocsSortedByCorax.Select(i => i.Num));
+        }
+    }
+    
+    private record Dto(string Num, string Id = null);
+}


### PR DESCRIPTION
… Max checking -> move pointer to right place & decode before comparison

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21177 
### Additional description


### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
