### PR TITLE
RavenDB-20949 : fix flaky test

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -401,7 +401,9 @@ namespace FastTests
             }
             catch (AllTopologyNodesDownException)
             {
-
+            }
+            catch (ConcurrencyException)
+            {
             }
             catch (Exception e)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20949/RachisTests.DatabaseCluster.AtomicClusterReadWriteTests.ClusterWideTransactionWhenRestoreFromIncrementalBackupAfterStoreAndUpdat

### Additional description

`GetDocumentStore.Dispose` : avoid throwing when we get a concurrency exception on attempt to delete the database (can happen if term was changed)

### Type of change

- Tests stabilization

### How risky is the change?

- Low 
