### PR TITLE
RavenDB-20602 & RavenDB-21108: reduce subscription memory usage and reduce checks in trigger databases

### DIFF
--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -22,6 +22,7 @@ using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using static Raven.Server.Documents.Subscriptions.SubscriptionStorage;
 
 namespace Raven.Server.Documents.Handlers
 {
@@ -416,26 +417,10 @@ namespace Raven.Server.Documents.Handlers
                         [nameof(SubscriptionState.Disabled)] = x.Disabled,
                         [nameof(SubscriptionState.LastClientConnectionTime)] = x.LastClientConnectionTime,
                         [nameof(SubscriptionState.LastBatchAckTime)] = x.LastBatchAckTime,
-                        ["Connection"] = GetSubscriptionConnectionJson(x.Connection),
-                        ["Connections"] = GetSubscriptionConnectionsJson(x.Connections),
-                        ["RecentConnections"] = x.RecentConnections?.Select(r => new DynamicJsonValue()
-                        {
-                            ["State"] = new DynamicJsonValue()
-                            {
-                                ["LatestChangeVectorClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPoint,
-                                ["Query"] = r.SubscriptionState.Query
-                            },
-                            ["Connection"] = GetSubscriptionConnectionJson(r)
-                        }),
-                        ["FailedConnections"] = x.RecentRejectedConnections?.Select(r => new DynamicJsonValue()
-                        {
-                            ["State"] = new DynamicJsonValue()
-                            {
-                                ["LatestChangeVectorClientACKnowledged"] = r.SubscriptionState.ChangeVectorForNextBatchStartingPoint,
-                                ["Query"] = r.SubscriptionState.Query
-                            },
-                            ["Connection"] = GetSubscriptionConnectionJson(r)
-                        }).ToList()
+                        [nameof(SubscriptionGeneralDataAndStats.Connections)] = GetSubscriptionConnectionsJson(x.Connections),
+                        [nameof(SubscriptionGeneralDataAndStats.RecentConnections)] = x.RecentConnections == null ? Array.Empty<SubscriptionConnectionInfo>() : x.RecentConnections.Select(r => r.ToJson()),
+                        [nameof(SubscriptionGeneralDataAndStats.RecentRejectedConnections)] = x.RecentRejectedConnections == null ? Array.Empty<SubscriptionConnectionInfo>() : x.RecentRejectedConnections.Select(r => r.ToJson()),
+                        [nameof(SubscriptionGeneralDataAndStats.CurrentPendingConnections)] = x.CurrentPendingConnections == null ? Array.Empty<SubscriptionConnectionInfo>() : x.CurrentPendingConnections.Select(r => r.ToJson())
                     });
 
                     writer.WriteArray(context, "Results", subscriptionsAsBlittable, (w, c, subscription) => c.Write(w, subscription));

--- a/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
@@ -66,6 +66,12 @@ namespace Raven.Server.Documents.Subscriptions
                     {
                         var connectionAggregators =
                             new List<SubscriptionConnectionStatsAggregator>();
+
+                        // add history aggregators
+                        connectionAggregators.AddRange(subscriptionConnections.RecentConnections.Select(x => x.LastConnectionStats));
+                        connectionAggregators.AddRange(subscriptionConnections.RecentRejectedConnections.Select(x => x.LastConnectionStats));
+                        connectionAggregators.AddRange(subscriptionConnections.PendingConnections.Select(x => x.LastConnectionStats));
+
                         foreach (var currentConnection in subscriptionConnections.GetConnections())
                         {
                             // add inProgress aggregator
@@ -79,11 +85,6 @@ namespace Raven.Server.Documents.Subscriptions
                                 subscriptionItem.ConnectionPerformance = connectionPerformance.ToArray();
                             }
                         }
-
-                        // add history aggregators
-                        connectionAggregators.AddRange(subscriptionConnections.RecentConnections.Select(x => x.GetPerformanceStats()));
-                        connectionAggregators.AddRange(subscriptionConnections.RecentRejectedConnections.Select(x => x.GetPerformanceStats()));
-                        connectionAggregators.AddRange(subscriptionConnections.PendingConnections.Select(x => x.GetPerformanceStats()));
                     }
                 }
 
