### PR TITLE
RavenDB-21005 "Start indexing" on an errored index doesn't start it

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -327,10 +327,9 @@ export function useIndexesPage(database: database, stale: boolean) {
                     const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
 
                     for (const location of locations) {
-                        const indexStatus = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details
-                            ?.status;
+                        const details = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details;
 
-                        if (indexStatus === "Paused") {
+                        if (details?.status === "Paused" && details?.state !== "Error") {
                             startRequests.push(
                                 indexesService.resume(index, database, location).then(() => {
                                     dispatch({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21005

### Additional description

Now start indexing will resume index only if running status = "Paused" and sate != "Error"

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
