### PR TITLE
RavenDB-21235  Write text for "About this view"

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -312,15 +312,36 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
                                 targetId="1"
                                 icon="about"
                                 color="info"
-                                description="Get additional info on what this feature can offer you"
+                                description="Get additional info on this feature"
                                 heading="About this view"
                             >
                                 <p>
-                                    <strong>Document Revisions</strong> is a feature that allows developers to keep
-                                    track of changes made to a document over time. When a document is updated in
-                                    RavenDB, a new revision is automatically created, preserving the previous version of
-                                    the document. This is particularly useful for scenarios where historical data and
-                                    versioning are crucial.
+                                    Creating <strong>Document Revisions</strong> allows keeping track of changes made to a document over time.
+                                </p>
+                                <p>
+                                    A document revision will be created when:
+                                    <ul>
+                                        <li>Revisions are defined and enabled for the document's collection.</li>
+                                        <li>The document has been modified.</li>
+                                    </ul>
+                                </p>
+                                <p>
+                                    Define the revisions configuration in this view:
+                                    <ul>
+                                        <li>Under section DEFAULTS:<br/>
+                                            Set default revisions configuration for all non-conflicting and conflicting documents.
+                                        </li>
+                                        <li>Under section COLLECTIONS:<br/>
+                                            Set revisions configuration for specific collections, overriding the defaults.
+                                        </li>
+                                    </ul>
+                                </p>
+                                <p>
+                                    This view also provides these options:
+                                    <ul>
+                                        <li>Revert all documents to a specific point in time.</li>
+                                        <li>Enforce the current configuration on all existing revisions in the database per collection.</li>
+                                    </ul>
                                 </p>
                                 <hr />
                                 <div className="small-label mb-2">useful links</div>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -316,23 +316,30 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
                                 heading="About this view"
                             >
                                 <p>
-                                    Creating <strong>Document Revisions</strong> allows keeping track of changes made to a document over time.
+                                    Creating <strong>Document Revisions</strong> allows keeping track of changes made to
+                                    a document over time.
                                 </p>
                                 <p>
                                     A document revision will be created when:
                                     <ul>
-                                        <li>Revisions are defined and enabled for the document's collection.</li>
+                                        <li>Revisions are defined and enabled for the document&apos;s collection.</li>
                                         <li>The document has been modified.</li>
                                     </ul>
                                 </p>
                                 <p>
                                     Define the revisions configuration in this view:
                                     <ul>
-                                        <li>Under section DEFAULTS:<br/>
-                                            Set default revisions configuration for all non-conflicting and conflicting documents.
+                                        <li>
+                                            Under section DEFAULTS:
+                                            <br />
+                                            Set default revisions configuration for all non-conflicting and conflicting
+                                            documents.
                                         </li>
-                                        <li>Under section COLLECTIONS:<br/>
-                                            Set revisions configuration for specific collections, overriding the defaults.
+                                        <li>
+                                            Under section COLLECTIONS:
+                                            <br />
+                                            Set revisions configuration for specific collections, overriding the
+                                            defaults.
                                         </li>
                                     </ul>
                                 </p>
@@ -340,7 +347,10 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
                                     This view also provides these options:
                                     <ul>
                                         <li>Revert all documents to a specific point in time.</li>
-                                        <li>Enforce the current configuration on all existing revisions in the database per collection.</li>
+                                        <li>
+                                            Enforce the current configuration on all existing revisions in the database
+                                            per collection.
+                                        </li>
                                     </ul>
                                 </p>
                                 <hr />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -345,7 +345,7 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
                                 </p>
                                 <hr />
                                 <div className="small-label mb-2">useful links</div>