@@ -102,11 +103,11 @@ namespace Raven.Server.Documents.Subscriptions
                         // add batches history for previous connections
                         foreach (var recentConnection in subscriptionConnections.RecentConnections)
                         {
-                            batchesAggregators.AddRange(recentConnection.GetBatchesPerformanceStats());
+                            batchesAggregators.AddRange(recentConnection.LastBatchesStats);
                         }
                         foreach (var recentRejectedConnection in subscriptionConnections.RecentRejectedConnections)
                         {
-                            batchesAggregators.AddRange(recentRejectedConnection.GetBatchesPerformanceStats());
+                            batchesAggregators.AddRange(recentRejectedConnection.LastBatchesStats);
                         }
                         // add batch stats to results
                         var subscriptionItem = results.Find(x => x.TaskId == kvp.Value.Handler.SubscriptionId);
@@ -182,9 +183,9 @@ namespace Raven.Server.Documents.Subscriptions
                             }
                             
                             // ... and for any pending connections (waiting for free, etc)
-                            foreach (SubscriptionConnection pendingConnection in subscriptionConnections.PendingConnections)
+                            foreach (SubscriptionConnectionInfo pendingConnection in subscriptionConnections.PendingConnections)
                             {
-                                var pendingConnectionStats = pendingConnection.GetPerformanceStats();
+                                var pendingConnectionStats = pendingConnection.LastConnectionStats;
                                 if (connectionsAggregators.Contains(pendingConnectionStats) == false)
                                 {
                                     connectionsAggregators.Add(pendingConnectionStats);
@@ -285,7 +286,7 @@ namespace Raven.Server.Documents.Subscriptions
             using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var subscription = Database.SubscriptionStorage.GetSubscription(context, null, subscriptionName, true);
+                var subscription = Database.SubscriptionStorage.GetSubscription(context, null, subscriptionName, history: false);
                 _perSubscriptionConnectionStats.TryAdd(subscriptionName, new SubscriptionAndPerformanceConnectionStatsList(subscription));
                 
                 if (_perSubscriptionBatchStats.ContainsKey(subscriptionName))

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionInfo.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Server.Documents.Subscriptions.Stats;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Subscriptions;
+
+public class SubscriptionConnectionInfo : IDynamicJson
+{
+    public string ClientUri { get; set; }
+    public string Query { get; set; }
+    public string LatestChangeVector { get; set; }
+    public SubscriptionOpeningStrategy Strategy { get; set; }
+    public DateTime Date { get; set; }
+    public SubscriptionException ConnectionException { get; set; }
+    public List<string> RecentSubscriptionStatuses { get; set; }
+    public DynamicJsonValue TcpConnectionStats { get; set; }
+
+    public SubscriptionConnectionStatsAggregator LastConnectionStats { get; set; }
+    public List<SubscriptionBatchStatsAggregator> LastBatchesStats { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(ClientUri)] = ClientUri,
+            [nameof(Query)] = Query,
+            [nameof(LatestChangeVector)] = LatestChangeVector,
+            [nameof(Strategy)] = Strategy,
+            [nameof(Date)] = Date,
+            [nameof(ConnectionException)] = ConnectionException?.Message,
+            [nameof(TcpConnectionStats)] = TcpConnectionStats,
+            [nameof(RecentSubscriptionStatuses)] = new DynamicJsonArray(RecentSubscriptionStatuses == null ? Array.Empty<string>(): RecentSubscriptionStatuses)
+        };
+    }
+}

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionInfo.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Util;
 using Raven.Server.Documents.Subscriptions.Stats;
+using Raven.Server.Documents.TcpHandlers;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Subscriptions;
@@ -20,6 +23,24 @@ public class SubscriptionConnectionInfo : IDynamicJson
 
     public SubscriptionConnectionStatsAggregator LastConnectionStats { get; set; }
     public List<SubscriptionBatchStatsAggregator> LastBatchesStats { get; set; }
