### PR TITLE
RavenDB-21161 Arguments is null in case when random order has no parameter.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1234,7 +1234,7 @@ public static class CoraxQueryBuilder
         {
             if (field.OrderingType == OrderByFieldType.Random)
             {
-                var seed = field.Arguments.Length > 0 ? 
+                var seed = field.Arguments is {Length: > 0} ? 
                     (int)Hashing.XXHash32.CalculateRaw(field.Arguments[0].NameOrValue) :
                     Random.Shared.Next(); // use a random seed if none is provided  
                 sortArray[sortIndex++] = new OrderMetadata(seed);

--- a/test/SlowTests/Issues/RavenDB_11257.cs
+++ b/test/SlowTests/Issues/RavenDB_11257.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Issues
         }
 
         [Theory]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void RandomOrderingShouldWork(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
…meter.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21161 


### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
