### PR TITLE
RavenDB-21363 Invalid detection of configuration change caused by comparing by reference which is not needed at all

### DIFF
--- a/src/Raven.Server/Documents/QueueSink/QueueSinkLoader.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkLoader.cs
@@ -301,7 +301,7 @@ public class QueueSinkLoader : IDisposable
             {
                 var diff = process.Configuration.Compare(config);
 
-                if (diff == QueueSinkConfigurationCompareDifferences.None && process.Configuration.Equals(config))
+                if (diff == QueueSinkConfigurationCompareDifferences.None)
                 {
                     existing = config;
                     break;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21363/Queue-Sink-Invalid-detection-of-configuration-change

### Additional description

Same issue as found in https://github.com/ravendb/ravendb/pull/17275

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
