### PR TITLE
RavenDB-21328 Corax Querying fixing Duplicated result returned - we n…

### DIFF
--- a/src/Corax/Queries/AllEntriesMatch.cs
+++ b/src/Corax/Queries/AllEntriesMatch.cs
@@ -14,11 +14,12 @@ namespace Corax.Queries
         private readonly long _count;
         private Lookup<Int64LookupKey>.ForwardIterator _entriesPagesIt;
 
-        public bool DoNotSortResults()
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            return false; //we are already returning in sorted order
+            //we are already returning in sorted order
+            return SkipSortingResult.ResultsNativelySorted;
         }
-        
+
         public AllEntriesMatch(IndexSearcher.IndexSearcher searcher, Transaction tx)
         {
             _count = searcher.NumberOfEntries;

--- a/src/Corax/Queries/AndNotMatch.Erasure.cs
+++ b/src/Corax/Queries/AndNotMatch.Erasure.cs
@@ -17,7 +17,8 @@ namespace Corax.Queries
             _functionTable = functionTable;
         }
 
-        public bool DoNotSortResults() => _inner.DoNotSortResults();
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
+
         public bool IsBoosting => _inner.IsBoosting;
 
         public long Count => _functionTable.CountFunc(ref this);

--- a/src/Corax/Queries/AndNotMatch.cs
+++ b/src/Corax/Queries/AndNotMatch.cs
@@ -35,10 +35,12 @@ namespace Corax.Queries
 
         private bool _doNotSortResults;
 
-        public bool DoNotSortResults()
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            _doNotSortResults = true;
-            return true;
+            var r = _inner.AttemptToSkipSorting();
+            // if the inner requires sorting, we also require it
+            _doNotSortResults = r != SkipSortingResult.SortingIsRequired;
+            return r;
         }
 
         public QueryCountConfidence Confidence => _confidence;

--- a/src/Corax/Queries/BinaryMatch.Boolean.cs
+++ b/src/Corax/Queries/BinaryMatch.Boolean.cs
@@ -47,7 +47,7 @@ namespace Corax.Queries
                     
                     // The problem is that multiple Fill calls do not ensure that we will get a sequence of ordered
                     // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
-                    if (match._doNotSortResults == false && iterations >= 1 || inner is SpatialMatch.SpatialMatch)
+                    if (match._doNotSortResults == false && iterations >= 1)
                     {
                         if (totalResults > 0)
                         {

--- a/src/Corax/Queries/BinaryMatch.Erasure.cs
+++ b/src/Corax/Queries/BinaryMatch.Erasure.cs
@@ -18,7 +18,8 @@ namespace Corax.Queries
             _functionTable = functionTable;
         }
 
-        public bool DoNotSortResults() => _inner.DoNotSortResults();
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
+
         public bool IsBoosting => _inner.IsBoosting;
 
         public long Count => _functionTable.CountFunc(ref this);

--- a/src/Corax/Queries/BinaryMatch.cs
+++ b/src/Corax/Queries/BinaryMatch.cs
@@ -28,12 +28,16 @@ namespace Corax.Queries
 
         private bool _doNotSortResults;
 
-        public bool DoNotSortResults()
-        {
-            _doNotSortResults = true;
-            return true;
-        }
 
+        public SkipSortingResult AttemptToSkipSorting()
+        {
+            var r = _inner.AttemptToSkipSorting();
+            // if inner requires sorting, so do we
+            _doNotSortResults = r != SkipSortingResult.SortingIsRequired &&
+                                // for spatial, we get them in 
+                                _inner is not SpatialMatch.SpatialMatch;
+            return r;
+        }
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
 

--- a/src/Corax/Queries/BoostingMatch.cs
+++ b/src/Corax/Queries/BoostingMatch.cs
@@ -42,10 +42,7 @@ namespace Corax.Queries
 
         public long Count => _inner.Count;
 
-        public bool DoNotSortResults()
-        {
-            return _inner.DoNotSortResults();
-        }
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Queries/IncludeNullMatch.cs
+++ b/src/Corax/Queries/IncludeNullMatch.cs
@@ -27,9 +27,10 @@ where TInner : IQueryMatch
     private TInner _inner;
     
     public long Count { get; }
-    public bool DoNotSortResults()
+
+    public SkipSortingResult AttemptToSkipSorting()
     {
-        return true;
+        return SkipSortingResult.WillSkipSorting;
     }
 
     public QueryCountConfidence Confidence { get; }

--- a/src/Corax/Queries/MemoizationMatch.Erasure.cs
+++ b/src/Corax/Queries/MemoizationMatch.Erasure.cs
@@ -19,10 +19,7 @@ namespace Corax.Queries
 
         public long Count => _functionTable.CountFunc(ref this);
 
-        public bool DoNotSortResults()
-        {
-            return _inner.DoNotSortResults();
-        }
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Queries/MemoizationMatch.cs
+++ b/src/Corax/Queries/MemoizationMatch.cs
@@ -15,9 +15,11 @@ namespace Corax.Queries
 
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _inner.Count;
-        public bool DoNotSortResults()
+
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            return _inner.DoNotSortResults();
+             _inner.SkipSortingResults();
+             return SkipSortingResult.WillSkipSorting;
         }
 
         public QueryCountConfidence Confidence => _inner.Confidence;

