### PR TITLE
RavenDB-21189 - RachisTests.AddNodeToClusterTests.RemoveNodeWithDb

### DIFF
--- a/src/Raven.Client/Http/ClusterTopology.cs
+++ b/src/Raven.Client/Http/ClusterTopology.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Http
@@ -181,6 +182,14 @@ namespace Raven.Client.Http
                     dic[node.Key] = node.Value;
                 }
                 return dic;
+            }
+        }
+
+        public override string ToString()
+        {
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                return ctx.ReadObject(ToJson(), "cluster-topology").ToString();
             }
         }
 

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -112,5 +112,10 @@ namespace Raven.Client.Http
 
             return nodes;
         }
+
+        public override string ToString()
+        {
+            return $"{{Url: {Url}, Database: {Database}, ClusterTag: {ClusterTag}, ServerRole: {ServerRole}}}";
+        }
     }
 }

--- a/src/Raven.Client/Http/Topology.cs
+++ b/src/Raven.Client/Http/Topology.cs
@@ -6,5 +6,10 @@ namespace Raven.Client.Http
     {
         public long Etag;
         public List<ServerNode> Nodes;
+
+        public override string ToString()
+        {
+            return $"{{{nameof(Nodes)}: [{string.Join(",", Nodes ?? new List<ServerNode>())}], {nameof(Etag)}: {Etag}}}";
+        }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1574,7 +1574,8 @@ namespace Raven.Server.Documents.Replication
             {
                 string[] remoteDatabaseUrls;
                 // fetch hub cluster node urls
-                using (var requestExecutor = RequestExecutor.Create(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
+                // use short term request executor that doesn't execute FirstTopologyUpdate because we do not have the authentication for that at this point
+                using (var requestExecutor = RequestExecutor.CreateForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1574,7 +1574,7 @@ namespace Raven.Server.Documents.Replication
             {
                 string[] remoteDatabaseUrls;
                 // fetch hub cluster node urls
-                using (var requestExecutor = RequestExecutor.CreateForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
+                using (var requestExecutor = RequestExecutor.Create(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
                     var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask);

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Utils
 
         private static async Task<TcpConnectionInfo> GetTcpInfoAsync(string url, GetTcpInfoCommand getTcpInfoCommand, X509Certificate2 certificate, CancellationToken token)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))//TODO stav: createForFixed instead?
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 await requestExecutor.ExecuteAsync(getTcpInfoCommand, context, token: token);

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -360,7 +360,7 @@ namespace RachisTests
             var dbWatcher = GetDatabaseName();
 
             var fromSeconds = Debugger.IsAttached ? TimeSpan.FromSeconds(15) : TimeSpan.FromSeconds(5);
-            var (_, leader) = await CreateRaftCluster(5);
+            var (nodes, leader) = await CreateRaftCluster(5, leaderIndex: 0);
             Assert.True(leader.ServerStore.LicenseManager.HasHighlyAvailableTasks());
 
             var db = await CreateDatabaseInCluster(dbMain, 5, leader.WebUrl);
@@ -397,7 +397,7 @@ namespace RachisTests
 
                 Assert.True(watcher.MentorNode != watcherDb.Servers[0].ServerStore.NodeTag);
 
-                var watcherRes = await AddWatcherToReplicationTopology((DocumentStore)leaderStore, watcher);
+                var watcherRes = await AddWatcherToReplicationTopology((DocumentStore)leaderStore, watcher, nodes.Select(n => n.WebUrl).ToArray());
                 var tasks = new List<Task>();
                 foreach (var ravenServer in Servers)
                 {
@@ -468,7 +468,7 @@ namespace RachisTests
                     }
                 }
 
-                Assert.True(WaitForDocument<User>(watcherStore, "users/3", u => u.Name == "Karmel3", 30_000));
+                Assert.True(WaitForDocument<User>(watcherStore, "users/3", u => u.Name == "Karmel3", 30_000), $"Doc 'users/3' did not reach watcherStore");
 
                 // rejoin the node
                 var newLeader = await ActionWithLeader(l => l.ServerStore.AddNodeToClusterAsync(responsibleServer.WebUrl, watcherRes.ResponsibleNode));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21189

### Additional description

Node was removed from cluster during replication which triggered failover. However, sometimes the removed node would be the node which is set to be the replication's `TopologyDiscoveryUrls` (the only one set) so the replication wasn't able to failover.
Added all the nodes to be the `TopologyDiscoveryUrls` to allow failover.

Also when running in debug, assertions checks and NRE exceptions were thrown. 
After the node removal there was an attempt to access the removed node during `UpdateTopologyAsync`. `/topology` endpoint tried to find its db tag in the cluster topology but the cluster topology on that node was empty due to the removal.
This caused to return a null for the url field in the response, which threw the NREs.
Fixed so now we do not return the node info at all in the response if it is not found in the cluster topology.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