+
+    public SubscriptionConnectionInfo()
+    {
+    }
+
+    public SubscriptionConnectionInfo(SubscriptionConnection connection)
+    {
+        ClientUri = connection.ClientUri;
+        Query = connection.SubscriptionConnectionsState.Query;
+        LatestChangeVector = connection.SubscriptionConnectionsState.LastChangeVectorSent;
+        ConnectionException = connection.ConnectionException;
+        RecentSubscriptionStatuses = connection.RecentSubscriptionStatuses.ToList();
+        Date = SystemTime.UtcNow;
+        Strategy = connection.Strategy;
+        TcpConnectionStats = connection.TcpConnection.GetConnectionStats();
+        LastConnectionStats = connection.GetPerformanceStats();
+        LastBatchesStats = connection.GetBatchesPerformanceStats();
+    }
 
     public DynamicJsonValue ToJson()
     {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -264,19 +264,7 @@ namespace Raven.Server.Documents.Subscriptions
                         _recentConnections.TryDequeue(out SubscriptionConnectionInfo _);
                     }
 
-                    _recentConnections.Enqueue(new SubscriptionConnectionInfo()
-                    {
-                        ClientUri = incomingConnection.ClientUri,
-                        Query = incomingConnection.SubscriptionConnectionsState.Query,
-                        LatestChangeVector = incomingConnection.SubscriptionConnectionsState.LastChangeVectorSent,
-                        ConnectionException = incomingConnection.ConnectionException,
-                        RecentSubscriptionStatuses = incomingConnection.RecentSubscriptionStatuses.ToList(),
-                        Date = SystemTime.UtcNow,
-                        Strategy = incomingConnection.Strategy,
-                        TcpConnectionStats = incomingConnection.TcpConnection.GetConnectionStats(),
-                        LastConnectionStats = incomingConnection.GetPerformanceStats(),
-                        LastBatchesStats = incomingConnection.GetBatchesPerformanceStats()
-                    });
+                    _recentConnections.Enqueue(new SubscriptionConnectionInfo(incomingConnection));
 
                     DropSingleConnection(incomingConnection);
                 });
@@ -392,19 +380,7 @@ namespace Raven.Server.Documents.Subscriptions
                 _rejectedConnections.TryDequeue(out SubscriptionConnectionInfo _);
             }
 
-            _rejectedConnections.Enqueue(new SubscriptionConnectionInfo()
-            {
-                ClientUri = connection.ClientUri,
-                Query = connection.SubscriptionConnectionsState.Query,
-                LatestChangeVector = connection.SubscriptionConnectionsState.LastChangeVectorSent,
-                ConnectionException = connection.ConnectionException,
-                RecentSubscriptionStatuses = connection.RecentSubscriptionStatuses.ToList(),
-                Date = SystemTime.UtcNow,
-                Strategy = connection.Strategy,
-                TcpConnectionStats = connection.TcpConnection.GetConnectionStats(),
-                LastConnectionStats = connection.GetPerformanceStats(),
-                LastBatchesStats = connection.GetBatchesPerformanceStats()
-            });
+            _rejectedConnections.Enqueue(new SubscriptionConnectionInfo(connection));
         }
 
         public SubscriptionConnectionsDetails GetSubscriptionConnectionsDetails()

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -380,15 +380,9 @@ namespace Raven.Server.Documents.Subscriptions
                 if (take-- <= 0)
                     yield break;
 
-                var subscriptionState = JsonDeserializationClient.SubscriptionState(keyValue.Value);
-                var subscriptionConnectionsState = GetSubscriptionConnectionsState(serverStoreContext, subscriptionState.SubscriptionName);
+                var task = JsonDeserializationClient.SubscriptionState(keyValue.Value);
+                var subscriptionGeneralData = new SubscriptionGeneralDataAndStats(task);
 
