### PR TITLE
RavenDB-21225 Corax invalid stored field type

### DIFF
--- a/src/Corax/IndexSearcher/IndexSearcher.cs
+++ b/src/Corax/IndexSearcher/IndexSearcher.cs
@@ -206,7 +206,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
         else if (binding.Mode is FieldIndexingMode.Exact || analyzer is null)
         {
-            using var _ = Allocator.AllocateDirect(originalTerm.Length, ByteStringType.Mutable, out var originalTermSliced);
+            Allocator.AllocateDirect(originalTerm.Length, ByteStringType.Mutable, out var originalTermSliced);
             originalTerm.CopyTo(originalTermSliced.ToSpan());
             terms.Add(new Slice(originalTermSliced)); 
             return;

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -297,6 +297,9 @@ public unsafe struct EntryTermsReader
                     case StoredFieldType.Empty | StoredFieldType.Raw:
                         IsRaw = true;
                         goto case StoredFieldType.Empty;
+                    case StoredFieldType.None:
+                        System.Diagnostics.Debug.Assert(false, $"This should not happen, got None stored field, type is: {type}");
+                        goto case StoredFieldType.Null;
                     default:
                         throw new ArgumentOutOfRangeException(type.ToString());
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -142,7 +142,7 @@ public struct CoraxBooleanItem : IQueryMatch
             return new Slice(bs);
         }
 
-        var term = _indexSearcher.EncodeAndApplyAnalyzer(Field, TermAsString, true).AsSpan();
+        var term = _indexSearcher.EncodeAndApplyAnalyzer(Field, TermAsString).AsSpan();
         _indexSearcher.Allocator.Allocate(term.Length, out var output);
 
         term.CopyTo(output.ToSpan());

--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -445,12 +445,17 @@ namespace Voron.Data.PostingLists
                         continue;
                     }
 
-                    PostingListLeafPage.Merge(_llt.Allocator, ref decoder, leafPage.Header,
-                        parent.LastSearchPosition == 0 ? leafPage.Header : siblingHeader,
-                        parent.LastSearchPosition == 0 ? siblingHeader : leafPage.Header
-                    );
+                    // we assume that the two pages can be merged, note that they don't *have* to
+                    // we do a quick validation above, but we don't check if shared prefixes, etc are involved
+                    if (PostingListLeafPage.TryMerge(_llt.Allocator, ref decoder, leafPage.Header,
+                            parent.LastSearchPosition == 0 ? leafPage.Header : siblingHeader,
+                            parent.LastSearchPosition == 0 ? siblingHeader : leafPage.Header
+                        ))
+                    {
+                        
+                        MergeSiblingsAtParent();
+                    }
 
-                    MergeSiblingsAtParent();
                 }
             }
 

--- a/test/SlowTests/Issues/RavenDB-21255.cs
+++ b/test/SlowTests/Issues/RavenDB-21255.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21255 : RavenTestBase
+{
+    public RavenDB_21255(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanQueryByFullTextWithHyphens(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new ItemIdx().Execute(store);
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item("Dog-Cat-Snake"));
+            s.SaveChanges();
+        }
+        
+        Indexes.WaitForIndexing(store);
+        
+        using (var s = store.OpenSession())
+        {
+            var results = s.Query<Item, ItemIdx>()
+                .Search(x => x.Desc, "Dog-Cat-Snake")
+                .ToList();
+            Assert.NotEmpty(results);
+        }
+
+        
+    }
+
+    private record Item(string Desc);
+
+    private class ItemIdx : AbstractIndexCreationTask<Item>
+    {
+        public ItemIdx()
+        {
+            Map = items => from i in items select new { i.Desc };
+            Index(x => x.Desc, FieldIndexing.Search);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21225.cs
+++ b/test/SlowTests/Issues/RavenDB_21225.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21225 : RavenTestBase
+{
+    public RavenDB_21225(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanStoreAndDeleteEntryWithNumericStoredField(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        new Items_Index().Execute(store);
+
+        string id;
+        using (var s = store.OpenSession())
+        {
+            var item = new Item("Banana", 10, 1);
+            s.Store(item);
+            id = s.Advanced.GetDocumentId(item);
+            s.SaveChanges();
+        }
+        Indexes.WaitForIndexing(store);
+        
+        using (var s = store.OpenSession())
+        {
+            s.Delete(id);
+            s.SaveChanges();
+        }
+        Indexes.WaitForIndexing(store);
+        
+        
+        using (var s = store.OpenSession())
+        {
+            int count = s.Query<Items_Index>().Count();
+            Assert.Equal(0, count);
+        }
+
+    }
+
+    private record Item(string Name, double CostPerItem, int Quantity);
+
+
+    private class Items_Index : AbstractIndexCreationTask<Item, Items_Index.Result>
+    {
+        public record Result(string Name, double Amount);
+        
+        public Items_Index()
+        {
+            Map = items =>
+                from i in items
+                select new { i.Name, Amount = i.Quantity * i.CostPerItem };
+            
+            Store(x=>x.Amount, FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
…ion: Specified argument was out of the range of valid values. (Parameter 'Tuple')

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21225 
https://issues.hibernatingrhinos.com/issue/RavenDB-21253
https://issues.hibernatingrhinos.com/issue/RavenDB-21255

### Additional description

Couldn't reproduce this, but pretty sure that this was fixed previously by changing how we record nulls.
At any rate, added explicit checks for this which should provide additional insight.