### PR TITLE
RavenDB-21379 Fixing the load of documents using LoadStartingWith option by changing the type of objects that the streaming works on - instead of Document we use BlittableJsonReaderObject.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -150,10 +150,15 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         });
     }
 
-    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
+    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+        DocumentsOperationContext context, IEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        writer.WritePropertyName(propertyName);
+        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+    }
 
+    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+        DocumentsOperationContext context, IAsyncEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
+    {
         return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
     }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
         protected override async ValueTask<(long numberOfResults, long totalDocumentsSizeInBytes)> GetCollectionDocumentsAndWriteAsync(TransactionOperationContext context, string name, int start, int pageSize, CancellationToken token)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal,
-                "RavenDB-19066 See `null` passed as etag to above new ShardedCollectionPreviewOperation()");
+                "RavenDB-19066 See `null` passed as etag to below new ShardedCollectionPreviewOperation(etag: null)");
 
             var continuationToken = RequestHandler.ContinuationTokens.GetOrCreateContinuationToken(context, start, pageSize);
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -91,12 +91,18 @@ internal sealed class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHa
         return result;
     }
 
-    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer, TransactionOperationContext context, string propertyName, List<BlittableJsonReaderObject> documentsToWrite,
+    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+        TransactionOperationContext context, IEnumerable<BlittableJsonReaderObject> documentsToWrite,
         bool metadataOnly, CancellationToken token)
     {
-        await writer.WriteArrayAsync(propertyName, documentsToWrite);
+        return await writer.WriteObjectsAsync(context, documentsToWrite, token);
+    }
 
-        return (documentsToWrite.Count, -1);
+    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+        TransactionOperationContext context, IAsyncEnumerable<BlittableJsonReaderObject> documentsToWrite,
+        bool metadataOnly, CancellationToken token)
+    {
+        return await writer.WriteObjectsAsync(context, documentsToWrite, token);
     }
 
     protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, TransactionOperationContext context, string propertyName, List<BlittableJsonReaderObject> includes, CancellationToken token)
@@ -141,7 +147,7 @@ internal sealed class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHa
 
         Disposables.Add(streams);
 
-        IAsyncEnumerable<ShardStreamItem<Document>> documents;
+        IAsyncEnumerable<ShardStreamItem<BlittableJsonReaderObject>> documents;
         if (startsWith != null)
         {
             documents = RequestHandler.DatabaseContext.Streaming.GetDocumentsAsyncById(streams, token);

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -147,19 +147,6 @@ namespace Raven.Server.Documents.Sharding
                     pagingContinuation);
             }
 
-            public IAsyncEnumerable<ShardStreamItem<Document>> PagedShardedDocumentsById(
-                CombinedReadContinuationState combinedState,
-                string name,
-                ShardedPagingContinuation pagingContinuation)
-            {
-                return PagedShardedStream(
-                    combinedState,
-                    name,
-                    ShardResultConverter.BlittableToDocumentConverter,
-                    DocumentIdComparer.Instance,
-                    pagingContinuation);
-            }
-
             public IAsyncEnumerable<ShardStreamItem<BlittableJsonReaderObject>> PagedShardedDocumentsBlittableByLastModified(
                 CombinedReadContinuationState combinedState,
                 string name,
@@ -236,14 +223,24 @@ namespace Raven.Server.Documents.Sharding
                     pagingContinuation);
             }
 
-            public IAsyncEnumerable<ShardStreamItem<Document>> GetDocumentsAsync(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results") => 
-                PagedShardedDocumentsByLastModified(documents, resultPropertyName, pagingContinuation);
+            public IAsyncEnumerable<ShardStreamItem<BlittableJsonReaderObject>> GetDocumentsAsync(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation) =>
+                PagedShardedStream(
+                documents,
+                "Results",
+                x => x,
+                DocumentLastModifiedComparer.Instance,
+                pagingContinuation);
 
-            public IAsyncEnumerable<ShardStreamItem<Document>> GetDocumentsAsyncById(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation, string resultPropertyName = "Results") => 
-                PagedShardedDocumentsById(documents, resultPropertyName, pagingContinuation);
+            public IAsyncEnumerable<ShardStreamItem<BlittableJsonReaderObject>> GetDocumentsAsyncById(CombinedReadContinuationState documents, ShardedPagingContinuation pagingContinuation) =>
+                PagedShardedStream(
+                documents,
+                "Results",
+                x => x,
+                BlittableIdComparer.Instance,
+                pagingContinuation);
 
-            
-            public static async IAsyncEnumerable<Document> UnwrapDocuments(IAsyncEnumerable<ShardStreamItem<Document>> docs,
+
+            public static async IAsyncEnumerable<T> UnwrapDocuments<T>(IAsyncEnumerable<ShardStreamItem<T>> docs,
                 ShardedPagingContinuation shardedPagingContinuation)
             {
                 await foreach (var doc in docs)

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -125,7 +125,7 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
     }
 
     protected override IAsyncEnumerable<ShardStreamItem<Document>> GetDocumentsAsync() =>
-        RequestHandler.DatabaseContext.Streaming.GetDocumentsAsync(_combinedReadState, _continuationToken);
+        RequestHandler.DatabaseContext.Streaming.PagedShardedDocumentsByLastModified(_combinedReadState, "Results", _continuationToken);
 
     protected override async ValueTask<List<string>> GetAvailableColumnsAsync()
     {

--- a/test/SlowTests/MailingList/LoadAllStartingWith.cs
+++ b/test/SlowTests/MailingList/LoadAllStartingWith.cs
@@ -54,6 +54,9 @@ namespace SlowTests.MailingList
 
                     Assert.Equal(1, testClasses.Value.Count());
                     Assert.Equal(1, test2Classes.Count());
+
+                    Assert.NotNull(session.Advanced.GetChangeVectorFor(testClasses.Value.First().Value));
+                    Assert.NotNull(session.Advanced.GetChangeVectorFor(test2Classes.First()));
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21379

### Additional description

We wrote some metadata twice. See below example - `@change-vector` and `@last-modified`:

```
"@metadata": {
                "@change-vector": "A:1-69+xPBLhpkewXlBh/wkkFQ",
                "@collection": "Abcs",
                "@id": "abc/1",
                "@last-modified": "2023-09-21T08:20:52.5588697Z",
                "Raven-Clr-Type": "SlowTests.MailingList.LoadAllStartingWith+Abc, SlowTests",
                "@change-vector": null,
                "@last-modified": "2023-09-21T08:20:52.5588697Z"
            }
```

This caused that we had `null` change vector on the client side.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
