### PR TITLE
RavenDB-21386 Skip archived documents from sending by data subscriptions even when fetching documents from the resend list

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -135,20 +135,6 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
             if (Fetcher.FetchingFrom == SubscriptionFetcher.FetchingOrigin.Storage)
             {
-                if (item.Flags.Contain(DocumentFlags.Archived) && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ExcludeArchived)
-                {
-                    reason = $"{id} is archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
-                    result.Status = SubscriptionBatchItemStatus.Skip;
-                    return result;
-                }
-                
-                if (item.Flags.Contain(DocumentFlags.Archived) == false && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ArchivedOnly)
-                {
-                    reason = $"{id} is not archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
-                    result.Status = SubscriptionBatchItemStatus.Skip;
-                    return result;
-                }
-                
                 var conflictStatus = GetConflictStatus(item.ChangeVector);
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
@@ -189,6 +175,20 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                 };
             }
 
+            if (item.Flags.Contain(DocumentFlags.Archived) && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ExcludeArchived)
+            {
+                reason = $"{id} is archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
+                result.Status = SubscriptionBatchItemStatus.Skip;
+                return result;
+            }
+            
+            if (item.Flags.Contain(DocumentFlags.Archived) == false && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ArchivedOnly)
+            {
+                reason = $"{id} is not archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
+                result.Status = SubscriptionBatchItemStatus.Skip;
+                return result;
+            }
+            
             if (Patch == null)
             {
                 result.Status = SubscriptionBatchItemStatus.Send;

--- a/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -171,18 +171,19 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                     Data = current.Data, 
                     Id = current.Id, // use proper casing
                     LowerId = current.LowerId, 
-                    ChangeVector = current.ChangeVector
+                    ChangeVector = current.ChangeVector,
+                    Flags = current.Flags
                 };
             }
 
-            if (item.Flags.Contain(DocumentFlags.Archived) && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ExcludeArchived)
+            if (result.Document.Flags.Contain(DocumentFlags.Archived) && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ExcludeArchived)
             {
                 reason = $"{id} is archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
                 result.Status = SubscriptionBatchItemStatus.Skip;
                 return result;
             }
             
-            if (item.Flags.Contain(DocumentFlags.Archived) == false && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ArchivedOnly)
+            if (result.Document.Flags.Contain(DocumentFlags.Archived) == false && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ArchivedOnly)
             {
                 reason = $"{id} is not archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
                 result.Status = SubscriptionBatchItemStatus.Skip;

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -1153,7 +1153,7 @@ namespace SlowTests.Client.Subscriptions
             }
         }
 
-        private class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
+        internal class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
         {
             private readonly string _database;
             private readonly string _name;
@@ -1191,7 +1191,7 @@ namespace SlowTests.Client.Subscriptions
             public override bool IsReadRequest => true;
         }
 
-        private class ResendListResult
+        internal class ResendListResult
         {
 #pragma warning disable CS0649
             public List<ResendItem> Results;

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
@@ -21,9 +21,12 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents.Subscriptions;
 using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Server;
+using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -490,6 +493,160 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
             Assert.DoesNotContain("Company Name 2", result);
             Assert.DoesNotContain("Company Name 3", result);
         }
