### PR TITLE
RavenDB-21327 Index staleness prevents node promotion even when the index has caught up

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/ModifyDatabaseTopologyOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/ModifyDatabaseTopologyOperation.cs
@@ -25,6 +25,11 @@ namespace Raven.Client.ServerWide.Operations
             _databaseName = databaseName;
         }
 
+        public ModifyDatabaseTopologyOperation(string databaseName, int shardNumber, DatabaseTopology databaseTopology) : this(databaseName, databaseTopology)
+        {
+            _databaseName = ClientShardHelper.ToShardName(databaseName, shardNumber);
+        }
+
         public RavenCommand<ModifyDatabaseTopologyResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
             return new ModifyDatabaseTopologyCommand(conventions, _databaseName, _databaseTopology);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -283,6 +283,14 @@ namespace Raven.Server.ServerWide.Maintenance
                                     using (context.OpenReadTransaction())
                                     {
                                         bucketReport.LastChangeVector = shardedInstance.ShardedDocumentsStorage.GetMergedChangeVectorInBucket(context, currentMigration.Bucket);
+                                       
+                                        var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(context, currentMigration.Bucket);
+                                        if (stats != null)
+                                        {
+                                            bucketReport.NumberOfDocuments = stats.NumberOfDocuments;
+                                            bucketReport.Size = stats.Size;
+                                            bucketReport.LastAccess = stats.LastModified;
+                                        }
                                     }
 
                                     report.ReportPerBucket[currentMigration.Bucket] = bucketReport;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -918,6 +918,14 @@ namespace Raven.Server.ServerWide.Maintenance
                 return RawDatabase.Settings;
             }
 
+            public bool HasActiveMigrations()
+            {
+                if (RawDatabase.IsSharded == false)
+                    return false;
+
+                return RawDatabase.Sharding.HasActiveMigrations();
+            }
+
             public DatabaseStatusReport GetCurrentDatabaseReport(string node)
             {
                 if (Current.TryGetValue(node, out var report) == false)

--- a/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
+++ b/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
@@ -84,6 +84,17 @@ public sealed class RawShardingConfiguration
         }
     }
 
+    public bool HasActiveMigrations()
+    {
+        foreach (var m in BucketMigrations)
+        {
+            if (m.Value.IsActive)
+                return true;
+        }
+
+        return false;
+    }
+
     private Dictionary<int, DatabaseTopology> _shards;
 
     public Dictionary<int, DatabaseTopology> Shards

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalShardingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalShardingTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.DataArchival;
 
-public class DataArchivalShardingTests(ITestOutputHelper output) : ClusterTestBase(output)
+public class DataArchivalShardingTests : ClusterTestBase
 {
     [RavenFact(RavenTestCategory.ExpirationRefresh | RavenTestCategory.Sharding)]
     public async Task ShouldArchiveDocsForSharding()
@@ -105,5 +105,9 @@ public class DataArchivalShardingTests(ITestOutputHelper output) : ClusterTestBa
                 }
             }
         }
+    }
+
+    public DataArchivalShardingTests(ITestOutputHelper output) : base(output)
+    {
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -84,6 +84,7 @@ public partial class RavenTestBase
 
         public async Task WaitForAllNodesToBeMembersAsync(IDocumentStore store, string databaseName = null, CancellationToken token = default)
         {
+            using var _ = GetOrCreateCancellationToken(ref token);
             while (true)
             {
                 token.ThrowIfCancellationRequested();
@@ -111,8 +112,19 @@ public partial class RavenTestBase
             }
         }
 
+        public IDisposable GetOrCreateCancellationToken(ref CancellationToken token)
+        {
+            if (token.CanBeCanceled)
+                return null;
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            token = cts.Token;
+            return cts;
+        }
+
         public async Task WaitForNodeToBeRehabAsync(IDocumentStore store, string node, string databaseName = null, CancellationToken token = default)
         {
+            using var _ = GetOrCreateCancellationToken(ref token);
             while (true)
             {
                 token.ThrowIfCancellationRequested();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21327

### Additional description

This is workaround for sharding, were all indexes are stale when rehsarding is on going. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
