### PR TITLE
RavenDB-21173 - Concurrency Exception on cluster transaction

### DIFF
--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -51,7 +51,7 @@ namespace Raven.Client.Http
 
         public string LastServerVersion { get; private set; }
 
-        public string ServerVersion
+        internal string ServerVersion
         {
             get
             {

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -51,7 +51,31 @@ namespace Raven.Client.Http
 
         public string LastServerVersion { get; private set; }
 
-        internal bool SupportsAtomicClusterWrites { get; set; }
+        public string ServerVersionFromDatabaseTopology
+        {
+            get
+            {
+                return LastServerVersion;
+            }
+            private set
+            {
+                UpdateServerVersion(value);
+            }
+        }
+
+        private bool? _supportsAtomicClusterWrites;
+
+        internal bool SupportsAtomicClusterWrites
+        {
+            get
+            {
+                if (_supportsAtomicClusterWrites.HasValue)
+                    return _supportsAtomicClusterWrites.Value;
+
+                UpdateServerVersion(LastServerVersion);
+                return _supportsAtomicClusterWrites.Value;
+            }
+        }
 
         public bool ShouldUpdateServerVersion()
         {
@@ -69,12 +93,12 @@ namespace Raven.Client.Http
             if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
             {
                 // 5.2 or higher
-                SupportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 ||
-                                              ver.Major > 5;
+                _supportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 ||
+                                               ver.Major > 5;
             }
             else
             {
-                SupportsAtomicClusterWrites = false;
+                _supportsAtomicClusterWrites = false;
             }
         }
 

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -51,7 +51,7 @@ namespace Raven.Client.Http
 
         public string LastServerVersion { get; private set; }
 
-        public string ServerVersionFromDatabaseTopology
+        public string ServerVersion
         {
             get
             {

--- a/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
+++ b/src/Raven.Client/ServerWide/Operations/BuildNumber.cs
@@ -12,6 +12,8 @@ namespace Raven.Client.ServerWide.Operations
 
         public string FullVersion { get; set; }
 
+        public string AssemblyVersion { get; set; }
+
         public override bool Equals(object obj)
         {
             return Equals(obj as BuildNumber);
@@ -22,10 +24,11 @@ namespace Raven.Client.ServerWide.Operations
             if (other == null)
                 return false;
 
-            return string.Equals(ProductVersion, other.ProductVersion) && 
-                   BuildVersion == other.BuildVersion && 
-                   string.Equals(CommitHash, other.CommitHash) && 
-                   string.Equals(FullVersion, other.FullVersion);
+            return string.Equals(ProductVersion, other.ProductVersion) &&
+                   BuildVersion == other.BuildVersion &&
+                   string.Equals(CommitHash, other.CommitHash) &&
+                   string.Equals(FullVersion, other.FullVersion) &&
+                   string.Equals(AssemblyVersion, other.AssemblyVersion);
         }
 
         public override int GetHashCode()
@@ -36,6 +39,7 @@ namespace Raven.Client.ServerWide.Operations
                 hashCode = (hashCode * 397) ^ BuildVersion;
                 hashCode = (hashCode * 397) ^ (CommitHash != null ? CommitHash.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (FullVersion != null ? FullVersion.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (AssemblyVersion != null ? AssemblyVersion.GetHashCode() : 0);
                 return hashCode;
             }
         }
@@ -47,7 +51,8 @@ namespace Raven.Client.ServerWide.Operations
                 [nameof(ProductVersion)] = ProductVersion,
                 [nameof(BuildVersion)] = BuildVersion,
                 [nameof(CommitHash)] = CommitHash,
-                [nameof(FullVersion)] = FullVersion
+                [nameof(FullVersion)] = FullVersion,
+                [nameof(AssemblyVersion)] = AssemblyVersion
             };
         }
     }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -23,6 +23,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
+using Raven.Client.Properties;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
@@ -78,7 +79,8 @@ namespace Raven.Server.Commercial
             BuildVersion = ServerVersion.Build,
             ProductVersion = ServerVersion.Version,
             CommitHash = ServerVersion.CommitHash,
-            FullVersion = ServerVersion.FullVersion
+            FullVersion = ServerVersion.FullVersion,
+            AssemblyVersion = ServerVersion.AssemblyVersion
         };
 
         public LicenseStatus LicenseStatus { get; private set; } = new LicenseStatus();

