### PR TITLE
RavenDB-21208 Optimize Corax indexes to use batches & prefetching

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.TermMatch.cs
@@ -27,7 +27,7 @@ public partial class IndexSearcher
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private long GetContainerIdOfNumericalTerm<TNumeric>(in FieldMetadata field, out FieldMetadata numericalField, TNumeric term)
     {
-        long containerId = default;
+        long containerId = -1;
         numericalField = default;
         if (typeof(TNumeric) == typeof(long))
         {
@@ -53,7 +53,7 @@ public partial class IndexSearcher
     {
         var containerId = GetContainerIdOfNumericalTerm(field, out var numericalField, term);
 
-        return containerId == 0 
+        return containerId == -1 
             ? TermMatch.CreateEmpty(this, Allocator) 
             : TermQuery(numericalField, containerId, 1);
     }
@@ -247,7 +247,7 @@ public partial class IndexSearcher
     
     private long NumberOfDocumentsUnderSpecificTerm(long containerId)
     {
-        if (containerId == 0)
+        if (containerId == -1)
             return 0;
         
         if ((containerId & (long)TermIdMask.PostingList) != 0)

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1590,6 +1590,7 @@ namespace Corax
                     for (int i = 0; i < read; i++)
                     {
                         long entryId = buffer[i];
+                        Debug.Assert(entryId > 0);
                         _deletedEntries.Add(entryId);
                     }
                     _numberOfModifications -= read;
@@ -1617,6 +1618,7 @@ namespace Corax
                     for (int i = 0; i < read; i++)
                     {
                         long entryId = output[i];
+                        Debug.Assert(entryId > 0);
                         _deletedEntries.Add(entryId);
                     }
                     _numberOfModifications -= read;
@@ -1626,6 +1628,7 @@ namespace Corax
             }
 
             singleEntryId = containerId;
+            Debug.Assert(containerId > 0);
             _deletedEntries.Add(containerId);
             _numberOfModifications--;
             return true;

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1675,9 +1675,8 @@ namespace Corax
 
                 using (staticFieldScope.For(CommitOperation.TextualValues))
                 {
-                    var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
+                    using var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
                     inserter.InsertTextualField();
-                    inserter.Dispose();
                 }
                 
                 using (staticFieldScope.For(CommitOperation.IntegerValues))
@@ -1706,10 +1705,9 @@ namespace Corax
 
                     using (dynamicFieldScope.For(CommitOperation.TextualValues))
                     {
-                        var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
+                        using var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
                         inserter.InsertTextualField();
-                        inserter.Dispose();
-                    }
+                   }
                     using (dynamicFieldScope.For(CommitOperation.IntegerValues))
                         InsertNumericFieldLongs(entriesToTermsTree, indexedField, workingBuffer);
                     

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1978,9 +1978,6 @@ namespace Corax
         {
             var fieldTree = _fieldsTree.CompactTreeFor(indexedField.Name);
             
-            var currentFieldTerms = indexedField.Textual;
-            int termsCount = currentFieldTerms.Count;
-
             ClearEntriesForTerm();
             using var dumper = new IndexTermDumper(_fieldsTree, indexedField.Name);
 
@@ -2007,7 +2004,7 @@ namespace Corax
                 PrepareTextualFieldBatch(buffers, 
                     indexedField, 
                     fieldTree,
-                    sortedTerms,
+                    sortedTerms, 
                     termsOffsets,
                     out var keys,
                     out var postListIds,

--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -2417,10 +2417,7 @@ namespace Corax
         private long AllocatedSpaceForSmallSet(Span<byte> encoded, LowLevelTransaction llt, out Span<byte> space)
         {
             long termIdInTree = Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
-            if (termIdInTree == 4431904)
-            {
-                Console.WriteLine();
-            }
+            
             return EntryIdEncodings.Encode(termIdInTree, 0, TermIdMask.SmallPostingList);
         }
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -421,10 +421,15 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             match._cancellationToken.ThrowIfCancellationRequested();
             if (totalRead > allMatches.Length * 2)
             {
+                // We may have _already_ matched some items, in which case they show up as negative 
+                // numbers in the matches (since we want to filter them), we need to pass the matches to the 
+                // direct SortResult, but first we need to remove all the items that we already matched
+                int notMatchedYet = FilterAlreadyFoundMatches(allMatches);
+
                 // if we scanned through the index more than twice the amount of records of the query, but still
                 // didn't find enough to fill the page size, we'll fall back to normal sorting, instead of using the
                 // index method. That would prevent degenerate cases.
-                SortResults<TEntryComparer>(ref match, allMatches);
+                SortResults<TEntryComparer>(ref match, allMatches[..notMatchedYet]);
                 return;
             }
 
@@ -493,6 +498,19 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             throw new NotSupportedException(typeof(TDirection).FullName);
         }
     }
+    
+    private static int FilterAlreadyFoundMatches(Span<long> items)
+    {
+        int output = 0;
+        for (int i = 0; i < items.Length; i++)
+        {
+            if ((items[i] & ~long.MaxValue) != 0)
+                continue;
+            items[output++] = items[i];
+        }
+        return output;
+    }
+
 
     private static void InitializeIndexesTopHalf(Span<long> span)
     {

--- a/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Queries/TermProviders/TermProvider.Exists.cs
@@ -29,13 +29,18 @@ namespace Corax.Queries.TermProviders
             _tree = tree;
             _field = field;
             _searcher = searcher;
-            if ((_nullExists = _searcher.TryGetPostingListForNull(field, out  _postingListId)) == false)
-                _nullIterator = default;
-            else
+            _nullIterator = default;
+            _nullExists = false;
+            _fetchNulls = false;
+            if (_searcher.TryGetPostingListForNull(field, out  _postingListId))
             {
                 _nullPostingList = searcher.GetPostingList(_postingListId);
-                _nullIterator = _nullPostingList.Iterate();
-                _fetchNulls = true;
+                _nullExists = _nullPostingList.State.NumberOfEntries > 0;
+                if (_nullExists)
+                {
+                    _nullIterator = _nullPostingList.Iterate();
+                    _fetchNulls = true;
+                }
             }
             
             _iterator = tree.Iterate<TLookupIterator>();

--- a/src/Raven.Client/Documents/Indexes/AbstractGenericIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractGenericIndexCreationTask.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Raven.Client.Documents.Indexes.Spatial;
+using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -27,13 +28,20 @@ namespace Raven.Client.Documents.Indexes
             TermVectorsStrings = new Dictionary<string, FieldTermVector>();
             SpatialIndexes = new Dictionary<Expression<Func<TReduceResult, object>>, SpatialOptions>();
             SpatialIndexesStrings = new Dictionary<string, SpatialOptions>();
-            CompoundFields = new List<string[]>();
+            CompoundFieldsStrings = new List<string[]>();
+            CompoundFields = new List<Expression<Func<TReduceResult, object>>[]>();
         }
 
         /// <summary>
         /// Expert: List of compound fields that Corax can use to optimize certain queries
         /// </summary>
-        public List<string[]> CompoundFields { get; set; }
+        public List<string[]> CompoundFieldsStrings { get; set; }
+        
+        /// <summary>
+        /// Expert: List of compound fields that Corax can use to optimize certain queries
+        /// </summary>
+        public List<Expression<Func<TReduceResult, object>>[]> CompoundFields { get; set; }
+
 
         public override bool IsMapReduce => Reduce != null;
 
@@ -215,5 +223,16 @@ namespace Raven.Client.Documents.Indexes
 
             AdditionalAssemblies.Add(assembly);
         }