--- a/src/Corax/Queries/MemoizationMatch.cs
+++ b/src/Corax/Queries/MemoizationMatch.cs
@@ -6,7 +6,7 @@ using Corax.Queries.Meta;
 namespace Corax.Queries
 {    
     [DebuggerDisplay("{DebugView,nq}")]
-    public unsafe struct MemoizationMatch<TInner> : IQueryMatch
+    public struct MemoizationMatch<TInner> : IQueryMatch
         where TInner : IQueryMatch
     {
         private MemoizationMatchProvider<TInner> _inner;

--- a/src/Corax/Queries/Meta/IQueryMatch.cs
+++ b/src/Corax/Queries/Meta/IQueryMatch.cs
@@ -1,68 +1,80 @@
 ﻿using System;
 
-namespace Corax.Queries.Meta
+namespace Corax.Queries.Meta;
+
+public static class QueryMatch
 {
-    public static class QueryMatch
+    public const long Invalid = -1;
+    public const long Start = 0;
+}
+
+public enum QueryCountConfidence : int
+{
+    Low = 0,
+    Normal = 1,
+    High = 2,
+}
+
+public static class QueryConfidenceExtensions
+{
+    public static QueryCountConfidence Min(this QueryCountConfidence c1, QueryCountConfidence c2)
     {
-        public const long Invalid = -1;
-        public const long Start = 0;
+        if (c1 < c2)
+            return c1;
+        return c2;
     }
 
-    public enum QueryCountConfidence : int
+    public static QueryCountConfidence Max(this QueryCountConfidence c1, QueryCountConfidence c2)
     {
-        Low = 0,
-        Normal = 1,
-        High = 2,
+        if (c1 > c2)
+            return c1;
+        return c2;
     }
+}
 
-    public static class QueryConfidenceExtensions
-    {
-        public static QueryCountConfidence Min(this QueryCountConfidence c1, QueryCountConfidence c2)
-        {
-            if (c1 < c2)
-                return c1;
-            return c2;
-        }
+public interface IQueryMatch
+{
+    long Count { get; }
 
-        public static QueryCountConfidence Max(this QueryCountConfidence c1, QueryCountConfidence c2)
-        {
-            if (c1 > c2)
-                return c1;
-            return c2;
-        }
-    }
 
-    public interface IQueryMatch
-    {
-        long Count { get; }
-
-        bool DoNotSortResults();
+    /// <summary>
+    /// This is called when the call is not interested in getting
+    /// the results in sorted order (may want to do its own sorting, etc)
+    /// The match will let the caller know whatever this is possible
+    /// </summary>
+    SkipSortingResult AttemptToSkipSorting();
         
-        // The confidence of the query count.
-        //  - High: We know exactly how many items there are.
-        //  - Normal: We know roughly that it is in the order of magnitude.
-        //  - Low: We know very little about it.
-        QueryCountConfidence Confidence { get; }
+    // The confidence of the query count.
+    //  - High: We know exactly how many items there are.
+    //  - Normal: We know roughly that it is in the order of magnitude.
+    //  - Low: We know very little about it.
+    QueryCountConfidence Confidence { get; }
 
-        bool IsBoosting { get; }
+    bool IsBoosting { get; }
 
-        // Guarantees: The output of Fill will be sorted and deduplicated for the call.
-        //             Different calls to Fill may return identical values are not guaranteed to be sorted between calls.
-        //             0 return means no more matches. 
-        int Fill(Span<long> matches);
+    // Guarantees: The output of Fill will be sorted and deduplicated for the call.
+    //             Different calls to Fill may return identical values are not guaranteed to be sorted between calls.
+    //             0 return means no more matches. 
+    int Fill(Span<long> matches);
 
-        // Guarantees: AndWith accepts sorted and returns sorted.
-        //             May optimize for continued sorted.
-        //             0 return means no more matches from the provided span, and may need to go to the next batch
-        // Requirements: Cannot be called with .Fill() from same instance.
-        int AndWith(Span<long> buffer, int matches);
+    // Guarantees: AndWith accepts sorted and returns sorted.
+    //             May optimize for continued sorted.
+    //             0 return means no more matches from the provided span, and may need to go to the next batch
+    // Requirements: Cannot be called with .Fill() from same instance.
+    int AndWith(Span<long> buffer, int matches);
 
-        // Guarantees: The output of this for unscored sequences should be a no-op.
-        // Requirements: The upmost call 
-        void Score(Span<long> matches, Span<float> scores, float boostFactor);
+    // Guarantees: The output of this for unscored sequences should be a no-op.
+    // Requirements: The upmost call 
+    void Score(Span<long> matches, Span<float> scores, float boostFactor);
 
-        QueryInspectionNode Inspect();
+    QueryInspectionNode Inspect();
 
-        string DebugView => Inspect().ToString();
-    }
+    string DebugView => Inspect().ToString();
+}
+
+public enum SkipSortingResult
+{
+    ResultsNativelySorted,
+    WillSkipSorting,
+    SortingIsRequired
 }

--- a/src/Corax/Queries/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Queries/MultiTermMatch.Erasure.cs
@@ -19,8 +19,8 @@ namespace Corax.Queries
             _functionTable = functionTable;
         }
 
-        public bool DoNotSortResults() => _inner.DoNotSortResults();
-        
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
+
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -35,8 +35,9 @@ namespace Corax.Queries
         private Bm25Relevance[] _frequenciesHolder;
         private int _currentFreqIdx;
 
-        //In case of streaming we cannot sort the results since the order will not be persisted. This is possible only in case when MTM is not in Binary AST and single document has only 1 term.
-        private bool _doNotSortResultsDueToStreaming;
+        //In case of streaming we cannot sort the results since the order will not be persisted. This is possible only in case when MulitTermMAtch
+        //is not in Binary AST and single document has only 1 term.
+        private readonly bool _doNotSortResultsDueToStreaming;
 
         private int FrequenciesHolderSize => _frequenciesHolder?.Length ?? 0;
 
@@ -49,10 +50,9 @@ namespace Corax.Queries
         public bool IsBoosting => _isBoosting;
         public long Count => _totalResults;
 
-        public bool DoNotSortResults()
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            _doNotSortResults = true;
-            return true;
+            return SkipSortingResult.SortingIsRequired;
         }
 
         public QueryCountConfidence Confidence => _confidence;
