### PR TITLE
RavenDB-21414 Remove defaultOpen for features with limits

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -246,7 +246,7 @@ export function IndexesPage(props: IndexesPageProps) {
                             )}
                         </Col>
                         <Col xs="auto">
-                            <AboutViewFloating defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+                            <AboutViewFloating>
                                 <AccordionItemWrapper
                                     icon="about"
                                     color="info"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
@@ -158,7 +158,7 @@ export default function DocumentExpiration({ db }: NonShardedViewProps) {
                         </Form>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+                        <AboutViewAnchored>
                             <AccordionItemWrapper
                                 targetId="1"
                                 icon="about"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.tsx
@@ -155,7 +155,7 @@ export default function DocumentRefresh({ db }: NonShardedViewProps) {
                         </Form>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+                        <AboutViewAnchored>
                             <AccordionItemWrapper
                                 targetId="1"
                                 icon="about"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -322,7 +322,7 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
                         </div>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+                        <AboutViewAnchored>
                             <AccordionItemWrapper
                                 targetId="1"
                                 icon="about"

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
@@ -10,7 +10,7 @@ export function EditIndexInfoHub() {
     const isProfessionalOrAbove = useAppSelector(licenseSelectors.isProfessionalOrAbove);
 
     return (
-        <AboutViewFloating defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+        <AboutViewFloating>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
@@ -17,7 +17,7 @@ export function TimeSeriesInfoHub() {
     ];
 
     return (
-        <AboutViewFloating defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+        <AboutViewFloating>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -13,7 +13,7 @@ export function EditSubscriptionTaskInfoHub() {
     const subscriptionTasksDocsLink = useRavenLink({ hash: "I5TMCK" });
 
     return (
-        <AboutViewFloating defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+        <AboutViewFloating>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"

--- a/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
@@ -18,7 +18,7 @@ export function CertificatesInfoHub() {
 
 
     return (
-        <AboutViewFloating defaultOpen={isProfessionalOrAbove ? null : "licensing"}>
+        <AboutViewFloating>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21414

### Additional description
Removed `defaultOpen` Info Hub value from views where the features are limited, not fully locked

### Type of change
- Optimization

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
