### PR TITLE
RavenDB-21270: Remove the requirement to zero out memory.

### DIFF
--- a/src/Voron/Impl/SliceSmallSet.cs
+++ b/src/Voron/Impl/SliceSmallSet.cs
@@ -221,7 +221,17 @@ namespace Voron.Impl
             _perCorePools.KeySizesPool.Return(_keySizes);
             _perCorePools.KeyHashesPool.Return(_keyHashes);
             _perCorePools.KeysPool.Return(_keys);
+
+            // If we are holding references, then we will clear the portion of the values array
+            // that it is in use.
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+            {
+                int valuesLength = Math.Min(_currentIdx, _length - 1) + 1;
+                if (valuesLength >= 0)
+                    _values.AsSpan(0, valuesLength).Clear();
+            }
             _perCorePools.ValuesPool.Return(_values);
+
             PerCoreArrayPools.TryPush(_perCorePools);
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21270

### Additional description

SliceSmallSet is performance sensitive, specially during querying it will increase latency. Removing the requirement from zeroing memory on dispose has an impact of 7.77% on the latency of a query. 

Errors on this particular class are known to cause subtle transaction sharing therefore extensive test and review has to be conducted. Special attention on the behavior of `_currentIdx` is required.

The most prominent type of error is: `"Cannot add a value in a read only transaction on $Root in Read"`, it is recommended to run multiple instances of test before merging. 

### Type of change
- Optimization

### How risky is the change?
- Moderate

### Backward compatibility
- Non breaking change