### PR TITLE
RavenDB-20987 - Check revision tombstone with id that require escaping

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -306,7 +306,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             protected virtual void HandleRevisionTombstone(DocumentsOperationContext context, LazyStringValue id, out Slice changeVectorSlice, out Slice keySlice, List<IDisposable> toDispose)
             {
-                toDispose.Add(Slice.From(context.Allocator, id, out keySlice));
+                toDispose.Add(DocumentIdWorker.GetSliceFromId(context, id, out keySlice));
                 toDispose.Add(RevisionTombstoneReplicationItem.TryExtractChangeVectorSliceFromKey(context.Allocator, id, out changeVectorSlice));
             }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1175,7 +1175,7 @@ namespace Raven.Server.Documents.Revisions
 
         internal static void CreateRevisionTombstoneKeySlice(DocumentsOperationContext context, string documentId, string changeVector, out Slice changeVectorSlice, out Slice keySlice, List<IDisposable> toDispose)
         {
-            toDispose.Add(Slice.From(context.Allocator, documentId, out var documentIdSlice));
+            toDispose.Add(DocumentIdWorker.GetSliceFromId(context, documentId, out var documentIdSlice));
             toDispose.Add(CreateRevisionTombstoneKeySlice(context, documentIdSlice, changeVector, out changeVectorSlice, out keySlice));
         }
 

