### PR TITLE
RavenDB-20173 - SlowTests.Client.Operations.StudioOperationsTests.ShouldGetNotModifiedStatusForGetStudioCollectionFields

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
@@ -24,6 +24,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             var prefix = RequestHandler.GetStringQueryString("prefix", required: false);
 
             using (ContextPool.AllocateOperationContext(out TOperationContext context))
+            using (OpenReadTransaction(context))
             {
                 var fields = await GetFieldsAsync(context, collection, prefix);
 
@@ -49,6 +50,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
                 }
             }
         }
+
+        protected abstract DocumentsTransaction OpenReadTransaction(TOperationContext context);
     }
 
     [Flags]

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
@@ -35,5 +35,10 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio
                 return collectionFields.Result;
             }
         }
+
+        protected override DocumentsTransaction OpenReadTransaction(TransactionOperationContext context)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20173

### Additional description

`ReadTransaction` in the handler processor was closed while its `LazyStrings` were passed on outside of its scope to be written to stream. This caused memory corruption.
Fixed the scope of the `ReadTransaction` so it will include the writing to the stream.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
