### PR TITLE
RavenDB-21249 Fix loading non-existing document in cluster transaction

### DIFF
--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -264,10 +264,9 @@ namespace Raven.Server.Documents.Handlers
                             changeVector.Contains(Database.ClusterTransactionId) == false)
                         {
                             Debug.Assert(includeCompareExchangeValues != null, nameof(includeCompareExchangeValues) + " != null");
-                            long? guardIndex = includeCompareExchangeValues.GetAtomicGuardIndex(ClusterTransactionCommand.GetAtomicGuardKey(id), lastModifiedIndex);
-                            if (guardIndex != null)
+                            if (includeCompareExchangeValues.TryGetAtomicGuard(ClusterTransactionCommand.GetAtomicGuardKey(id), lastModifiedIndex, out var guardIndex, out _))
                             {
-                                var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, Database.ClusterTransactionId, guardIndex.Value, changeVector);
+                                var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, Database.ClusterTransactionId, guardIndex, changeVector);
                                 Debug.Assert(isValid, "ChangeVector didn't have ClusterTransactionId tag but now does?!");
                                 document.ChangeVector = cv;
                             }

--- a/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
@@ -76,16 +76,27 @@ namespace Raven.Server.Documents.Includes
             _includedKeys.Add(id);
         }
 
-        public long? GetAtomicGuardIndex(string key, long maxAllowedRaftId)
+        public bool TryGetAtomicGuard(string key, long maxAllowedRaftId, out long index, out BlittableJsonReaderObject value)
         {
-            if (_serverContext == null) CreateServerContext();
-            var value = _database.ServerStore.Cluster.GetCompareExchangeValue(_serverContext, CompareExchangeKey.GetStorageKey(_database.Name, key));
+            index = -1;
+            value = null;
 
-            if(value.Index > maxAllowedRaftId)
-                return null; // we are seeing partially committed value, skip it
-            if (value.Index < 0)
-                return null; 
-            return value.Index;
+            if (_serverContext == null)
+            {
+                CreateServerContext();
+            }
+
+            var result = _database.ServerStore.Cluster.GetCompareExchangeValue(_serverContext, CompareExchangeKey.GetStorageKey(_database.Name, key));
+
+            if (result.Index > maxAllowedRaftId)
+                return false; // we are seeing partially committed value, skip it
+
+            if (result.Index < 0)
+                return false;
+            
+            index = result.Index;
+            value = result.Value;
+            return true;
         }
         
         internal void Materialize(long maxAllowedRaftId)
@@ -93,22 +104,17 @@ namespace Raven.Server.Documents.Includes
             if (_includedKeys == null || _includedKeys.Count == 0)
                 return;
 
-            if (_serverContext == null) CreateServerContext();
-
             foreach (var includedKey in _includedKeys)
             {
                 if (string.IsNullOrEmpty(includedKey))
                     continue;
 
-                var value = _database.ServerStore.Cluster.GetCompareExchangeValue(_serverContext, CompareExchangeKey.GetStorageKey(_database.Name, includedKey));
-
-                if(value.Index > maxAllowedRaftId)
-                    continue; // we are seeing partially committed value, skip it
+                if (TryGetAtomicGuard(includedKey, maxAllowedRaftId, out var index, out var value) == false)
+                    continue;
                 
-                if (Results == null)
-                    Results = new Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>>(StringComparer.OrdinalIgnoreCase);
+                Results ??= new Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>>(StringComparer.OrdinalIgnoreCase);
 
-                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, value.Index, value.Value));
+                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, index, value));
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-19629.cs
+++ b/test/SlowTests/Issues/RavenDB-19629.cs
@@ -14,6 +14,18 @@ public class RavenDB_19629 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+    public async Task CanLoadAndSaveNonExistingDocument()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            var arava = await session.LoadAsync<User>("users/arava") ?? new User();
+            await session.StoreAsync(arava, "users/arava");
+            await session.SaveChangesAsync();
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
     public async Task CanDeleteCmpXchgValue2()
     {
         using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21249 

### Additional description

When loading non existing document via cluster tx, we got back the change vector `TRXN:-1-<guid>`. 
Saving it afterwards in the same session would send this change vector to the state machine, which is unable to process a negative index.

### Type of change

- Bug fix
- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
