### PR TITLE
RavenDB-21264 If query statistics were not requested the client can tell the server that it doesn't have to calculate and return them

### DIFF
--- a/src/Raven.Client/Documents/Queries/IndexQuery.cs
+++ b/src/Raven.Client/Documents/Queries/IndexQuery.cs
@@ -28,6 +28,7 @@ namespace Raven.Client.Documents.Queries
                 hasher.Write(Query);
                 hasher.Write(WaitForNonStaleResults);
                 hasher.Write(SkipDuplicateChecking);
+                hasher.Write(SkipStatistics);
                 hasher.Write(WaitForNonStaleResultsTimeout?.Ticks);
                 hasher.Write(QueryParameters, conventions, serializer);
 
@@ -64,6 +65,8 @@ namespace Raven.Client.Documents.Queries
         /// </summary>
         public bool SkipDuplicateChecking { get; set; }
 
+        public bool SkipStatistics { get; set; }
+
         public virtual bool Equals(IndexQuery<T> other)
         {
             if (ReferenceEquals(null, other))
@@ -72,7 +75,8 @@ namespace Raven.Client.Documents.Queries
                 return true;
 
             return base.Equals(other) &&
-                   SkipDuplicateChecking == other.SkipDuplicateChecking;
+                   SkipDuplicateChecking == other.SkipDuplicateChecking &&
+                   SkipStatistics == other.SkipStatistics;
         }
 
         public override bool Equals(object obj)
@@ -90,6 +94,7 @@ namespace Raven.Client.Documents.Queries
             {
                 var hashCode = base.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SkipDuplicateChecking ? 1 : 0);
+                hashCode = (hashCode * 397) ^ (SkipStatistics ? 1 : 0);
                 return hashCode;
             }
         }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -171,6 +171,8 @@ namespace Raven.Client.Documents.Session
 
         private string _includesAlias;
 
+        private bool _statsRequested;
+
         private TimeSpan DefaultTimeout
         {
             get
@@ -1181,6 +1183,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         public void Statistics(out QueryStatistics stats)
         {
             stats = QueryStats;
+            _statsRequested = true;
         }
 
         /// <summary>
@@ -1215,7 +1218,8 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 WaitForNonStaleResultsTimeout = Timeout,
                 QueryParameters = QueryParameters,
                 DisableCaching = DisableCaching,
-                ProjectionBehavior = ProjectionBehavior
+                ProjectionBehavior = ProjectionBehavior,
+                SkipStatistics = _statsRequested == false
             };
 
             return indexQuery;

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -35,6 +35,13 @@ namespace Raven.Client.Extensions
                 writer.WriteComma();
             }
 
+            if (query.SkipStatistics)
+            {
+                writer.WritePropertyName(nameof(query.SkipStatistics));
+                writer.WriteBool(query.SkipStatistics);
+                writer.WriteComma();
+            }
+
             writer.WritePropertyName(nameof(query.QueryParameters));
             if (query.QueryParameters != null)
                 writer.WriteObject(conventions.Serialization.DefaultConverter.ToBlittable(query.QueryParameters, context));

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -97,13 +97,6 @@ namespace Raven.Server.Documents.Queries
         [JsonDeserializationIgnore]
         public bool IsCountQuery => Limit == 0 && Offset == 0;
 
-        // The ability to skip statistics will eventually have to be implemented at the client, when that is done
-        // this property should be modified to account for that. 
-        // https://issues.hibernatingrhinos.com/issue/RavenDB-21266
-        [JsonDeserializationIgnore]
-        public bool SkipStatistics => false;
-
-
         private BlittableJsonReaderObject _asJson;
 
         public BlittableJsonReaderObject ToJson(JsonOperationContext context)

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -280,6 +280,9 @@ namespace Raven.Server.Documents.Queries
                             case "skipDuplicateChecking":
                                 result.SkipDuplicateChecking = bool.Parse(item.Value[0]);
                                 break;
+                            case "skipStatistics":
+                                result.SkipStatistics = bool.Parse(item.Value[0]);
+                                break;
                             case "projectionBehavior":
                                 result.ProjectionBehavior = Enum.Parse<ProjectionBehavior>(item.Value[0], ignoreCase: true);
                                 break;

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -998,6 +998,10 @@ namespace Raven.Server.Json
             writer.WriteBool(query.SkipDuplicateChecking);
             writer.WriteComma();
 
+            writer.WritePropertyName(nameof(query.SkipStatistics));
+            writer.WriteBool(query.SkipStatistics);
+            writer.WriteComma();
+
             writer.WritePropertyName(nameof(query.Start));
             writer.WriteInteger(query.Start);
             writer.WriteComma();

--- a/test/FastTests/Client/Indexing/DebugIndexing.cs
+++ b/test/FastTests/Client/Indexing/DebugIndexing.cs
@@ -51,6 +51,7 @@ namespace FastTests.Client.Indexing
                     }, "query/parameters"))
                     {
                         SkipDuplicateChecking = q.SkipDuplicateChecking,
+                        SkipStatistics = q.SkipStatistics,
                         WaitForNonStaleResults = q.WaitForNonStaleResults,
                         WaitForNonStaleResultsTimeout = q.WaitForNonStaleResultsTimeout
                     };

--- a/test/FastTests/Corax/Bugs/RavenDB-21180.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21180.cs
@@ -31,6 +31,11 @@ namespace FastTests.Corax.Bugs
             await Indexes.WaitForIndexingAsync(store);
             using var session = store.OpenAsyncSession();
             Assert.Equal(10_000, await session.Advanced.AsyncDocumentQuery<Dto, Index>().WhereExists(x => x.Name).CountAsync());
+
+            var results = await session.Advanced.AsyncDocumentQuery<Dto, Index>().Statistics(out var stats).WhereExists(x => x.Name).Take(10).ToListAsync();
+
+            Assert.Equal(10_000, stats.TotalResults);
+            Assert.Equal(10, results.Count);
         }
 
         private sealed record Dto(string Name, long Num, string Id = null);

--- a/test/SlowTests/Issues/RavenDB_21264.cs
+++ b/test/SlowTests/Issues/RavenDB_21264.cs
@@ -1,0 +1,42 @@
+﻿using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21264 : RavenTestBase
+{
+    public RavenDB_21264(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void ShouldSetSkipStatisticsAccordingly()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var indexQuery = session.Advanced.AsyncDocumentQuery<Employee>()
+                    .WhereStartsWith(p => p.FirstName, "bob")
+                    .OrderBy(x => x.Birthday)
+                    .GetIndexQuery();
+                
+                Assert.True(indexQuery.SkipStatistics);
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var indexQuery = session.Advanced.DocumentQuery<Employee>()
+                    .Statistics(out var stats)
+                    .WhereStartsWith(p => p.FirstName, "bob")
+                    .OrderBy(x => x.Birthday)
+                    .GetIndexQuery();
+
+                Assert.False(indexQuery.SkipStatistics);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21264/Detect-that-a-query-doesnt-require-to-return-statistics-QueryResult.TotalResults-in-particular

### Additional description

Client side detection if a user requested the statistics during the query

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
