### PR TITLE
RavenDB-21084 : Sharding - disable database doesn't remove the sharded database from ShardedDatabasesCache

### DIFF
--- a/test/SlowTests/Sharding/Issues/RavenDB_21084.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_21084.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues;
+
+public class RavenDB_21084 : RavenTestBase
+{
+    public RavenDB_21084(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task DisableShardedDb_ShouldRemoveDbFromShardedDatabasesCache()
+    {
+        using (var store = Sharding.GetDocumentStore())
+        {
+            var dbLandlord = Server.ServerStore.DatabasesLandlord;
+
+            Assert.True(dbLandlord.ShardedDatabasesCache.TryGetValue(store.Database, out _));
+
+            var shardingConfig = await Sharding.GetShardingConfigurationAsync(store);
+            foreach (var shardNumber in shardingConfig.Shards.Keys)
+            {
+                var shard = ShardHelper.ToShardName(store.Database, shardNumber);
+                Assert.True(dbLandlord.DatabasesCache.TryGetValue(shard, out _));
+            }
+
+            var operationResult = await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: true));
+            Assert.True(operationResult.Success);
+            Assert.True(operationResult.Disabled);
+
+            // should remove document databases from DatabasesCache
+            foreach (var shardNumber in shardingConfig.Shards.Keys)
+            {
+                var shard = ShardHelper.ToShardName(store.Database, shardNumber);
+                Assert.False(dbLandlord.DatabasesCache.TryGetValue(shard, out _));
+            }
+
+            // should remove sharded database context from ShardedDatabasesCache
+            Assert.False(dbLandlord.ShardedDatabasesCache.TryGetValue(store.Database, out _));
+
+            await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: false));
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21084

### Additional description

in `HandleClusterDatabaseChanged`, if database is sharded and relevant for this node, check first if database is disabled and needs to be unloaded (instead of always updating the sharded database context)

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
