### PR TITLE
RavenDB-20726 - NRE during deleting a conflict on attachments

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1123,8 +1123,8 @@ namespace Raven.Server.Documents
             if (conflictDocument.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject conflictMetadata) == false ||
                 conflictMetadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray conflictAttachments) == false)
                 return;
-
-            if (document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+            
+            if (document == null || document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
                 metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
             {
                 attachments = null;

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -341,7 +341,6 @@ namespace Raven.Server.Documents
             if (size <= 0)
                 return NonPersistentDocumentFlags.None;
 
-            Debug.Assert(document != null, "This is not a delete conflict so we should also provide the document.");
             using (var conflictDocument = new BlittableJsonReaderObject(dataPtr, size, context))
             {
                 _documentsStorage.AttachmentsStorage.DeleteAttachmentConflicts(context, lowerId, document, conflictDocument, changeVector);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20726

### Additional description

In `DeleteAttachmentConflicts` we are extracting the existing document's attachments from its metadata in order to check if they exist in the resolved doc's attachments and delete them if not.
However when deleting the document entirely, the document param is null which causes us to throw.
When deleting the document entirely the check becomes redundant (we want to delete all attachment metadata related to the doc) so there is no need to extract the metadata anyway.
Added a null check to the document so the check will be skipped.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Tests have been added

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
