### PR TITLE
RavenDB-21153 Fixes in Kafka Sink

### DIFF
--- a/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkProcessState.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkProcessState.cs
@@ -5,7 +5,7 @@ namespace Raven.Client.Documents.Operations.QueueSink;
 
 public class QueueSinkProcessState : IDatabaseTaskStatus
 {
-    public string NodeTag { get; }
+    public string NodeTag { get; set; }
     
     public string ConfigurationName { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForDeleteOngoingTask.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForDeleteOngoingTask.cs
@@ -130,10 +130,17 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
 
                 if (_deletingQueueSink.Name != null)
                 {
+                    long? maxIndex = null;
+
                     foreach (var script in _deletingQueueSink.Scripts)
                     {
                         var (index, _) = await _serverStore.RemoveQueueSinkProcessState(_context, _requestHandler.DatabaseName, _deletingQueueSink.Name, script,
                             $"{raftRequestId}/{script}");
+
+                        if (maxIndex.HasValue == false)
+                            maxIndex = index;
+                        else
+                            maxIndex = Math.Max(maxIndex.Value, index);
 
                         await _requestHandler.WaitForIndexNotificationAsync(index);
                     }

--- a/src/Raven.Server/Documents/QueueSink/Commands/BatchQueueSinkScriptCommand.cs
+++ b/src/Raven.Server/Documents/QueueSink/Commands/BatchQueueSinkScriptCommand.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.QueueSink.Stats;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.QueueSink.Commands;
+
+public sealed class BatchQueueSinkScriptCommand : DocumentMergedTransactionCommand
+{
+    private readonly List<BlittableJsonReaderObject> _messages;
+    private readonly string _script;
+    private readonly QueueSinkStatsScope _scriptProcessingScope;
+    private readonly QueueSinkProcessStatistics _statistics;
+    private readonly Logger _logger;
+
+    public BatchQueueSinkScriptCommand(string script, List<BlittableJsonReaderObject> messages, QueueSinkStatsScope scriptProcessingScope,
+        QueueSinkProcessStatistics statistics, Logger logger)
+    {
+        _messages = messages;
+        _script = script;
+        _scriptProcessingScope = scriptProcessingScope;
+        _statistics = statistics;
+        _logger = logger;
+    }
+
+    private BatchQueueSinkScriptCommand(string script, List<BlittableJsonReaderObject> messages)
+    {
+        _messages = messages;
+        _script = script;
+        _scriptProcessingScope = null;
+        _statistics = null;
+        _logger = null;
+    }
+
+    public int ProcessedSuccessfully { get; private set; }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        var mainScript = new PatchRequest(_script, PatchRequestType.QueueSink);
+
+        context.DocumentDatabase.Scripts.GetScriptRunner(mainScript, false, out var documentScript);
+
+        var processed = 0L;
+
+        foreach (var message in _messages)
+        {
+            try
+            {
+                processed++;
+
+                using (message)
+                using (documentScript.Run(context, context, "execute", new object[] { message }))
+                {
+                }
+
+                _scriptProcessingScope?.RecordProcessedMessage();
+                ProcessedSuccessfully++;
+            }
+            catch (Exception e)
+            {
+                if (_logger?.IsOperationsEnabled == true)
+                    _logger.Operations("Failed to process consumed message by the script.", e);
+
+                _scriptProcessingScope?.RecordScriptProcessingError();
+                _statistics?.RecordScriptExecutionError(e);
+            }
+        }
+
+        return processed;
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
+    {
+        var dto = new Dto
+        {
+            Script = _script,
+            Messages = _messages.ToList()
+        };
+
+        return dto;
+    }
+
+    public class Dto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand>
+    {
+        public string Script { get; set; }
+
+        public List<BlittableJsonReaderObject> Messages { get; set; }
+
+        public DocumentMergedTransactionCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new BatchQueueSinkScriptCommand(Script, Messages);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -37,6 +37,9 @@ namespace Raven.Server.Documents.QueueSink;
 
 public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
 {
+    internal const string KafkaTag = "Kafka Sink"; 
+    internal const string RabbitMqTag = "RabbitMQ Sink";
+
     private const int MinBatchSize = 16;
 
     private CancellationTokenSource _cts;
@@ -76,9 +79,9 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
         switch (configuration.BrokerType)
         {
             case QueueBrokerType.Kafka:
-                return new KafkaQueueSink(configuration, script, database, "Kafka Sink");
+                return new KafkaQueueSink(configuration, script, database, KafkaTag);
             case QueueBrokerType.RabbitMq:
-                return new RabbitMqQueueSink(configuration, script, database, "RabbitMQ Sink");
+                return new RabbitMqQueueSink(configuration, script, database, RabbitMqTag);
             default:
                 throw new NotSupportedException($"Unknown broker type: {configuration.BrokerType}");
         }

--- a/src/Raven.Server/Documents/QueueSink/RabbitMqQueueSink.cs
+++ b/src/Raven.Server/Documents/QueueSink/RabbitMqQueueSink.cs
@@ -4,7 +4,7 @@ using Raven.Client.Documents.Operations.QueueSink;
 
 namespace Raven.Server.Documents.QueueSink;
 
-public class RabbitMqQueueSink : QueueSinkProcess
+public sealed class RabbitMqQueueSink : QueueSinkProcess
 {
     public RabbitMqQueueSink(QueueSinkConfiguration configuration, QueueSinkScript script, DocumentDatabase database,
         string tag) : base(configuration, script, database, tag)

--- a/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
+++ b/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
@@ -18,6 +18,7 @@ using Raven.Server.Documents.Handlers.Admin.Processors.Revisions;
 using Raven.Server.Documents.Handlers.Processors.HiLo;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.QueueSink.Commands;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
@@ -270,6 +271,9 @@ namespace Raven.Server.Documents
 
                 case nameof(TimeSeriesRollups.TimeSeriesRetentionCommand):
                     return jsonSerializer.Deserialize<TimeSeriesRollups.TimeSeriesRetentionCommand.TimeSeriesRetentionCommandDto>(reader);
+
+                case nameof(BatchQueueSinkScriptCommand):
+                    return jsonSerializer.Deserialize<BatchQueueSinkScriptCommand.Dto>(reader);
 
                 default:
                     throw new ReplayTransactionsException($"Can't read {type} for replay", peepingTomStream);

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -178,7 +178,9 @@ namespace Raven.Server.ServerWide
             [nameof(PutShardedSubscriptionBatchCommand)] = 60_000,
             
             [nameof(AddQueueSinkCommand)] = 60_000,            
-            [nameof(UpdateQueueSinkCommand)] = 60_000,            
+            [nameof(UpdateQueueSinkCommand)] = 60_000,
+            [nameof(RemoveQueueSinkProcessStateCommand)] = 60_000,
+            [nameof(UpdateQueueSinkProcessStateCommand)] = 60_000,
         };
 
         public bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -505,6 +505,8 @@ namespace Raven.Server.ServerWide
                     case nameof(UpdateSubscriptionClientConnectionTime):
                     case nameof(UpdateSnmpDatabaseIndexesMappingCommand):
                     case nameof(RemoveEtlProcessStateCommand):
+                    case nameof(UpdateQueueSinkProcessStateCommand):
+                    case nameof(RemoveQueueSinkProcessStateCommand):
                         SetValueForTypedDatabaseCommand(context, type, cmd, index, out result);
                         if (result != null)
                             leader?.SetStateOf(index, result);

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlProcessStateCommand.cs
@@ -162,23 +162,6 @@ namespace Raven.Server.ServerWide.Commands.ETL
             return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(etlState.ToJson(), GetItemId()));
         }
 
-        public static Func<string> GetLastResponsibleNode(
-           bool hasHighlyAvailableTasks,
-           DatabaseTopology topology,
-           string nodeTag)
-        {
-            return () =>
-            {
-                if (hasHighlyAvailableTasks)
-                    return null;
-
-                if (topology.Members.Contains(nodeTag) == false)
-                    return null;
-
-                return nodeTag;
-            };
-        }
-
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(ConfigurationName)] = ConfigurationName;

--- a/src/Raven.Server/ServerWide/Commands/QueueSink/RemoveQueueSinkProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/QueueSink/RemoveQueueSinkProcessStateCommand.cs
@@ -1,0 +1,41 @@
+﻿using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.QueueSink;
+
+public sealed class RemoveQueueSinkProcessStateCommand : UpdateValueForDatabaseCommand
+{
+    public string ConfigurationName { get; set; }
+
+    public string ScriptName { get; set; }
+
+    public RemoveQueueSinkProcessStateCommand()
+    {
+        // for deserialization
+    }
+
+    public RemoveQueueSinkProcessStateCommand(string databaseName, string configurationName, string scriptName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+    {
+        ConfigurationName = configurationName;
+        ScriptName = scriptName;
+    }
+
+    public override string GetItemId()
+    {
+        return QueueSinkProcessState.GenerateItemName(DatabaseName, ConfigurationName, ScriptName);
+    }
+
+    protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context,
+        BlittableJsonReaderObject existingValue)
+    {
+        return new UpdatedValue(UpdatedValueActionType.Delete, value: null);
+    }
+
+    public override void FillJson(DynamicJsonValue json)
+    {
+        json[nameof(ConfigurationName)] = ConfigurationName;
+        json[nameof(ScriptName)] = ScriptName;
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/QueueSink/UpdateQueueSinkProcessStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/QueueSink/UpdateQueueSinkProcessStateCommand.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Client.ServerWide;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.QueueSink;
+
+public sealed class UpdateQueueSinkProcessStateCommand : UpdateValueForDatabaseCommand
+{
+    public UpdateQueueSinkProcessStateCommand()
+    {
+        // for deserialization
+    }
+
+    public UpdateQueueSinkProcessStateCommand(string databaseName, QueueSinkProcessState state, bool hasHighlyAvailableTasks, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+    {
+        State = state;
+        HasHighlyAvailableTasks = hasHighlyAvailableTasks;
+    }
+
+    public QueueSinkProcessState State { get; set; }
+
+    public bool HasHighlyAvailableTasks { get; set; }
+
+    public override string GetItemId()
+    {
+        var databaseName = ShardHelper.ToDatabaseName(DatabaseName);
+
+        return QueueSinkProcessState.GenerateItemName(databaseName, State.ConfigurationName, State.ScriptName);
+    }
+
+    public override void FillJson(DynamicJsonValue json)
+    {
+        json[nameof(State)] = State.ToJson();
+        json[nameof(HasHighlyAvailableTasks)] = HasHighlyAvailableTasks;
+    }
+
+    protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context, BlittableJsonReaderObject existingValue)
+    {
+        if (existingValue != null)
+        {
+            var databaseTask = record.QueueSinks.FirstOrDefault(x => x.Name == State.ConfigurationName);
+
+            if (databaseTask == null)
+                throw new RachisApplyException($"Can't update state of Queue Sink '{State.ConfigurationName}' by node {State.NodeTag}, because its configuration can't be found");
+
+            var topology = record.Topology;
+            var lastResponsibleNode = GetLastResponsibleNode(HasHighlyAvailableTasks, topology, State.NodeTag);
+            if (topology.WhoseTaskIsIt(RachisState.Follower, databaseTask, lastResponsibleNode) != State.NodeTag)
+                throw new RachisApplyException($"Can't update state of Queue Sink {State.ConfigurationName} by node {State.NodeTag}, because it's not its task to update this Queue Sink");
+        }
+
+        return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(State.ToJson(), GetItemId()));
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -107,6 +107,23 @@ namespace Raven.Server.ServerWide.Commands
             return databaseName;
         }
 
+        public static Func<string> GetLastResponsibleNode(
+            bool hasHighlyAvailableTasks,
+            DatabaseTopology topology,
+            string nodeTag)
+        {
+            return () =>
+            {
+                if (hasHighlyAvailableTasks)
+                    return null;
+
+                if (topology.Members.Contains(nodeTag) == false)
+                    return null;
+
+                return nodeTag;
+            };
+        }
+
         protected enum UpdatedValueActionType
         {
             Noop,
@@ -130,6 +147,7 @@ namespace Raven.Server.ServerWide.Commands
             {
                 Value?.Dispose();
             }
+
         }
     }
 }

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -279,7 +279,11 @@ namespace Raven.Server.ServerWide
             [nameof(SourceMigrationSendCompletedCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationSendCompletedCommand>(),
             [nameof(DestinationMigrationConfirmCommand)] = GenerateJsonDeserializationRoutine<DestinationMigrationConfirmCommand>(),
             [nameof(SourceMigrationCleanupCommand)] = GenerateJsonDeserializationRoutine<SourceMigrationCleanupCommand>(),
-            [nameof(UpdateServerPublishedUrlsCommand)] = GenerateJsonDeserializationRoutine<UpdateServerPublishedUrlsCommand>()
+            [nameof(UpdateServerPublishedUrlsCommand)] = GenerateJsonDeserializationRoutine<UpdateServerPublishedUrlsCommand>(),
+            [nameof(AddQueueSinkCommand)] = GenerateJsonDeserializationRoutine<AddQueueSinkCommand>(),
+            [nameof(UpdateQueueSinkCommand)] = GenerateJsonDeserializationRoutine<AddQueueSinkCommand>(),
+            [nameof(UpdateQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueSinkProcessStateCommand>(),
+            [nameof(RemoveQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<RemoveQueueSinkProcessStateCommand>(),
         };
     }
 }

--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -586,6 +586,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (topology.Rehabs.Contains(member) == false)
             {
                 topology.Members.Remove(member);
+
                 topology.Rehabs.Add(member);
             }
 

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
@@ -805,6 +806,29 @@ namespace Raven.Server.ServerWide
                 }
 
                 return _queueEtls;
+            }
+        }
+
+        private List<QueueSinkConfiguration> _queueSinks;
+
+        public List<QueueSinkConfiguration> QueueSinks
+        {
+            get
+            {
+                if (_materializedRecord != null)
+                    return _materializedRecord.QueueSinks;
+
+                if (_queueSinks == null)
+                {
+                    _queueSinks = new List<QueueSinkConfiguration>();
+                    if (_record.TryGet(nameof(DatabaseRecord.QueueSinks), out BlittableJsonReaderArray bjra) && bjra != null)
+                    {
+                        foreach (BlittableJsonReaderObject element in bjra)
+                            _queueSinks.Add(JsonDeserializationCluster.QueueSinkConfiguration(element));
+                    }
+                }
+
+                return _queueSinks;
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1074,6 +1074,7 @@ namespace Raven.Server.ServerWide
         private void OnStateChanged(object sender, RachisConsensus.StateTransition state)
         {
             var msg = $"{DateTime.UtcNow}, State changed: {state.From} -> {state.To} in term {state.CurrentTerm}, because {state.Reason}";
+
             if (Engine.Log.IsInfoEnabled)
             {
                 Engine.Log.Info(msg);
@@ -2389,6 +2390,13 @@ namespace Raven.Server.ServerWide
         public Task<(long, object)> RemoveEtlProcessState(TransactionOperationContext context, string databaseName, string configurationName, string transformationName, string raftRequestId)
         {
             var command = new RemoveEtlProcessStateCommand(databaseName, configurationName, transformationName, raftRequestId);
+
+            return SendToLeaderAsync(command);
+        }
+
+        public Task<(long, object)> RemoveQueueSinkProcessState(TransactionOperationContext context, string databaseName, string configurationName, string scriptName, string raftRequestId)
+        {
+            var command = new RemoveQueueSinkProcessStateCommand(databaseName, configurationName, scriptName, raftRequestId);
 
             return SendToLeaderAsync(command);
         }


### PR DESCRIPTION
- using tx merger instead of transactions directly
- added persistance of queue sink state in the cluster so we'll try to remain on the same node
- fixes in error handling
- added missing code in cluster machinery

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21153/Kafka-Sink-Task-is-moved-immediately-to-another-node-after-processing-batch-of-data

https://issues.hibernatingrhinos.com/issue/RavenDB-21160

### Additional description

Direct root cause of moving tasks between the nodes was the usage of the transaction directly which resulted in missing update of database change vector. Now it's handled with the usage of command via tx merger so the db change vector is updated correctly after pulling a batch of messages.

I can still see that a task is moved between the nodes but not so often. We have https://issues.hibernatingrhinos.com/issue/RavenDB-21203 to address that issue.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
