### PR TITLE
RavenDB-21379  Fixing dynamic map reduce queries with aliases in order by clause on sharded database

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -2898,5 +2898,10 @@ function execute(doc, args){
 
             return RootAliasPaths.TryGetValue(expr.Compound[0], out _);
         }
+
+        internal bool IsAliasedField(FieldExpression fe)
+        {
+            return _aliasToName.ContainsKey(fe.Compound[0].Value);
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_21379.cs
+++ b/test/SlowTests/Issues/RavenDB_21379.cs
@@ -1,0 +1,66 @@
+﻿using FastTests;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21379 : RavenTestBase
+{
+    public RavenDB_21379(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public void QueryMapReduceWithCount(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                User user1 = new() {name = "John"};
+
+                User user2 = new() {name = "John"};
+
+                User user3 = new() { name = "Tarzan" };
+
+                session.Store(user1, "users/1");
+                session.Store(user2, "users/2");
+                session.Store(user3, "users/3");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var documentQuery = session.Advanced.DocumentQuery<User>().GroupBy("name")
+                    .SelectKey()
+                    .SelectCount("count")
+                    .OrderByDescending("count")
+                    .OfType<ReduceResult>();
+
+                var res = documentQuery.ToList();
+
+                Assert.Equal(2, res[0].count);
+                Assert.Equal("John", res[0].name);
+
+                Assert.Equal(1, res[1].count);
+                Assert.Equal("Tarzan", res[1].name);
+            }
+        }
+    }
+
+    private class User
+    {
+        public string name { get; set; }
+    }
+
+    private class ReduceResult
+    {
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+        public int count;
+        public string name;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21379

### Additional description

When sending a dynamic map-reduce query to a sharded database we're dropping the aliases. This means that a query:
```
from 'Users' group by name order by count desc select key(), count() as count
```
become
```
from 'Users' group by name order by count desc select key(), count()
```
and was throwing:
```
InvalidQueryException: Field 'count' isn't neither an aggregation operation nor part of the group by key
```

Now it will be converted to:

```
from 'Users' group by name order by count() desc select key(), count()
```

Also now a query like:

```
from Orders group by ShipTo.City order by c select count() as count, ShipTo.City as c
```

will be converted to the following when sending to shards:

```
from Orders group by ShipTo.City order by  ShipTo.City select count(), ShipTo.City
```


### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
