### PR TITLE
RavenDB-21219 - fix NRE in Dispose when database initialization fails

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -909,7 +909,8 @@ namespace Raven.Server.Documents
 
             exceptionAggregator.Execute(() =>
             {
-                IoChanges.OnIoChange -= CheckWriteRateAndNotifyIfNecessary;
+                if (IoChanges != null)
+                    IoChanges.OnIoChange -= CheckWriteRateAndNotifyIfNecessary;
             });
 
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing MasterKey");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21219/NRE-in-SlowTests.Issues.EncryptedDatabaseGroup.CanRemoveNodeWithNoKey

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 