@@ -335,7 +335,7 @@ namespace Corax.Queries
             End:
             if (_doNotSortResultsDueToStreaming == false && _doNotSortResults == false && requiresSort && count > 1)
             {
-                count = Sorting.SortAndRemoveDuplicates(buffer[0..count]);
+                count = Sorting.SortAndRemoveDuplicates(buffer[..count]);
             }
             _totalResults += count;
             return count;

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -34,7 +34,7 @@ namespace Corax.Queries
         private Bm25Relevance[] _frequenciesHolder;
         private int _currentFreqIdx;
 
-        //In case of streaming we cannot sort the results since the order will not be persisted. This is possible only in case when MulitTermMAtch
+        //In case of streaming we cannot sort the results since the order will not be persisted. This is possible only in case when MultiTermMatch
         //is not in Binary AST and single document has only 1 term.
         private readonly bool _doNotSortResultsDueToStreaming;
 

--- a/src/Corax/Queries/MultiTermMatch.cs
+++ b/src/Corax/Queries/MultiTermMatch.cs
@@ -29,7 +29,6 @@ namespace Corax.Queries
         private long _readTerms, _totalResults;
         private readonly long _maxNumberOfTerms;
         private long _current;
-        private bool _doNotSortResults;
         private QueryCountConfidence _confidence;
 
         private Bm25Relevance[] _frequenciesHolder;
