### PR TITLE
RavenDB-21150 Deletion of non replicated tombstones

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -111,12 +111,15 @@ namespace Raven.Server.Documents.Replication
 
         public long GetMinimalEtagForReplication()
         {
+            DatabaseTopology topology;
             long minEtag = long.MaxValue;
 
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
-                var externals = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name).ExternalReplications;
+                var dbRecord = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name);
+                topology = dbRecord.Topology;
+                var externals = dbRecord.ExternalReplications;
                 if (externals != null)
                 {
                     foreach (var external in externals)
@@ -127,10 +130,20 @@ namespace Raven.Server.Documents.Replication
                     }
                 }
             }
+            var replicationNodes = new List<ReplicationNode>();
 
-            var replicationNodes = Destinations?.ToList();
-            if (replicationNodes == null || replicationNodes.Count == 0)
-                return minEtag;
+            foreach (var node in topology.AllNodes)
+            {
+                if (node == _server.NodeTag)
+                    continue;
+                var internalReplication = new InternalReplication
+                {
+                    NodeTag = node,
+                    Url = _clusterTopology.GetUrlFromTag(node),
+                    Database = Database.Name
+                };
+                replicationNodes.Add(internalReplication);
+            }
 
             foreach (var lastEtagPerDestination in _lastSendEtagPerDestination)
             {

--- a/test/SlowTests/Issues/RavenDB-21150.cs
+++ b/test/SlowTests/Issues/RavenDB-21150.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21150 : ClusterTestBase
+    {
+        public RavenDB_21150(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Replication)]
+        public async Task DontDeleteNonReplicatedTombstone()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            var databaseName = GetDatabaseName();
+            var nodeToRemove = leader.WebUrl == nodes[2].WebUrl ? nodes[0] : nodes[2];
+            using (var store1 = GetDocumentStore(new Options
+            {
+                   ModifyDatabaseName = s => databaseName,
+                   ReplicationFactor = 3,
+                   Server = leader,
+                   RunInMemory = false,
+                   ModifyDocumentStore = (store) => store.Conventions.DisableTopologyUpdates = true
+            }))
+            using (var store2 = new DocumentStore
+            {
+                   Database = databaseName,
+                   Urls = new []{ nodes.First(x => x.WebUrl != leader.WebUrl && x.WebUrl != nodeToRemove.WebUrl).WebUrl},
+                   Conventions = new DocumentConventions()
+                   {
+                       DisableTopologyUpdates = true
+                   }
+            }.Initialize())
+            {
+                using (var session = store1.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(TimeSpan.FromSeconds(30), replicas: 2);
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToRemove);
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    session.Delete( "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.True(WaitForDocumentDeletion(store1, "users/1", 15000));
+                Assert.True(WaitForDocumentDeletion(store2, "users/1", 15000));
+                DocumentDatabase documentDatabase;
+                nodes.Remove(nodeToRemove);
+
+                foreach (var node in nodes)
+                {
+                    documentDatabase = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+                    using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        Assert.Equal(1, documentDatabase.DocumentsStorage.GetNumberOfTombstones(ctx));
+                    }
+                }
+
+                foreach (var node in nodes)
+                {
+                    await node.ServerStore.DatabasesLandlord.RestartDatabase(databaseName);
+                }
+
+                int desCount;
+                await WaitForValueAsync(async () =>
+                {
+                    desCount = 0;
+                    foreach (var node in nodes)
+                    {
+                        documentDatabase = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
+                        desCount += documentDatabase.ReplicationLoader.Destinations.Count;
+                    }
+                    return desCount;
+                }, 3, 90000);
+
+                foreach (var node in nodes)
+                {
+                    documentDatabase = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                    long count = await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+                    Assert.Equal(0, count);
+                }
+
+                foreach (var node in nodes)
+                {
+                    documentDatabase = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store1.Database);
+                    using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var numberOfTombstone = documentDatabase.DocumentsStorage.GetNumberOfTombstones(ctx);
+                        Assert.Equal(1, numberOfTombstone);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21150

### Additional description

We didn't include all nodes when we checked for min Etag for replication. 
After the change, we include all nodes at node destinations before the tombstone deletion.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
