### PR TITLE
RavenDB-21129 Make Backup Encryption Key visible

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -172,23 +172,6 @@
                     </div>
                 </div>
             </div>
-            <div data-bind="with: restoreSourceObject().items()[0].selectedRestorePoint">
-                <div class="form-group" data-bind="visible: isEncrypted, validationElement: $parent.backupEncryptionKey">
-                    <label class="control-label">
-                        Backup Encryption Key <small class="text-muted">(Base64 Encoding)</small>
-                    </label>
-                    <input type="text" class="form-control" placeholder="Key" autocomplete="off"
-                           data-bind="textInput: $parent.backupEncryptionKey">
-                </div>
-                <div class="panel panel-info padding flex-horizontal" data-bind="visible: isSnapshotRestore && isEncrypted">
-                    <i class="icon-info"></i>
-                    <div class="margin-left">Selected restore point is encrypted. The Backup Encryption Key will be used as the Database Encryption Key.</div>
-                </div>
-                <div class="panel panel-info padding flex-horizontal" data-bind="visible: isSnapshotRestore && !isEncrypted">
-                    <i class="icon-info"></i>
-                    <div class="margin-left">Selected restore point is not encrypted. 'Encryption' tab was disabled.</div>
-                </div>
-            </div>
         </div>
         
         <!-- RavenDB Cloud -->
@@ -451,6 +434,24 @@
                     </div>
                 </div>
                 <div data-bind="template: { name: 'remote-folder-and-restore-point-selector' }"></div>
+            </div>
+        </div>
+
+        <div data-bind="with: restoreSourceObject().items()[0].selectedRestorePoint">
+            <div class="form-group" data-bind="visible: isEncrypted, validationElement: $parent.backupEncryptionKey">
+                <label class="control-label">
+                    Backup Encryption Key <small class="text-muted">(Base64 Encoding)</small>
+                </label>
+                <input type="text" class="form-control" placeholder="Key" autocomplete="off"
+                       data-bind="textInput: $parent.backupEncryptionKey">
+            </div>
+            <div class="panel panel-info padding flex-horizontal" data-bind="visible: isSnapshotRestore && isEncrypted">
+                <i class="icon-info"></i>
+                <div class="margin-left">Selected restore point is encrypted. The Backup Encryption Key will be used as the Database Encryption Key.</div>
+            </div>
+            <div class="panel panel-info padding flex-horizontal" data-bind="visible: isSnapshotRestore && !isEncrypted">
+                <i class="icon-info"></i>
+                <div class="margin-left">Selected restore point is not encrypted. 'Encryption' tab was disabled.</div>
             </div>
         </div>
 


### PR DESCRIPTION
### Issue link

[RavenDB-21112](https://issues.hibernatingrhinos.com/issue/RavenDB-21112)

### Additional description

Backup Encryption Key was visible only for local source

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