+    }
+
+    [Fact]
+    public async Task DocumentFromTryoutListWontBeReturnedIfItWasArchivedInMeantime()
+    {
+        var reasonableWaitTime = TimeSpan.FromSeconds(15);
+        var retires = DateTime.UtcNow + TimeSpan.FromMinutes(5);
+        using (var store = GetDocumentStore())
+        {
+            using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < 128; i++)
+                {
+                    await bulkInsert.StoreAsync(new Order {Freight = i}, $"orders/{i}-A", new MetadataAsDictionary {{Constants.Documents.Metadata.ArchiveAt, retires}});
+                }
+            }
+            var collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+            var docs = collectionStats.Collections["Orders"];
+            Assert.Equal(128, docs);
+            
+            
+            // create a new subscription
+            var sub = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions() { Query = "from 'Orders'" });
+            var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sub)
+            {
+                TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
+            });
+            
+            
+            var mre = new AsyncManualResetEvent();
+            var mre2 = new AsyncManualResetEvent();
+            
+            var exceptions = new List<Exception>();
+            subscription.OnUnexpectedSubscriptionError += exception =>
+            {
+                exceptions.Add(exception);
+            };
+            
+            // fetch all docs from storage to the received subscription batch, then wait on mre2
+            var fetchFromStorageTask = subscription.Run(async x =>
+            {
+                mre.Set();
+                Assert.True(await mre2.WaitAsync(reasonableWaitTime), "await mre2.WaitAsync(_reasonableWaitTime)");
+            });
+            
+            // wait for setting mre above
+            Assert.True(await mre.WaitAsync(reasonableWaitTime), "await mre.WaitAsync(_reasonableWaitTime)");
+            
+            
+            // drop subscription
+            await subscription.DisposeAsync(false);
+            try
+            {
+                // set mre2 and wait for fetchFromStorageTask to realize that its set already
+                mre2.Set();
+                await fetchFromStorageTask;
+            }
+            catch (Exception)
+            {
+                // no one cares
+            }
+            
+            Assert.True(exceptions.Count == 0, $"{string.Join(Environment.NewLine, exceptions.Select(x => x.ToString()))}");
+            
+            // assert that all previously fetched items are on the resend list already
+            var executor = store.GetRequestExecutor();
+            using var _ = executor.ContextPool.AllocateOperationContext(out var ctx);
+            var cmd = new GetSubscriptionResendListCommand(store.Database, subscription.SubscriptionName);
+            await executor.ExecuteAsync(cmd, ctx);
+            var res = cmd.Result;
+            
+            Assert.Equal(128, res.Results.Count);
+            
+            // Activate the archival manually - change docs archival status while they're on the resend list
+            await SetupDataArchival(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+            var documentsArchiver = database.DataArchivist;
+            await documentsArchiver.ArchiveDocs();
+            
+            // start new worker it will process from resend
+            subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sub)
+            {
+                TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16),
+                MaxDocsPerBatch = 1
+            });
+            try
+            {
+                var items = new HashSet<string>();
+                var fetchFromResendListTask = subscription.Run(batch =>
+                {
+                    foreach (var item in batch.Items)
+                    {
+                        items.Add(item.Id);
+                    }
+                });
+                
+                // assert that documents are skipped in this scenario
+                Assert.Equal(0, await WaitForValueAsync(() => items.Count, docs, timeout: 10_000));
+            }
+            finally
+            {
+                await subscription.DisposeAsync();
+            }
+        }
+    }
+    private class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
+    {
+        private readonly string _database;
+        private readonly string _name;
+
+        public GetSubscriptionResendListCommand(string database, string name)
+        {
+            _database = database;
+            _name = name;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{_database}/debug/subscriptions/resend?name={_name}";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+            {
+                Result = null;
+                return;
+            }
+
+            var deserialize = JsonDeserializationBase.GenerateJsonDeserializationRoutine<ResendListResult>();
+            Result = deserialize.Invoke(response);
+        }
+
+        public override bool IsReadRequest => true;
+    }
+
+    private class ResendListResult
+    {
+#pragma warning disable CS0649
+        public List<ResendItem> Results;
+#pragma warning restore CS0649
+    }
+
+    private class User
+    {
+        public string Name;
     }
 }
 

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
@@ -26,6 +26,7 @@ using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
@@ -495,7 +496,7 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Subscriptions)]
     public async Task DocumentFromTryoutListWontBeReturnedIfItWasArchivedInMeantime()
     {
         var reasonableWaitTime = TimeSpan.FromSeconds(15);

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
@@ -22,6 +22,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents.Subscriptions;
+using SlowTests.Client.Subscriptions;
 using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
@@ -510,39 +511,40 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
                     await bulkInsert.StoreAsync(new Order {Freight = i}, $"orders/{i}-A", new MetadataAsDictionary {{Constants.Documents.Metadata.ArchiveAt, retires}});
                 }
             }
+
             var collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
             var docs = collectionStats.Collections["Orders"];
             Assert.Equal(128, docs);
