### PR TITLE
RavenDB-19337 Upgrade to Jint 3.0.0-beta-2051

### DIFF
--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -167,7 +167,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Jint" Version="3.0.0-beta-2050" />
+    <PackageReference Include="Jint" Version="3.0.0-beta-2051" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.6.0" />
     <PackageReference Include="Lextm.SharpSnmpLib.Engine" Version="11.3.102" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19337/

### Additional description

This concludes the earlier PR by having a version that doesn't support `JsArray` construction directly from `PropertyDescriptor[]`. It also now has some [array access performance improvements](https://github.com/sebastienros/jint/pull/1625) and [engine construction is faster](https://github.com/sebastienros/jint/pull/1621). 

[Release notes](https://github.com/sebastienros/jint/releases/tag/v3.0.0-beta-2051).

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests should cover

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
