### PR TITLE
RavenDB-21341 Added retry mechanism for InitTransactions of Kafka producer. Added configuration option.

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -46,5 +46,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(64 * 1024)]
         [ConfigurationEntry("ETL.OLAP.MaxNumberOfExtractedDocuments", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int? OlapMaxNumberOfExtractedDocuments { get; protected set; }
+
+        [Description("Timeout to initialize transactions for the Kafka producer")]
+        [DefaultValue(60)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("ETL.Queue.Kafka.InitTransactionsTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting KafkaInitTransactionsTimeout { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -608,7 +608,7 @@ namespace Raven.Server.Documents.ETL
                             {
                                 var diff = kafkaEtl.Configuration.Compare(config);
 
-                                if (diff == EtlConfigurationCompareDifferences.None && kafkaEtl.Configuration.Equals(config))
+                                if (diff == EtlConfigurationCompareDifferences.None)
                                 {
                                     existing = config;
                                     break;
@@ -631,7 +631,7 @@ namespace Raven.Server.Documents.ETL
                             {
                                 var diff = rabbitMqEtl.Configuration.Compare(config);
 
-                                if (diff == EtlConfigurationCompareDifferences.None && rabbitMqEtl.Configuration.Equals(config))
+                                if (diff == EtlConfigurationCompareDifferences.None)
                                 {
                                     existing = config;
                                     break;

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
@@ -73,6 +73,8 @@ public class KafkaEtl : QueueEtl<KafkaItem>
             }
             catch (Exception e)
             {
+                producer.Dispose();
+
                 string msg = $" ETL process: {Name}. Failed to initialize transactions for the producer instance. " +
                              $"If you are using a single node Kafka cluster then the following settings might be required:{Environment.NewLine}" +
                              $"- transaction.state.log.replication.factor: 1 {Environment.NewLine}" +


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21341/Kafka-ETL-Allow-to-configure-timeout-for-producers-transactions-init-and-retry-on-KafkaRetriableException



### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Not relevant

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
