### PR TITLE
RavenDB-21371 Add 'archived.archivedAt' method to the patch API

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -884,10 +884,9 @@ namespace Raven.Server.Documents.Patch
 
                 if (args[1].IsNull() || args[1].IsUndefined() || args[1].IsString() == false)
                     throw new InvalidOperationException("archiveAt(doc, utcDateTimeString) must take string as the second argument");
-
-                if (DateTime.TryParse(args[1].ToString(), out DateTime _) == false)
-                    throw new InvalidOperationException(
-                        $"Invalid datetime string: '{args[1]}'. Method archiveAt(doc, utcDateTimeString) takes UTC DateTime string as a second argument, in the following format: '1970-01-01T12:00:00.0000000Z'");
+                
+                // Validate correct datetime format
+                GetDateArg(args[1].ToString(), "archiveAt(doc, utcDateTimeString)", "utcDateTimeString");
                 
                 var archivedDocId = GetIdFromArg(args[0], _unarchiveSignature);
                 using (var doc = _database.DocumentsStorage.Get(_docsCtx, archivedDocId, DocumentFields.Data, throwOnConflict: true))

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalIndexingTests.cs
@@ -1319,7 +1319,7 @@ User: counter.DocumentId
         }
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Patching)]
     public async Task CanScheduleDocumentsToBeArchivedUsingPatch()
     {
         using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21371/Document-patching-allow-updating-archive-at-metadata-property

### Additional description

Extended the `archived` patch API with a new method - `archived.archiveAt(doc, utcDateTimeString)`, that correctly sets the `@archive-at` metadata for the user, with some additional checks.  

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
