### PR TITLE
RavenDB-21189 Cannot create Sharded database when Cluster is not bootstraped

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
@@ -571,7 +571,7 @@ class databaseCreationModel {
                 Shards: shards,
                 Orchestrator: {
                     Topology: {
-                        Members: orchestrators
+                        Members: orchestrators[0] === "?" ? null : orchestrators
                     }
                 }
             } : null


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21189/Cannot-create-Sharded-database-when-Cluster-is-not-bootstraped

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
