### PR TITLE
RavenDB-21044 Added option to display unsuccessful responses data in command line for Raven.Debug

### DIFF
--- a/tools/Raven.Debug/CommandLineApp.cs
+++ b/tools/Raven.Debug/CommandLineApp.cs
@@ -325,6 +325,7 @@ namespace Raven.Debug
                 var certArg = cmd.Option("--certificate-path", "Path to pfx certificate file.", CommandOptionType.SingleOrNoValue);
                 var certPassArg = cmd.Option("--certificate-password", "Certificate password.", CommandOptionType.SingleOrNoValue);
                 var threadsArg = cmd.Option("--threads", $"Number of concurrent threads to run (default: {concurrentThreadsCount})", CommandOptionType.SingleValue);
+                var logUnsuccessfulResponsesArg = cmd.Option("--log-unsuccessful-responses", "Log unsuccessful responses in command line.", CommandOptionType.NoValue);
 
                 cmd.OnExecuteAsync(async (_) =>
                 {
@@ -374,8 +375,9 @@ namespace Raven.Debug
 
                     var cert = certArg.HasValue() ? certArg.Value() : null;
                     var certPass = certPassArg.HasValue() ? certPassArg.Value() : null;
+                    var logUnsuccessfulResponses = logUnsuccessfulResponsesArg.HasValue();
 
-                    using (var logTrafficWatchReply = new TrafficWatchReplay(path, cert, certPass, host, port, threads))
+                    using (var logTrafficWatchReply = new TrafficWatchReplay(path, cert, certPass, host, port, logUnsuccessfulResponses, threads))
                     {
                         Console.CancelKeyPress += (sender, args) =>
                         {

--- a/tools/Raven.Debug/LogTrafficWatch/TrafficWatchReplay.cs
+++ b/tools/Raven.Debug/LogTrafficWatch/TrafficWatchReplay.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -288,25 +289,29 @@ namespace Raven.Debug.LogTrafficWatch
 
             private static void OutputLogToConsole(HttpResponseMessage response, byte[] responseBuffer, TrafficWatchHttpChange item)
             {
-                Console.WriteLine("Failed to execute request");
+                StringBuilder sb = new ();
                 
-                Console.WriteLine($"Http method: {item.HttpMethod}");
+                sb.AppendLine("Failed to execute request");
                 
-                Console.WriteLine($"Request Uri: {item.RequestUri}");
+                sb.AppendLine($"Http method: {item.HttpMethod}");
                 
-                Console.WriteLine($"Absolute Uri: {item.AbsoluteUri}");
+                sb.AppendLine($"Request Uri: {item.RequestUri}");
+                
+                sb.AppendLine($"Absolute Uri: {item.AbsoluteUri}");
                         
-                Console.WriteLine($"Custom info: {item.CustomInfo}");
+                sb.AppendLine($"Custom info: {item.CustomInfo}");
                         
-                Console.WriteLine($"Status code: {(int)response.StatusCode}");
+                sb.AppendLine($"Status code: {(int)response.StatusCode}");
                 
-                Console.WriteLine($"Request size in bytes: {item.RequestSizeInBytes}");
+                sb.AppendLine($"Request size in bytes: {item.RequestSizeInBytes}");
                 
-                Console.WriteLine($"Response size in bytes: {item.ResponseSizeInBytes}");
+                sb.AppendLine($"Response size in bytes: {item.ResponseSizeInBytes}");
                 
-                Console.WriteLine($"Request Id: {item.RequestId}");
+                sb.AppendLine($"Request Id: {item.RequestId}");
                     
-                Console.WriteLine(System.Text.Encoding.Default.GetString(responseBuffer));
+                sb.AppendLine(Encoding.Default.GetString(responseBuffer));
+                
+                Console.WriteLine(sb);
             }
         }
 


### PR DESCRIPTION
### Issue link


### Additional description

We want to log data of responses with status code other than `2XX` if needed.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