@@ -226,7 +225,7 @@ namespace Corax.Queries
                         }
                     }
 
-                    if (match is {_doNotSortResultsDueToStreaming: false, _doNotSortResults: false} && postingListCalls > 1)
+                    if (match is {_doNotSortResultsDueToStreaming: false} && postingListCalls > 1)
                         currentIdx = Sorting.SortAndRemoveDuplicates(sortedIds[0..currentIdx]);
 
                     return currentIdx;
@@ -333,7 +332,7 @@ namespace Corax.Queries
             _current = count != 0 ? buffer[count - 1] : QueryMatch.Invalid;
 
             End:
-            if (_doNotSortResultsDueToStreaming == false && _doNotSortResults == false && requiresSort && count > 1)
+            if (_doNotSortResultsDueToStreaming == false &&  requiresSort && count > 1)
             {
                 count = Sorting.SortAndRemoveDuplicates(buffer[..count]);
             }

--- a/src/Corax/Queries/MultiUnaryMatch.cs
+++ b/src/Corax/Queries/MultiUnaryMatch.cs
@@ -378,9 +378,10 @@ public struct MultiUnaryMatch<TInner> : IQueryMatch
     }
 
     public long Count { get; }
-    public bool DoNotSortResults()
+
+    public SkipSortingResult AttemptToSkipSorting()
     {
-        return _inner.DoNotSortResults();
+        return _inner.AttemptToSkipSorting();
     }
 
     public QueryCountConfidence Confidence => QueryCountConfidence.Low;

--- a/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.Erasure.cs
@@ -23,8 +23,7 @@ namespace Corax.Queries.SortingMatches
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
 
         public long Count => throw new NotSupportedException();
-
-        public bool DoNotSortResults() => _inner.DoNotSortResults();
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 
         public QueryCountConfidence Confidence => throw new NotSupportedException();
 

--- a/src/Corax/Queries/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMatch.cs
@@ -40,7 +40,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     
     private SortingDataTransfer _sortingDataTransfer;
     public long TotalResults;