+
+        protected void CompoundField(string firstField, string secondField)
+        {
+            CompoundFieldsStrings.Add(new[]{firstField, secondField});
+        }
+        
+        protected void CompoundField(Expression<Func<TReduceResult, object>> first, Expression<Func<TReduceResult, object>> second)
+        {
+            CompoundFields.Add(new[]{first, second});
+        }
+
     }
 }

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -305,7 +305,8 @@ namespace Raven.Client.Documents.Indexes
                 Priority = Priority,
                 State = State,
                 DeploymentMode = DeploymentMode,
-                CompoundFields = CompoundFields,                
+                CompoundFieldsStrings = CompoundFieldsStrings,
+                CompoundFields = CompoundFields,
             }.ToIndexDefinition(Conventions);
 
             return indexDefinition;

--- a/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -95,7 +95,9 @@ namespace Raven.Client.Documents.Indexes
                 LockMode = LockMode,
                 Priority = Priority,
                 State = State,
-                DeploymentMode = DeploymentMode
+                DeploymentMode = DeploymentMode,
+                CompoundFields = CompoundFields,
+                CompoundFieldsStrings = CompoundFieldsStrings
             }.ToIndexDefinition(Conventions, validateMap: false);
 
             foreach (var map in _maps.Select(generateMap => generateMap()))

