### PR TITLE
RavenDB-21174: High contention fixes.

### DIFF
--- a/src/Sparrow/Collections/ConcurrentSet.cs
+++ b/src/Sparrow/Collections/ConcurrentSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -75,7 +76,8 @@ namespace Sparrow.Collections
 
         public IEnumerator<T> GetEnumerator()
         {
-            return _inner.Keys.GetEnumerator();
+            foreach (var item in _inner)
+                yield return item.Key;
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21174

### Additional description
Iterating over keys in ConcurrentSet causes locks and therefore is susceptible to high contention and convoys.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
