### PR TITLE
RavenDB-21115 Add Info Hub to Periodic Backups view

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
@@ -1,0 +1,32 @@
+﻿import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
+import AccordionCommunityLicenseNotIncluded from "components/common/AccordionCommunityLicenseNotIncluded";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useAppSelector } from "components/store";
+import React from "react";
+
+export function EditPeriodicBackupTaskInfoHub() {
+    const licenseType = useAppSelector(licenseSelectors.licenseType);
+
+    return (
+        <AboutViewFloating>
+            <AccordionItemWrapper
+                targetId="about"
+                icon="about"
+                color="info"
+                heading="About this view"
+                description="Get additional info on this feature"
+            >
+                <p>
+                    This is periodic backup task edit view
+                </p>
+            </AccordionItemWrapper>
+            {licenseType === "Community" && (
+                <AccordionCommunityLicenseNotIncluded
+                    targetId="licensing"
+                    featureName="Periodic Backups"
+                    featureIcon="periodic-backup"
+                />
+            )}
+        </AboutViewFloating>
+    );
+}

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -14,6 +14,7 @@ import periodicBackupConfiguration = require("models/database/tasks/periodicBack
 import shardViewModelBase from "viewmodels/shardViewModelBase";
 import database from "models/resources/database";
 import licenseModel from "models/auth/licenseModel";
+import { EditPeriodicBackupTaskInfoHub } from "./EditPeriodicBackupTaskInfoHub";
 
 type backupConfigurationClass = manualBackupConfiguration | periodicBackupConfiguration;
 
@@ -26,6 +27,8 @@ class editPeriodicBackupTask extends shardViewModelBase {
     backupDestinationTestCredentialsView = require("views/partial/backupDestinationTestCredentialsResults.html");
     pinResponsibleNodeButtonsScriptView = require("views/partial/pinResponsibleNodeButtonsScript.html");
     pinResponsibleNodeTextScriptView = require("views/partial/pinResponsibleNodeTextScript.html");
+
+    infoHubView: ReactInKnockout<typeof EditPeriodicBackupTaskInfoHub>;
 
     titleForView: KnockoutComputed<string>;
     configuration = ko.observable<backupConfigurationClass>();
@@ -45,6 +48,10 @@ class editPeriodicBackupTask extends shardViewModelBase {
         this.bindToCurrentInstance("testCredentials", "setState");
         
         this.titleForView = ko.pureComputed(() => this.configuration().getTitleForView(this.isAddingNewBackupTask()));
+
+        this.infoHubView = ko.pureComputed(() => ({
+            component: EditPeriodicBackupTaskInfoHub
+        }));
     }
 
     activate(args: any) { 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -1,9 +1,14 @@
 <form class="content-margin edit-backup edit-ongoing-task" data-bind="with: configuration" autocomplete="off">
-    <div class="align-items-center d-flex gap-2 margin-bottom-md">
-        <i class="icon-periodic-backup" data-bind="visible: backupOperation === 'periodic'"></i>
-        <i class="icon-backup" data-bind="visible: backupOperation === 'manual'"></i>
-        <h2 data-bind="text: $root.titleForView" class="mb-0"></h2>
-        <span class="badge license-restricted-badge" data-bind="if: backupOperation === 'periodic' && licenseType === 'Community'">Professional +</span>
+    <div class="align-items-center justify-content-between d-flex gap-2 margin-bottom-md padding-top-xs">
+        <div class="flex-horizontal gap-2">
+            <i class="icon-periodic-backup" data-bind="visible: backupOperation === 'periodic'"></i>
+            <i class="icon-backup" data-bind="visible: backupOperation === 'manual'"></i>
+            <h2 data-bind="text: $root.titleForView" class="mb-0"></h2>
+            <span class="badge license-restricted-badge" data-bind="if: backupOperation === 'periodic' && licenseType === 'Community'">Professional +</span>
+        </div>
+        <div data-bind="if: backupOperation === 'periodic'">
+            <div class="flex-end margin-right-xs" data-bind="react: $root.infoHubView"></div>
+        </div>
     </div>
     <div class="toolbar" data-bind="with: $root">
         <button data-bind="click: onSubmit, enable: dirtyFlag().isDirty" type="submit" class="btn btn-primary">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21115

### Additional description
Added floating Info Hub button to Periodic Backups view

### Type of change
- New feature

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