--- a/src/Raven.Server/ServerWide/ServerVersion.cs
+++ b/src/Raven.Server/ServerWide/ServerVersion.cs
@@ -10,6 +10,7 @@ namespace Raven.Server.ServerWide
         private static string _commitHash;
         private static string _version;
         private static string _fullVersion;
+        private static string _assemblyVersion;
 
         public static string Version => 
             _version ?? (_version = RavenVersionAttribute.Instance.Version);
@@ -22,6 +23,9 @@ namespace Raven.Server.ServerWide
             _commitHash ?? (_commitHash = RavenVersionAttribute.Instance.CommitHash);
         public static string FullVersion => 
             _fullVersion ?? (_fullVersion = RavenVersionAttribute.Instance.FullVersion);
+
+        public static string AssemblyVersion =>
+            _assemblyVersion ?? (_assemblyVersion = RavenVersionAttribute.Instance.AssemblyVersion);
 
         public const int DevBuildNumber = 54;
 

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -266,7 +266,7 @@ namespace Raven.Server.Web.System
 
             if(details != null)
             {
-                json[nameof(ServerNode.ServerVersionFromDatabaseTopology)] =
+                json[nameof(ServerNode.ServerVersion)] =
                     details.BuildInfo.AssemblyVersion ?? details.BuildInfo.ProductVersion;
             }
 

--- a/test/SlowTests/Issues/RavenDB-21173.cs
+++ b/test/SlowTests/Issues/RavenDB-21173.cs
@@ -60,7 +60,7 @@ public class RavenDB_21173 : ClusterTestBase
         }
     }
 
-    public class Doc
+    private class Doc
     {
         public string Id { get; set; }
         public int Progress { get; set; }

--- a/test/SlowTests/Issues/RavenDB-21173.cs
+++ b/test/SlowTests/Issues/RavenDB-21173.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21173 : ClusterTestBase
+{
+    public RavenDB_21173(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException()
+    {
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3);
+        using var store = GetDocumentStore(new Options
+        {
+            Server = leader,
+            ReplicationFactor = nodes.Count
+        });
+        var databaseName = store.Database;
+
+        var disposeNodeTask = Task.Run(async () =>
+        {
+            await Task.Delay(400);
+            var tag = store.GetRequestExecutor(databaseName).TopologyNodes.First().ClusterTag;
+            var server = nodes.Single(n => n.ServerStore.NodeTag == tag);
+            await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+        });
+        await ProcessDocument(store, "Docs/1-A");
+
+        await disposeNodeTask;
+    }
+
+    private async Task ProcessDocument(IDocumentStore store, string id)
+    {
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            var doc = new Doc { Id = id };
+            await session.StoreAsync(doc);
+            await session.SaveChangesAsync();
+        }
+
+        for (int i = 0; i < 2000; i++)
+        {
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var doc = await session.LoadAsync<Doc>(id);
+                doc.Progress = i;
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    public class Doc
+    {
+        public string Id { get; set; }
+        public int Progress { get; set; }
+    }
+
+}
+

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -30,9 +30,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new AttachmentsReplication(testOutputHelper))
+                    using (var test = new RavenDB_21173(testOutputHelper))
                     {
-                        await test.ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder_RevisionsDisabled_MissingAttachmentLoop();
+                        await test.ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException();
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21173/Concurrency-Exception-on-cluster-transaction

### Additional description

Concurrency Exception on cluster transaction.

Concurrency Exception on cluster transaction.
When the request executor gets the first topology, it gets it without the server versions, so in the first request (which is cluster-transaction), it send it with with DisableAtomicWrites=true, so it gets index 0 and throws a Concurrency exception.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
