### PR TITLE
RavenDB-21081 - Error during resharding

### DIFF
--- a/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs
@@ -108,13 +108,15 @@ public sealed class ShardReplicationLoader : ReplicationLoader
 
             // can happened if all nodes are in Rehab
             if (destNode == null)
+            {
+                toRemove.Add(migrationHandler.BucketMigrationNode);
                 continue;
+            }
 
             var source = newRecord.Topology.WhoseTaskIsIt(RachisState.Follower, migration, getLastResponsibleNode: null);
             if (_server.NodeTag != source || migrationHandler.Destination.Url != _clusterTopology.GetUrlFromTag(destNode))
             {
                 toRemove.Add(migrationHandler.BucketMigrationNode);
-                continue;
             }
 
             // even if the status is ownership transferred we will keep the connection open to send any left overs if needed
@@ -138,7 +140,6 @@ public sealed class ShardReplicationLoader : ReplicationLoader
 
                 if (current == null)
                 {
-
                     var destTopology = GetTopologyForShard(process.DestinationShard);
                     var destNode = destTopology.WhoseTaskIsIt(RachisState.Follower, process, getLastResponsibleNode: null);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21081/Error-during-resharding

### Additional description

Reproduction:
During resharding task, the database topology changes multiple times.

For example:
On `HandleMigrationReplication` method:
- Two threads are running the method (each invoked by topology update). There are no connections at this point - thus, both create and start a new migration connection. _Note:_ we get two connections only when the destination nodes are different (otherwise, `_outgoing.TryAdd() == false`, and we dispose the connection).
- A third thread runs the method, reads the shard topology from the disk, and continue without dropping the connections because all nodes are in `Rehab` (https://github.com/ravendb/ravendb/blob/v6.0/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs#L110). Then, exception thrown at  https://github.com/ravendb/ravendb/blob/v6.0/src/Raven.Server/Documents/Replication/ShardReplicationLoader.cs#L136).

The fix:
Drop an existing connection even when all nodes are in `Rahab`. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
