### PR TITLE
RavenDB-21179 - verify the subscription state on the node that is handling the subscription

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -660,22 +660,14 @@ namespace Raven.Server.Documents.Subscriptions
                     if (currentLastNoopAckTicks != localLastNoopAckTicks)
                         return _lastNoopAckTask;
 
-                    var ackTask = DocumentDatabase.SubscriptionStorage.AcknowledgeBatchProcessed(
-                        SubscriptionId,
-                        SubscriptionName,
-                        nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
-                        SubscriptionConnection.NonExistentBatch, docsToResend: null);
+                    var ackTask = DocumentDatabase.SubscriptionStorage.SendNoopAck(SubscriptionId, SubscriptionName);
 
                     Interlocked.Exchange(ref _lastNoopAckTask, ackTask);
 
                     return ackTask;
                 }
 
-                return DocumentDatabase.SubscriptionStorage.AcknowledgeBatchProcessed(
-                    SubscriptionId,
-                    SubscriptionName,
-                    nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange),
-                    SubscriptionConnection.NonExistentBatch, docsToResend: null);
+                return DocumentDatabase.SubscriptionStorage.SendNoopAck(SubscriptionId, SubscriptionName);
             }
 
             return DocumentDatabase.SubscriptionStorage.LegacyAcknowledgeBatchProcessed(

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -663,14 +663,14 @@ namespace Raven.Server.Documents.Subscriptions
                     if (currentLastNoopAckTicks != localLastNoopAckTicks)
                         return _lastNoopAckTask;
 
-                    var ackTask = SendNoopAck(SubscriptionId, SubscriptionName);
+                    var ackTask = SendNoopAckAsync(SubscriptionId, SubscriptionName);
 
                     Interlocked.Exchange(ref _lastNoopAckTask, ackTask);
 
                     return ackTask;
                 }
 
-                return SendNoopAck(SubscriptionId, SubscriptionName);
+                return SendNoopAckAsync(SubscriptionId, SubscriptionName);
             }
 
             return DocumentDatabase.SubscriptionStorage.LegacyAcknowledgeBatchProcessed(
@@ -680,7 +680,7 @@ namespace Raven.Server.Documents.Subscriptions
                 nameof(Client.Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange));
         }
 
-        private async Task SendNoopAck(long subscriptionId, string name)
+        private async Task SendNoopAckAsync(long subscriptionId, string name)
         {
             var command = new AcknowledgeSubscriptionBatchCommand(_documentsStorage.DocumentDatabase.Name, RaftIdGenerator.NewId())
             {

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(subscription.ToJson(), subscriptionName));
         }
 
-        private void AssertSubscriptionState(RawDatabaseRecord record, IDatabaseTask subscription, string subscriptionName)
+        public void AssertSubscriptionState(RawDatabaseRecord record, IDatabaseTask subscription, string subscriptionName)
         {
             var topology = record.Topology;
             var lastResponsibleNode = GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);
@@ -201,7 +201,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             return msg;
         }
 
-        private class SubscriptionTask : IDatabaseTask
+        public class SubscriptionTask : IDatabaseTask
         {
             private readonly BlittableJsonReaderObject _rawSubscription;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21179/Reducing-the-use-of-AcknowledgeSubscriptionBatchCommand-for-noop-acknowledgements

### Additional description

The reason that we send the Noop Ack is to verify that we are still in charge of the subscription.
We can do that on the node that is running the subscription.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
