### PR TITLE
RavenDB-21399 Fixing lookup merge/split issues with large number of records & updates

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
@@ -30,6 +30,8 @@ unsafe partial class CompactTree
 
     public void VerifyOrderOfElements()
     {
+        _inner.VerifyStructure();
+        
         var it = Iterate();
         it.Reset();
 

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -97,7 +97,12 @@ public sealed partial class CompactTree : IPrepareForCommit
             Key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
             return Key;
         }
-        
+
+        public void Init<T>(Lookup<T> parent) where T : struct, ILookupKey
+        {
+            GetKey(parent);
+        }
+
         public int CompareTo<T>(Lookup<T> parent, long currentKeyId) where T : struct, ILookupKey
         {
             var llt = parent.Llt;
@@ -478,4 +483,9 @@ public sealed partial class CompactTree : IPrepareForCommit
         _inner.AllEntriesIn(p)
             .Select(x=>(x.Item1.GetKey(_inner).ToString(), x.Item2))
             .ToList();
+
+    public void VerifyStructure()
+    {
+        _inner.VerifyStructure();
+    }
 }

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -1087,8 +1087,8 @@ namespace Voron.Data.Containers
 
         public static Item MaybeGetFromSamePage(LowLevelTransaction llt, ref Page page, long id)
         {
-            if (id == 0)
-                throw new InvalidOperationException("Got an invalid container id: 0");
+            if (id <= 0)
+                throw new InvalidOperationException("Got an invalid container id: " + id);
 
             var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
             if(!page.IsValid || pageNum != page.PageNumber)

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -45,6 +45,11 @@ public struct DoubleLookupKey : ILookupKey
     
     public static long MinValue => BitConverter.DoubleToInt64Bits(double.MinValue);
 
+    public void Init<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        
+    }
+
     [Pure]
     public int CompareTo<T>(Lookup<T> parent, long l) where T : struct, ILookupKey
     {

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -10,6 +10,8 @@ public interface ILookupKey
     static abstract T FromLong<T>(long l);
 
     static abstract long MinValue { get; }
+    
+    void Init<T>(Lookup<T> parent) where T : struct, ILookupKey;
 
     int CompareTo<T>(Lookup<T> parent, long l) where T : struct, ILookupKey;
     

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -34,6 +34,11 @@ public struct Int64LookupKey : ILookupKey
 
     public static long MinValue => long.MinValue;
 
+    public void Init<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        
+    }
+
     public int CompareTo<T>(Lookup<T> parent, long l) where T : struct, ILookupKey
     {
         return Value.CompareTo(l);

--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -71,9 +71,14 @@ namespace Voron.Data.Lookups
                         i++;
                         state.LastSearchPosition++;
                     }
-                    else if (_tree.GoToNextPage(ref _cursor) == false)
+                    else
                     {
-                        i++;
+                        if (_tree.GoToNextPage(ref _cursor) == false)
+                        {
+                            i++;
+                        }
+
+                        state = ref _cursor._stk[_cursor._pos];
                     }
                 }
 
@@ -98,7 +103,7 @@ namespace Voron.Data.Lookups
                     state = ref cState._stk[cState._pos];
                 }
             }
-            
+
             public int FillKeys(Span<long> results)
             {
                 if (_cursor._pos < 0)
@@ -120,6 +125,7 @@ namespace Voron.Data.Lookups
                     {
                         return 0;
                     }
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
 
@@ -150,6 +156,8 @@ namespace Voron.Data.Lookups
                     {
                         return 0;
                     }
+
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
             
@@ -176,6 +184,8 @@ namespace Voron.Data.Lookups
                         value = default;
                         return false;
                     }
+
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
 
@@ -213,6 +223,8 @@ namespace Voron.Data.Lookups
                         hasPreviousValue = false;
                         return false;
                     }
+
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
 
@@ -282,9 +294,14 @@ namespace Voron.Data.Lookups
                         i++;
                         state.LastSearchPosition--;
                     }
-                    else if (_tree.GoToPreviousPage(ref _cursor) == false)
+                    else
                     {
-                        i++;
+                        if (_tree.GoToPreviousPage(ref _cursor) == false)
+                        {
+                            i++;
+                        }
+
+                        state = ref _cursor._stk[_cursor._pos];
                     }
                 }
 
@@ -344,6 +361,7 @@ namespace Voron.Data.Lookups
                     {
                         return 0;
                     }
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
 
@@ -370,6 +388,7 @@ namespace Voron.Data.Lookups
                         value = default;
                         return false;
                     }
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
 
@@ -407,6 +426,7 @@ namespace Voron.Data.Lookups
                         hasPreviousValue = false;
                         return false;
                     }
