### PR TITLE
RavenDB-21223 In case when last free page is released we've to remove…

### DIFF
--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -830,6 +830,9 @@ namespace Voron.Data.Containers
             txState.FreeListRemovals.Add(pageNum);
             txState.Additions.Remove(pageNum);
             txState.Removals.Add(pageNum);
+
+            if (txState.LastFreePageByPageLevelMetadata.TryGetValue(rootContainer.Header.PageLevelMetadata, out var page) && page == pageNum)
+                txState.LastFreePageByPageLevelMetadata.Remove(rootContainer.Header.PageLevelMetadata);
         }
         
         private bool HasEnoughSpaceFor(int reqSize)

--- a/test/FastTests/Corax/Bugs/RavenDB-21223.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21223.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Voron;
+using Voron.Data.Containers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs
+{
+    public class RavenDB_21223 : StorageTest
+    {
+        public RavenDB_21223(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ContainerAllocateDeleteAndAllocate()
+        {
+            List<long> toDelete = new();
+
+            {
+                using var wtx = Env.WriteTransaction();
+                var rootContainer = wtx.OpenContainer("TestContainer");
+                for (int i = 0; i < 1000; i++)
+                {
+                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    space.Fill(1);
+                }
+
+                wtx.Commit();
+            }
+
+
+            {
+                using var wtx = Env.WriteTransaction();
+                var rootContainer = wtx.OpenContainer("TestContainer");
+                for (int i = 0; i < 1000; i++)
+                {
+                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    space.Fill(1);
+                    toDelete.Add(allocatedPage);
+                }
+                foreach (var id in toDelete)
+                    Container.Delete(wtx.LowLevelTransaction, rootContainer, id);
+
+                var newPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var allocatedSpace);
+                allocatedSpace.Fill(2);
+
+                wtx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
… it's id from LastFreePageByPageLevelMetadata to avoid modifying non-existing page.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21223 

### Additional description

We've to ensure we will not touch non-existing pages in case of multiple commits in the same batch,


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor



### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
