### PR TITLE
[RFC] RavenDB-21043: Change the limits for different cases

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -35,23 +35,38 @@ namespace Raven.Server.Config.Categories
             QueryClauseCacheSize = PlatformDetails.Is32Bits ? new Size(32, SizeUnit.Megabytes) : (MemoryInformation.TotalPhysicalMemory / 10);
             MaximumSizePerSegment = new Size(PlatformDetails.Is32Bits ? 128 : 1024, SizeUnit.Megabytes);
             LargeSegmentSizeToMerge = new Size(PlatformDetails.Is32Bits ? 16 : 32, SizeUnit.Megabytes);
-            MaxAllocationsAtDictionaryTraining = new Size(PlatformDetails.Is32Bits ? 128 : 2048, SizeUnit.Megabytes);
 
             var totalMem = MemoryInformation.TotalPhysicalMemory;
 
+            Size defaultAllocationsForDictionaryTraining;
             Size defaultEncryptedTransactionSizeLimit;
-
             if (PlatformDetails.Is32Bits || _root.Storage.ForceUsing32BitsPager || totalMem <= new Size(1, SizeUnit.Gigabytes))
+            {
+                defaultAllocationsForDictionaryTraining = new Size(128, SizeUnit.Megabytes);
                 defaultEncryptedTransactionSizeLimit = new Size(96, SizeUnit.Megabytes);
+            }
             else if (totalMem <= new Size(4, SizeUnit.Gigabytes))
+            {
+                defaultAllocationsForDictionaryTraining = new Size(128, SizeUnit.Megabytes);
                 defaultEncryptedTransactionSizeLimit = new Size(128, SizeUnit.Megabytes);
+            }
             else if (totalMem <= new Size(16, SizeUnit.Gigabytes))
+            {
+                defaultAllocationsForDictionaryTraining = new Size(256, SizeUnit.Megabytes);
                 defaultEncryptedTransactionSizeLimit = new Size(256, SizeUnit.Megabytes);
+            }
             else if (totalMem <= new Size(64, SizeUnit.Gigabytes))
+            {
+                defaultAllocationsForDictionaryTraining = new Size(1024, SizeUnit.Megabytes);
                 defaultEncryptedTransactionSizeLimit = new Size(512, SizeUnit.Megabytes);
+            }
             else
+            {
+                defaultAllocationsForDictionaryTraining = new Size(2048, SizeUnit.Megabytes);
                 defaultEncryptedTransactionSizeLimit = new Size(1024, SizeUnit.Megabytes);
+            }
 
+            MaxAllocationsAtDictionaryTraining = defaultAllocationsForDictionaryTraining;
             EncryptedTransactionSizeLimit = defaultEncryptedTransactionSizeLimit;
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21043

### Additional description
After the issue was open, I really don't know how unmanaged allocations are not being tracked properly by `NativeMemory.CurrentThreadStats` class. Which is pretty clear the case of what we are using to control the training process.

Either way, it seems from analyzing the initialization code that Encrypted databases are treated like a 32bits  system, therefore it makes sense to share the behavior in this case and be much more strict in the memory usage.

Following that concept and considering cases where 10s or 100s of indexes are created in a single go, I went ahead and create a similar scaling to be considered for inclusion. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Documentation update
- If accepted this change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.