--- a/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
+++ b/src/Raven.Client/Documents/Queries/Timings/QueryTimings.cs
@@ -11,7 +11,7 @@ namespace Raven.Client.Documents.Queries.Timings
 
         public IDictionary<string, QueryTimings> Timings { get; set; }
         
-        public object QueryPlan { get; set; }
+        public IDynamicJson QueryPlan { get; set; }
 
         internal bool ShouldBeIncluded { get; set; }
 

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -496,7 +496,7 @@ namespace Raven.Server.Config.Categories
         public bool CoraxIncludeSpatialDistance { get; set; }
         
         [Description("The maximum amount of memory that Corax can use for a memoization clause during query processing")]
-        [DefaultValue(128)]
+        [DefaultValue(512)]
         [SizeUnit(SizeUnit.Megabytes)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Corax.MaxMemoizationSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -872,11 +872,11 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.Timings));
                 writer.WriteQueryTimings(context, result.Timings);
-                if (result.Timings.QueryPlan is IDynamicJson j)
+                if (result.Timings.QueryPlan != null)
                 {
                     writer.WriteComma();
                     writer.WritePropertyName(nameof(result.Timings.QueryPlan));
-                    var value = j.ToJson();
+                    var value = result.Timings.QueryPlan.ToJson();
                     writer.WriteObject(context.ReadObject(value, nameof(result.Timings.QueryPlan)));
                 }
             }

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -199,6 +199,20 @@ namespace Voron.Data.BTrees
             return *(int*)read.Reader.Base;
 
         }
+        
+        /// <summary>
+        /// This is using little endian
+        /// </summary>
+        public T? ReadStructure<T>(Slice key)
+            where T : unmanaged
+        {
+            var read = Read(key);
+            if (read == null) 
+                return null;
+            Debug.Assert(read.Reader.Length == sizeof(T));
+            return *(T*)read.Reader.Base;
+
+        }
 
         public void Add(Slice key, byte value)
         {

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -18,6 +18,8 @@ namespace Voron.Data.CompactTrees;
 // when the same key is reused on multiple operations in the same transaction.
 public sealed unsafe class CompactKey : IDisposable
 {
+    public static readonly CompactKey NullInstance = new();
+    
     private static readonly ArrayPool<byte> StoragePool = ArrayPool<byte>.Shared;
     private static readonly ArrayPool<long> KeyMappingPool = ArrayPool<long>.Shared;
 

--- a/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
@@ -50,4 +50,9 @@ unsafe partial class CompactTree
             compactKey.Dispose();
         }
     }
+    
+    public void Render()
+    {
+        _inner.Render();
+    }
 }

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -499,8 +499,12 @@ namespace Voron.Data.Containers
             if (container.HasEnoughSpaceFor(reqSize) == false)
                 throw new VoronErrorException($"After checking for space and defrag, we ended up with not enough free space ({reqSize}) on page {container.Header.PageNumber}");
 
-            Debug.Assert(container.Header.PageLevelMetadata == -1 || container.Header.PageLevelMetadata == pageLevelMetadata);
-            container.Header.PageLevelMetadata = pageLevelMetadata;
+            Debug.Assert(container.Header.PageLevelMetadata == -1 || container.Header.PageLevelMetadata == pageLevelMetadata || pageLevelMetadata == -1, 
+                "container.Header.PageLevelMetadata == -1 || container.Header.PageLevelMetadata == pageLevelMetadata || pageLevelMetadata == -1");
+            if (pageLevelMetadata != -1) // we may place an entry with -1 in any page, so don't modify the page value if the caller doesn't care
+            {
+                container.Header.PageLevelMetadata = pageLevelMetadata;
+            }
             return container.Allocate(size, pos, out allocatedSpace);
         }
 

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -1015,6 +1015,7 @@ namespace Voron.Data.Containers
             var container = new Container(page);
             var metadata = container.MetadataFor(OffsetToIndex(offset));
             Debug.Assert(metadata.IsFree == false);
+            Debug.Assert(metadata.IsFree == false, "metadata.IsFree == false");
             var pagePointer= page.Pointer;
             int size = metadata.Get(ref pagePointer);
             return new Span<byte>(pagePointer, size);

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -825,6 +825,9 @@ namespace Voron.Data.Containers
             txState.FreeListRemovals.Add(pageNum);
             txState.Additions.Remove(pageNum);
             txState.Removals.Add(pageNum);
