### PR TITLE
RavenDB-21387 Replication Hub in Secure server: toggle is not visible

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
@@ -94,8 +94,12 @@
                                         <label for="allowHubToSink">Allow replication from Hub to Sink</label>
                                     </div>
                                     <div class="toggle">
-                                        <div data-placement="right" data-toggle="tooltip" title="Server must be secured in order to use Sink to Hub mode" data-animation="true" data-bind="visible: !$root.canDefineCertificates">
-                                            <input id="allowSinkToHub" type="checkbox" data-bind="checked: allowReplicationFromSinkToHub, disable: !$root.canDefineCertificates" />
+                                        <div data-bind="visible: !$root.canDefineCertificates" data-placement="right" data-toggle="tooltip" title="Server must be secured in order to use Sink to Hub mode" data-animation="true">
+                                            <input type="checkbox" data-bind="checked: false, disable: true" />
+                                            <label>Allow replication from Sink to Hub</label>
+                                        </div>
+                                        <div data-bind="visible: $root.canDefineCertificates">
+                                            <input id="allowSinkToHub" type="checkbox" data-bind="checked: allowReplicationFromSinkToHub" />
                                             <label for="allowSinkToHub">Allow replication from Sink to Hub</label>
                                         </div>
                                     </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21387/Replication-Hub-in-Secure-server-toggle-is-not-visible

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
