### PR TITLE
RavenDB-21231: Trying to create an Slice from a 0 length (null pointer) should not fail

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -251,6 +251,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                         // We need to get the actual field, not the dynamic field. 
                         int propIdx = document.Data.GetPropertyIndex(fieldDescription.FieldName);
+                        if (propIdx < 0)
+                            continue; // The property does not exist in the data object, there is nothing to highlight.
+
                         BlittableJsonReaderObject.PropertyDetails property = default;
                         document.Data.GetPropertyByIndex(propIdx, ref property);
 

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -323,6 +323,8 @@ namespace Voron
 
         public readonly Span<byte> AsSpan()
         {
+            if (Size == 0)
+                return Span<byte>.Empty;
             return new Span<byte>(Content.Ptr, Size);
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21231

### Additional description
An slice from a null pointer (size 0) should not fail. It is a valid operation, that's why the Empty span exists.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
