### PR TITLE
RavenDB-21369 - SlowTests.Sharding.Cluster.SubscriptionsWithReshardingTests.ContinueSubscriptionAfterReshardingInAClusterRF1WithOrchestratorFailover

### DIFF
--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -1049,7 +1049,7 @@ namespace SlowTests.Sharding.Cluster
             }
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions, Skip = "RavenDB-21361")]
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions)]
         public async Task ContinueSubscriptionAfterReshardingInAClusterRF3WithOrchestratorFailover()
         {
             var cluster = await CreateRaftCluster(5, watcherCluster: true, shouldRunInMemory: false);
@@ -1161,7 +1161,7 @@ namespace SlowTests.Sharding.Cluster
             await Sharding.Subscriptions.AssertNoItemsInTheResendQueueAsync(store, id, cluster.Nodes);
         }
 
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions, Skip = "RavenDB-21369")]
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Subscriptions)]
         public async Task ContinueSubscriptionAfterReshardingInAClusterRF1WithOrchestratorFailover()
         {
             var cluster = await CreateRaftCluster(5, watcherCluster: true, shouldRunInMemory: false);

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -117,7 +117,7 @@ public partial class RavenTestBase
             if (token.CanBeCanceled)
                 return null;
 
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             token = cts.Token;
             return cts;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21369
