### PR TITLE
RavenDB-21287 Remove licensing tab from ongoing tasks Info Hub

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -409,13 +409,6 @@ export function OngoingTasksPage(props: OngoingTasksPageProps) {
                                 <Icon icon="newtab" /> Docs - Ongoing Tasks
                             </a>
                         </AccordionItemWrapper>
-                        <AccordionLicenseLimited
-                            targetId="license-limit"
-                            description="Unleash the full potential and upgrade your plan."
-                            featureName="Ongoing Tasks"
-                            featureIcon="ongoing-tasks"
-                            isLimited={!isProfessionalOrAbove}
-                        />
                     </AboutViewFloating>
                 </div>
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21287

### Additional description
Removed licensing tab from ongoing tasks Info Hub as it had no much sense

### Type of change
- Bug fix

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
