### PR TITLE
RavenDB-21203 Increasing the default value of Cluster.MaxChangeVectorDistance configuration option from 10000 to 65536

### DIFF
--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -114,7 +114,7 @@ namespace Raven.Server.Config.Categories
         public TimeSetting CompareExchangeExpiredCleanupInterval { get; set; }
 
         [Description("Excceding the allowed change vector distance between two nodes, will move the lagged node to rehab.")]
-        [DefaultValue(10_000)]
+        [DefaultValue(65536)]
         [ConfigurationEntry("Cluster.MaxChangeVectorDistance", ConfigurationEntryScope.ServerWideOnly)]
         public long MaxChangeVectorDistance { get; set; }
         


### PR DESCRIPTION
This way we want to avoid moving a node to rehab immediately after getting a big batch of updates (e.g. from bulk insert, patch or queue sink)

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21203/Discussion-DatabaseTopologyUpdater-is-very-eager-to-move-node-to-Rehab-state-at-high-frequency

### Additional description

The idea is to reduce the eagerness of moving a node to rehab after pushing more inserts/updates there. Note that all tasks handled by this node are switched immediately to another node (member). 

### Type of change

- UX improvement

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing (during Kafka Sink testing)

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work
- No UI work is needed
