### PR TITLE
RavenDB-21346 Show cluster limits without need to refresh the page

### DIFF
--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -181,49 +181,35 @@ namespace Raven.Server.Web.Studio
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
-                if (ServerStore.LicenseManager.LicenseStatus.Type == LicenseType.Community)
+                using (context.OpenReadTransaction())
                 {
-                    // TODO [grisha] temporary code
-                    using (context.OpenReadTransaction())
+                    var limits = new LicenseLimitsUsage
                     {
-                        var limits = new LicenseLimitsUsage
-                        {
-                            ClusterAutoIndexes = 0,
-                            ClusterStaticIndexes = 0,
-                            ClusterSubscriptionTasks = 0
-                        };
+                        ClusterAutoIndexes = 0,
+                        ClusterStaticIndexes = 0,
+                        ClusterSubscriptionTasks = 0
+                    };
 
-                        foreach (var database in ServerStore.Cluster.GetAllRawDatabases(context))
-                        {
-                            limits.ClusterStaticIndexes += database.CountOfStaticIndexes;
-                            limits.ClusterAutoIndexes += database.CountOfAutoIndexes;
-                            limits.ClusterSubscriptionTasks += GetSubscriptionCount(context, database.DatabaseName);
-                        }
-
-                        context.Write(writer, limits.ToJson());
+                    foreach (var database in ServerStore.Cluster.GetAllRawDatabases(context))
+                    {
+                        limits.ClusterStaticIndexes += database.CountOfStaticIndexes;
+                        limits.ClusterAutoIndexes += database.CountOfAutoIndexes;
+                        limits.ClusterSubscriptionTasks += GetSubscriptionCount(context, database.DatabaseName);
                     }
 
-                    return;
+                    context.Write(writer, limits.ToJson());
                 }
-
-                context.Write(writer, new DynamicJsonValue
-                {
-                    [nameof(LicenseLimitsUsage.ClusterStaticIndexes)] = null,
-                    [nameof(LicenseLimitsUsage.ClusterAutoIndexes)] = null,
-                    [nameof(LicenseLimitsUsage.ClusterSubscriptionTasks)] = null
-                });
             }
+        }
 
-            return;
+        static int GetSubscriptionCount(TransactionOperationContext context, string databaseName)
+        {
+            var count = 0;
+            foreach (var _ in ClusterStateMachine.ReadValuesStartingWith(context, SubscriptionState.SubscriptionPrefix(databaseName)))
+                count++;
 
-            static int GetSubscriptionCount(TransactionOperationContext context, string databaseName)
-            {
-                var count = 0;
-                foreach (var _ in ClusterStateMachine.ReadValuesStartingWith(context, SubscriptionState.SubscriptionPrefix(databaseName)))
-                    count++;
-
-                return count;
-            }
+            return count;
         }
     }
 }
+

--- a/src/Raven.Studio/typescript/components/common/shell/setup.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/setup.ts
@@ -10,7 +10,6 @@ import { licenseActions } from "./licenseSlice";
 import collectionsTracker from "common/helpers/database/collectionsTracker";
 import { collectionsTrackerActions } from "./collectionsTrackerSlice";
 import changesContext from "common/changesContext";
-import { todo } from "common/developmentHelper";
 import { services } from "hooks/useServices";
 import viewModelBase from "viewmodels/viewModelBase";
 
@@ -38,9 +37,9 @@ function updateReduxCollectionsTracker() {
     );
 }
 
-function updateLicenseLimitsUsage() {
+export const throttledUpdateLicenseLimitsUsage = _.throttle(() => {
     services.licenseService.getLimitsUsage().then((dto) => globalDispatch(licenseActions.limitsUsageLoaded(dto)));
-}
+}, 200);
 
 function initRedux() {
     if (initialized) {
@@ -81,9 +80,7 @@ function initRedux() {
 
     licenseModel.licenseStatus.subscribe((licenseStatus) => {
         globalDispatch(licenseActions.statusLoaded(licenseStatus));
-
-        todo("Other", "Damian", "Call it only when the usage have changed");
-        updateLicenseLimitsUsage();
+        throttledUpdateLicenseLimitsUsage();
     });
 
     collectionsTracker.default.registerOnGlobalChangeVectorUpdatedHandler(updateReduxCollectionsTracker);

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -59,8 +59,8 @@ import { FlexGrow } from "components/common/FlexGrow";
 import OngoingTaskAddModal from "./OngoingTaskAddModal";
 import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
-import AccordionLicenseLimited from "components/common/AccordionLicenseLimited";
 import { useRavenLink } from "components/hooks/useRavenLink";
+import { throttledUpdateLicenseLimitsUsage } from "components/common/shell/setup";
 
 interface OngoingTasksPageProps {
     database: database;
@@ -165,6 +165,10 @@ export function OngoingTasksPage(props: OngoingTasksPageProps) {
         subscriptions,
         hubDefinitions,
     } = filteredTasks;
+
+    useEffect(() => {
+        throttledUpdateLicenseLimitsUsage();
+    }, [subscriptions.length]);
 
     const getSelectedTaskShardedInfos = () =>
         [...tasks.tasks, ...tasks.subscriptions, ...tasks.replicationHubs]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21346/Show-cluster-limits-without-need-to-refresh-the-page

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