-                                <a href="https://ravendb.net/l/SOMRWC/6.0/Csharp" target="_blank">
+                                <a href="https://ravendb.net/l/OFVLX8/latest" target="_blank">
                                     <Icon icon="newtab" /> Docs - Document Revisions
                                 </a>
                             </AccordionItemWrapper>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -244,7 +244,7 @@ export default function EditRevision(props: EditRevisionProps) {
                     <Button type="button" color="secondary" onClick={toggle}>
                         Cancel
                     </Button>
-                    <Button type="submit" color="success" disabled={disableSubmitButton}>
+                    <Button type="submit" color="success" disabled={disableSubmitButton} title="Add this configuration">
                         <Icon icon={getSubmitIcon(taskType)} />
                         {_.startCase(taskType)} config
                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -297,12 +297,15 @@ export function BackupsPage(props: BackupsPageProps) {
                                     This view enables creating:
                                     <ul>
                                         <li className="margin-bottom-xs margin-top-xs">
-                                            <strong>Manual Backup</strong><br />
+                                            <strong>Manual Backup</strong>
+                                            <br />
                                             Create a one-time backup for this database.
                                         </li>
                                         <li>
-                                            <strong>Periodic Backups</strong><br />
-                                            Define an ongoing-task that will automatically create periodic backups for this database at the defined schedule.  
+                                            <strong>Periodic Backups</strong>
+                                            <br />
+                                            Define an ongoing-task that will automatically create periodic backups for
+                                            this database at the defined schedule.
                                         </li>
                                     </ul>
                                 </p>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -308,7 +308,7 @@ export function BackupsPage(props: BackupsPageProps) {
                                 </p>
                                 <hr />
                                 <div className="small-label mb-2">useful links</div>
-                                <a href="https://ravendb.net/l/GMBYOH/6.0/Csharp" target="_blank">
+                                <a href="https://ravendb.net/l/GMBYOH/latest" target="_blank">
                                     <Icon icon="newtab" /> Docs - Backups
                                 </a>
                             </AccordionItemWrapper>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -287,15 +287,24 @@ export function BackupsPage(props: BackupsPageProps) {
                                 icon="about"
                                 color="info"
                                 heading="About this view"
-                                description="Get additional info on what this feature can offer you"
+                                description="Get additional info on this feature"
                             >
                                 <p>
                                     <strong>Backups</strong> save your data at a specific point in time and allow you to
-                                    restore your database from that point.
+                                    restore your database to that point.
                                 </p>
                                 <p>
-                                    This Studio view enables you to create ongoing periodic backup tasks, as well as
-                                    one-time manual backups, for a particular database.
+                                    This view enables creating:
+                                    <ul>
+                                        <li className="margin-bottom-xs margin-top-xs">
+                                            <strong>Manual Backup</strong><br />
+                                            Create a one-time backup for this database.
+                                        </li>
+                                        <li>
+                                            <strong>Periodic Backups</strong><br />
+                                            Define an ongoing-task that will automatically create periodic backups for this database at the defined schedule.  
+                                        </li>
+                                    </ul>
                                 </p>
                                 <hr />
                                 <div className="small-label mb-2">useful links</div>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
@@ -17,7 +17,26 @@ export function EditKafkaSinkTaskInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is subscription task edit view
+                    Define a <strong>Kafka Sink ongoing-task</strong> in order to consume and process incoming messages from Kafka topics.
+                </p>
+                <p>
+                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the incoming messages.
+                </p>
+                <p>
+                    <ul>
+                        <li className="margin-top">
+                            In the task definition:<br />
+                            Define the connection string (bootstrap servers and any additional connection options).
+                        </li>
+                        <li className="margin-top-xxs">
+                            In the script definition:<br />
+                            Define the Kafka topic the script will subscribe to.<br />
+                            The script can be tested to preview the resulting documents.
+                        </li>
+                        <li className="margin-top-xxs">
+                            Incoming messages are expected only as JSON.
+                        </li>
+                    </ul>    
                 </p>
             </AccordionItemWrapper>
             {licenseType === "Community" && (

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
@@ -3,6 +3,7 @@ import AccordionLicenseNotIncluded from "components/common/AccordionLicenseNotIn
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
+import {Icon} from "components/common/Icon";
 
 export function EditPeriodicBackupTaskInfoHub() {
     const licenseType = useAppSelector(licenseSelectors.licenseType);
@@ -17,8 +18,30 @@ export function EditPeriodicBackupTaskInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is periodic backup task edit view
+                    Define an ongoing-task that will automatically create periodic backups for this database at the defined <strong>schedule</strong>.
                 </p>
+                <p>
+                    Configuration options available:
+                    <ul>
+                        <li>Customize the backup type (Backup or Snapshot)</li>
+                        <li>Select full and/or incremental backups</li>
+                        <li>Set the backups retention period</li>
+                        <li>Specify destinations, where the backup files will be stored</li>
+                        <li>Opt for backup data encryption to enhance data security</li>
+                    </ul>
+                </p>
+                <p>
+                    In addition:
+                    <ul>
+                        <li>The task state can be disabled as needed</li>
+                        <li>You can define a specific node to handle this task</li>
+                    </ul>
+                </p>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href="https://ravendb.net/l/GMBYOH/6.0/Csharp" target="_blank">
+                    <Icon icon="newtab" /> Docs - Backups
+                </a>
             </AccordionItemWrapper>
             {licenseType === "Community" && (
                 <AccordionLicenseNotIncluded

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
@@ -34,7 +34,7 @@ export function EditPeriodicBackupTaskInfoHub() {
                     In addition:
                     <ul>
                         <li>The task state can be disabled as needed</li>
-                        <li>You can define a specific node to handle this task</li>
+                        <li>You can set a responsible node to handle this task</li>
                     </ul>
                 </p>
                 <hr />

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
@@ -39,7 +39,7 @@ export function EditPeriodicBackupTaskInfoHub() {
                 </p>
                 <hr />
                 <div className="small-label mb-2">useful links</div>
-                <a href="https://ravendb.net/l/GMBYOH/6.0/Csharp" target="_blank">
+                <a href="https://ravendb.net/l/GMBYOH/latest" target="_blank">
                     <Icon icon="newtab" /> Docs - Backups
                 </a>
             </AccordionItemWrapper>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
@@ -17,7 +17,26 @@ export function EditRabbitMqSinkTaskInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is subscription task edit view
+                    Define a <strong>RabbitMQ Sink ongoing-task</strong> in order to consume and process incoming messages from RabbitMQ queues.
+                </p>
+                <p>
+                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the incoming messages.
+                </p>
+                <p>
+                    <ul>
+                        <li className="margin-top">
+                            In the task definition:<br />
+                            Define the connection string.
+                        </li>
+                        <li className="margin-top-xxs">
+                            In the script definition:<br />
+                            Define the RabbitMQ queue the script will subscribe to.<br />
+                            The script can be tested to preview the resulting documents.
+                        </li>
+                        <li className="margin-top-xxs">
+                            Incoming messages are expected only as JSON.
+                        </li>
+                    </ul>
                 </p>
             </AccordionItemWrapper>
             {licenseType === "Community" && (

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -3,6 +3,7 @@ import AccordionLicenseLimited from "components/common/AccordionLicenseLimited";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
+import {Icon} from "components/common/Icon";
 
 export function EditSubscriptionTaskInfoHub() {
     const licenseType = useAppSelector(licenseSelectors.licenseType);
@@ -17,8 +18,29 @@ export function EditSubscriptionTaskInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is subscription task edit view
+                    Define a <strong>Subscription Query</strong> in this view to create a subscription-task on the server to which clients can subscribe.
                 </p>
+                <p>
+                    When a client opens a connection to this task, RavenDB sends all documents <strong>matching the defined query</strong> to the client for processing.
+                </p>
+                <p>
+                    This is an <strong>ongoing process</strong>, whenever a new or updated document matches the subscription query, it will also be sent to the client.
+                </p>
+                <p>
+                    Documents are sent to the client in <strong>batches</strong>.<br />
+                    The client processes a batch and receives the next one only after acknowledging the batch was processed.
+                </p>
+                <p>
+                    <ul>
+                        <li>The <strong>starting point</strong> from where to send the matching documents can be configured.</li>
+                        <li>You can <strong>test the subscription</strong> in this view to preview sample document results that will be sent.</li>
+                    </ul>
+                </p>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href="https://ravendb.net/l/I5TMCK/6.0/Csharp" target="_blank">
+                    <Icon icon="newtab" /> Docs - Subscription Task
+                </a>
             </AccordionItemWrapper>
             {licenseType === "Community" && (
                 <AccordionLicenseLimited

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -38,7 +38,7 @@ export function EditSubscriptionTaskInfoHub() {
                 </p>
                 <hr />
                 <div className="small-label mb-2">useful links</div>
-                <a href="https://ravendb.net/l/I5TMCK/6.0/Csharp" target="_blank">
+                <a href="https://ravendb.net/l/I5TMCK/latest" target="_blank">
                     <Icon icon="newtab" /> Docs - Subscription Task
                 </a>
             </AccordionItemWrapper>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqSinkTask.ts
@@ -21,7 +21,6 @@ import queueSinkSyntax from "viewmodels/database/tasks/queueSinkSyntax";
 import patchDebugActions from "viewmodels/database/patch/patchDebugActions";
 import licenseModel from "models/auth/licenseModel";
 import { EditRabbitMqSinkTaskInfoHub } from "./EditRabbitMqSinkTaskInfoHub";
- 
 
 class rabbitMqTaskTestMode {
     db: KnockoutObservable<database>;
@@ -47,6 +46,9 @@ class rabbitMqTaskTestMode {
         this.db = db;
         this.validateParent = validateParent;
         this.configurationProvider = configurationProvider;
+
+        // on edit RabbitMQ view we want to show documents by default
+        this.actions.showDocumentsInModified(true);
     }
 
     initObservables() {

--- a/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
@@ -3,6 +3,7 @@ import AccordionLicenseNotIncluded from "components/common/AccordionLicenseNotIn
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
+import {Icon} from "components/common/Icon";
 
 export function EditServerWideBackupInfoHub() {
     const licenseType = useAppSelector(licenseSelectors.licenseType);
@@ -40,6 +41,11 @@ export function EditServerWideBackupInfoHub() {
                         <li>Disabling this task will disable the corresponding tasks per database.</li>
                     </ul>
                 </p>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href="https://ravendb.net/l/SXSM33/latest" target="_blank">
+                    <Icon icon="newtab" /> Docs - Server-Wide Backup Task
+                </a>
             </AccordionItemWrapper>
             {licenseType === "Community" && (
                 <AccordionLicenseNotIncluded

--- a/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
@@ -17,7 +17,28 @@ export function EditServerWideBackupInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is server-wide backup task edit view
+                    Defining a <strong>Server-Wide backup task</strong> will create an ongoing periodic backup task for each database in your cluster.
+                    <ul className="margin-top-xs">
+                        <li>You can select specific databases to exclude from the task.</li>
+                        <li>The configurations set in the Server-Wide task will be applied to the corresponding ongoing backup task created per database.</li>
+                    </ul>
+                </p>
+                <p>
+                    Configuration options available:
+                    <ul className="margin-top-xs">
+                        <li>Customize the backup type (Backup or Snapshot)</li>
+                        <li>Select full and/or incremental backups</li>
+                        <li>Set the backups retention period</li>
+                        <li>Specify destinations, where the backup files will be stored</li>
+                        <li>Opt for backup data encryption to enhance data security</li>
+                    </ul>
+                </p>
+                <p>
+                    In addition:
+                    <ul className="margin-top-xs">
+                        <li>You can set a responsible node to handle this task.</li>
+                        <li>Disabling this task will disable the corresponding tasks per database.</li>
+                    </ul>
                 </p>
             </AccordionItemWrapper>
             {licenseType === "Community" && (

--- a/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideExternalReplicationInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideExternalReplicationInfoHub.tsx
@@ -17,7 +17,18 @@ export function EditServerWideExternalReplicationInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    This is server-wide external replication task edit view
+                    Defining a <strong>Server-Wide External-Replication task</strong> will create an ongoing External-Replication task for each database in your cluster.
+                    <ul className="margin-top-xs">
+                        <li>You can select specific databases to exclude from the task.</li>
+                        <li>The configurations set in the Server-Wide task will be applied to the corresponding ongoing task created per database.</li>
+                    </ul>
+                </p>
+                <p>
+                    The <strong>connection string</strong> used in each corresponding database task will be composed of:
+                    <ul className="margin-top-xs">
+                        <li>The discovery URLs provided here.</li>
+                        <li>The target database name will be the individual source database name.</li>
+                    </ul>
                 </p>
             </AccordionItemWrapper>
             {licenseType === "Community" && (

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaSinkTask.html
@@ -316,7 +316,7 @@
             </ul>
         </div>
         <div class="tab-content flex-grow" data-bind="css: { 'pe-none item-disabled': $root.licenseType === 'Community' }">
-            <div class="tab-pane fade in active margin-bottom" id="testResultsModified">
+            <div role="tabpanel" class="tab-pane fade in active margin-bottom" id="testResultsModified">
                 <div data-bind="with: actions">
                     <div data-bind="compose: $root.patchDebugActionsModifiedView"></div>
                 </div>
@@ -326,7 +326,7 @@
                     <div data-bind="compose: $root.patchDebugActionsLoadedView"></div>
                 </div>
             </div>
-            <div class="tab-pane fade margin-bottom" id="testResultsDeleted">
+            <div role="tabpanel" class="tab-pane fade margin-bottom" id="testResultsDeleted">
                 <div data-bind="with: actions">
                     <div data-bind="compose: $root.patchDebugActionsDeletedView"></div>
                 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqSinkTask.html
@@ -287,15 +287,15 @@
         <div class="tabs" data-bind="css: { 'pe-none item-disabled': $root.licenseType === 'Community' }">
             <ul class="nav nav-tabs" role="tablist">
                 <li role="presentation" data-bind="visible: testAlreadyExecuted" class="active">
-                    <a href="#testResultsLoaded" role="tab" data-toggle="tab">
-                        <i class="icon-import"></i><span>Loaded</span>
-                        <span class="label label-primary  margin-left-xxs" data-bind="text: actions.loadedCount() || ''"></span>
+                    <a href="#testResultsModified" role="tab" data-toggle="tab">
+                        <i class="icon-export"></i><span>Put</span>
+                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.modifiedCount() || ''"></span>
                     </a>
                 </li>
                 <li role="presentation" data-bind="visible: testAlreadyExecuted">
-                    <a href="#testResultsModified" role="tab" data-toggle="tab">
-                        <i class="icon-export"></i><span>Modified</span>
-                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.modifiedCount() || ''"></span>
+                    <a href="#testResultsLoaded" role="tab" data-toggle="tab">
+                        <i class="icon-import"></i><span>Loaded</span>
+                        <span class="label label-primary margin-left-xxs" data-bind="text: actions.loadedCount() || ''"></span>
                     </a>
                 </li>
                 <li role="presentation" data-bind="visible: testAlreadyExecuted">
@@ -312,17 +312,17 @@
             </ul>
         </div>
         <div class="tab-content flex-grow" data-bind="css: { 'pe-none item-disabled': $root.licenseType === 'Community' }">
-            <div role="tabpanel" class="tab-pane fade in active" id="testResultsLoaded">
-                <div data-bind="with: actions">
-                    <div data-bind="compose: $root.patchDebugActionsLoadedView"></div>
-                </div>
-            </div>
-            <div class="tab-pane fade margin-bottom" id="testResultsModified">
+            <div role="tabpanel" class="tab-pane fade margin-bottom in active" id="testResultsModified">
                 <div data-bind="with: actions">
                     <div data-bind="compose: $root.patchDebugActionsModifiedView"></div>
                 </div>
             </div>
-            <div class="tab-pane fade margin-bottom" id="testResultsDeleted">
+            <div role="tabpanel" class="tab-pane fade margin-bottom" id="testResultsLoaded">
+                <div data-bind="with: actions">
+                    <div data-bind="compose: $root.patchDebugActionsLoadedView"></div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane fade margin-bottom" id="testResultsDeleted">
                 <div data-bind="with: actions">
                     <div data-bind="compose: $root.patchDebugActionsDeletedView"></div>
                 </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21235/Write-About-this-view-texts

### Additional description
1. Added text for:
-  Server-Wide Backups
- Server-Wide External Replication
- Kafka Sink
- RabbitMQ Sink
- Document Revisions
- Periodic Backups
- Subscriptions Revisions

2. Fixed tabs in the RabbitMQ Test Area (@ml054) 

### Type of change
- Task + bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform platform-specific issue?
- No

### Documentation update
See https://issues.hibernatingrhinos.com/issue/RDoc-2489/Document-RavenDB-Queue-Sink-support

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
