### PR TITLE
RavenDB-18816 Fix a race when raft command with the same guid could be accepted twice

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1745,7 +1745,7 @@ namespace Raven.Client.Http
             public IDisposable ReturnContext;
         }
 
-        private async Task<TResult> Broadcast<TResult>(RavenCommand<TResult> command, SessionInfo sessionInfo, CancellationToken token)
+        internal async Task<TResult> Broadcast<TResult>(RavenCommand<TResult> command, SessionInfo sessionInfo, CancellationToken token)
         {
             var broadcastCommand = command as IBroadcast;
             if (broadcastCommand == null)
@@ -2378,7 +2378,7 @@ namespace Raven.Client.Http
             return _nodeSelector.GetFastestNode();
         }
 
-        private async Task EnsureNodeSelector()
+        internal async Task EnsureNodeSelector()
         {
             if (_disableTopologyUpdates == false)
                 await WaitForTopologyUpdate(_firstTopologyUpdate).ConfigureAwait(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18816

### Additional description

Fix a regression that was introduced here https://github.com/ravendb/ravendb/pull/16293
We could accept raft command with the same guid more than once, when the command is in the raft log but _not_ committed yet.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
