### PR TITLE
RavenDB-21170 - fix a race in ThreadHoppingReaderWriterLock

### DIFF
--- a/test/FastTests/Voron/ReaderWriterLockTests.cs
+++ b/test/FastTests/Voron/ReaderWriterLockTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Voron.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class ReaderWriterLockTests : NoDisposalNeeded
+    {
+        public ReaderWriterLockTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task WriterWhileHavingMultipleReaders()
+        {
+            var readWriteLock = new ThreadHoppingReaderWriterLock();
+            const int timeoutInMs = 30_000;
+
+            var reader1Wait = new SemaphoreSlim(initialCount: 0);
+            var reader1Signal = new SemaphoreSlim(initialCount: 0);
+            readWriteLock.ForTestingPurposesOnly().BeforeReaderWriterWait = () =>
+            {
+                reader1Signal.Release();
+                reader1Wait.Wait();
+            };
+
+            readWriteLock.EnterWriteLock();
+
+            var reader1Task = Task.Run(() =>
+            {
+                var sp = Stopwatch.StartNew();
+                var lockTaken = readWriteLock.TryEnterReadLock(timeout: TimeSpan.FromMilliseconds(timeoutInMs));
+                return (LockTaken: lockTaken, ElapsedInMs: sp.ElapsedMilliseconds);
+            });
+
+            reader1Signal.Wait();
+
+            var reader2Signal = new SemaphoreSlim(initialCount: 0);
+            var reader2Wait = new SemaphoreSlim(initialCount: 0);
+            readWriteLock.ForTestingPurposesOnly().BeforeResetOfReaderWait = () =>
+            {
+                reader2Signal.Release();
+                reader2Wait.Wait();
+            };
+
+            var reader2 = Task.Run(() =>
+            {
+                var sp = Stopwatch.StartNew();
+                var lockTaken = readWriteLock.TryEnterReadLock(timeout: TimeSpan.FromMilliseconds(timeoutInMs));
+                return (LockTaken: lockTaken, ElapsedInMs: sp.ElapsedMilliseconds);
+            });
+
+
+            reader2Signal.Wait();
+
+            readWriteLock.ExitWriteLock();
+
+            reader2Wait.Release();
+
+            var resultReader2 = await reader2;
+            Assert.True(resultReader2.LockTaken);
+            Assert.True(resultReader2.ElapsedInMs < 10, $"elapsed: {resultReader2.ElapsedInMs}");
+
+            reader1Wait.Release();
+
+            var resultReader1 = await reader1Task;
+            Assert.True(resultReader1.LockTaken);
+            Assert.True(resultReader1.ElapsedInMs < 10, $"elapsed: {resultReader1.ElapsedInMs}");
+        }
+    }
+}

--- a/test/FastTests/Voron/ReaderWriterLockTests.cs
+++ b/test/FastTests/Voron/ReaderWriterLockTests.cs
@@ -63,13 +63,13 @@ namespace FastTests.Voron
 
             var resultReader2 = await reader2;
             Assert.True(resultReader2.LockTaken);
-            Assert.True(resultReader2.ElapsedInMs < 10, $"elapsed: {resultReader2.ElapsedInMs}");
+            Assert.True(resultReader2.ElapsedInMs < 1000, $"elapsed: {resultReader2.ElapsedInMs}");
 
             reader1Wait.Release();
 
             var resultReader1 = await reader1Task;
             Assert.True(resultReader1.LockTaken);
-            Assert.True(resultReader1.ElapsedInMs < 10, $"elapsed: {resultReader1.ElapsedInMs}");
+            Assert.True(resultReader1.ElapsedInMs < 1000, $"elapsed: {resultReader1.ElapsedInMs}");
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21170/Cluster-transaction-is-taking-a-lot-of-time-to-execute

### Additional description

We might have a write transaction that is waiting for a running flusher to finish.
In some cases, we might end up waiting for the signal for `30sec`, and the transaction would appear to run for a long time.
In other cases, we might get - `Waited for 00:00:30 for read access of the flushing in progress lock, but could not get it, the flushing in progress lock is currently owned by thread`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed
