### PR TITLE
RavenDB-20988 : sharding - fix stuck export bug

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -7,7 +7,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Changes
 {
-    internal sealed class DatabaseChanges : AbstractDatabaseChanges<DatabaseConnectionState>, IDatabaseChanges
+    internal class DatabaseChanges : AbstractDatabaseChanges<DatabaseConnectionState>, IDatabaseChanges
     {
         public DatabaseChanges(RequestExecutor requestExecutor, string databaseName, Action onDispose, string nodeTag) 
             : base(requestExecutor, databaseName, onDispose, nodeTag, throttleConnection: false)

--- a/src/Raven.Server/Documents/Sharding/Changes/DatabaseChangesForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/DatabaseChangesForShard.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net.WebSockets;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Http;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Documents.Sharding.Changes;
+
+internal class DatabaseChangesForShard : DatabaseChanges
+{
+    private readonly ServerStore _server;
+
+    public DatabaseChangesForShard(ServerStore server, RequestExecutor requestExecutor, string databaseName, Action onDispose, string nodeTag)
+        : base(requestExecutor, databaseName, onDispose, nodeTag)
+    {
+        _server = server;
+    }
+
+    protected override ClientWebSocket CreateClientWebSocket(RequestExecutor requestExecutor) => 
+        ShardedDatabaseChanges.CreateClientWebSocket(_server, requestExecutor);
+}

--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseChanges.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseChanges.cs
@@ -22,13 +22,15 @@ internal sealed class ShardedDatabaseChanges : AbstractDatabaseChanges<ShardedDa
         _server = server;
     }
 
-    protected override ClientWebSocket CreateClientWebSocket(RequestExecutor requestExecutor)
+    protected override ClientWebSocket CreateClientWebSocket(RequestExecutor requestExecutor) => CreateClientWebSocket(_server, requestExecutor);
+
+    public static ClientWebSocket CreateClientWebSocket(ServerStore server, RequestExecutor requestExecutor)
     {
         var clientWebSocket = new ClientWebSocket();
         if (requestExecutor.Certificate != null)
         {
             clientWebSocket.Options.ClientCertificates.Add(requestExecutor.Certificate);
-            clientWebSocket.Options.RemoteCertificateValidationCallback = _server.Sharding.ShardingCustomValidationCallback;
+            clientWebSocket.Options.RemoteCertificateValidationCallback = server.Sharding.ShardingCustomValidationCallback;
         }
 
         return clientWebSocket;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
 using Raven.Server.Documents.Operations;
+using Raven.Server.Documents.Sharding.Changes;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
@@ -143,6 +144,6 @@ public partial class ShardedDatabaseContext
             }
         }
 
-        internal DatabaseChanges GetChanges(ShardedDatabaseIdentifier key) => _changes.GetOrAdd(key, k => new DatabaseChanges(_context.ShardExecutor.GetRequestExecutorAt(k.ShardNumber), ShardHelper.ToShardName(_context.DatabaseName, k.ShardNumber), onDispose: null, k.NodeTag));
+        internal DatabaseChanges GetChanges(ShardedDatabaseIdentifier key) => _changes.GetOrAdd(key, k => new DatabaseChangesForShard(_context.ServerStore, _context.ShardExecutor.GetRequestExecutorAt(k.ShardNumber), ShardHelper.ToShardName(_context.DatabaseName, k.ShardNumber), onDispose: null, k.NodeTag));
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20988/Export-is-stuck

### Additional description

`ShardedOperations.GetChanges` :
return a `DatabaseChangesForShard` object which uses the `ShardingCustomValidationCallback` 
as it's `ClientWebSocket.RemoteCertificateValidationCallback`  
(instead of returning the regular `DatabaseChanges` that uses `OnServerCertificateCustomValidationCallback`)

more details [here](https://issues.hibernatingrhinos.com/issue/RavenDB-20988/Export-is-stuck#focus=Comments-67-809615.0-0)

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