--- a/test/SlowTests/Issues/RavenDB_20987.cs
+++ b/test/SlowTests/Issues/RavenDB_20987.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20987 : ReplicationTestBase
+    {
+        public RavenDB_20987(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RevisionTombstoneWithIdThatRequireEscaping(Options options)
+        {
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store1);
+
+                var id = "users~shiran\r\n1";
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    user.Name = "shiran";
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(new DeleteRevisionsOperation.Parameters
+                {
+                    DocumentIds = new[] { id }
+                }));
+
+                await EnsureReplicatingAsync(store1, store2);
+
+                var documentDatabase = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, id);
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var tombstones = documentDatabase.DocumentsStorage.GetTombstonesFrom(ctx, 0, 0, int.MaxValue).ToList();
+                    Assert.Equal(2, tombstones.Count);
+                    foreach (var tombstone in tombstones)
+                        Assert.Equal(Tombstone.TombstoneType.Revision, tombstone.Type);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_20987.cs
+++ b/test/SlowTests/Issues/RavenDB_20987.cs
@@ -1,6 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide.Context;
@@ -19,7 +23,7 @@ namespace SlowTests.Issues
 
         [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task RevisionTombstoneWithIdThatRequireEscaping(Options options)
+        public async Task ReplicationOfRevisionTombstoneWithIdThatRequireEscaping(Options options)
         {
             using (var store1 = GetDocumentStore(options))
             using (var store2 = GetDocumentStore(options))
@@ -51,15 +55,180 @@ namespace SlowTests.Issues
 
                 await EnsureReplicatingAsync(store1, store2);
 
-                var documentDatabase = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, id);
-                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                using (ctx.OpenReadTransaction())
+                await CheckData(store2, options.DatabaseMode, id, expectedRevisionTombstones: 2);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ReplicationOfAttachmentTombstoneWithIdThatRequireEscaping(Options options)
+        {
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store1);
+
+                var id = "users~shiran\r\n1";
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = store1.OpenAsyncSession())
                 {
-                    var tombstones = documentDatabase.DocumentsStorage.GetTombstonesFrom(ctx, 0, 0, int.MaxValue).ToList();
-                    Assert.Equal(2, tombstones.Count);
-                    foreach (var tombstone in tombstones)
-                        Assert.Equal(Tombstone.TombstoneType.Revision, tombstone.Type);
+                    await session.StoreAsync(new User(), id);
+                    session.Advanced.Attachments.Store(id, "profile.png", profileStream);
+                    await session.SaveChangesAsync();
                 }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(new DeleteRevisionsOperation.Parameters
+                {
+                    DocumentIds = new[] { id }
+                }));
+
+                await EnsureReplicatingAsync(store1, store2);
+              
+                await CheckData(store2, options.DatabaseMode, id, expectedRevisionTombstones: 2, expectedAttachmentTombstones: 1);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.BackupExportImport)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ImportRevisionTombstoneWithIdThatRequireEscaping(Options options)
+        {
+            var file = GetTempFileName();
+            try
+            {
+                using (var store1 = GetDocumentStore(options))
+                using (var store2 = GetDocumentStore(options))
+                {
+                    await RevisionsHelper.SetupRevisionsAsync(store1);
+
+                    var id = "users~shiran\r\n1";
+
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), id);
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<User>(id);
+                        user.Name = "shiran";
+                        await session.SaveChangesAsync();
+                    }
+
+                    await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(new DeleteRevisionsOperation.Parameters
+                    {
+                        DocumentIds = new[] { id }
+                    }));
+
+                    await CheckData(store1, options.DatabaseMode, id, expectedRevisionTombstones: 2);
+
+                    var exportOptions = new DatabaseSmugglerExportOptions
+                    {
+                        OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Tombstones
+                    };
+                    var operation = await store1.Smuggler.ExportAsync(exportOptions, file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    var importOptions = new DatabaseSmugglerImportOptions
+                    {
+                        OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Tombstones
+                    };
+                    var importOperation = await store2.Smuggler.ImportAsync(importOptions, file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    await CheckData(store2, options.DatabaseMode, id, expectedRevisionTombstones: 2);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.BackupExportImport | RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ImportAttachmentRevisionTombstoneWithIdThatRequireEscaping(Options options)
+        {
+            var file = GetTempFileName();
+            try
+            {
+                using (var store1 = GetDocumentStore(options))
+                using (var store2 = GetDocumentStore(options))
+                {
+                    await RevisionsHelper.SetupRevisionsAsync(store1);
+
+                    var id = "users~shiran\r\n1";
+
+                    using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), id);
+                        session.Advanced.Attachments.Store(id, "profile.png", profileStream);
+                        await session.SaveChangesAsync();
+                    }
+
+                    await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(new DeleteRevisionsOperation.Parameters
+                    {
+                        DocumentIds = new[] { id }
+                    }));
+
+                    await CheckData(store1, options.DatabaseMode, id, expectedRevisionTombstones: 2, expectedAttachmentTombstones: 1);
+
+                    var exportOptions = new DatabaseSmugglerExportOptions
+                    {
+                        OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Tombstones
+                    };
+                    var operation = await store1.Smuggler.ExportAsync(exportOptions, file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                    var importOptions = new DatabaseSmugglerImportOptions
+                    {
+                        OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Tombstones
+                    };
+                    var importOperation = await store2.Smuggler.ImportAsync(importOptions, file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    await CheckData(store2, options.DatabaseMode, id, expectedRevisionTombstones: 2, expectedAttachmentTombstones: 1);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        private async Task CheckData(IDocumentStore store, RavenDatabaseMode mode, string id, long expectedRevisionTombstones, long expectedAttachmentTombstones = 0)
+        {
+            var documentDatabase = await GetDocumentDatabaseInstanceForAsync(store, mode, id);
+            using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var totalExpected = expectedRevisionTombstones + expectedAttachmentTombstones;
+                var tombstones = documentDatabase.DocumentsStorage.GetTombstonesFrom(ctx, 0, 0, int.MaxValue).ToList();
+                Assert.Equal(totalExpected, tombstones.Count);
+
+                var revisionTombstones = 0;
+                var attachmentTombstones = 0;
+                var counterTombstones = 0;
+                foreach (var tombstone in tombstones)
+                {
+                    switch (tombstone.Type)
+                    {
+                        case Tombstone.TombstoneType.Revision:
+                            revisionTombstones++;
+                            break;
+                        case Tombstone.TombstoneType.Attachment:
+                            attachmentTombstones++;
+                            break;
+                    }
+                }
+
+                Assert.Equal(expectedRevisionTombstones, revisionTombstones);
+                Assert.Equal(expectedAttachmentTombstones, attachmentTombstones);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20987/Check-revision-tombstone-with-id-that-require-escaping

### Additional info

This PR contains the following fixes:
- Original issue
- Bug with revision tombstones after replication: converting `RevisionTombstone` key (`LazyStringValue`) to `Slice` converts the `SpecialChars.RecordSeparator` [30] to encoded string [\u001E], which caused two duplicate revision tombstones in storage. It was fixed by recreating the key.
- Bug in Import operation (only for sharded db) for `RevisionTombstone` and `AttachmentTombstone`. We calculated the shard number based on the entire key instead of the document ID.

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
