### PR TITLE
RavenDB-20922 Disabled auto index cluster wide cannot be enabled

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoIndexDefinitionBaseServerSide.cs
@@ -10,8 +10,8 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     internal abstract class AutoIndexDefinitionBaseServerSide : IndexDefinitionBaseServerSide<AutoIndexField>
     {
-        protected AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
-            IndexDefinitionClusterState clusterState, long? indexVersion = null)
+        internal AutoIndexDefinitionBaseServerSide(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
+            IndexDefinitionClusterState clusterState = null, long? indexVersion = null)
             : base(indexName, new[] {collection}, IndexLockMode.Unlock, IndexPriority.Normal, IndexState.Normal, fields, indexVersion ?? IndexVersion.CurrentVersion,
                 deploymentMode, clusterState, archivedDataProcessingBehavior: null)
         {

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -40,8 +40,9 @@ namespace Raven.Server.Documents.Indexes.Auto
 
         public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)
         {
-            SetLock(definition.LockMode);
-            SetPriority(definition.Priority);
+            bool startIndex = UpdateIndexState(definition, true);
+            if (startIndex && Status != IndexRunningStatus.Running)
+                Start();
         }
 
         public override void SetState(IndexState state, bool inMemoryOnly = false, bool ignoreWriteError = false)

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     internal sealed class AutoMapIndexDefinition : AutoIndexDefinitionBaseServerSide
     {
-        public AutoMapIndexDefinition(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
+        internal AutoMapIndexDefinition(string indexName, string collection, AutoIndexField[] fields, IndexDeploymentMode? deploymentMode,
             IndexDefinitionClusterState clusterState, long? indexVersion = null)
             : base(indexName, collection, fields, deploymentMode, clusterState, indexVersion)
         {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Indexes
 
         public ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
 
-        internal readonly IndexDefinitionClusterState ClusterState;
+        internal IndexDefinitionClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -341,15 +341,6 @@ namespace Raven.Server.Documents.Indexes
                         existingIndex.SetPriority(definition.Priority);
                     }
 
-                    if ((differences & IndexDefinitionCompareDifferences.State) != 0)
-                    {
-                        // this can only be set by cluster
-                        // and if local state is disabled or error
-                        // then we are ignoring this change
-                        if (existingIndex.State == IndexState.Normal || existingIndex.State == IndexState.Idle)
-                            existingIndex.SetState(definition.State);
-                    }
-
                     existingIndex.Update(definition, existingIndex.Configuration);
 
                     return null;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -81,7 +81,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)
         {
-            SetPriority(definition.Priority);
+            bool startIndex = UpdateIndexState(definition, true);
+            if (startIndex && Status != IndexRunningStatus.Running)
+                Start();
         }
 
         public override void SetState(IndexState state, bool inMemoryOnly = false, bool ignoreWriteError = false)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexDefinition.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
         public List<string> GroupByFieldNames { get; }
 
-        public AutoMapReduceIndexDefinition(string indexName, string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, List<string> groupByFieldNames, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState, long? indexVersion = null)
+        internal AutoMapReduceIndexDefinition(string indexName, string collection, AutoIndexField[] mapFields, AutoIndexField[] groupByFields, List<string> groupByFieldNames, IndexDeploymentMode? deploymentMode, IndexDefinitionClusterState clusterState = null, long? indexVersion = null)
             : base(indexName, collection, mapFields, deploymentMode, clusterState, indexVersion)
         {
             OrderedGroupByFields = groupByFields.OrderBy(x => x.Name, StringComparer.Ordinal).ToArray();

--- a/test/SlowTests/Issues/RavenDB-20922.cs
+++ b/test/SlowTests/Issues/RavenDB-20922.cs
@@ -1,0 +1,428 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.ServerWide.Commands.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20922 : ClusterTestBase
+    {
+        public RavenDB_20922(ITestOutputHelper output) : base(output)
+        {
+        }
+        private class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+        }
+
+        private static async Task<IndexDefinition[]> CreateAutoMapIndex(IDocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Query<TestObj>().Where(x => x.Prop == "1").ToArrayAsync();
+            }
+
+            var index = await store.Maintenance.SendAsync(new GetIndexesOperation(0, 10));
+            return index;
+        }
+
+        private static async Task<(long? Index, Raven.Server.Documents.Indexes.Index Instance)> CreateAutoMapReduceIndex(DocumentDatabase documentDatabase)
+        {
+            var usersByCountAndTotalAgeGroupedByLocation = new AutoMapReduceIndexDefinition("Users",
+                new[]
+                {
+                    new AutoIndexField { Name = "Count", Storage = FieldStorage.Yes, Aggregation = AggregationOperation.Count, },
+                    new AutoIndexField { Name = "TotalAge", Storage = FieldStorage.Yes, Aggregation = AggregationOperation.Sum },
+                },
+                new[] { new AutoIndexField { Name = "Location", Storage = FieldStorage.Yes, } });
+
+            var index = await documentDatabase.IndexStore.CreateIndex(usersByCountAndTotalAgeGroupedByLocation, Guid.NewGuid().ToString());
+            return index;
+        }
+
+        private static async Task EnableIndexClusterWide(DocumentStore store, string name)
+        {
+            await AssertWaitForValueAsync(async () =>
+            {
+                await store.Maintenance.SendAsync(new EnableIndexOperation(name, true));
+                var indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(name));
+                return indexDefinition.State;
+            }, IndexState.Normal);
+        }
+
+        private static async Task DisableIndexClusterWide(IDocumentStore store, string name)
+        {
+            await AssertWaitForValueAsync(async () =>
+            {
+                await store.Maintenance.SendAsync(new DisableIndexOperation(name, true));
+                var indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(name));
+                return indexDefinition.State;
+            }, IndexState.Disabled);
+        }
+
+        private async Task CheckIndexStateInTheCluster(string database, string name, IndexState state)
+        {
+            DocumentDatabase documentDatabase = null;
+            foreach (var server in Servers)
+            {
+                await WaitForValueAsync(async () =>
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                    return documentDatabase.IndexStore.GetIndex(name).State;
+                }, state);
+                Assert.Equal(state, documentDatabase.IndexStore.GetIndex(name).State);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task DisableAutoMapIndexClusterWideAndEnableAutoMapIndexClusterWide()
+        {
+            const int numberOfNodes = 3;
+            var (_, leader) = await CreateRaftCluster(numberOfNodes);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = numberOfNodes });
+
+            IndexDefinition[] index = await CreateAutoMapIndex(store);
+            WaitForUserToContinueTheTest(store);
+            // Disable index cluster wide
+            await DisableIndexClusterWide(store, index[0].Name);
+
+            //Enable index cluster wide
+            await EnableIndexClusterWide(store, index[0].Name);
+
+            var documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
+            Assert.Equal(IndexState.Normal, autoIndex.State);
+            Assert.Equal(IndexRunningStatus.Running, autoIndex.Status);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task DisableAutoMapReduceIndexClusterWideAndEnableAutoMapReduceIndexClusterWide()
+        {
+            const int numberOfNodes = 3;
+            var (_, leader) = await CreateRaftCluster(numberOfNodes);
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = numberOfNodes });
+            var documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+            var index = await CreateAutoMapReduceIndex(documentDatabase);
+
+            await DisableIndexClusterWide(store, index.Instance.Name);
+
+            //Enable index cluster wide
+            await EnableIndexClusterWide(store, index.Instance.Name);
+
+            var autoIndex = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+            Assert.Equal(IndexState.Normal, autoIndex.State);
+            Assert.Equal(IndexRunningStatus.Running, autoIndex.Status);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task LastSetStateDetermineTheStateAutoMapIndex()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            DocumentDatabase documentDatabase = null;
+            using (var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                IndexDefinition[] index = await CreateAutoMapIndex(store);
+
+                //Check index is enabled and running
+                foreach (var server in Servers)
+                {
+                    await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(index[0].Name).Status;
+                    }, IndexRunningStatus.Running);
+                    Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(index[0].Name).Status);
+                }
+
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
+
+                var count = 0;
+                string info = "";
+
+                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index[0].Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                    Servers);
+                //Check index is disabled
+                await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Disabled);
+
+                //Set index to normal
+                autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                autoIndex.SetState(IndexState.Normal);
+
+                count = 0;
+
+                await WaitForValueAsync(async () =>
+                {
+                    count = 0;
+                    info = "";
+                    foreach (var server in Servers)
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        var index2 = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                        var state = index2.State;
+                        info += $"Index state for node {server.ServerStore.NodeTag} is {state} in definition {index2.Definition.State}.  ";
+                        foreach (var error in index2.GetErrors())
+                        {
+                            info += $"{error.Error} , ";
+                        }
+                        if (state == IndexState.Normal)
+                            count++;
+                    }
+
+                    return count;
+                }, 1);
+
+                Assert.True(1 == count, info);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task LastSetStateDetermineTheStateAutoMapReduceIndex()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            DocumentDatabase documentDatabase = null;
+            using (var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                // Create Auto map index
+                var index = await CreateAutoMapReduceIndex(documentDatabase);
+
+                //Check index is enabled and running
+                foreach (var server in Servers)
+                {
+                    await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Normal);
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndex(index.Instance.Name).Status;
+                    }, IndexRunningStatus.Running);
+                    Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(index.Instance.Name).Status);
+                }
+
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var autoIndex = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+
+                var count = 0;
+                string info = "";
+
+                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Instance.Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                    Servers);
+                //Check index is disabled
+                await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Disabled);
+
+                //Set index to normal
+                autoIndex = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+                autoIndex.SetState(IndexState.Normal);
+
+                count = 0;
+
+                await WaitForValueAsync(async () =>
+                {
+                    count = 0;
+                    info = "";
+                    foreach (var server in Servers)
+                    {
+                        documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        var index2 = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+                        var state = index2.State;
+                        info += $"Index state for node {server.ServerStore.NodeTag} is {state} in definition {index2.Definition.State}.  ";
+                        foreach (var error in index2.GetErrors())
+                        {
+                            info += $"{error.Error} , ";
+                        }
+                        if (state == IndexState.Normal)
+                            count++;
+                    }
+
+                    return count;
+                }, 1);
+
+                Assert.True(1 == count, info);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task ChangeLocallyAutoMapIndexStateToDisableAndEnableClusterWide()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            using (var store = new DocumentStore
+                   {
+                       Database = database,
+                       Urls = new[] { leader.WebUrl }
+                   }.Initialize())
+            {
+                IndexDefinition[] index = await CreateAutoMapIndex(store);
+
+                await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
+
+                DocumentDatabase documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index0 = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                index0.SetState(IndexState.Disabled);
+
+                var count = 0;
+
+                foreach (var server in Servers)
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                    if (documentDatabase.IndexStore.GetIndex(index[0].Name).State == IndexState.Disabled)
+                        count++;
+                }
+
+                Assert.Equal(1, count);
+
+                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index[0].Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
+                    Servers);
+
+                await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task ChangeLocallyAutoMapReduceIndexStateToDisableAndEnableClusterWide()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            DocumentDatabase documentDatabase = null;
+            using (var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index = await CreateAutoMapReduceIndex(documentDatabase);
+
+                await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Normal);
+
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index0 = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+                index0.SetState(IndexState.Disabled);
+
+                var count = 0;
+
+                foreach (var server in Servers)
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                    if (documentDatabase.IndexStore.GetIndex(index.Instance.Name).State == IndexState.Disabled)
+                        count++;
+                }
+
+                Assert.Equal(1, count);
+
+                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Instance.Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
+                    Servers);
+
+                await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Normal);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task DisableAutoMapIndexClusterWideAndEnableLocally()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            DocumentDatabase documentDatabase = null;
+            using (var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                IndexDefinition[] index = await CreateAutoMapIndex(store);
+
+                await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
+
+                await DisableIndexClusterWide(store, index[0].Name);
+
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index0 = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                index0.SetState(IndexState.Normal);
+
+                var count = 0;
+
+                foreach (var server in Servers)
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                    if (documentDatabase.IndexStore.GetIndex(index[0].Name).State == IndexState.Normal)
+                        count++;
+                }
+
+                Assert.Equal(1, count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task DisableAutoMapReduceIndexClusterWideAndEnableLocally()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+            var database = GetDatabaseName();
+            await CreateDatabaseInClusterInner(new DatabaseRecord(database), 3, leader.WebUrl, null);
+
+            DocumentDatabase documentDatabase = null;
+            using (var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index = await CreateAutoMapReduceIndex(documentDatabase);
+
+                await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Normal);
+
+                await DisableIndexClusterWide(store, index.Instance.Name);
+                await CheckIndexStateInTheCluster(database, index.Instance.Name, IndexState.Disabled);
+
+                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                var index0 = documentDatabase.IndexStore.GetIndex(index.Instance.Name);
+                index0.SetState(IndexState.Normal);
+
+                var count = 0;
+
+                foreach (var server in Servers)
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                    if (documentDatabase.IndexStore.GetIndex(index.Instance.Name).State == IndexState.Normal)
+                        count++;
+                }
+
+                Assert.Equal(1, count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20922

### Additional description

Disable and enable auto indexes cluster wide

_Please delete below the options that are not relevant_

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
