### PR TITLE
RavenDB-21379 Fixing null change vector of included documents in sharding

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -121,7 +121,7 @@ public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TI
                 if (result.Includes is List<BlittableJsonReaderObject> blittableIncludes)
                     blittableIncludes.Add(include.Clone(context));
                 else if (result.Includes is List<Document> documentIncludes)
-                    documentIncludes.Add(new Document { Id = context.GetLazyString(id), Data = include.Clone(context) });
+                    documentIncludes.Add(new Document { Id = context.GetLazyString(id), Data = include.Clone(context), ChangeVector = include.GetMetadata().GetChangeVector() });
                 else
                     throw new NotSupportedException($"Unknown includes type: {result.Includes.GetType().FullName}");
             }

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Loaders;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Documents.Indexes;
@@ -715,7 +716,8 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
                         documentIncludes.Add(new Document
                         {
                             Id = id,
-                            Data = missing
+                            Data = missing,
+                            ChangeVector = metadata.GetChangeVector()
                         });
                     }
                 }

--- a/test/FastTests/Client/Includes.cs
+++ b/test/FastTests/Client/Includes.cs
@@ -133,6 +133,12 @@ namespace FastTests.Client
 
                     var customers = session.Load<Customer>(orders.Select(x => x.CustomerId));
                     Assert.Equal(2, customers.Count);
+
+                    foreach (var customer in customers)
+                    {
+                        Assert.NotNull(session.Advanced.GetChangeVectorFor(customer.Value));
+                    }
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
             }

--- a/test/SlowTests/Client/Queries/RavenDB-17041.cs
+++ b/test/SlowTests/Client/Queries/RavenDB-17041.cs
@@ -86,12 +86,16 @@ namespace SlowTests.Client.Queries
                     Assert.Equal(1, users.Count);
 
                     var loaded = session.Load<RoleData>("role/1");
+                    Assert.NotNull(session.Advanced.GetChangeVectorFor(loaded));
+
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                     Assert.Equal(loaded.Role, "role/1");
 
                     loaded = session.Load<RoleData>("role/2");
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                     Assert.Equal(loaded.Role, "role/2");
+                    Assert.NotNull(session.Advanced.GetChangeVectorFor(loaded));
+
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB_2124.cs
+++ b/test/SlowTests/Issues/RavenDB_2124.cs
@@ -79,6 +79,8 @@ namespace SlowTests.Issues
                     Assert.Equal("Street1", address.Street);
 
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+                    Assert.NotNull(session.Advanced.GetChangeVectorFor(address));
                 }
             }
         }

--- a/test/SlowTests/SlowTests/RavenDB-14600.cs
+++ b/test/SlowTests/SlowTests/RavenDB-14600.cs
@@ -2,12 +2,13 @@ using System;
 using System.Linq;
 using FastTests;
 using Newtonsoft.Json;
+using Orders;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Tests.Infrastructure;
-using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
+using Order = Tests.Infrastructure.Entities.Order;
 
 namespace SlowTests.SlowTests
 {
@@ -35,7 +36,10 @@ namespace SlowTests.SlowTests
                 Assert.NotEmpty(facets["Employee"].Values);
                 foreach (var f in facets["Employee"].Values)
                 {
-                    s.Load<object>(f.Range);
+                    var e = s.Load<Employee>(f.Range);
+
+                    string cv = s.Advanced.GetChangeVectorFor(e);
+                    Assert.NotNull(cv);
                 }
                 Assert.Equal(1, s.Advanced.NumberOfRequests);
             }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21379

### Additional description

We were returning `@change-vector: null` instead an actual CV value that we got from shards

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
