### PR TITLE
RavenDB-21382 - NRE in enforce revisions configuration

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1866,12 +1866,9 @@ namespace Raven.Server.Documents.Revisions
                 var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
 
                 var local = _documentsStorage.GetDocumentOrTombstone(context, lowerId, throwOnConflict: false);
-                var deletedDoc = local.Document == null && local.Tombstone != null;
-                Debug.Assert(local.Document != null || local.Tombstone != null);
+                var deletedDoc = local.Document == null;
 
-                var docFlags = deletedDoc ? local.Tombstone.Flags : local.Document.Flags;
-
-                var configuration = GetRevisionsConfiguration(collectionName.Name, docFlags, deleteRevisionsWhenNoCofiguration: true);
+                var configuration = GetRevisionsConfiguration(collectionName.Name, deleteRevisionsWhenNoCofiguration: true);
 
                 var result = DeleteOldRevisions(context, table, lowerIdPrefix, collectionName, configuration, 
                     NonPersistentDocumentFlags.ByEnforceRevisionConfiguration,

--- a/test/SlowTests/Issues/RavenDB-21382.cs
+++ b/test/SlowTests/Issues/RavenDB-21382.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Graph;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21382 : ReplicationTestBase
+    {
+        public RavenDB_21382(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task EnforceConfigurationShouldntThrowNreInDeletedDocWithNoTombstone()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
+            });
+            var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, } };
+            await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+            var user = new User { Id = "Users/1-A", Name = "Shahar" };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    (await session.LoadAsync<User>(user.Id)).Name = $"Shahar{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                session.Delete(user.Id);
+                await session.SaveChangesAsync();
+            }
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+            {
+                using (context.OpenReadTransaction())
+                {
+                    var count = database.DocumentsStorage.GetTombstonesFrom(context, "Users", 0, 0, 128).Count();
+                    Assert.Equal(1, count);
+                }
+
+                await database.TombstoneCleaner.ExecuteCleanup();
+
+                using (context.OpenReadTransaction())
+                {
+                    var count = database.DocumentsStorage.GetTombstonesFrom(context, "Users", 0, 0, 128).Count();
+                    Assert.Equal(0, count);
+                }
+
+            }
+
+            using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
+                await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, false, token: token);
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21382/NRE-in-enforce-revisions-configuration

### Additional description

NRE in enforce revisions configuration, when trying to enforce on deleted doc that its tombstones was already deleted by the tombstone cleaner.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
