### PR TITLE
RavenDB-21272 Fixing Corax crashing on map/reduce index

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -2280,7 +2280,7 @@ namespace Corax
             {
                 Sort.Run(_entriesForTermsRemovalsBuffer.RawItems, _entriesForTermsRemovalsBuffer.Count);
                 entriesToTerms.InitializeCursorState();
-                for (int i = 0; i < _entriesForTermsAdditionsBuffer.Count; i++)
+                for (int i = 0; i < _entriesForTermsRemovalsBuffer.Count; i++)
                 {
                     Int64LookupKey key = _entriesForTermsRemovalsBuffer.RawItems[i];
                     if (entriesToTerms.TryGetNextValue(ref key, out _))

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -6,7 +6,12 @@ namespace Voron.Data.Lookups;
 public struct DoubleLookupKey : ILookupKey
 {
     public double Value;
-    
+
+    public void Reset()
+    {
+        
+    }
+
     public long ToLong()
     {
         return BitConverter.DoubleToInt64Bits(Value);

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -4,6 +4,7 @@ namespace Voron.Data.Lookups;
 
 public interface ILookupKey
 {
+    void Reset();
     long ToLong();
 
     static abstract T FromLong<T>(long l);

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -6,7 +6,12 @@ namespace Voron.Data.Lookups;
 public struct Int64LookupKey : ILookupKey
 {
     public long Value;
-    
+
+    public void Reset()
+    {
+        
+    }
+
     public long ToLong()
     {
         return Value;

--- a/test/FastTests/Corax/Bugs/RavenDB-21272.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21272.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using System.Text;
+using FastTests.Voron;
+using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_21272 : StorageTest
+{
+    public RavenDB_21272(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void CanHandleDeletionOfSeparatorKeyWhenTheLeafKeyWasAlreadyRemoved()
+    {
+        const int Size = 2048;
+        var keys = new CompactTree.CompactKeyLookup[Size];
+        var vals = new long[Size];
+        var offsets = new int[Size];
+
+        int separatorIndex = -1;
+        
+        using (var wtx = Env.WriteTransaction())
+        {
+            var tree = wtx.CompactTreeFor("test");
+            
+            for (int i = 0; i < Size; i++)
+            {
+                keys[i].Key = new CompactKey();
+                keys[i].Key.Initialize(wtx.LowLevelTransaction);
+                keys[i].Key.Set(Encoding.UTF8.GetBytes(i.ToString("00000")));
+                keys[i].Key.ChangeDictionary(tree.DictionaryId);
+                keys[i].Key.EncodedWithCurrent(out _);
+                keys[i].ContainerId = -1;
+                vals[i] = 100000 + i;
+            }
+
+            // we create a tree that has mulitple pages
+
+            var k = keys;
+            var v = vals;
+            var o = offsets;
+            int index = 0;
+            while (k.Length > 0)
+            {
+                int adjustment = 0;
+                tree.InitializeStateForTryGetNextValue();
+                var changed = tree.CheckTreeStructureChanges();
+                var num = tree.BulkUpdateStart(k, v, o, out var page);
+                int i = 0;
+                for (; i < num; i++)
+                {
+                    index++;
+                    tree.BulkUpdateSet(ref k[i], index + 10_000, page, o[i], ref adjustment);
+                    if (changed.Changed)
+                    {
+                        for (int j = i; j < num; j++)
+                        {
+                            k[j].ContainerId = -1;
+                        }
+                        i++;
+                        if (separatorIndex == -1)
+                        {
+                            separatorIndex = index;
+                        }
+                        break;
+                    }
+                }
+
+                k = k[i..];
+                v = v[i..];
+                o = o[i..];
+            }
+
+            // we remove the entry that is the first key on the right most page
+            //  root: [0...100], [101, 200]
+            //      So we remove the value of 101, but the _separator_ remains 101
+            tree.TryRemove(keys[separatorIndex], out _);
+
+            // now we do a bulk operation that would:
+            // first do a lookup on the key (which will load its container term id)
+            // then delete _other values_, to trigger a page merge
+            // as part of the page merge, we remove the separator key
+            // and then we try to add the value again, which cause us to try to insert the key with
+            // a term that was already removed
+            k = keys.Skip(10).Take(separatorIndex-10).Concat(new[]{keys[separatorIndex]}).ToArray();
+            for (int i = 0; i < k.Length; i++)
+            {
+                k[i].ContainerId = -1;
+            }
+            v = vals;
+            o = offsets;
+            while (k.Length > 0)
+            {
+                int adjustment = 0;
+                tree.InitializeStateForTryGetNextValue();
+                var changed = tree.CheckTreeStructureChanges();
+                var num = tree.BulkUpdateStart(k, v, o, out var page);
+                int i = 0;
+                for (; i < num; i++)
+                {
+                    index++;
+                    if (k[i].Key == keys[separatorIndex].Key)
+                    {
+                        tree.BulkUpdateSet(ref k[i], index + 10_000, page, o[i], ref adjustment);
+                    }
+                    else
+                    {
+                        tree.BulkUpdateRemove(ref k[i], page, o[i], ref adjustment, out _);
+                    }
+                    if (changed.Changed)
+                    {
+                        for (int j = i; j < num; j++)
+                        {
+                            k[j].ContainerId = -1;
+                        }
+                        break;
+                    }
+                }
+
+                k = k[i..];
+                v = v[i..];
+                o = o[i..];
+            }
+            
+            wtx.Commit();
+        }
+    }
+}

--- a/test/SlowTests/MailingList/MultiMapIndexQueryTests.cs
+++ b/test/SlowTests/MailingList/MultiMapIndexQueryTests.cs
@@ -101,7 +101,7 @@ namespace SlowTests.MailingList
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
         }
 
         private class Article


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21272

### Additional description

This scenario was exposed by map/reduce index (so a lot of updates), which triggered an odd scenario where we have a deletion of a key (used as a separator), then we do a page merge, then we insert the key again

The challenge is that with bulk operations, we may remember the old key that we deleted and try to use it.