### PR TITLE
RavenDB-21145 - FastTests.Client.Hilo.Should_Resolve_Conflict_With_Highest_Number(options: DatabaseMode = Sharded , SearchEngineMode = Lucene)

### DIFF
--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -254,7 +254,9 @@ namespace FastTests.Client
                         Max = 128
                     };
                     s1.Store(hiloDoc, "Raven/Hilo/users");
-                    s1.Store(new User(), "marker/doc");
+                    s1.SaveChanges();
+
+                    s1.Store(new User(), "marker/doc$Raven/Hilo/users");
                     s1.SaveChanges();
                 }
                 using (var s2 = store2.OpenSession())
@@ -285,7 +287,7 @@ namespace FastTests.Client
             {
                 using (var session = store2.OpenSession())
                 {
-                    if (session.Load<object>("marker/doc") != null)
+                    if (session.Load<object>("marker/doc$Raven/Hilo/users") != null)
                         break;
                     Thread.Sleep(32);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21145

### Additional description

Fixed race in test where we wait for marker but it might be "bound" to a different shard than the one we fetch the asserted data from.

### Type of change

- Bug fix

### How risky is the change?

- Low 
