### PR TITLE
RavenDB-21097 - SlowTests.Client.Attachments.AttachmentsReplication.DeleteAttachments(options: DatabaseMode = Sharded , SearchEngineMode = Lucene)

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -294,10 +294,10 @@ namespace SlowTests.Client.Attachments
                 store1.Commands().Delete("users/1", null);
                 using (var session = store1.OpenSession())
                 {
-                    session.Store(new User { Name = "Marker 2" }, "marker2");
+                    session.Store(new User { Name = "Marker 2" }, "users/1$marker2");
                     session.SaveChanges();
                 }
-                Assert.True(WaitForDocument(store2, "marker2"));
+                Assert.True(WaitForDocument(store2, "users/1$marker2"));
                 await AssertAttachmentCount(store2, 0);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21097

### Additional description

Marker in test was stored on a different shard than the attachment so waiting for it did not indicate completion of the replication of the attachment's shard.
Now storing the marker on the attachment's shard.

### Type of change

- Bug fix

### How risky is the change?

- Low 

