### PR TITLE
RavenDB-21334 Fixing handling of empty array that is stored in Corax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexedEntriesReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexedEntriesReader.cs
@@ -91,7 +91,11 @@ public sealed unsafe class CoraxIndexedEntriesReader : IDisposable
             }
             else if (entryReader.IsRaw)
             {
-                SetValue(fieldName, new BlittableJsonReaderObject(span.Address, span.Length, _ctx));
+                // span.Length == 0 may be set if we stored an empty array (List | Raw | Empty) is marked
+                if (span.Length > 0)
+                {
+                    SetValue(fieldName, new BlittableJsonReaderObject(span.Address, span.Length, _ctx));
+                }
             }
             else
             {
@@ -117,6 +121,7 @@ public sealed unsafe class CoraxIndexedEntriesReader : IDisposable
             if (doc.TryGetValue(name, out var existing) == false)
             {
                 doc[name] = new List<object>();
+                return;
             }
 
             if (existing is List<object>)

--- a/src/Voron/Data/PostingLists/NativeIntegersList.cs
+++ b/src/Voron/Data/PostingLists/NativeIntegersList.cs
@@ -127,7 +127,8 @@ public unsafe struct NativeIntegersList : IDisposable
 
         var bufferPtr = outputBufferPtr;
         var bufferEndPtr = bufferPtr + Count - 1;
-        Debug.Assert((*bufferPtr & 1) == 0);
+        Debug.Assert((*bufferPtr & 1) == 0,
+            "Removal as first item means that we have an orphaned removal, not supposed to happen!");
         while (bufferPtr < bufferEndPtr)
         {
             // here we check equality without caring if this is removal or not, skipping moving

--- a/test/SlowTests/Issues/RavenDB-21334.cs
+++ b/test/SlowTests/Issues/RavenDB-21334.cs
@@ -1,0 +1,75 @@
+﻿using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Operations;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21334 : RavenTestBase
+{
+    public RavenDB_21334(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CanStoreNullDynamicArrayAndGetIndexEntries(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+        {
+            Name = "idx",
+            Maps =
+            {
+                @"
+                from i in docs.Items
+                let owner = LoadDocument(i.Owner, ""Users"")
+                let company = LoadDocument(owner.Company, ""Companies"")
+                select new 
+                {
+                    i.Owner,
+                    Country = company.Addresses.Select(x => x.Country).ToList()
+                }"
+            },
+            Fields =
+            {
+                ["Country"] = new IndexFieldOptions
+                {
+                    Storage = FieldStorage.Yes
+                }
+            }
+        }));
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item("users/123"));
+            s.SaveChanges();
+        }
+        
+        Indexes.WaitForIndexing(store);
+
+        using (var s = store.OpenSession())
+        {
+            QueryCommand queryCommand = new QueryCommand((InMemoryDocumentSessionOperations)s, new IndexQuery
+            {
+                Query = "from index idx"
+            },metadataOnly: false, indexEntriesOnly: true);
+            s.Advanced.RequestExecutor.Execute(queryCommand, s.Advanced.Context, s.Advanced.SessionInfo);
+            QueryResult result = queryCommand.Result;
+            Assert.Equal(1, result.Results.Length);
+            var entry = (BlittableJsonReaderObject)result.Results[0];
+            Assert.True(entry.TryGet("Country", out BlittableJsonReaderArray arr));
+            Assert.Equal(0, arr.Length);
+        }
+    }
+
+    private record Item(string Owner);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21334 

### Additional description

We didn't handle storing of empty arrays properly when loading index entries