### PR TITLE
RavenDB-10786: Revive Memory Validation that has been broken for several years.

### DIFF
--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Platform;
+using Sparrow.Server.Platform.Win32;
 using Sparrow.Utils;
 using Constants = Voron.Global.Constants;
 
@@ -329,8 +330,7 @@ namespace Voron.Impl.Paging
 
         private EncryptionBuffer GetBufferAndAddToTxState(long pageNumber, CryptoTransactionState state, int numberOfPages)
         {
-            var ptr = _encryptionBuffersPool.Get(numberOfPages, out var size, out var thread);
-
+            var ptr = _encryptionBuffersPool.Get(this,numberOfPages, out var size, out var thread);
             var buffer = new EncryptionBuffer(_encryptionBuffersPool)
             {
                 Size = size,
@@ -442,12 +442,12 @@ namespace Voron.Impl.Paging
             if (buffer.OriginalSize != null && buffer.OriginalSize != 0)
             {
                 // First page of a separated section, returned with its original size.
-                _encryptionBuffersPool.Return(buffer.Pointer, (long)buffer.OriginalSize, buffer.AllocatingThread, buffer.Generation);
+                _encryptionBuffersPool.Return(this, buffer.Pointer, (long)buffer.OriginalSize, buffer.AllocatingThread, buffer.Generation);
             }
             else
             {
                 // Normal buffers
-                _encryptionBuffersPool.Return(buffer.Pointer, buffer.Size, buffer.AllocatingThread, buffer.Generation);
+                _encryptionBuffersPool.Return(this, buffer.Pointer, buffer.Size, buffer.AllocatingThread, buffer.Generation);
             }
         }
 

--- a/test/FastTests/Issues/RavenDB-20292.cs
+++ b/test/FastTests/Issues/RavenDB-20292.cs
@@ -56,7 +56,10 @@ namespace FastTests.Issues
                 }
                 sw.Stop();
 
-#if MEM_GUARD_STACK
+#if !MEM_GUARD_STACK
+                // RavenDB-10786: Testing performance requirements during validation is not necessary and counterproductive
+                // as extra validations will require readjusting this value. However, this test should be available to execute
+                // to ensure memory validation will happen for the rest of the test.
                 Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5));
 #endif
             }

--- a/test/FastTests/Issues/RavenDB-20292.cs
+++ b/test/FastTests/Issues/RavenDB-20292.cs
@@ -56,7 +56,9 @@ namespace FastTests.Issues
                 }
                 sw.Stop();
 
+#if MEM_GUARD_STACK
                 Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5));
+#endif
             }
         }
 

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -176,7 +176,7 @@ namespace FastTests.Sparrow
                 context.Release(ref repeat);
             }
         } 
-#endif
+
 
         [Fact]
         public void FailValidationTryingToReleaseInAnotherContext()
@@ -234,5 +234,7 @@ namespace FastTests.Sparrow
                 }
             });
         }
+
+#endif
     }
 }

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -1,4 +1,5 @@
-﻿using Sparrow.Server;
+﻿using System;
+using Sparrow.Server;
 using Sparrow.Threading;
 using Xunit;
 using Xunit.Abstractions;
@@ -174,7 +175,8 @@ namespace FastTests.Sparrow
                 Assert.Equal(first.Key >> 32, repeat._pointer->Key >> 32);
                 context.Release(ref repeat);
             }
-        }
+        } 
+#endif
 
         [Fact]
         public void FailValidationTryingToReleaseInAnotherContext()
@@ -232,7 +234,5 @@ namespace FastTests.Sparrow
                 }
             });
         }
-#endif
-
     }
 }

--- a/test/FastTests/Voron/EncryptionBufferPool.cs
+++ b/test/FastTests/Voron/EncryptionBufferPool.cs
@@ -6,6 +6,7 @@ using Sparrow.LowMemory;
 using Sparrow.Utils;
 using Tests.Infrastructure;
 using Voron.Impl;
+using Voron.Impl.Paging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -195,7 +196,7 @@ namespace FastTests.Voron
         {
             var encryptionBuffersPool = new EncryptionBuffersPool(registerLowMemory: false, registerCleanup: false);
 
-            var ptr = encryptionBuffersPool.Get(1, out var initialSize, out var threadStats);
+            var ptr = encryptionBuffersPool.Get(null, 1, out var initialSize, out var threadStats);
 
             var size = initialSize;
             var free4KbAlignedMemoryCount = 0;

--- a/test/Tests.Infrastructure/ParallelTestBase.cs
+++ b/test/Tests.Infrastructure/ParallelTestBase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Util;
+using Sparrow.Server.Debugging;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Xunit;
@@ -28,6 +29,8 @@ public class ParallelTestBase : LinuxRaceConditionWorkAround, IAsyncLifetime
 
     static ParallelTestBase()
     {
+        DebugStuff.Attach();
+
         var maxNumberOfConcurrentTests = Math.Max(ProcessorInfo.ProcessorCount / 2, 2);
 
         if (int.TryParse(Environment.GetEnvironmentVariable("RAVEN_MAX_RUNNING_TESTS"), out var maxRunningTests))

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -32,6 +32,7 @@ using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Server.Debugging;
 using Sparrow.Server.Platform;
 using Sparrow.Utils;
 using Tests.Infrastructure;
@@ -83,6 +84,8 @@ namespace FastTests
 
         static unsafe TestBase()
         {
+            DebugStuff.Attach();
+
             IgnoreProcessorAffinityChanges(ignore: true);
             LicenseManager.AddLicenseStatusToLicenseLimitsException = true;
             RachisStateMachine.EnableDebugLongCommit = true;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-10786

### Additional description

The problem arise because concurrent accesses to protected memory happening by leasing the memory to other transactions can cause access violations.

### Type of change
- Bug fix

### How risky is the change?
- Not relevant

### Backward compatibility
- Non breaking change
