### PR TITLE
RavenDB-21043: Bound of 128Mb of allocations for 32bits during dictionary training.

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -35,6 +35,7 @@ namespace Raven.Server.Config.Categories
             QueryClauseCacheSize = PlatformDetails.Is32Bits ? new Size(32, SizeUnit.Megabytes) : (MemoryInformation.TotalPhysicalMemory / 10);
             MaximumSizePerSegment = new Size(PlatformDetails.Is32Bits ? 128 : 1024, SizeUnit.Megabytes);
             LargeSegmentSizeToMerge = new Size(PlatformDetails.Is32Bits ? 16 : 32, SizeUnit.Megabytes);
+            MaxAllocationsAtDictionaryTraining = new Size(PlatformDetails.Is32Bits ? 128 : 2048, SizeUnit.Megabytes);
 
             var totalMem = MemoryInformation.TotalPhysicalMemory;
 
@@ -500,6 +501,13 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Corax.MaxMemoizationSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MaxMemoizationSize { get; set; }
+
+        [Description("Expert: The maximum amount of MB that we'll allocate for training indexing dictionaries.")]
+        [DefaultValue(DefaultValueSetInConstructor)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [IndexUpdateType(IndexUpdateType.Reset)]
+        [ConfigurationEntry("Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public Size MaxAllocationsAtDictionaryTraining { get; protected set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -9,6 +9,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Indexing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Voron;
@@ -140,7 +141,6 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             queryContext.OpenReadTransaction();
 
             using var tx = indexContext.OpenWriteTransaction();
-            
             
             // We are creating a new converter because converters get tied through their accessors to the structure, and since on Map-Reduce indexes
             // we only care about the map and not the reduce hilarity can ensure when properties do not share the type. 

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -42,6 +42,7 @@ class configurationItem {
         "Indexing.Corax.IncludeDocumentScore",
         "Indexing.Corax.IncludeSpatialDistance",
         "Indexing.Corax.MaxMemoizationSizeInMb",
+        "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
 
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -85,8 +85,8 @@ namespace FastTests.Issues
                 "Indexing.Corax.IncludeDocumentScore",
                 "Indexing.Corax.IncludeSpatialDistance",
                 "Indexing.Corax.MaxMemoizationSizeInMb",
-                
-                
+                "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
+
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21043

### Additional description
In 32 bits mode we have to be extra conscious when using resources. Because of  that we are only allowing to use 128Mb of memory allocations (not actual memory) per index. Since in 32 bits we are already working under special conditions, this is more than enough to get reasonable compression and not use big amounts of memory. 

This number could be customized, but it seems that this number is good enough to reach good compression and still be resource conscious. So I moved against that. If we ever find on the field that this is better to be modifiable, it is a very simple change to enable that. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- Yes. 32 bits.