+                    state = ref _cursor._stk[_cursor._pos];
                 }
             }
             
@@ -462,6 +482,7 @@ namespace Voron.Data.Lookups
                     state = ref cstate._stk[cstate._pos];
                 } 
                 while (state.Header->IsBranch);
+                Debug.Assert(state.Header->PageFlags.HasFlag(LookupPageFlags.Leaf));
                 return true;
             }
         }

--- a/test/SlowTests/Issues/RavenDB-21399-2.cs
+++ b/test/SlowTests/Issues/RavenDB-21399-2.cs
@@ -1,0 +1,121 @@
+﻿using FastTests.Voron;
+using Voron.Data.Lookups;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21399_2 : StorageTest
+{
+    public RavenDB_21399_2(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public unsafe void CanHandleDeletesAndUpdatesToLeftmostLeafPage()
+    {
+        using var wtx = Env.WriteTransaction();
+
+        var lookup = wtx.LookupFor<Int64LookupKey>("test");
+        long k = 1;
+        
+        // we are waiting until the tree structure looks like
+        // * Root
+        // * * Branch - min value
+        // * * Branch - SomeVal
+
+        while (lookup.State.BranchPages < 2)
+        {
+            lookup.Add(k++, 0);
+        }
+
+        // here we wait to add *another* page to the right most branch, so we'll have:
+        // * Root
+        // * * Branch - min value
+        // * * Branch - $SomeVal
+        // * * * Leaf -  $SomeVal
+        // * * * Leaf -  $SomeVal + 10
+        // * * * Leaf -  $SomeVal + 20
+        var changed = lookup.CheckTreeStructureChanges();
+        while (changed.Changed == false)
+        {
+            lookup.Add(k++, 0);
+        }
+        
+        var rootState = new Lookup<Int64LookupKey>.CursorState
+        {
+            Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)
+        };
+
+        long keyData = Lookup<Int64LookupKey>.GetKeyData(ref rootState, rootState.Header->NumberOfEntries - 1);
+        changed = lookup.CheckTreeStructureChanges();
+        
+        // Now we remove until we have this situation:
+        // * Root
+        // * * Branch - min value
+        // * * Branch - $SomeVal
+        //  REMOVED THIS ONE: --- * * * Leaf -  $SomeVal
+        // * * * Leaf -  $SomeVal + 10
+        // * * * Leaf -  $SomeVal + 20
+        while (changed.Changed == false)
+        {
+            lookup.TryRemove(keyData++, out _);
+        }
+        
+        // Now we insert $SomeVal+8, which will go to the $SomeVal + 10 key 
+        lookup.Add(keyData-2, 0);
+        
+        // Problem
+        lookup.VerifyStructure();
+    }
+    
+    [Fact]
+    public unsafe void CanHandleDeletesAndUpdatesToMiddleLeafPage()
+    {
+        using var wtx = Env.WriteTransaction();
+
+        var lookup = wtx.LookupFor<Int64LookupKey>("test");
+        long k = 1;
+        
+        // we are waiting until the tree structure looks like
+        // * Root
+        // * * Branch - min value
+        // * * Branch - SomeVal
+        // * * Branch - SomeVal + 100
+
+        while (lookup.State.BranchPages < 4)
+        {
+            lookup.Add(k++, 0);
+        }
+
+        // here we wait to add *another* page to the right most branch, so we'll have:
+        // * Root
+        // * * Branch - min value
+        // * * Branch - $SomeVal
+        // * * Branch - $SomeVal + 100
+
+        var rootState = new Lookup<Int64LookupKey>.CursorState
+        {
+            Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)
+        };
+
+        long keyData = Lookup<Int64LookupKey>.GetKeyData(ref rootState, rootState.Header->NumberOfEntries /2);
+        
+        // Now we remove until we have this situation:
+        // * Root
+        // * * Branch - min value
+        // REMOVED THIS ONE: ---- * * Branch - $SomeVal
+        // * * Branch - $SomeVal + 100
+
+        long branches = lookup.State.BranchPages;
+        while (branches == lookup.State.BranchPages)
+        {
+            lookup.TryRemove(keyData++, out _);
+        }
+
+        lookup.Add(keyData-2, 0);
+        
+        // Problem
+        lookup.VerifyStructure();
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21399

### Additional description

We had a few issues WRT merging and splitting of branch pages when the number of records exceeded 1.7M and 3.4M items.
Updating specific items in the tree (leftmost item in a branch page) would merge improperly and sometimes lead to a missing value.

Reworked the way this is handled, added additional diagnostics and made the process simpler.

### Tests

Testes were added to ensure that the behavior is valid.