### PR TITLE
RavenDB-21338 Handling updating an index that has indexed a field wit…

### DIFF
--- a/src/Corax/IndexWriter.cs
+++ b/src/Corax/IndexWriter.cs
@@ -1354,7 +1354,7 @@ namespace Corax
                           // We dont want to reclaim the term name
                     }
                     ref var nullTerm = ref field.Storage.GetAsRef(nullTermLocation);
-                    nullTerm.Removal(_entriesAllocator, entryToDelete, reader.Frequency);
+                    nullTerm.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, reader.Frequency);
                     continue;
                 }
                 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -162,7 +162,7 @@ public struct CoraxBooleanItem : IQueryMatch
             };
                 
             if (Operation is UnaryMatchOperation.NotEquals)
-                match = _indexSearcher.AndNot(_indexSearcher.ExistsQuery(Field), match);
+                match = _indexSearcher.AndNot(_indexSearcher.AllEntries(), match);
                 
             return match;
         }

--- a/test/SlowTests/Issues/RavenDB-21324.cs
+++ b/test/SlowTests/Issues/RavenDB-21324.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Operations;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21324 : RavenTestBase
+{
+    public RavenDB_21324(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string[] Tags;
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanFindNegationToEntryWithEmptyArray(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item
+            {
+                Tags = new string[]{}
+            }, "items/1");
+            s.SaveChanges();
+        }
+
+        using (var s = store.OpenSession())
+        {
+            Assert.Equal(1, s.Advanced.RawQuery<Item>("from Items where Tags != 'Hamster'").Count());
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21338.cs
+++ b/test/SlowTests/Issues/RavenDB_21338.cs
@@ -1,0 +1,67 @@
+﻿using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.Operations;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21338 : RavenTestBase
+{
+    public RavenDB_21338(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string[] Tags;
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CanUpdateEntryWithArrayContainingNull(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+        {
+            Name = "idx",
+            Maps =
+            {
+                @"
+                from i in docs.Items
+                select new 
+                {
+                    i.Tags
+                }"
+            },
+            Fields = { ["Tags"] = new IndexFieldOptions { Storage = FieldStorage.Yes } }
+        }));
+ 
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item
+            {
+                Tags = new string[]{null, null}
+            }, "items/1");
+            s.SaveChanges();
+        }
+        Indexes.WaitForIndexing(store);
+WaitForUserToContinueTheTest(store);
+        using (var s = store.OpenSession())
+        {
+            Item item = s.Load<Item>("items/1");
+            item.Tags = new string[] { null, null, null };
+            s.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21338.cs
+++ b/test/SlowTests/Issues/RavenDB_21338.cs
@@ -53,7 +53,7 @@ public class RavenDB_21338 : RavenTestBase
             s.SaveChanges();
         }
         Indexes.WaitForIndexing(store);
-WaitForUserToContinueTheTest(store);
+
         using (var s = store.OpenSession())
         {
             Item item = s.Load<Item>("items/1");


### PR DESCRIPTION
…h multiple null values in it (stored)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21338 

### Additional description

We had a missing argument for null handling, which caused us to not handle multiple null values for a field properly during updates.