### PR TITLE
RavenDB-21309 Test studio when one node is down

### DIFF
--- a/src/Raven.Studio/typescript/commands/resources/getDatabasesStateForStudioCommand.ts
+++ b/src/Raven.Studio/typescript/commands/resources/getDatabasesStateForStudioCommand.ts
@@ -17,8 +17,7 @@ class getDatabasesStateForStudioCommand extends commandBase {
             nodeTag: this.nodeTag
         }
 
-        return this.query<StudioDatabasesResponse>(url, args)
-            .fail((response: JQueryXHR) => this.reportError("Failed to load databases state", response.responseText, response.statusText));
+        return this.query<StudioDatabasesResponse>(url, args);
     }
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21309 

### Additional description

Fail silently on node failure. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change




