### PR TITLE
RavenDB-21222 Set ProjectionNullValue reference as internal equivalent of null for MoreLikeThis purpose.

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -74,8 +74,8 @@ public partial class IndexSearcher
             // If either the term or the field does not exist the request will be empty. 
             return TermMatch.CreateEmpty(this, Allocator);
         }
-
-        if (term is null)
+        
+        if (term is null || ReferenceEquals(term, Constants.ProjectionNullValue))
         {
             return TryGetPostingListForNull(field, out var postingListId) 
                 ? TermQuery(field, postingListId, 1D) 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21222 
### Additional description

Let's treat NULL_VALUE reference from constants as an internal equivalent of null. This allows us to avoid changing MoreLikeThis API.

### Type of change

- Regression bug fix


### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Failing test fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
