### PR TITLE
 RavenDB-21043 Dictionary training enhancements

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -12,7 +12,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server;
 using Sparrow.Utils;
-using Voron;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
@@ -134,7 +133,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
     }
 
     private readonly DocumentsStorage _documentStorage;
-    private readonly QueryOperationContext _queryContext;
+    private readonly DocumentsOperationContext _docsContext;
     private readonly TransactionOperationContext _indexContext;
     private readonly Index _index;
     private readonly IndexType _indexType;
@@ -147,7 +146,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
     private readonly CancellationToken _token;
     private readonly Size _maxAllocatedMemory;
 
-    public CoraxDocumentTrainEnumerator(TransactionOperationContext indexContext, CoraxDocumentConverterBase converter, Index index, IndexType indexType, DocumentsStorage storage, QueryOperationContext queryContext, HashSet<string> collections, CancellationToken token, int take = int.MaxValue)
+    public CoraxDocumentTrainEnumerator(TransactionOperationContext indexContext, CoraxDocumentConverterBase converter, Index index, IndexType indexType, DocumentsStorage storage, DocumentsOperationContext docsContext, HashSet<string> collections, CancellationToken token, int take = int.MaxValue)
     {
         _indexContext = indexContext;
         _index = index;
@@ -163,7 +162,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
         _maxAllocatedMemory = _index.Configuration.MaxAllocationsAtDictionaryTraining;
 
         _documentStorage = storage;
-        _queryContext = queryContext;
+        _docsContext = docsContext;
         _collections = collections;
         _terms = new List<(int FieldId, string FieldName, ByteString Value)>();
         _builder = new Builder(indexContext.Allocator, _terms);
@@ -186,10 +185,10 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
             // We retrieve the baseline memory in order to calculate the difference.
             var atStartAllocated = new Size(NativeMemory.CurrentThreadStats.TotalAllocated, SizeUnit.Bytes);
 
-            using var itemEnumerator = _index.GetMapEnumerator(GetItemsEnumerator(_queryContext, collection, _take, _token), collection, _indexContext, scope, _indexType);
+            using var itemEnumerator = _index.GetMapEnumerator(GetItemsEnumerator(_docsContext, collection, _take, _token), collection, _indexContext, scope, _indexType);
             while (true)
             {
-                if (itemEnumerator.MoveNext(_queryContext.Documents, out var mapResults, out _) == false)
+                if (itemEnumerator.MoveNext(_docsContext, out var mapResults, out _) == false)
                     break;
 
                 var doc = (Document)itemEnumerator.Current.Item;
@@ -256,23 +255,23 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
         }
     }
 
-    private IEnumerator<Document> GetDocumentsEnumerator(QueryOperationContext queryContext, string collection, long take, CancellationToken token)
+    private IEnumerator<Document> GetDocumentsEnumerator(DocumentsOperationContext docsContext, string collection, long take, CancellationToken token)
     {
-        var size = queryContext.Documents.DocumentDatabase.Configuration.Databases.PulseReadTransactionLimit;
+        var size = docsContext.DocumentDatabase.Configuration.Databases.PulseReadTransactionLimit;
         var coraxDocumentTrainDocumentSource = new CoraxDocumentTrainSourceEnumerator(_documentStorage);
         
         if (collection == Constants.Documents.Collections.AllDocumentsCollection)
-            return new PulsedTransactionEnumerator<Document, CoraxDocumentTrainSourceState>(queryContext.Documents,
-                state => coraxDocumentTrainDocumentSource.GetDocumentsForDictionaryTraining(queryContext.Documents, state), new(queryContext.Documents, size, take, token)); 
+            return new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document, CoraxDocumentTrainSourceState>(docsContext,
+                state => coraxDocumentTrainDocumentSource.GetDocumentsForDictionaryTraining(docsContext, state), new(docsContext, size, take, token)), docsContext); 
 
-        return new PulsedTransactionEnumerator<Document,CoraxDocumentTrainSourceState>(queryContext.Documents, 
-            state =>  coraxDocumentTrainDocumentSource.GetDocumentsForDictionaryTraining(queryContext.Documents, collection, state)
-            , new CoraxDocumentTrainSourceState(queryContext.Documents, size, take, token));
+        return new TransactionForgetAboutDocumentEnumerator(new PulsedTransactionEnumerator<Document,CoraxDocumentTrainSourceState>(docsContext, 
+            state =>  coraxDocumentTrainDocumentSource.GetDocumentsForDictionaryTraining(docsContext, collection, state)
+            , new CoraxDocumentTrainSourceState(docsContext, size, take, token)), docsContext);
     }
 
-    private IEnumerable<IndexItem> GetItemsEnumerator(QueryOperationContext queryContext, string collection, long take, CancellationToken token)
+    private IEnumerable<IndexItem> GetItemsEnumerator(DocumentsOperationContext docsContext, string collection, long take, CancellationToken token)
     {
-        foreach (var document in GetDocumentsEnumerator(queryContext, collection, take, token))
+        foreach (var document in GetDocumentsEnumerator(docsContext, collection, take, token))
         {
             yield return new DocumentIndexItem(document.Id, document.LowerId, document.Etag, document.LastModified, document.Data.Size, document, document.Flags);
         }

--- a/test/SlowTests/Issues/RavenDB_21043.cs
+++ b/test/SlowTests/Issues/RavenDB_21043.cs
@@ -1,0 +1,103 @@
+﻿using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.DocumentsCompression;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21043 : RavenTestBase
+{
+    public RavenDB_21043(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Should_Be_Able_To_Train_Corax_Dictionary_on_Compare_Exchange_Values_and_compressed_docs(Options options)
+    {
+        const int numberOfCompanies = 256;
+        const int numberOfAddresses = 16;
+
+        DoNotReuseServer();
+
+        using (var store = GetDocumentStore(options))
+        {
+            // turn on compression
+            store.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration(false, true)));
+
+            using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                for (var i = 0; i < numberOfAddresses; i++)
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"addresses/{i}", new Address { City = $"Address_{i}" });
+                }
+
+                session.SaveChanges();
+            }
+
+            using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < numberOfCompanies; i++)
+                {
+                    bulk.Store(new Company
+                    {
+                        Name = $"Company_{i}",
+                        ExternalId = $"addresses/{i % numberOfAddresses}"
+                    });
+                }
+            }
+
+            new Companies_ByCity().Execute(store);
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Companies_ByCity.Result, Companies_ByCity>()
+                    .Select(x => new
+                    {
+                        Name = x.Name,
+                        City = x.City
+                    })
+                    .ToList();
+
+                Assert.Equal(numberOfCompanies, results.Count);
+
+                foreach (var result in results)
+                {
+                    Assert.NotNull(result.Name);
+                    Assert.NotNull(result.City); // should not be null
+                }
+            }
+        }
+    }
+
+    private class Companies_ByCity : AbstractIndexCreationTask<Company>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+
+            public string City { get; set; }
+        }
+
+        public Companies_ByCity()
+        {
+            Map = companies => from company in companies
+                let address = LoadCompareExchangeValue<Address>(company.ExternalId)
+                select new
+                {
+                    Name = company.Name,
+                    City = address.City
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21043

### Additional description

- Avoid passing QueryOperationContext - we just need DocumentsOperationContext
- Make sure we call forget about for compressed docs - TransactionForgetAboutDocumentEnumerator
- Added tests to verify that the dicitonary training works on indexes with compare exchanges on compressed documents

### Type of change

- Enhancements / refactoring

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
