### PR TITLE
RavenDB-21016 Databases view: Database stays in Offline mode on UI after enabling it

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
@@ -90,19 +90,8 @@ export const syncDatabaseDetails = (): AppThunk<UnsubscribeListener> => (dispatc
     return dispatch(
         addAppListener({
             actionCreator: databasesSlice.actions.databasesLoaded,
-            effect: (action, api) => {
-                const state = api.getState();
-                const existingData = state.databasesView.databaseDetailedInfo.ids;
-
-                const needsRefresh = action.payload.some((db) => {
-                    const locations = DatabaseUtils.getLocations(db);
-                    const ids = locations.map((l) => databasesViewSliceInternal.selectDatabaseInfoId(db.name, l));
-                    return ids.some((id) => !existingData.includes(id));
-                });
-
-                if (needsRefresh) {
-                    api.dispatch(throttledReloadDatabaseDetails);
-                }
+            effect: (_, api) => {
+                api.dispatch(throttledReloadDatabaseDetails);
             },
         })
     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21016/Databases-view-Database-stays-in-Offline-mode-on-UI-after-enabling-it

### Additional description

Not only differences in ids require database details refresh.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
