### PR TITLE
RavenDB-21379 1st round of fixes after running with sharded database against jvm client

### DIFF
--- a/src/Raven.Client/Exceptions/Sharding/ShardedPatchBehaviorViolationException.cs
+++ b/src/Raven.Client/Exceptions/Sharding/ShardedPatchBehaviorViolationException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Sharding;
+
+public sealed class ShardedPatchBehaviorViolationException : RavenException
+{
+    public ShardedPatchBehaviorViolationException()
+    {
+    }
+
+    public ShardedPatchBehaviorViolationException(string message)
+        : base(message)
+    {
+    }
+
+    public ShardedPatchBehaviorViolationException(string message, Exception e)
+        : base(message, e)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -29,16 +29,15 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/revisions/count", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetRevisionsCountFor()
         {
-            using (var processor = new RevisionsHandlerProcessorForGetRevisionsCount(this))
-            {
+            using (var processor = new RevisionsHandlerProcessorForGetRevisionsCount(this)) 
                 await processor.ExecuteAsync();
-            }
         }
 
         [RavenAction("/databases/*/revisions", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetRevisionsFor()
         {
-            using (var processor = new RevisionsHandlerProcessorForGetRevisions(this)) await processor.ExecuteAsync();
+            using (var processor = new RevisionsHandlerProcessorForGetRevisions(this)) 
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/revisions/revert", "POST", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Documents.Patch
             if (runIfMissing != null)
                 runIfMissing.DebugMode = _debugMode;
 
-            using (DocumentIdWorker.GetLower(context.Allocator, id, out Slice lowerId))
+            using (DocumentIdWorker.GetSliceFromId(context.Allocator, id, out Slice lowerId))
             {
                 _database.DocumentsStorage.ValidateId(context, lowerId, type: DocumentChangeTypes.Put);
             }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -23,6 +23,7 @@ using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Patching;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static.Spatial;
@@ -1133,8 +1134,10 @@ namespace Raven.Server.Documents.Patch
                 {
                     reader = JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, args[1].AsObject(), usageMode: BlittableJsonDocumentBuilder.UsageMode.ToDisk);
 
-                    if (_database is ShardedDocumentDatabase)
-                        id = GenerateIdForShard(id);
+                    if (_database is ShardedDocumentDatabase sharded)
+                    {
+                        id = GenerateIdForShard(sharded, id);
+                    }
 
                     var putResult = _database.DocumentsStorage.Put(
                         _docsCtx,
@@ -1168,10 +1171,27 @@ namespace Raven.Server.Documents.Patch
                 }
             }
 
-            private string GenerateIdForShard(string id)
+            private string GenerateIdForShard(ShardedDocumentDatabase shardedDocumentDatabase, string id)
             {
-                if (id?[^1] != _database.IdentityPartsSeparator)
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    id = $"{Guid.NewGuid()}${OriginalDocumentId}";
+                }
+                
+                if (id[^1] != _database.IdentityPartsSeparator)
+                {
+                    var config = shardedDocumentDatabase.ShardingConfiguration;
+                    var originalBucket = ShardHelper.GetBucketFor(config, _docsCtx.Allocator, OriginalDocumentId);
+                    var currentBucketId = ShardHelper.GetBucketFor(config, _docsCtx.Allocator, id);
+                    if (originalBucket != currentBucketId)
+                    {
+                        throw new ShardedPatchBehaviorViolationException(
+                            $"The original ID '{OriginalDocumentId}' isn't in the same bucket as the requested ID '{id}'.{Environment.NewLine}" +
+                            $"To Ensure they will be in the same bucket use the '$' convention.{Environment.NewLine}" +
+                            $"E.g. '{id}${OriginalDocumentId}' or use server-side generated IDs");
+                    }
                     return id;
+                }
 
                 return ShardHelper.GenerateStickyId(id, OriginalDocumentId, _database.IdentityPartsSeparator);
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ContinuationTokens/ShardedPagingContinuation.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ContinuationTokens/ShardedPagingContinuation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 
@@ -7,6 +8,15 @@ public sealed class ShardedPagingContinuation : ContinuationToken
 {
     public int PageSize;
     public Dictionary<int, ShardPaging> Pages;
+    
+    // if we asked to skip more than 'DeepPagingThreshold' items, we will approximate the paging
+    private const int DeepPagingThreshold = 10_000;
+
+    // Those properties are not sent back to the user
+    // They used only for the very first request to figure out whether we should be precise on paging when 'start' param is passed
+    // or if we in deep paging we will approximate the paging
+    public int Skip;
+    public bool DeepPaging;
 
     public ShardedPagingContinuation()
     {
@@ -16,9 +26,23 @@ public sealed class ShardedPagingContinuation : ContinuationToken
     public ShardedPagingContinuation(ShardedDatabaseContext databaseContext, int start, int pageSize)
     {
         var shards = databaseContext.ShardCount;
-        var startPortion = start / shards;
-        var remaining = start - startPortion * shards;
 
+        DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "Make this configurable?");
+        DeepPaging = start * shards > DeepPagingThreshold;
+
+        int startPortion = 0;
+        int remaining = 0;
+        
+        if (DeepPaging)
+        {
+            startPortion = start / shards;
+            remaining = start - startPortion * shards;
+        }
+        else
+        {
+            Skip = start;
+        }
+        
         Pages = new Dictionary<int, ShardPaging>(shards);
 
         foreach (var shardToTopology in databaseContext.ShardsTopology)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -153,7 +153,7 @@ internal sealed class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHa
 
         return new DocumentsResult
         {
-            DocumentsAsync = ShardedDatabaseContext.ShardedStreaming.UnwrapDocuments(documents),
+            DocumentsAsync = ShardedDatabaseContext.ShardedStreaming.UnwrapDocuments(documents, token),
             ContinuationToken = token,
             Etag = results.CombinedEtag
         };

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedReplicationHandlerProcessorForGetConflicts.cs
@@ -71,6 +71,12 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
                 var pageSize = _token.PageSize;
                 foreach (var res in _handler.DatabaseContext.Streaming.CombinedResults(results, r => r.Results, ConflictsLastModifiedComparer.Instance))
                 {
+                    if (_token.Skip > 0)
+                    {
+                        _token.Skip--;
+                        continue;
+                    }
+
                     final.Results.Add(res.Item);
                     pageSize--;
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsHandler.cs
@@ -9,19 +9,15 @@ namespace Raven.Server.Documents.Sharding.Handlers
         [RavenShardedAction("/databases/*/revisions", "GET")]
         public async Task GetRevisionsFor()
         {
-            using (var processor = new ShardedRevisionsHandlerProcessorForGetRevisions(this))
-            {
+            using (var processor = new ShardedRevisionsHandlerProcessorForGetRevisions(this)) 
                 await processor.ExecuteAsync();
-            }
         }
 
         [RavenShardedAction("/databases/*/revisions/count", "GET")]
         public async Task GetRevisionsCountFor()
         {
-            using (var processor = new ShardedRevisionsHandlerProcessorForGetRevisionsCount(this))
-            {
+            using (var processor = new ShardedRevisionsHandlerProcessorForGetRevisionsCount(this)) 
                 await processor.ExecuteAsync();
-            }
         }
 
         [RavenShardedAction("/databases/*/admin/revisions/config", "POST")]

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -118,6 +118,12 @@ namespace Raven.Server.Documents.Sharding
                 var results = StreamCombinedArray(combinedState, name, converter, comparer);
                 await foreach (var result in results.WithCancellation(combinedState.CancellationToken))
                 {
+                    if (pagingContinuation.Skip > 0)
+                    {
+                        pagingContinuation.Skip--;
+                        continue;
+                    }
+
                     if (pageSize-- <= 0)
                         yield break;
 
@@ -237,10 +243,17 @@ namespace Raven.Server.Documents.Sharding
                 PagedShardedDocumentsById(documents, resultPropertyName, pagingContinuation);
 
             
-            public static async IAsyncEnumerable<Document> UnwrapDocuments(IAsyncEnumerable<ShardStreamItem<Document>> docs)
+            public static async IAsyncEnumerable<Document> UnwrapDocuments(IAsyncEnumerable<ShardStreamItem<Document>> docs,
+                ShardedPagingContinuation shardedPagingContinuation)
             {
                 await foreach (var doc in docs)
                 {
+                    if (shardedPagingContinuation.Skip > 0)
+                    {
+                        shardedPagingContinuation.Skip--;
+                        continue;
+                    }
+
                     yield return doc.Item;
                 }
             }
@@ -254,6 +267,12 @@ namespace Raven.Server.Documents.Sharding
                 var pageSize = pagingContinuation.PageSize;
                 foreach (var result in CombinedResults(results, selector, comparer))
                 {
+                    if (pagingContinuation.Skip > 0)
+                    {
+                        pagingContinuation.Skip--;
+                        continue;
+                    }
+
                     if (pageSize-- <= 0)
                         yield break;
 

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Utils
         /// </summary>
         public static int GetBucketFor(ShardingConfiguration configuration, ByteStringContext context, string id)
         {
-            using (DocumentIdWorker.GetLower(context, id, out var lowerId))
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
             {
                 return GetBucketFor(configuration, lowerId);
             }
@@ -156,7 +156,7 @@ namespace Raven.Server.Utils
 
         public static int GetShardNumberFor(ShardingConfiguration configuration, Slice id) => GetShardNumberAndBucketFor(configuration, id).ShardNumber;
 
-        public static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, Slice id)
+        private static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, Slice id)
         {
             int bucket = GetBucketFor(configuration, id);
             return (FindBucketShard(configuration.BucketRanges, bucket), bucket);
@@ -164,7 +164,7 @@ namespace Raven.Server.Utils
 
         public static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, ByteStringContext allocator, string id)
         {
-            using (DocumentIdWorker.GetLower(allocator, id, out var lowerId))
+            using (DocumentIdWorker.GetSliceFromId(allocator, id, out var lowerId))
             {
                 return GetShardNumberAndBucketFor(configuration, lowerId);
             }
@@ -173,7 +173,7 @@ namespace Raven.Server.Utils
         public static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, ByteStringContext allocator, LazyStringValue id)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "Avoid the allocation of the LazyStringValue below");
-            using (DocumentIdWorker.GetLower(allocator, id, out var lowerId))
+            using (DocumentIdWorker.GetSliceFromId(allocator, id, out var lowerId))
             {
                 return GetShardNumberAndBucketFor(configuration, lowerId);
             }

--- a/test/SlowTests/Issues/RavenDB-14724.cs
+++ b/test/SlowTests/Issues/RavenDB-14724.cs
@@ -5,6 +5,7 @@ using Raven.Client;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,12 +17,13 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task DeleteDocumentAndRevisions()
+        [RavenTheory(RavenTestCategory.Revisions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DeleteDocumentAndRevisions(Options options)
         {
             var user = new User { Name = "Raven" };
             var id = "user/1";
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 await RevisionsHelper.SetupRevisionsAsync(store);
 
@@ -52,6 +54,7 @@ namespace SlowTests.Issues
        
                     await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
                 }
+
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -9,7 +9,9 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Patching;
+using Raven.Client.Exceptions.Sharding;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -49,10 +51,11 @@ namespace SlowTests.Server.Documents.Patching
         return (comment == ""one"") ? comment + "" test"" : comment;
     });";
 
-        [Fact]
-        public async Task CanApplyBasicScriptAsPatch()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanApplyBasicScriptAsPatch(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -80,10 +83,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task ComplexVariableTest()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ComplexVariableTest(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -107,10 +111,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanUseTrim()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUseTrim(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -129,10 +134,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanUseMathFloor()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUseMathFloor(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -151,10 +157,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanUseSplit()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUseSplit(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -174,10 +181,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task ComplexVariableTest2()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ComplexVariableTest2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -202,10 +210,11 @@ namespace SlowTests.Server.Documents.Patching
         }
 
       
-        [Fact]
-        public async Task CanPatchUsingRavenJObjectVars()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanPatchUsingRavenJObjectVars(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -228,10 +237,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanRemoveFromCollectionByValue()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanRemoveFromCollectionByValue(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -249,10 +259,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanRemoveFromCollectionByCondition()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanRemoveFromCollectionByCondition(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -270,10 +281,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanPatchUsingVars()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanPatchUsingVars(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -295,10 +307,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanHandleNonsensePatching()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanHandleNonsensePatching(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -317,10 +330,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanThrowIfValueIsWrong()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanThrowIfValueIsWrong(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -339,10 +353,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanOutputDebugInformation()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanOutputDebugInformation(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -372,10 +387,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanOutputNestedDebugInformation()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanOutputNestedDebugInformation(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 CustomType customType;
                 using (var session = store.OpenSession())
@@ -419,10 +435,11 @@ namespace SlowTests.Server.Documents.Patching
         }
 
 
-        [Fact]
-        public async Task CannotUseInfiniteLoop()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CannotUseInfiniteLoop(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -439,10 +456,11 @@ namespace SlowTests.Server.Documents.Patching
             }
         }
 
-        [Fact]
-        public async Task CanUseToISOString()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUseToISOString(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -474,10 +492,11 @@ this.DateOffsetOutput = new Date(this.DateOffset).toISOString();
             }
         }
 
-        [Fact]
-        public async Task CanUpdateBasedOnAnotherDocumentProperty()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanUpdateBasedOnAnotherDocumentProperty(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -508,10 +527,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanPatchMetadata()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanPatchMetadata(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -543,10 +563,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanUpdateOnMissingProperty()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUpdateOnMissingProperty(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -572,10 +593,11 @@ this.Value = another.Value;
         }
 
 
-        [Fact]
-        public async Task WillNotErrorOnMissingDocument()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task WillNotErrorOnMissingDocument(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 await store.Operations.SendAsync(new PatchOperation("products/1", null, new PatchRequest
                 {
@@ -584,10 +606,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanCreateDocument()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanCreateDocument(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -598,13 +621,13 @@ this.Value = another.Value;
                 await store.Operations.SendAsync(new PatchOperation("CustomTypes/1", null, new PatchRequest
                 {
                     Script = @"put(
-        'NewTypes/1', 
+        'NewTypes/1$CustomTypes/1', 
         { 'CopiedValue':  this.Value, '@metadata': {'CreatedBy': 'JS_Script'} });",
                 }));
 
                 using (var commands = store.Commands())
                 {
-                    dynamic doc = await commands.GetAsync("NewTypes/1");
+                    dynamic doc = await commands.GetAsync("NewTypes/1$CustomTypes/1");
                     dynamic metadata = doc[Constants.Documents.Metadata.Key];
                     var copiedValue = (int)doc.CopiedValue;
                     var createdBy = metadata.CreatedBy.ToString();
@@ -615,10 +638,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanUpdateDocument()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanUpdateDocument(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -629,17 +653,17 @@ this.Value = another.Value;
                 await store.Operations.SendAsync(new PatchOperation("CustomTypes/1", null, new PatchRequest
                 {
                     Script = @"put(
-        'NewTypes/1', 
+        'NewTypes/1$CustomTypes/1', 
         { 'CopiedValue':this.Value, '@metadata': {'CreatedBy': 'JS_Script'}} );
 
         put(
-        'NewTypes/1', 
+        'NewTypes/1$CustomTypes/1', 
         { 'CopiedValue': this.Value, '@metadata': {'CreatedBy': 'JS_Script 2'} } );",
                 }));
 
                 using (var commands = store.Commands())
                 {
-                    dynamic doc = await commands.GetAsync("NewTypes/1");
+                    dynamic doc = await commands.GetAsync("NewTypes/1$CustomTypes/1");
                     dynamic metadata = doc[Constants.Documents.Metadata.Key];
                     var copiedValue = (int)doc.CopiedValue;
                     var createdBy = metadata.CreatedBy.ToString();
@@ -650,10 +674,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanCreateMultipleDocuments()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanCreateMultipleDocuments(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -664,7 +689,7 @@ this.Value = another.Value;
                 await store.Operations.SendAsync(new PatchOperation("Items/1", null, new PatchRequest
                 {
                     Script = @"this.Comments.map(function(comment){
-                                     put('Comments/' + comment, { 'Comment':comment });
+                                     put('Comments/' + comment + '$Items/1', { 'Comment':comment });
                                  })",
                 }));
 
@@ -673,7 +698,7 @@ this.Value = another.Value;
                     var docs = await commands.GetAsync(0, 10);
                     Assert.Equal(4, docs.Count());
 
-                    docs = await commands.GetAsync(new[] { "Comments/one", "Comments/two", "Comments/three" });
+                    docs = await commands.GetAsync(new[] { "Comments/one$Items/1", "Comments/two$Items/1", "Comments/three$Items/1" });
                     Assert.Equal("one", docs.ElementAt(0).Comment.ToString());
                     Assert.Equal("two", docs.ElementAt(1).Comment.ToString());
                     Assert.Equal("three", docs.ElementAt(2).Comment.ToString());
@@ -681,10 +706,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanSkipBeyondCountForLargeIterator()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanSkipBeyondCountForLargeIterator(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -695,10 +721,10 @@ this.Value = another.Value;
                 await store.Operations.SendAsync(new PatchOperation("Items/1", null, new PatchRequest
                 {
                     Script = @"this.Comments.map(function(comment){
-                                     put('Comments/' + comment, { 'Comment':comment });
+                                     put('Comments/' + comment + '$Items/1', { 'Comment':comment });
                                  })",
                 }));
-
+                WaitForUserToContinueTheTest(store);
                 using (var commands = store.Commands())
                 {
                     var docs = await commands.GetAsync(101, 10);
@@ -707,10 +733,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CreateDocumentWillNotThrowIfEmptyKeyProvided()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CreateDocumentWillNotThrowIfEmptyKeyProvided(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -728,16 +755,17 @@ this.Value = another.Value;
                     Script = @"put('    ', { 'Property': 'Value'});",
                 }));
 
-                var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+                var stats = await store.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
 
                 Assert.Equal(3, stats.CountOfDocuments);
             }
         }
 
-        [Fact]
-        public async Task CreateDocumentShouldThrowInvalidEtagException()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CreateDocumentShouldThrowInvalidEtagException(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -748,18 +776,19 @@ this.Value = another.Value;
                 {
                     await store.Operations.SendAsync(new PatchOperation("doc", null, new PatchRequest
                     {
-                        Script = @"put('Items/1', { Property: 1}, 'invalid-etag');",
+                        Script = @"put('Items/1$doc', { Property: 1}, 'invalid-etag');",
                     }));
                 });
 
-                Assert.Contains("Document Items/1 does not exist, but Put was called with change vector: invalid-etag. Optimistic concurrency violation, transaction will be aborted.", exception.Message);
+                Assert.Contains("Document Items/1$doc does not exist, but Put was called with change vector: invalid-etag. Optimistic concurrency violation, transaction will be aborted.", exception.Message);
             }
         }
 
-        [Fact]
-        public async Task ShouldThrowConcurrencyExceptionIfNonCurrentEtagWasSpecified()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldThrowConcurrencyExceptionIfNonCurrentEtagWasSpecified(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -772,20 +801,21 @@ this.Value = another.Value;
                     await store.Operations.SendAsync(new PatchOperation("CustomTypes/1", null, new PatchRequest
                     {
                         Script = @"put(
-    'Items/1', 
+    'Items/1$CustomTypes/1', 
     { 'Property':'Value'},
     '123456789' );",
                     }));
                 });
 
-                Assert.Contains("Document Items/1 does not exist, but Put was called with change vector: 123456789. Optimistic concurrency violation, transaction will be aborted.", exception.Message);
+                Assert.Contains("Document Items/1$CustomTypes/1 does not exist, but Put was called with change vector: 123456789. Optimistic concurrency violation, transaction will be aborted.", exception.Message);
             }
         }
 
-        [Fact]
-        public async Task CanCreateEmptyDocument()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanCreateEmptyDocument(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -795,21 +825,22 @@ this.Value = another.Value;
 
                 await store.Operations.SendAsync(new PatchOperation("CustomTypes/1", null, new PatchRequest
                 {
-                    Script = @"put('NewTypes/1', { });",
+                    Script = @"put('NewTypes/1$CustomTypes/1', { });",
                 }));
 
                 using (var commands = store.Commands())
                 {
-                    var doc = await commands.GetAsync("NewTypes/1");
+                    var doc = await commands.GetAsync("NewTypes/1$CustomTypes/1");
                     Assert.Equal(0 + 1, doc.BlittableJson.Count); // +1 @metadata
                 }
             }
         }
 
-        [Fact]
-        public async Task CreateDocumentShouldThrowIfSpecifiedJsonIsNullOrEmptyString()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CreateDocumentShouldThrowIfSpecifiedJsonIsNullOrEmptyString(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -827,10 +858,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task CanCreateDocumentsIfPatchingAppliedByIndex()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanCreateDocumentsIfPatchingAppliedByIndex(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -877,10 +909,11 @@ this.Value = another.Value;
             }
         }
 
-        [Fact]
-        public async Task PreventRecursion()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task PreventRecursion(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -918,10 +951,11 @@ this.Else = a;
             }
         }
 
-        [Fact]
-        public async Task CanPerformAdvancedPatching()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanPerformAdvancedPatching(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -950,10 +984,11 @@ this.Else = a;
             }
         }
 
-        [Fact]
-        public async Task CanPerformAdvancedWithSetBasedUpdates()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanPerformAdvancedWithSetBasedUpdates(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 var item1 = new CustomType
                 {
@@ -1015,10 +1050,11 @@ this.Else = a;
             }
         }
 
-        [Fact]
-        public async Task CanDeserializeModifiedDocument()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanDeserializeModifiedDocument(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var commands = store.Commands())
                 {
@@ -1043,10 +1079,11 @@ this.Else = a;
             }
         }
 
-        [Fact]
-        public void CanDoPatchIfMissing()
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CanDoPatchIfMissing(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 store.Operations.Send(new PatchOperation("CustomTypes/123", null,
                     new PatchRequest
@@ -1062,6 +1099,80 @@ this.Else = a;
                     var result = session.Load<CustomType>("CustomTypes/123");
                     Assert.NotNull(result);
                     Assert.Equal(12, result.Value);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task PatchedDocumentMustBeInSameBucket(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new CustomType { Value = 10 }, "CustomTypes/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var ex = await Assert.ThrowsAsync<ShardedPatchBehaviorViolationException>(() => store.Operations.SendAsync(new PatchOperation("CustomTypes/1", null, new PatchRequest
+                {
+                    Script = @"put(
+        'NewTypes/1', 
+        { 'CopiedValue':  this.Value, '@metadata': {'CreatedBy': 'JS_Script'} });",
+                })));
+
+                Assert.Contains("To Ensure they will be in the same bucket use the '$' convention", ex.Message);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task PatchedDocumentCanBeServerSideGenerated(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new CustomType
+                    {
+                        Id = "Item/1",
+                        Value = 1
+                    });
+                    await session.StoreAsync(new CustomType
+                    {
+                        Id = "Item/2",
+                        Value = 2
+                    });
+                    await session.SaveChangesAsync();
+                }
+
+                store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition
+                {
+                    Maps = { @"from doc in docs.CustomTypes 
+                            select new { doc.Value }" },
+                    Name = "TestIndex"
+                }}));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.Advanced.AsyncDocumentQuery<CustomType>("TestIndex")
+                        .WaitForNonStaleResults()
+                        .ToListAsync();
+                }
+
+                var operation = await store.Operations.SendAsync(new PatchByQueryOperation(
+                    "FROM INDEX 'TestIndex' WHERE Value = 1 update { put('NewItem/', {'CopiedValue': this.Value });}"
+                ));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
+
+                using (var commands = store.Commands())
+                {
+                    var documents = await commands.GetAsync(0, 10);
+                    Assert.Equal(3, documents.Count());
+
+                    dynamic jsonDocument = documents.Single(x => x["@metadata"]["@id"].StartsWith("NewItem/"));
+                    Assert.Equal(1, (int)jsonDocument.CopiedValue);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21379

### Additional description

1. Unify the way we calculate the the bucket for an id, so an escaped id will be handled same way on the orchestrator & shard.
2. Calculate the Etag header for revisions even when doc has zero revisions.
3. Patching will throw a dedicated exception if the original document and the patched one, aren't in the same bucket.
4. the sharded continuation token will prefer accuracy if we ask to skip less than 10000 docs

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
