### PR TITLE
RavenDB-21096 set DatabaseGroupId and ClusterTransactionId in during …

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -387,6 +387,7 @@ namespace Raven.Server.Documents
                 if (record == null)
                     DatabaseDoesNotExistException.Throw(Name);
 
+                SetIds(record);
                 OnDatabaseRecordChanged(record);
 
                 ReplicationLoader = CreateReplicationLoader();


### PR DESCRIPTION
…initialization of DocumentDatabase to avoid a race between database startup and executing the cluster transaction

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21096