+
+            if (txState.LastFreePageByPageLevelMetadata.TryGetValue(rootContainer.Header.PageLevelMetadata, out var page) && page == pageNum)
+                txState.LastFreePageByPageLevelMetadata.Remove(rootContainer.Header.PageLevelMetadata);
         }
         
         private bool HasEnoughSpaceFor(int reqSize)

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -294,7 +294,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         ref var state = ref _internalCursor._stk[_internalCursor._pos];
         if (state.LastMatch != 0)
         {
-            value = default;
+            value = -1;
             return false;
         }
 
@@ -317,7 +317,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         FindPageFor(ref key, ref _internalCursor);
         if (_internalCursor._stk[_internalCursor._pos].LastMatch != 0)
         {
-            value = default;
+            value = -1;
             return false;
         }
         return TryRemoveExistingValue(ref key, out value);
@@ -1488,7 +1488,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
                 state = ref _internalCursor._stk[_internalCursor._pos];
                 if (state.LastMatch != 0)
                 {
-                    value = default;
+                    value = -1;
                     return false;
                 }
 

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -1373,7 +1373,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     {
         ref var state = ref _internalCursor._stk[_internalCursor._pos];
         if (state.Page.PageNumber != pageNum)
-            throw new InvalidOperationException("Different page number provided fro BulkUpdateSet");
+            throw new InvalidOperationException("Different page number provided from BulkUpdateSet");
 
         if (offset >= 0)
         {
@@ -1400,7 +1400,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     {
         ref var state = ref _internalCursor._stk[_internalCursor._pos];
         if (state.Page.PageNumber != pageNum)
-            throw new InvalidOperationException("Different page number provided fro BulkUpdateSet");
+            throw new InvalidOperationException("Different page number provided from BulkUpdateSet");
 
         if (offset < 0)
         {

--- a/src/Voron/Data/PostingLists/NativeIntegersList.cs
+++ b/src/Voron/Data/PostingLists/NativeIntegersList.cs
@@ -115,6 +115,9 @@ public unsafe struct NativeIntegersList : IDisposable
             return;
         Sort.Run(RawItems, Count);
         
+        // blog post explaining this
+        // https://ayende.com/blog/200065-B/optimizing-a-three-way-merge?key=67d6f65d63ba4fb79d31dfc49ae5aa1d
+        
         // The idea here is that we can do all of the process with no branches at all and make this 
         // easily predictable to the CPU
 

--- a/src/Voron/Data/PostingLists/NativeIntegersList.cs
+++ b/src/Voron/Data/PostingLists/NativeIntegersList.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow;
@@ -171,4 +173,53 @@ public unsafe struct NativeIntegersList : IDisposable
         
         GrowListUnlikely(requiredSize - Capacity);
     }
+
+    public Enumerator GetEnumerator() => new Enumerator(RawItems, Count);
+    
+    public struct Enumerator : IEnumerator<long>
+    {
+        private readonly long* _items;
+        private int _len;
+        private int _index;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator(long* items, int len)
+        {
+            _items = items;
+            _len = len;
+            _index = -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            int index = _index + 1;
+            if (index < _len)
+            {
+                _index = index;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _index = -1;
+        }
+
+        object IEnumerator.Current => Current;
+
+        public long Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _items[_index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+        }
+    }
+
 }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1062,9 +1062,12 @@ namespace Voron.Impl
                 return;
             
             // The reason why we reset the key, which in turn will null the storage is to avoid cases of reused keys
-            // been used by multiple operations. Eventually someone wil restore 
-            key.Reset();
-            _sharedCompactKeyPool.Free(key);
+            // been used by multiple operations. Eventually someone wil restore
+            if (ReferenceEquals(key, CompactKey.NullInstance) == false)
+            {
+                key.Reset();
+                _sharedCompactKeyPool.Free(key);
+            }
             key = null;
         }
 

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -80,6 +80,19 @@ namespace Voron
             return val;
         }
 
+        public T ReadStructure<T>()
+            where T : unmanaged
+        {
+            if (_len - _pos < sizeof (int))
+                throw new EndOfStreamException();
+            var val = *(T*) (_val + _pos);
+
+            _pos += sizeof (T);
+
+            return val;
+        }
+
+
 
         public long ReadLittleEndianInt64()
         {

--- a/test/FastTests/Corax/Bugs/RavenDB-21223.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21223.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Voron;
+using Voron.Data.Containers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs
+{
+    public class RavenDB_21223 : StorageTest
+    {
+        public RavenDB_21223(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ContainerAllocateDeleteAndAllocate()
+        {
+            List<long> toDelete = new();
+
+            {
+                using var wtx = Env.WriteTransaction();
+                var rootContainer = wtx.OpenContainer("TestContainer");
+                for (int i = 0; i < 1000; i++)
+                {
+                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    space.Fill(1);
+                }
+
+                wtx.Commit();
+            }
+
+
+            {
+                using var wtx = Env.WriteTransaction();
+                var rootContainer = wtx.OpenContainer("TestContainer");
+                for (int i = 0; i < 1000; i++)
+                {
+                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    space.Fill(1);
+                    toDelete.Add(allocatedPage);
+                }
+                foreach (var id in toDelete)
+                    Container.Delete(wtx.LowLevelTransaction, rootContainer, id);
+
+                var newPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var allocatedSpace);
+                allocatedSpace.Fill(2);
+
+                wtx.Commit();
+            }
+        }
+    }
+}

--- a/test/FastTests/Corax/CompoundFieldsOnIndex.cs
+++ b/test/FastTests/Corax/CompoundFieldsOnIndex.cs
@@ -146,10 +146,8 @@ public class CompoundFieldsOnIndex : RavenTestBase
                 from u in users 
                 select new { u.Name, u.Location, u.Birthday };
 
-            CompoundFields.Add(new[] { nameof(User.Name), nameof(User.Birthday) });
-            CompoundFields.Add(new[] { nameof(User.Location), nameof(User.Name) });
+            CompoundField(x => x.Name, x => x.Birthday);
+            CompoundField(x => x.Location, x => x.Name);
         }
     }
