### PR TITLE
RavenDB-21034

### DIFF
--- a/src/Raven.Server/Documents/QueueSink/RabbitMqSinkConsumer.cs
+++ b/src/Raven.Server/Documents/QueueSink/RabbitMqSinkConsumer.cs
@@ -51,7 +51,7 @@ public class RabbitMqSinkConsumer : DefaultBasicConsumer, IQueueSinkConsumer
     {
         if (_latestDeliveryTag > 0)
         {
-            _channel.BasicAck(0, true);    
+            _channel.BasicAck(_latestDeliveryTag, true);    
         }
     }
     

--- a/src/Raven.Server/Documents/QueueSink/RabbitMqSinkConsumer.cs
+++ b/src/Raven.Server/Documents/QueueSink/RabbitMqSinkConsumer.cs
@@ -10,7 +10,7 @@ public class RabbitMqSinkConsumer : DefaultBasicConsumer, IQueueSinkConsumer
     private readonly IModel _channel;
     private readonly BlockingCollection<(byte[] Body, IBasicProperties Properties, ulong deliveryTag)> _deliveries = new();
 
-    private ulong? _latestDeliveryTag;
+    private ulong _latestDeliveryTag;
 
     public RabbitMqSinkConsumer(IModel channel) : base(channel)
     {
@@ -49,9 +49,9 @@ public class RabbitMqSinkConsumer : DefaultBasicConsumer, IQueueSinkConsumer
 
     public void Commit()
     {
-        if (_latestDeliveryTag != null)
+        if (_latestDeliveryTag > 0)
         {
-            _channel.BasicAck(_latestDeliveryTag.Value, true);
+            _channel.BasicAck(0, true);    
         }
     }
     


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21385/Queue-Sink-Messages-consumed-by-RavenDB-sink-arent-acknowledged-in-Rabbit-MQ

### Additional description

Fix for not ack messages in rabbitmq. Delivery tag was always null.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
