### PR TITLE
RavenDB-21209: When deleting a database, the `SubscriptionState` related to that database is not removed

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1550,8 +1550,7 @@ namespace Raven.Server.ServerWide
                 context.Transaction.InnerTransaction.OpenTable(IdentitiesSchema, Identities).DeleteByPrimaryKeyPrefix(databaseSlice);
             }
 
-            databaseLowered = $"{databaseName.ToLowerInvariant()}{(char)SpecialChars.RecordSeparator}";
-            using (Slice.From(context.Allocator, databaseLowered, out var databaseSlice))
+            using (Slice.From(context.Allocator, databaseName.ToLowerInvariant(), SpecialChars.RecordSeparator, ByteStringType.Immutable, out var databaseSlice))
             {
                 context.Transaction.InnerTransaction.OpenTable(SubscriptionStateSchema, SubscriptionState).DeleteByPrimaryKeyPrefix(databaseSlice);
             }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1550,7 +1550,7 @@ namespace Raven.Server.ServerWide
                 context.Transaction.InnerTransaction.OpenTable(IdentitiesSchema, Identities).DeleteByPrimaryKeyPrefix(databaseSlice);
             }
 
-            databaseLowered = $"{databaseName.ToLowerInvariant()}{SpecialChars.RecordSeparator}";
+            databaseLowered = $"{databaseName.ToLowerInvariant()}{(char)SpecialChars.RecordSeparator}";
             using (Slice.From(context.Allocator, databaseLowered, out var databaseSlice))
             {
                 context.Transaction.InnerTransaction.OpenTable(SubscriptionStateSchema, SubscriptionState).DeleteByPrimaryKeyPrefix(databaseSlice);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21209

### Additional description

Fixed string interpolation to correctly append the `RecordSeparator` as a control character instead of its numeric value.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed