### PR TITLE
RavenDB-21339 throw exception when includes are requested in a non-tracking session

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
@@ -29,7 +29,7 @@ namespace Raven.Client.Documents.Session
         /// <param name = "path">The path.</param>
         public void Include(string path)
         {
-            TheSession.AssertNoIncludesInNonTrackingSession();
+            TheSession?.AssertNoIncludesInNonTrackingSession();
 
             DocumentIncludes.Add(path);
         }
@@ -50,7 +50,7 @@ namespace Raven.Client.Documents.Session
 
             if (includes.DocumentsToInclude is { Count: > 0 })
             {
-                TheSession.AssertNoIncludesInNonTrackingSession();
+                TheSession?.AssertNoIncludesInNonTrackingSession();
 
                 foreach (var doc in includes.DocumentsToInclude)
                 {
@@ -77,7 +77,7 @@ namespace Raven.Client.Documents.Session
             
             if (includes.CompareExchangeValuesToInclude is { Count: > 0 })
             {
-                TheSession.AssertNoIncludesInNonTrackingSession();
+                TheSession?.AssertNoIncludesInNonTrackingSession();
 
                 CompareExchangeValueIncludesTokens = new List<CompareExchangeValueIncludesToken>();
 
@@ -91,7 +91,7 @@ namespace Raven.Client.Documents.Session
             if (countersToIncludeByDocId?.Count > 0 == false)
                 return;
 
-            TheSession.AssertNoIncludesInNonTrackingSession();
+            TheSession?.AssertNoIncludesInNonTrackingSession();
 
             CounterIncludesTokens = new List<CounterIncludesToken>();
             _includesAlias = alias;
@@ -119,7 +119,7 @@ namespace Raven.Client.Documents.Session
             if (timeSeriesToInclude?.Count > 0 == false)
                 return;
 
-            TheSession.AssertNoIncludesInNonTrackingSession();
+            TheSession?.AssertNoIncludesInNonTrackingSession();
 
             TimeSeriesIncludesTokens = new List<TimeSeriesIncludesToken>();
             _includesAlias ??= alias;
@@ -135,7 +135,7 @@ namespace Raven.Client.Documents.Session
         
         private void IncludeRevisions(DateTime dateTime)
         {
-            TheSession.AssertNoIncludesInNonTrackingSession();
+            TheSession?.AssertNoIncludesInNonTrackingSession();
 
             RevisionsIncludesTokens ??= new List<RevisionIncludesToken>();
             RevisionsIncludesTokens.Add(RevisionIncludesToken.Create(dateTime));
@@ -146,7 +146,7 @@ namespace Raven.Client.Documents.Session
             if (revisionsToIncludeByChangeVector == null || revisionsToIncludeByChangeVector.Count == 0)
                 return;
 
-            TheSession.AssertNoIncludesInNonTrackingSession();
+            TheSession?.AssertNoIncludesInNonTrackingSession();
 
             RevisionsIncludesTokens ??= new List<RevisionIncludesToken>();
             foreach (var changeVector in revisionsToIncludeByChangeVector)

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Includes.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Session
         /// <param name = "path">The path.</param>
         public void Include(string path)
         {
+            TheSession.AssertNoIncludesInNonTrackingSession();
+
             DocumentIncludes.Add(path);
         }
 
@@ -46,8 +48,10 @@ namespace Raven.Client.Documents.Session
             if (includes == null)
                 return;
 
-            if (includes.DocumentsToInclude != null)
+            if (includes.DocumentsToInclude is { Count: > 0 })
             {
+                TheSession.AssertNoIncludesInNonTrackingSession();
+
                 foreach (var doc in includes.DocumentsToInclude)
                 {
                     DocumentIncludes.Add(doc);
@@ -71,8 +75,10 @@ namespace Raven.Client.Documents.Session
                 IncludeRevisions(includes.RevisionsToIncludeByChangeVector);
             }
             
-            if (includes.CompareExchangeValuesToInclude != null)
+            if (includes.CompareExchangeValuesToInclude is { Count: > 0 })
             {
+                TheSession.AssertNoIncludesInNonTrackingSession();
+
                 CompareExchangeValueIncludesTokens = new List<CompareExchangeValueIncludesToken>();
 
                 foreach (var compareExchangeValue in includes.CompareExchangeValuesToInclude)
@@ -84,6 +90,8 @@ namespace Raven.Client.Documents.Session
         {
             if (countersToIncludeByDocId?.Count > 0 == false)
                 return;
+
+            TheSession.AssertNoIncludesInNonTrackingSession();
 
             CounterIncludesTokens = new List<CounterIncludesToken>();
             _includesAlias = alias;
@@ -111,6 +119,8 @@ namespace Raven.Client.Documents.Session
             if (timeSeriesToInclude?.Count > 0 == false)
                 return;
 
+            TheSession.AssertNoIncludesInNonTrackingSession();
+
             TimeSeriesIncludesTokens = new List<TimeSeriesIncludesToken>();
             _includesAlias ??= alias;
 
@@ -125,12 +135,19 @@ namespace Raven.Client.Documents.Session
         
         private void IncludeRevisions(DateTime dateTime)
         {
+            TheSession.AssertNoIncludesInNonTrackingSession();
+
             RevisionsIncludesTokens ??= new List<RevisionIncludesToken>();
             RevisionsIncludesTokens.Add(RevisionIncludesToken.Create(dateTime));
         }
         
         private void IncludeRevisions(HashSet<string> revisionsToIncludeByChangeVector)
         {
+            if (revisionsToIncludeByChangeVector == null || revisionsToIncludeByChangeVector.Count == 0)
+                return;
+
+            TheSession.AssertNoIncludesInNonTrackingSession();
+
             RevisionsIncludesTokens ??= new List<RevisionIncludesToken>();
             foreach (var changeVector in revisionsToIncludeByChangeVector)
             {

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2607,9 +2607,17 @@ more responsive application.
             if (name.Contains('@'))
                 throw new InvalidDataException("Time Series from type Rollup cannot be Incremental");
         }
+
+        internal void AssertNoIncludesInNonTrackingSession()
+        {
+            if (NoTracking == false)
+                return;
+
+            throw new InvalidOperationException("This session does not track any entities, because of that registering includes is forbidden to avoid false expectations when later load operations are performed on those and no requests are being sent to the server. Please avoid any 'Include' operations during non-tracking session actions like load or query.");
+        }
     }
 
-    internal struct AsyncTaskHolder : IDisposable
+    internal readonly struct AsyncTaskHolder : IDisposable
     {
         private readonly InMemoryDocumentSessionOperations _session;
 

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -60,39 +60,62 @@ namespace Raven.Client.Documents.Session.Operations
 
         public LoadOperation WithIncludes(string[] includes)
         {
-            _includes = includes;
+            if (includes is { Length: > 0 })
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
+                _includes = includes;
+            }
+
             return this;
         }
 
         public LoadOperation WithCompareExchange(string[] compareExchangeValues)
         {
-            _compareExchangeValuesToInclude = compareExchangeValues;
+            if (compareExchangeValues is { Length: > 0 })
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
+                _compareExchangeValuesToInclude = compareExchangeValues;
+            }
+
             return this;
         }
 
         public LoadOperation WithCounters(string[] counters)
         {
-            if (counters != null)
+            if (counters is { Length: > 0 })
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
                 _countersToInclude = counters;
+            }
+
             return this;
         }
 
         public LoadOperation WithRevisions(string[] revisionsByChangeVector)
         {
-            if (revisionsByChangeVector != null)
+            if (revisionsByChangeVector is { Length: > 0 })
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
                 _revisionsToIncludeByChangeVector = revisionsByChangeVector;
+            }
+
             return this;
         }
 
         public LoadOperation WithRevisions(DateTime? revisionByDateTimeBefore)
         {
             if (revisionByDateTimeBefore != null)
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
                 _revisionsToIncludeByDateTimeBefore = revisionByDateTimeBefore;
+            }
+
             return this;
         }
 
         public LoadOperation WithAllCounters()
         {
+            _session.AssertNoIncludesInNonTrackingSession();
             _includeAllCounters = true;
             return this;
         }
@@ -100,7 +123,11 @@ namespace Raven.Client.Documents.Session.Operations
         public LoadOperation WithTimeSeries(IEnumerable<AbstractTimeSeriesRange> timeseries)
         {
             if (timeseries != null)
+            {
+                _session.AssertNoIncludesInNonTrackingSession();
                 _timeSeriesToInclude = timeseries;
+            }
+
             return this;
         }
 

--- a/test/SlowTests/Issues/RavenDB_11217.cs
+++ b/test/SlowTests/Issues/RavenDB_11217.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Issues
                     Assert.Equal(0, session.Advanced.NumberOfRequests);
 
                     var product1 = session
-                        .Load<Product>("products/1-A", builder => builder.IncludeDocuments(x => x.Supplier));
+                        .Load<Product>("products/1-A");
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
@@ -80,7 +80,7 @@ namespace SlowTests.Issues
                     Assert.False(session.Advanced.IsLoaded(supplier.Id));
 
                     var product2 = session
-                        .Load<Product>("products/1-A", builder => builder.IncludeDocuments(x => x.Supplier));
+                        .Load<Product>("products/1-A");
 
                     Assert.NotEqual(product1, product2);
                 }
@@ -131,7 +131,6 @@ namespace SlowTests.Issues
 
                     var products = session
                         .Query<Product>()
-                        .Include(x => x.Supplier)
                         .ToList();
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
@@ -153,7 +152,6 @@ namespace SlowTests.Issues
 
                     products = session
                         .Query<Product>()
-                        .Include(x => x.Supplier)
                         .ToList();
 
                     Assert.Equal(1, products.Count);

--- a/test/SlowTests/Issues/RavenDB_21339.cs
+++ b/test/SlowTests/Issues/RavenDB_21339.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21339 : RavenTestBase
+{
+    public RavenDB_21339(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task Using_Includes_In_Non_Tracking_Session_Should_Throw()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var supplier = new Supplier { Id = "suppliers/1" };
+
+                session.Store(supplier);
+                session.Store(new Product
+                {
+                    Id = "products/1",
+                    Supplier = supplier.Id
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = Assert.Throws<InvalidOperationException>(() => session.Load<Product>("products/1", includes => includes.IncludeDocuments(x => x.Supplier)));
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.LoadAsync<Product>("products/1", includes => includes.IncludeDocuments(x => x.Supplier)));
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+
+            using (var session = store.OpenSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = Assert.Throws<InvalidOperationException>(() => session.Query<Product>().Include(x => x.Supplier).ToList());
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Query<Product>().Include(x => x.Supplier).ToListAsync());
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+
+            using (var session = store.OpenSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = Assert.Throws<InvalidOperationException>(() => session.Advanced.DocumentQuery<Product>().Include(x => x.Supplier).ToList());
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                NoTracking = true
+            }))
+            {
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Advanced.AsyncDocumentQuery<Product>().Include(x => x.Supplier).ToListAsync());
+                Assert.Contains("registering includes is forbidden", e.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21339

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
