### PR TITLE
RavenDB-20608 - Excessive number of revisions after replication from …

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1448,7 +1448,6 @@ namespace Raven.Server.Documents.Replication
                                 // recreate attachments reference
                                 database.DocumentsStorage.AttachmentsStorage.PutAttachmentRevert(context, doc.Id, doc.Data, out _);
                                 
-                                doc.Data.Modifications = null;
                                 using var newVer = doc.Data.Clone(context);
                                 // now we save it again, and a side effect of that is syncing all the attachments
                                 context.DocumentDatabase.DocumentsStorage.Put(context, docId, null, newVer, lastModifiedTicks,

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1433,15 +1433,22 @@ namespace Raven.Server.Documents.Replication
                             var doc = context.DocumentDatabase.DocumentsStorage.Get(context, docId, DocumentFields.ChangeVector, throwOnConflict: false);
                             
                             // RavenDB-19421: if the document doesn't exist, the tombstone doesn't matter
-                            // and if the change vector is already merged, then it is already taken into consideration
+                            // and if the change vector is already merged, we should also check if we had a previous conflict on the existing document
+                            // if not, then it is already taken into consideration
                             // we need to force an update when this is _not_ the case, because this replication batch gave us the tombstone only, without
                             // the related document update, so we need to simulate that locally
                             if (doc != null &&
-                                ChangeVectorUtils.GetConflictStatus(cv, doc.ChangeVector) != ConflictStatus.AlreadyMerged) 
+                                (ChangeVectorUtils.GetConflictStatus(cv, doc.ChangeVector) != ConflictStatus.AlreadyMerged 
+                                 || doc.Flags.Contain(DocumentFlags.HasAttachments | DocumentFlags.Resolved)))
                             {   
                                 // have to load the full document
                                 doc = context.DocumentDatabase.DocumentsStorage.Get(context, docId, fields: DocumentFields.All, throwOnConflict: false);
                                 long lastModifiedTicks = Math.Max(modifiedTicks, doc.LastModified.Ticks); // old versions may send with 0 in the tombstone ticks
+
+                                // recreate attachments reference
+                                database.DocumentsStorage.AttachmentsStorage.PutAttachmentRevert(context, doc.Id, doc.Data, out _);
+                                
+                                doc.Data.Modifications = null;
                                 using var newVer = doc.Data.Clone(context);
                                 // now we save it again, and a side effect of that is syncing all the attachments
                                 context.DocumentDatabase.DocumentsStorage.Put(context, docId, null, newVer, lastModifiedTicks,

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -3,17 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client;
-using Raven.Client.Documents.Attachments;
-using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
-using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
-using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Utils;
@@ -298,9 +293,14 @@ namespace Raven.Server.Documents.Replication
 
             SaveConflictedDocumentsAsRevisions(context, resolved.Id, incoming);
 
-            // Resolved document should generate a new change vector, since it was changed locally.
-            // In a cluster this may cause a ping-pong replication which will be settled down by the fact that a conflict with identical content doesn't increase the local etag
-            var changeVector = _database.DocumentsStorage.CreateNextDatabaseChangeVector(context, resolved.ChangeVector);
+            // RavenDB-20608 
+            // put the resolved document change vector (merged change vector) when resolvedToLatest == true
+            // to avoid feature conflicts on the document due to one-way external replication
+            // if this is not the case (resolvedToLatest == false), we should generate a new change vector since it was changed locally.
+            // in a cluster this may cause a ping-pong replication which will be settled down by the fact that a conflict with identical content doesn't increase the local etag
+            var changeVector = resolvedToLatest ?
+                resolved.ChangeVector :
+                _database.DocumentsStorage.CreateNextDatabaseChangeVector(context, resolved.ChangeVector);
 
             if (resolved.Doc == null)
             {

--- a/test/SlowTests/Issues/RavenDB_20608.cs
+++ b/test/SlowTests/Issues/RavenDB_20608.cs
@@ -1,0 +1,399 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20608 : ReplicationTestBase
+    {
+        public RavenDB_20608(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        public async Task ReplicationShouldNotCauseConflictAfterResolve()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            using (var storeC = GetDocumentStore())
+            {
+                // create conflict of identical document
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.SaveChanges();
+                }
+
+                // set replication from A, B to C
+                await SetupReplicationAsync(storeA, storeC);
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeB, storeC);
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                // resolve a conflict of identical documents should not create conflicted revisions
+                await AssertRevisionsCountAsync(storeC, 0);
+
+                // update the document on B
+                // this should cause a conflict on C
+                using (var session = storeB.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeB, storeC);
+                await AssertRevisionsCountAsync(storeC, 3);
+
+                // update the document on A 
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                // set replication between A, B 
+                // from that point on any update of the document from A or B should not cause a conflict on C
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                // update the document again to ensure additional revision was not created in any store
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 50;
+                    session.SaveChanges();
+                }
+
+                await AssertRevisionsCountAsync(storeA, 0);
+                await AssertRevisionsCountAsync(storeB, 0);
+                await AssertRevisionsCountAsync(storeC, 3);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        public async Task ReplicationShouldNotCauseConflictAfterResolve2()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            using (var storeC = GetDocumentStore())
+            using (var storeD = GetDocumentStore())
+            {
+                // create conflict
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.SaveChanges();
+                }
+
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran2" }, "users/shiran");
+                    session.SaveChanges();
+                }
+
+                // set replication from A, B to C
+                await SetupReplicationAsync(storeA, storeC);
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeB, storeC);
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                // resolve to latest should create conflicted revisions
+                await AssertRevisionsCountAsync(storeC, 3);
+
+                // create the document on D
+                // this will cause a conflict in replication with the resolved document that exists on C 
+                using (var session = storeD.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran3" }, "users/shiran");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeD, storeC);
+                await EnsureReplicatingAsync(storeD, storeC);
+
+                // 3 conflicted revisions (from A, B, D), 1 resolved revision (A, B), 1 resolved revision (A, B, D)
+                await AssertRevisionsCountAsync(storeC, 5);
+
+                // set replication between A, B, D
+                // from that point on, any update of the document from A, B or D should not cause a conflict on C
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+               
+                await SetupReplicationAsync(storeD, storeA, storeB);
+                await EnsureReplicatingAsync(storeD, storeA);
+                await EnsureReplicatingAsync(storeD, storeB);
+
+                await SetupReplicationAsync(storeA, storeD);
+                await EnsureReplicatingAsync(storeA, storeD);
+
+                await SetupReplicationAsync(storeB, storeD);
+                await EnsureReplicatingAsync(storeB, storeD);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await AssertRevisionsCountAsync(storeC, 5);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+              
+                Assert.True(WaitForDocument<User>(storeC, "users/shiran", u => u.Age == 30));
+
+                await AssertRevisionsCountAsync(storeC, 5);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Attachments)]
+        public async Task ReplicationWithAttachmentsShouldNotCauseConflictAfterResolve()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            using (var storeC = GetDocumentStore())
+            {
+                // create conflict of identical document with same attachment
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeC);
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeB, storeC);
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeB.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 50;
+                    session.SaveChanges();
+                }
+                Assert.True(WaitForDocument<User>(storeC, "users/shiran", u => u.Age == 50));
+
+                await AssertRevisionsCountAsync(storeA, 0);
+                await AssertRevisionsCountAsync(storeB, 0);
+                await AssertRevisionsCountAsync(storeC, 3);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Attachments)]
+        public async Task ReplicationWithAttachmentsShouldNotCauseConflictAfterResolve2()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            using (var storeC = GetDocumentStore())
+            {
+                // create conflict of identical document with different attachments
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 4, 5, 6 }))
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeC);
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeB, storeC);
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeB.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await AssertRevisionsCountAsync(storeA, 3);
+                await AssertRevisionsCountAsync(storeB, 3);
+                await AssertRevisionsCountAsync(storeC, 7);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(storeC, "users/shiran", u => u.Age == 30));
+
+                await AssertRevisionsCountAsync(storeC, 7);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Attachments)]
+        public async Task GenerateNewChangeVectorInReplicationWithAttachmentConflict()
+        {
+            // unlike the previous tests, this one should create a new change vector
+            // because we recreated the attachment reference locally in the incoming replication (RavenDB-19421)
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+            using (var storeA = GetDocumentStore(options))
+            using (var storeB = GetDocumentStore(options))
+            using (var storeC = GetDocumentStore(options))
+            {
+                // create conflict of identical document with different attachments
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 4, 5, 6 }))
+                using (var session = storeB.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, "users/shiran");
+                    session.Advanced.Attachments.Store("users/shiran", "foo/bar", profileStream, "image/png");
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(storeA, storeC);
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeB, storeC);
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeA.OpenSession())
+                {
+                    session.Advanced.Attachments.Delete("users/shiran", "foo/bar");
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeB, storeC);
+
+                using (var session = storeB.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(storeA, storeC);
+
+                await SetupReplicationAsync(storeA, storeB);
+                await EnsureReplicatingAsync(storeA, storeB);
+
+                await SetupReplicationAsync(storeB, storeA);
+                await EnsureReplicatingAsync(storeB, storeA);
+
+                await AssertRevisionsCountAsync(storeA, 3);
+                await AssertRevisionsCountAsync(storeB, 3);
+                await AssertRevisionsCountAsync(storeC, 8);
+
+                using (var session = storeA.OpenSession())
+                {
+                    var user = session.Load<User>("users/shiran");
+                    user.Age = 40;
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(storeC, "users/shiran", u => u.Age == 40));
+
+                await AssertRevisionsCountAsync(storeC, 11);
+            }
+        }
+
+        private async Task AssertRevisionsCountAsync(IDocumentStore store, int expectedNumberOfRevisions)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var revisionsCount = await session.Advanced.Revisions.GetCountForAsync("users/shiran");
+                Assert.Equal(expectedNumberOfRevisions, revisionsCount);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -1257,8 +1257,8 @@ namespace SlowTests.Server.Replication
                     var rev3 = await session3.Advanced.Revisions.GetMetadataForAsync("foo/bar");
 
                     Assert.True(rev3.Count == rev2.Count, $"On the fly has {rev3.Count}, while from background has {rev2.Count}");
-                    Assert.Equal(4, rev3.Count);
-                    Assert.Equal(4, rev2.Count);
+                    Assert.Equal(3, rev3.Count);
+                    Assert.Equal(3, rev2.Count);
                 }
             }
         }


### PR DESCRIPTION
…sharded to non-sharded

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20608/Excessive-number-of-revisions-after-replication-from-sharded-to-non-sharded

### Additional description

Instead of creating a new change vector after resolving a conflict, we just put the resolved change vector (merged change vector). 
In addition, this PR contains a fix for RavenDB-19421 (https://issues.hibernatingrhinos.com/issue/RavenDB-19421/Missing-attachments-in-Replication):
we didn't actually recreate the reference between the document and the attachment, and the stream was deleted at the end of the batch, even though it shouldn't. 
_Note_: although this is a rare scenario, recreating attachment references generates a new change vector; thus, the original issue will still happen. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
