### PR TITLE
RavenDB-21207 - Get the data size without decompressing the data

### DIFF
--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -166,7 +166,8 @@ namespace Voron.Data.Tables
                     do
                     {
                         long id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
-                        table.DirectRead(id, out int size);
+                        var size = table.GetSize(id);
+
                         if (size > 32 * 1024)
                         {
                             if (totalSkipped++ > 16 * 1024)

--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -172,7 +172,7 @@ namespace Voron.Data.Tables
                         {
                             if (totalSkipped++ > 16 * 1024)
                                 return;  // we are scanning too much, no need to try this hard
-                                         // we don't want to skip documents that are too big, they will compress
+                                         // we want to skip documents that are too big, they will compress
                                          // well on their own, and likely be *too* unique to add meaningfully to the
                                          // dictionary
                             continue;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21207/TxMT-thread-consumes-all-memory-and-causes-OOM-restart-loop

### Additional description

When we train the dictionary, we use up to 256 documents.
We skip documents that are bigger than `32KB`. And we allow up to `16K` of skipped documents before we give up.
If the documents are large and compressed, we used to decompress them.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