-            
-            
+
+
             // create a new subscription
-            var sub = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions() { Query = "from 'Orders'" });
+            var sub = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions() {Query = "from 'Orders'"});
             var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sub)
             {
                 TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
             });
-            
-            
+
+
             var mre = new AsyncManualResetEvent();
             var mre2 = new AsyncManualResetEvent();
-            
+
             var exceptions = new List<Exception>();
             subscription.OnUnexpectedSubscriptionError += exception =>
             {
                 exceptions.Add(exception);
             };
-            
+
             // fetch all docs from storage to the received subscription batch, then wait on mre2
             var fetchFromStorageTask = subscription.Run(async x =>
             {
                 mre.Set();
                 Assert.True(await mre2.WaitAsync(reasonableWaitTime), "await mre2.WaitAsync(_reasonableWaitTime)");
             });
-            
+
             // wait for setting mre above
             Assert.True(await mre.WaitAsync(reasonableWaitTime), "await mre.WaitAsync(_reasonableWaitTime)");
-            
-            
+
+
             // drop subscription
             await subscription.DisposeAsync(false);
             try
@@ -555,30 +557,29 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
             {
                 // no one cares
             }
-            
+
             Assert.True(exceptions.Count == 0, $"{string.Join(Environment.NewLine, exceptions.Select(x => x.ToString()))}");
-            
+
             // assert that all previously fetched items are on the resend list already
             var executor = store.GetRequestExecutor();
             using var _ = executor.ContextPool.AllocateOperationContext(out var ctx);
-            var cmd = new GetSubscriptionResendListCommand(store.Database, subscription.SubscriptionName);
+            var cmd = new ConcurrentSubscriptionsTests.GetSubscriptionResendListCommand(store.Database, subscription.SubscriptionName);
             await executor.ExecuteAsync(cmd, ctx);
             var res = cmd.Result;
-            
+
             Assert.Equal(128, res.Results.Count);
-            
+
             // Activate the archival manually - change docs archival status while they're on the resend list
             await SetupDataArchival(store);
             var database = await Databases.GetDocumentDatabaseInstanceFor(store);
             database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
             var documentsArchiver = database.DataArchivist;
             await documentsArchiver.ArchiveDocs();
-            
+
             // start new worker it will process from resend
             subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sub)
             {
-                TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16),
-                MaxDocsPerBatch = 1
+                TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16), MaxDocsPerBatch = 1
             });
             try
             {
@@ -590,7 +591,7 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
                         items.Add(item.Id);
                     }
                 });
-                
+
                 // assert that documents are skipped in this scenario
                 Assert.Equal(0, await WaitForValueAsync(() => items.Count, docs, timeout: 10_000));
             }
@@ -599,55 +600,6 @@ public class DataArchivalDataSubscriptionsTests(ITestOutputHelper output) : Rave
                 await subscription.DisposeAsync();
             }
         }
-    }
-    private class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
-    {
-        private readonly string _database;
-        private readonly string _name;
-
-        public GetSubscriptionResendListCommand(string database, string name)
-        {
-            _database = database;
-            _name = name;
-        }
-
-        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-        {
-            url = $"{node.Url}/databases/{_database}/debug/subscriptions/resend?name={_name}";
-
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-            };
-
-            return request;
-        }
-
-        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-        {
-            if (response == null)
-            {
-                Result = null;
-                return;
-            }
-
-            var deserialize = JsonDeserializationBase.GenerateJsonDeserializationRoutine<ResendListResult>();
-            Result = deserialize.Invoke(response);
-        }
-
-        public override bool IsReadRequest => true;
-    }
-
-    private class ResendListResult
-    {
-#pragma warning disable CS0649
-        public List<ResendItem> Results;
-#pragma warning restore CS0649
-    }
-
-    private class User
-    {
-        public string Name;
     }
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21386/Consider-skipping-archived-documents-from-sending-by-data-subscriptions-when-fetching-documents-from-the-resend-list

### Additional description

Moved the data subscriptions' internal data archival-related checks to the outer scope, the checks will be also made when fetching docs from the resend list.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