-    public bool DoNotSortResults() => throw new NotSupportedException();
+    public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException();
 
     public SortingMatch(IndexSearcher.IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, int take = -1)
     {

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.Erasure.cs
@@ -22,11 +22,11 @@ namespace Corax.Queries.SortingMatches
 
         public long Count => throw new NotSupportedException();
 
-        public bool DoNotSortResults() => _inner.DoNotSortResults();
-
         public QueryCountConfidence Confidence => throw new NotSupportedException();
 
         public bool IsBoosting => _inner.IsBoosting;
+
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Fill(Span<long> buffer)

--- a/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Queries/SortingMatches/SortingMultiMatch.cs
@@ -37,7 +37,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     private NativeUnmanagedList<float> _scoresResults;
     
     public long TotalResults;
-    public bool DoNotSortResults() => throw new NotSupportedException();
+    public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException();
 
     public SortingMultiMatch(IndexSearcher.IndexSearcher searcher, in TInner inner, OrderMetadata[] orderMetadata, int take = -1, in CancellationToken token = default)
     {

--- a/src/Corax/Queries/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Queries/SpatialMatch/SpatialMatch.cs
@@ -72,10 +72,10 @@ public sealed class SpatialMatch : IQueryMatch
     }
 
     public long Count => long.MaxValue;
-    public bool DoNotSortResults() => true;
 
+    public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.WillSkipSorting;
     public QueryCountConfidence Confidence => QueryCountConfidence.Low;
-    public bool IsBoosting { get; }
+    public bool IsBoosting => false;
 
     public int Fill(Span<long> matches)
     {

--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -38,9 +38,9 @@ namespace Corax.Queries
         public string Term;
 #endif
 
-        public bool DoNotSortResults()
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            return false;// we already return results in sorted order
+            return SkipSortingResult.ResultsNativelySorted;
         }
 
         public QueryCountConfidence Confidence => QueryCountConfidence.High;

--- a/src/Corax/Queries/UnaryMatch.Erasure.cs
+++ b/src/Corax/Queries/UnaryMatch.Erasure.cs
@@ -24,10 +24,7 @@ namespace Corax.Queries
 
         public long Count => _functionTable.CountFunc(ref this);
 
-        public bool DoNotSortResults()
-        {
-            return _inner.DoNotSortResults();
-        }
+        public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Queries/UnaryMatch.cs
+++ b/src/Corax/Queries/UnaryMatch.cs
@@ -53,9 +53,9 @@ namespace Corax.Queries
         public long Count => _totalResults;
         public long Current => _current;
 
-        public bool DoNotSortResults()
+        public SkipSortingResult AttemptToSkipSorting()
         {
-            return _inner.DoNotSortResults();
+            return _inner.AttemptToSkipSorting();
         }
 
         public QueryCountConfidence Confidence => _confidence;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -210,7 +210,7 @@ public struct CoraxBooleanItem : IQueryMatch
         return baseMatch;
     }
 
-    public bool DoNotSortResults() => throw new InvalidOperationException(IQueryMatchUsageException);
+    public SkipSortingResult AttemptToSkipSorting() => throw new InvalidOperationException(IQueryMatchUsageException);
 
     public QueryCountConfidence Confidence => throw new InvalidOperationException(IQueryMatchUsageException);
     public int Fill(Span<long> matches) => throw new InvalidOperationException(IQueryMatchUsageException);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
@@ -66,7 +66,7 @@ public abstract class CoraxBooleanQueryBase : IQueryMatch
     protected const string QueryMatchUsageException =
         $"You tried to use {nameof(CoraxBooleanQueryBase)} as normal querying function. This class is only for type - relaxation inside {nameof(CoraxQueryBuilder)} to build big UnaryMatch stack";
 
-    public bool DoNotSortResults()  => throw new InvalidOperationException(QueryMatchUsageException);
+    public SkipSortingResult AttemptToSkipSorting() => throw new InvalidOperationException(QueryMatchUsageException);
 
     public long Count => throw new InvalidOperationException(QueryMatchUsageException);
     public QueryCountConfidence Confidence => throw new InvalidOperationException(QueryMatchUsageException);

--- a/test/SlowTests/Issues/RavenDB-21328.cs
+++ b/test/SlowTests/Issues/RavenDB-21328.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21328 : RavenTestBase
+{
+    public RavenDB_21328(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void QueryingOnMultipleTagsShouldReturnSingleResult(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item(new[]{"dogs/1", "dogs/2", "dogs/3"}, "Dogs"));
+            s.SaveChanges();
+        }
+
+        using (var s = store.OpenSession())
+        {
+            var items = s.Advanced
+                .RawQuery<object>("from Items where search(Tags, 'dogs*') order by Name select id(), Name")
+                .ToList();
+            Assert.Equal(1, items.Count);
+        }
+    }
+
+    private record Item(string[] Tags, string Name);
+}


### PR DESCRIPTION
…ow can tell properly when a clause requires us to sort internally

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21328 

### Additional description

The problem here was that we told an internal query match not to sort, and then we accepted the data from that match without checking if it returned duplicated values from internal values.

I changed things so the clause can report that it is not possible to _not_ sort, and report that upward.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