-                var subscriptionGeneralData = new SubscriptionGeneralDataAndStats(subscriptionState)
-                {
-                    Connections = subscriptionConnectionsState?.GetConnections(),
-                    RecentConnections = subscriptionConnectionsState?.RecentConnections,
-                    RecentRejectedConnections = subscriptionConnectionsState?.RecentRejectedConnections
-                };
                 GetSubscriptionInternal(subscriptionGeneralData, history);
                 yield return subscriptionGeneralData;
             }
@@ -541,14 +535,9 @@ namespace Raven.Server.Documents.Subscriptions
                 throw new SubscriptionDoesNotExistException($"Subscription with name '{name}' was not found in server store");
 
             var subscriptionState = JsonDeserializationClient.SubscriptionState(subscriptionBlittable);
-            var subscriptionConnectionsState = GetSubscriptionConnectionsState(context, subscriptionState.SubscriptionName);
 
-            var subscriptionJsonValue = new SubscriptionGeneralDataAndStats(subscriptionState)
-            {
-                Connections = subscriptionConnectionsState?.GetConnections(),
-                RecentConnections = subscriptionConnectionsState?.RecentConnections,
-                RecentRejectedConnections = subscriptionConnectionsState?.RecentRejectedConnections
-            };
+            var subscriptionJsonValue = new SubscriptionGeneralDataAndStats(subscriptionState);
+
             return subscriptionJsonValue;
         }
 
