### PR TITLE
RavenDB-21406 - ClusterTopologyChanged not sent on connectivity changes

### DIFF
--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -492,14 +492,19 @@ namespace Raven.Server.Rachis
             var isGracefulError = IsGracefulError(e);
             if (hadConnectionFailure || isGracefulError == false)
             {
-                Status = AmbassadorStatus.FailedToConnect;
-                StatusMessage = $"{message}.{Environment.NewLine}" + e;
-                if (_engine.Log.IsInfoEnabled)
+                //We don't want to notify about cluster change every time we check the connection, only if the change is new
+                if (Status != AmbassadorStatus.FailedToConnect)
                 {
-                    _engine.Log.Info(message, e);
-                }
+                    Status = AmbassadorStatus.FailedToConnect;
+                    StatusMessage = $"{message}.{Environment.NewLine}" + e;
 
-                _leader?.NotifyAboutException(_tag, $"Node {_tag} encountered an error", message, e);
+                    if (_engine.Log.IsInfoEnabled)
+                    {
+                        _engine.Log.Info(message, e);
+                    }
+
+                    _leader?.NotifyAboutException(_tag, $"Node {_tag} encountered an error", message, e);
+                }
             }
 
             if (isGracefulError)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21406

### Additional description

`ClusterTopologyChanged` is used by the studio to get new info about connectivity changes (node went down etc). We only fired it when the cluster topology `etag` changed, but we need to fire it regardless of the `etag`, when the connectivity changes as well.

Also `NotifyAboutClusterTopologyAndConnectivityChanges()` was being called every few seconds - each time there was a failed attempt to reconnect to the failed node (`StatusMessage` being updated triggers the notify chain). Now only notifying when there is a *new* change.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### UI work

- No UI work is needed
