### PR TITLE
RavenDB-21237 - High unamanged for a streaming query from an index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3079,7 +3079,7 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamQuery(HttpResponse response, IStreamQueryResultWriter<Document> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, OperationCancelToken token)
         {
-            var result = new StreamDocumentQueryResult(response, writer, token);
+            var result = new StreamDocumentQueryResult(response, writer, queryContext.Documents, token);
             await QueryInternal(result, query, queryContext, pulseDocsReadingTransaction: true, token);
             result.Flush();
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
         public override async Task ExecuteStreamQuery(IndexQueryServerSide query, QueryOperationContext queryContext, HttpResponse response, IStreamQueryResultWriter<Document> writer,
             OperationCancelToken token)
         {
-            var result = new StreamDocumentQueryResult(response, writer, token);
+            var result = new StreamDocumentQueryResult(response, writer, queryContext.Documents, token);
 
             using (queryContext.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -325,7 +325,7 @@ namespace Raven.Server.Documents.Queries
         {
             using (var context = QueryOperationContext.Allocate(Database, needsServerContext: false))
             {
-                var result = new StreamDocumentQueryResult(response, writer, token)
+                var result = new StreamDocumentQueryResult(response, writer, queryContext.Documents, token)
                 {
                     IndexName = Constants.Documents.Indexing.DummyGraphIndexName
                 };

--- a/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
@@ -3,11 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Queries
 {
     public class StreamDocumentQueryResult : StreamQueryResult<Document>
     {
+        private readonly DocumentsOperationContext _context;
+
         public override async ValueTask AddResultAsync(Document result, CancellationToken token)
         {
             if (HasAnyWrites() == false)
@@ -16,13 +19,16 @@ namespace Raven.Server.Documents.Queries
             using (result)
                 await GetWriter().AddResultAsync(result, token).ConfigureAwait(false);
 
+            _context.Transaction.InnerTransaction.ForgetAbout(result.StorageId);
+
             GetToken().Delay();
         }
 
-        public StreamDocumentQueryResult(HttpResponse response, IStreamQueryResultWriter<Document> writer, OperationCancelToken token) : base(response, writer, token)
+        public StreamDocumentQueryResult(HttpResponse response, IStreamQueryResultWriter<Document> writer, DocumentsOperationContext context, OperationCancelToken token) : base(response, writer, token)
         {
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");
+            _context = context;
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21237/High-unamanged-for-a-streaming-query-from-an-index

### Additional description

Using `ForgetAbout` in order to dispose of the allocated memory for a compressed document.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- It has been verified by manual testing