@@ -610,10 +599,10 @@ namespace Raven.Server.Documents.Subscriptions
 
         public class SubscriptionGeneralDataAndStats : SubscriptionState
         {
-            public SubscriptionConnection Connection => Connections?.FirstOrDefault();
             public List<SubscriptionConnection> Connections;
-            public IEnumerable<SubscriptionConnection> RecentConnections;
-            public IEnumerable<SubscriptionConnection> RecentRejectedConnections;
+            public IEnumerable<SubscriptionConnectionInfo> RecentConnections;
+            public IEnumerable<SubscriptionConnectionInfo> RecentRejectedConnections;
+            public IEnumerable<SubscriptionConnectionInfo> CurrentPendingConnections;
 
             public SubscriptionGeneralDataAndStats() { }
 
@@ -651,6 +640,7 @@ namespace Raven.Server.Documents.Subscriptions
         {
             subscriptionData.RecentConnections = subscriptionConnectionsState.RecentConnections;
             subscriptionData.RecentRejectedConnections = subscriptionConnectionsState.RecentRejectedConnections;
+            subscriptionData.CurrentPendingConnections = subscriptionConnectionsState.PendingConnections;
         }
 
         private static void GetRunningSubscriptionInternal(bool history, SubscriptionGeneralDataAndStats subscriptionData, SubscriptionConnectionsState subscriptionConnectionsState)
@@ -748,7 +738,7 @@ namespace Raven.Server.Documents.Subscriptions
 
                 var recentConnection = kvp.Value.MostRecentEndedConnection();
 
-                if (recentConnection != null && recentConnection.Stats.LastMessageSentAt < oldestPossibleIdleSubscription)
+                if (recentConnection != null && recentConnection.Date < oldestPossibleIdleSubscription)
                 {
                     if (_subscriptions.TryRemove(kvp.Key, out var subsState))
                     {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -690,6 +690,9 @@ namespace Raven.Server.Documents.Subscriptions
                         continue;
                     }
 
+                    if (subscriptionStateKvp.Value.IsSubscriptionActive() == false)
+                        continue;
+
                     var subscriptionState = JsonDeserializationClient.SubscriptionState(subscriptionBlittable);
                     if (subscriptionState.Disabled)
                     {

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -24,7 +24,6 @@ using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Tcp;
-using Raven.Client.Util;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -66,8 +65,8 @@ namespace Raven.Server.Documents.TcpHandlers
     {
         public static long NonExistentBatch = -1;
         internal static int WaitForChangedDocumentsTimeoutInMs = 3000;
-        private static readonly int BatchSizeInBytes = Constants.Size.Megabyte;
-        private static readonly int BufferCapacityInBytes = 2 * BatchSizeInBytes;
+        private static readonly int MaxBatchSizeInBytes = Constants.Size.Megabyte;
+        private static readonly int MaxBufferCapacityInBytes = 2 * MaxBatchSizeInBytes;
         private static readonly StringSegment DataSegment = new StringSegment("Data");
         private static readonly StringSegment IncludesSegment = new StringSegment(nameof(QueryResult.Includes));
         private static readonly StringSegment CounterIncludesSegment = new StringSegment(nameof(QueryResult.CounterIncludes));
@@ -166,8 +165,6 @@ namespace Raven.Server.Documents.TcpHandlers
             _connectionStatsIdForConnection = Interlocked.Increment(ref _connectionStatsId);
 
             CurrentBatchId = NonExistentBatch;
-
-            _buffer.Capacity = BufferCapacityInBytes;
         }
 
         private async Task ParseSubscriptionOptionsAsync()
@@ -253,19 +250,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
             _connectionScope.RecordConnectionInfo(SubscriptionState, ClientUri, _options.Strategy, WorkerId);
 
-            var connectionInfo = new SubscriptionConnectionInfo()
-            {
-                ClientUri = ClientUri,
-                Query = SubscriptionConnectionsState.Query,
-                LatestChangeVector = SubscriptionConnectionsState.LastChangeVectorSent,
-                ConnectionException = ConnectionException,
-                RecentSubscriptionStatuses = RecentSubscriptionStatuses.ToList(),
-                Date = SystemTime.UtcNow,
-                Strategy = Strategy,
-                TcpConnectionStats = TcpConnection.GetConnectionStats(),
-                LastConnectionStats = GetPerformanceStats(),
-                LastBatchesStats = GetBatchesPerformanceStats()
-            };
+            var connectionInfo = new SubscriptionConnectionInfo(this);
 
             _subscriptionConnectionsState._pendingConnections.Add(connectionInfo);
 
@@ -743,8 +728,11 @@ namespace Raven.Server.Documents.TcpHandlers
                                     AssertCloseWhenNoDocsLeft();
 
                                     // we might wait for new documents for a long times, lets reduce the stream capacity
-                                    if (_buffer.Capacity > BufferCapacityInBytes)
-                                        _buffer.Capacity = BufferCapacityInBytes;
+                                    if (_buffer.Capacity > MaxBufferCapacityInBytes)
+                                    {
+                                        Debug.Assert(_buffer.Length <= MaxBufferCapacityInBytes, $"{_buffer.Length} <= {MaxBufferCapacityInBytes}");
+                                        _buffer.Capacity = MaxBufferCapacityInBytes;
+                                    }
 
                                     if (await WaitForChangedDocs(replyFromClientTask))
                                         continue;
@@ -976,7 +964,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
                                 TcpConnection._lastEtagSent = -1;
                                 // perform flush for current batch after 1000ms of running or 1 MB
-                                if (_buffer.Length > BatchSizeInBytes ||
+                                if (_buffer.Length > MaxBatchSizeInBytes ||
                                     sendingCurrentBatchStopwatch.ElapsedMilliseconds > 1000)
                                 {
                                     await FlushDocsToClient(writer, docsToFlush);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20602
https://issues.hibernatingrhinos.com/issue/RavenDB-21108

### Additional description

- reduce checks in trigger databases if subscription is not active
- store relevant data in recent/rejected/pending connections (`SubscriptionConnectionInfo`) instead of storing whole the `SubscriptionConnection` object
-  actually add history aggregators in subscription task stats
- don't pull the recent/rejected/pending connections lists each time we open the subscription task from storage since we only use id, name, etc
- set capacity of the `_buffer` (`MemoryStream`) in `SubscriptionConnection` so we can free memory when we are in `WaitForChangedDocs` method.
- dispose document if sending from resend list (back port from v6.0)

### Type of change

- Bug fix
- Regression bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- No UI work is needed
