### PR TITLE
RavenDB-21202 Fixing large multi clause sorting in Corax

### DIFF
--- a/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
@@ -7,8 +7,10 @@ using Corax.Utils.Spatial;
 namespace Corax.Queries.SortingMatches
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public unsafe partial struct SortingMatch : IQueryMatch
+    public unsafe struct SortingMatch : IQueryMatch
     {
+        public const int SortBatchSize = 8192;
+
         private readonly FunctionTable _functionTable;
         private IQueryMatch _inner;
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -408,10 +408,10 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
         int maxResults = match._take == -1 ? int.MaxValue : match._take;
 
-        var indexesScope = allocator.Allocate(SortBatchSize * sizeof(long), out ByteString bs);
-        Span<long> indexesBuffer = new(bs.Ptr, SortBatchSize);
-        var sortedIdsScope = allocator.Allocate( sizeof(long) * SortBatchSize, out bs);
-        Span<long> sortedIdBuffer = new(bs.Ptr, SortBatchSize);
+        var indexesScope = allocator.Allocate(SortingMatch.SortBatchSize * sizeof(long), out ByteString bs);
+        Span<long> indexesBuffer = new(bs.Ptr,SortingMatch.SortBatchSize);
+        var sortedIdsScope = allocator.Allocate( sizeof(long) * SortingMatch.SortBatchSize, out bs);
+        Span<long> sortedIdBuffer = new(bs.Ptr, SortingMatch.SortBatchSize);
 
         var totalRead = 0;
         var reader = GetReader(ref match, allMatches[0], allMatches[^1]);
@@ -521,8 +521,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
         return l;
     }
-    
-    private const int SortBatchSize = 4096;
+
 
     private static void SortResults<TEntryComparer>(ref SortingMatch<TInner> match, Span<long> batchResults) 
         where TEntryComparer : struct,  IEntryComparer, IComparer<UnmanagedSpan>

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -102,9 +102,9 @@ public unsafe partial struct SortingMultiMatch<TInner>
             
             if (match._orderMetadata[0].Ascending)
                 indexes.Sort(new IndirectComparer<TComparer1, TComparer2, TComparer3>(ref match, batchTerms, comparer1,
-                comparer2, comparer3));
+                comparer2, comparer3, false));
             else
-                indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3));
+                indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3, true));
 
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21202 

### Additional description

This fixes a number of issues when sorting using descending values running using multiple sort fields in Corax.

* We didn't account for the negation during AVX sort, so we were looking at the wrong indexes (corruption / AVE)
* We didn't handle the scenario where the query would result in too many results for the VX sort

This PR introduce a `SortDirectly` approach, which will just bite the bullet and sort all the results if we cannot optimize it further.

Also increased the `SortBatchSize` to 8K, which applies to `SortingMatch` as well as `SortingMultiMatch`