### PR TITLE
RavenDB-21249 ClusterWaitFor should not do topology updates

### DIFF
--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -615,7 +615,18 @@ namespace Tests.Infrastructure
             string database, 
             Func<IDocumentStore, Task<T>> waitFunc)
         {
-            var stores = nodes.Select(n => new DocumentStore {Database = database, Urls = new[] {n.WebUrl}}.Initialize()).ToArray();
+            var stores = nodes.Select(n => new DocumentStore
+            {
+                Database = database, 
+                Urls = new[]
+                {
+                    n.WebUrl
+                },
+                Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            }.Initialize()).ToArray();
 
             using (new DisposableAction(Action))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21249

### Additional description

We want to wait on every node, so we must avoid the topology update

### Type of change

- Test fix