-    
-    
 }

--- a/test/FastTests/Corax/DynamicFieldsIntegration.cs
+++ b/test/FastTests/Corax/DynamicFieldsIntegration.cs
@@ -195,7 +195,6 @@ public class DynamicFieldsIntegration : RavenTestBase
 
         await index.ExecuteAsync(store);
         Indexes.WaitForIndexing(store);
-        WaitForUserToContinueTheTest(store);
         return store;
     }
 

--- a/test/FastTests/Corax/LookupBulkTests.cs
+++ b/test/FastTests/Corax/LookupBulkTests.cs
@@ -126,7 +126,9 @@ public class LookupBulkTests : StorageTest
                 {
                     if (wrote % 15 == 0)
                     {
-                        lookup.BulkUpdateRemove(ref curItems[i], pg, curOffsets[i], ref adjustment);
+                        var result = lookup.BulkUpdateRemove(ref curItems[i], pg, curOffsets[i], ref adjustment, out long v);
+                        if (result)
+                            Assert.Equal((curItems[i].Value % 601) + 1000, v);
                         removed.Add(curItems[i].Value);
                     }
                     else

--- a/test/FastTests/Corax/LookupBulkTests.cs
+++ b/test/FastTests/Corax/LookupBulkTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FastTests.Voron;
+using FastTests.Voron.FixedSize;
 using Voron.Data.Lookups;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,11 +14,12 @@ public class LookupBulkTests : StorageTest
     public LookupBulkTests(ITestOutputHelper output) : base(output)
     {
     }
-
-    [Fact]
-    public void CanBulkAddToEmptyLookup()
+    [Theory]
+    [InlineData(214)]
+    [InlineDataWithRandomSeed]
+    public void CanBulkAddToEmptyLookup(int seed)
     {
-        var random = new Random(214);
+        var random = new Random(seed);
         var items = Enumerable.Range(0, 1024)
             .Select(_ => new Int64LookupKey(random.NextInt64()))
             .OrderBy(x=>x.Value).ToArray();
@@ -69,14 +71,15 @@ public class LookupBulkTests : StorageTest
         }
     }
     
-    [Fact]
-    public void CanBulkUpdateAndInsertAndRemove()
+    [Theory]
+    [InlineData(214)]
+    [InlineDataWithRandomSeed]
+    public void CanBulkUpdateAndInsertAndRemove(int seed)
     {
         int count = 0;
         var random = new Random(214);
         var firstItems = Enumerable.Range(0, 1024)
-            //.Select(_ => new Int64LookupKey(random.NextInt64()))
-            .Select(_=> new Int64LookupKey(++count))
+            .Select(_ => new Int64LookupKey(random.NextInt64()))
             .ToArray();
 
         using (var wtx = Env.WriteTransaction())
@@ -93,8 +96,7 @@ public class LookupBulkTests : StorageTest
 
 
         var secondItems = Enumerable.Range(0, 512)
-            //.Select(_ => new Int64LookupKey(random.NextInt64()))
-            .Select(_=> new Int64LookupKey(++count + 1000))
+            .Select(_ => new Int64LookupKey(random.NextInt64()))
             .ToArray();
         var updatesAndInserts = secondItems
             .Concat(firstItems.Where((_, i) => i % 2 == 0)) // update half of them

--- a/test/FastTests/Corax/LookupBulkTests.cs
+++ b/test/FastTests/Corax/LookupBulkTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests.Voron;
+using Voron.Data.Lookups;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class LookupBulkTests : StorageTest
+{
+    public LookupBulkTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanBulkAddToEmptyLookup()
+    {
+        var random = new Random(214);
+        var items = Enumerable.Range(0, 1024)
+            .Select(_ => new Int64LookupKey(random.NextInt64()))
+            .OrderBy(x=>x.Value).ToArray();
+
+        var values = new long[items.Length];
+        var offsets = new int[items.Length];
+
+        using (var wtx = Env.WriteTransaction())
+        {
+            var lookup = wtx.LookupFor<Int64LookupKey>("test");
+            lookup.InitializeCursorState();
+            
+            int wrote = 0;
+            while (wrote < items.Length)
+            {
+                var curItems = items[wrote..];
+                var curValues = values[wrote..];
+                var curOffsets = offsets[wrote..];
+                var read = lookup.BulkUpdateStart(curItems, curValues, curOffsets, out var pg);
+
+                Assert.Equal(curItems.Length, read);
+                Assert.NotEqual(0, pg);
+
+                var changed = lookup.CheckTreeStructureChanges();
+                int adjustment = 0;
+                for (int i = 0; i < read && changed.Changed == false; i++)
+                {
+                    lookup.BulkUpdateSet(ref curItems[i], 1 + wrote, pg, curOffsets[i], ref adjustment);
+                    wrote++;
+                }
+            }
+            
+            wtx.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var lookup = rtx.LookupFor<Int64LookupKey>("test");
+            var it = lookup.Iterate();
+            it.Reset();
+            for (int i = 0; i < items.Length; i++)
+            {
+                Assert.True(it.MoveNext(out Int64LookupKey k, out var v, out _));
+                Assert.Equal(items[i].Value, k.Value);
+                Assert.Equal(i+1, v);
+            }
+            Assert.False(it.MoveNext(out Int64LookupKey _, out _, out _));
+
+        }
+    }
+    
+    [Fact]
+    public void CanBulkUpdateAndInsertAndRemove()
+    {
+        int count = 0;
+        var random = new Random(214);
+        var firstItems = Enumerable.Range(0, 1024)
+            //.Select(_ => new Int64LookupKey(random.NextInt64()))
+            .Select(_=> new Int64LookupKey(++count))
+            .ToArray();
+
+        using (var wtx = Env.WriteTransaction())
+        {
+            var lookup = wtx.LookupFor<Int64LookupKey>("test");
+
+            for (int i = 0; i < firstItems.Length; i++)
+            {
+                lookup.Add(ref firstItems[i],  (firstItems[i].Value % 601) + 1000);
+            }
+            
+            wtx.Commit();
+        }
+
+
+        var secondItems = Enumerable.Range(0, 512)
+            //.Select(_ => new Int64LookupKey(random.NextInt64()))
+            .Select(_=> new Int64LookupKey(++count + 1000))
+            .ToArray();
+        var updatesAndInserts = secondItems
+            .Concat(firstItems.Where((_, i) => i % 2 == 0)) // update half of them
+            .OrderBy(x => x.Value)
+            .ToArray();
+        
+        var values = new long[updatesAndInserts.Length];
+        var offsets = new int[updatesAndInserts.Length];
+        var removed = new HashSet<long>();
+        using (var wtx = Env.WriteTransaction())
+        {
+            var lookup = wtx.LookupFor<Int64LookupKey>("test");
+            
+            lookup.InitializeCursorState();
+            
+            int wrote = 0;
+            while (wrote < updatesAndInserts.Length)
+            {
+                var curItems = updatesAndInserts[wrote..];
+                var curValues = values[wrote..];
+                var curOffsets = offsets[wrote..];
+                var read = lookup.BulkUpdateStart(curItems, curValues, curOffsets, out var pg);
+
+                var changed = lookup.CheckTreeStructureChanges();
+                int adjustment = 0;
+                for (int i = 0; i < read && changed.Changed == false; i++)
+                {
+                    if (wrote % 15 == 0)
+                    {
+                        lookup.BulkUpdateRemove(ref curItems[i], pg, curOffsets[i], ref adjustment);
+                        removed.Add(curItems[i].Value);
+                    }
+                    else
+                    {
+                        lookup.BulkUpdateSet(ref curItems[i], (curItems[i].Value % 317), pg, curOffsets[i], ref adjustment);
+                    }
+                    wrote++;
+                }
+            }
+            
+            wtx.Commit();
+        }
+
+        var allItems = firstItems.Concat(secondItems).OrderBy(x => x.Value).ToArray();
+        using (var rtx = Env.ReadTransaction())
+        {
+            var lookup = rtx.LookupFor<Int64LookupKey>("test");
+            var it = lookup.Iterate();
+            it.Reset();
+            for (int i = 0; i < allItems.Length; i++)
+            {
+                if (removed.Contains(allItems[i].Value))
+                {
+                    continue; // was removed...
+                }
+                Assert.True(it.MoveNext(out Int64LookupKey k, out var v, out _));
+                Assert.Equal(allItems[i].Value, k.Value);
+                Assert.True(allItems[i].Value % 317 == v || v == (allItems[i].Value % 601) + 1000);
+            }
+            Assert.False(it.MoveNext(out Int64LookupKey _, out _, out _));
+        }
+    }
+}

--- a/test/FastTests/Corax/LookupBulkTests.cs
+++ b/test/FastTests/Corax/LookupBulkTests.cs
@@ -76,7 +76,6 @@ public class LookupBulkTests : StorageTest
     [InlineDataWithRandomSeed]
     public void CanBulkUpdateAndInsertAndRemove(int seed)
     {
-        int count = 0;
         var random = new Random(214);
         var firstItems = Enumerable.Range(0, 1024)
             .Select(_ => new Int64LookupKey(random.NextInt64()))

--- a/test/FastTests/Issues/RavenDB-11791.cs
+++ b/test/FastTests/Issues/RavenDB-11791.cs
@@ -26,7 +26,7 @@ namespace FastTests.Issues
         }
         
         [RavenTheory(RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void Test(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -36,9 +36,10 @@ namespace FastTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Person(), "people/1");
-                    session.Advanced.WaitForIndexesAfterSaveChanges();
                     session.SaveChanges();
                 }
+                
+                Indexes.WaitForIndexing(store);
 
 
                 using (var session = store.OpenSession())
@@ -46,11 +47,11 @@ namespace FastTests.Issues
                     session.Delete("people/1");
                     session.SaveChanges();
                 }
-
+                Indexes.WaitForIndexing(store);
+                
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Person());
-                    session.Advanced.WaitForIndexesAfterSaveChanges();
                     session.SaveChanges();
                 }
 

--- a/test/SlowTests/Issues/RavenDB-14806.cs
+++ b/test/SlowTests/Issues/RavenDB-14806.cs
@@ -41,7 +41,7 @@ public class RavenDB_14806 : RavenTestBase
                     SortOrder = c.SortOrder,
                     Description = c.Description
                 });
-
+WaitForUserToContinueTheTest(store);
             var result = await query.ToListAsync();
             Assert.Equal(1, result.Count);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21208 

### Additional description

This change modify the way Corax handles indexing (textual only, for now) to allow it to perform batch operations and ask the OS to prefetch memory before we are using it.

```
from u in docs.Users
select new {
    u.DisplayName,
    u.CreationDate
}
```

Current v6.0, indexing 17.9 M (11.47 GB) items: 6 minutes, 3 seconds.
With those changes: 5 minutes, 46 seconds.

Corax index size: ~4GB

Lucene timing: 15 minutes, 14 seconds.



Indexing 22.6M docs (118GB)

```
from q in docs.Questions
select new {
    q.CreationDate,
    q.Title,
    q.Owner
}
```

Full text on _Title_:

Lucene: `00:32:53.09` - Index size, 6.25GB
Corax: `19:04.72` - 6.25 GB