### PR TITLE
RavenDB-21235 Text for "About this view"

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
@@ -6,6 +6,8 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
+import {Icon} from "components/common/Icon";
+import {useRavenLink} from "hooks/useRavenLink";
 
 export function EditIndexInfoHub() {
     const hasAdditionalAssembliesFromNuGet = useAppSelector(licenseSelectors.statusValue("HasAdditionalAssembliesFromNuGet"));
@@ -19,7 +21,8 @@ export function EditIndexInfoHub() {
             },
         ],
     });
-
+    const indexViewDocsLink = useRavenLink({ hash: "XZXJP2" });
+    
     return (
         <AboutViewFloating>
             <AccordionItemWrapper
@@ -29,7 +32,52 @@ export function EditIndexInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>Text</p>
+                <p>
+                    Create a new index or edit an existing one in this view.
+                    <br/>
+                    The indexing process will immediately start upon saving the index.
+                </p>
+                <ul>
+                    <li>
+                        Various index types can be created:
+                        <br />
+                        Map / Multi-Map / Map-Reduce / Multi-Map-Reduce
+                    </li>
+                    <li className="margin-top-xxs">
+                        Select a deployment mode for the index:
+                        <br />
+                        Parallel / Rolling
+                    </li>
+                    <li className="margin-top-xxs">
+                        You can configure the index fields for:
+                        <br />
+                        Full-text search, Highlighting, Suggestions, Spatial queries,
+                        <br /> 
+                        and Store index fields.
+                    </li>
+                    <li className="margin-top-xxs">
+                        Customize the index configuration:
+                        <br />
+                        e.g. select indexing engine: Corax / Lucene
+                    </li>
+                    <li className="margin-top-xxs">
+                        Add additional assemblies and sources to enhance your index functions by referencing classes and
+                        methods from other files.
+                    </li>
+                    <li className="margin-top-xxs">
+                        The index can be tested in this view before saving it.
+                    </li>
+                    <li className="margin-top-xxs">
+                        Index history is available when editing an existing index,
+                        <br />
+                        showing the latest index revisions.
+                    </li>
+                </ul>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={indexViewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Index View
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasAdditionalAssembliesFromNuGet} data={featureAvailability} />
         </AboutViewFloating>

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
@@ -5,7 +5,7 @@ import viewModelBase = require("viewmodels/viewModelBase");
 class patchSyntax extends dialogViewModelBase {
     
     view = require("views/database/patch/patchSyntax.html");
-    patchSyntaxFunctionsView = require("views/database/patch/patchSyntaxFunctions.html");
+    scriptFunctionsSyntaxView = require("views/database/patch/scriptFunctionsSyntax.html");
 
     dialogContainer: Element;
     clientVersion = viewModelBase.clientVersion;

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
@@ -4,9 +4,12 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
+import {useRavenLink} from "hooks/useRavenLink";
+import {Icon} from "components/common/Icon";
 
 export function TimeSeriesInfoHub() {
     const hasTimeSeriesRollupsAndRetention = useAppSelector(licenseSelectors.statusValue("HasTimeSeriesRollupsAndRetention"));
+    const timeSeriesDocsLink = useRavenLink({ hash: "LNOMKT" });
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -27,7 +30,63 @@ export function TimeSeriesInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>Text</p>
+                <p>
+                    In this view, you can add a <strong>Time Series Configuration per collection</strong> to
+                    help manage the large volume of time series data that accumulates.
+                </p>
+                <div>
+                    The following can be configured per collection:
+                    <ul>
+                        <li className="margin-top-xxs">
+                            <strong>Rollup Policies</strong>:
+                            <br />
+                            =&gt; Define a Rollup Policy to aggregate time series data into smaller, summarized
+                            datasets called <strong>Rollups</strong>.
+                            Each entry in the Rollup time series is a summary of data from a defined interval of
+                            the original time series.
+                            <br />
+                            =&gt; Multiple Rollup Policies can be defined, each aggregating the previous Rollup time
+                            series. This reduces the granularity of the raw data and may simplify analysis.
+                            <br />
+                            =&gt; Rollup entries are not created for time series with entries that have more
+                            than 5 values (even if a policy is defined).
+                        </li>
+                        <li className="margin-top-xxs">
+                            <strong>Retention Periods</strong>:
+                            <br/>
+                            A retention period can be defined for both the raw data entries and each Rollup Policy.
+                            Time series entries that exceed this time frame will be removed.
+                        </li>
+                        <li className="margin-top-xxs">
+                            <strong>Named Values</strong>:
+                            <br/>
+                            Each time series entry has a specific timestamp and a set of up to 32 data values.
+                            A meaningful name can be given to each value in the time series entry.
+                        </li>
+                    </ul>
+                </div>
+                <hr/>
+                <div>
+                    Applying the configurations:
+                    <ul>
+                        <li className="margin-top-xxs">
+                            Ensure to set the <strong>Policy Check Frequency</strong> since the server will execute the
+                            defined rollup and retention policies only at that scheduled time.
+                        </li>
+                        <li className="margin-top-xxs">
+                            Each configuration per collection can be enabled or disabled.
+                        </li>
+                        <li className="margin-top-xxs">
+                            A configuration applies to all time series data of all documents within the given
+                            collection. The Rollups content can be viewed on the Document View.
+                        </li>
+                    </ul>
+                </div>
+                <hr/>
+                <div className="small-label mb-2">useful links</div>
+                <a href={timeSeriesDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Time Series
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
                 isUnlimited={hasTimeSeriesRollupsAndRetention}

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditElasticSearchEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditElasticSearchEtlInfoHub.tsx
@@ -24,7 +24,7 @@ export function EditElasticSearchEtlInfoHub() {
             >
                 <p>
                     An <strong>Elasticsearch ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from documents from this RavenDB database to an Elasticsearch destination.
+                    that transfers data from this RavenDB database to an Elasticsearch destination.
                 </p>
                 <ul>
                     <li>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaEtlInfoHub.tsx
@@ -22,7 +22,46 @@ export function EditKafkaEtlInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>Text</p>
+                <p>
+                    A <strong>Kafka ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
+                    that transfers data from this RavenDB database to topics of a Kafka broker.
+                </p>
+                <ul>
+                    <li>
+                        Data is extracted from documents only.
+                        <br/>
+                        Attachments, Counters, Time series, and Revisions are not sent.
+                    </li>
+                    <li className="margin-top-xxs">
+                        The sent data can be filtered and modified by multiple transformation JavaScript scripts that
+                        are added to the task.
+                    </li>
+                    <li className="margin-top-xxs">
+                        Each script specifies the RavenDB source collection(s) and the destination topic(s).
+                    </li>
+                    <li className="margin-top-xxs">
+                        The scripts are executed whenever documents in the source database are created or modified
+                        (excluding deletes).
+                    </li>
+                    <li className="margin-top-xxs">
+                        You can test each script in this view to preview the messages that will be sent by the ETL
+                        task to the destination.
+                    </li>
+                </ul>
+                <hr/>
+                <div>
+                    Task definition includes:
+                    <ul>
+                        <li>A connection string specifying Kafka&apos;s bootstrap servers.
+                            <br/>
+                            Connection options can be specified.
+                        </li>
+                        <li>The transformation scripts definitions.</li>
+                        <li>Per topic, select whether processed documents will be deleted from your RavenDB database.
+                        </li>
+                        <li>A responsible node to handle this task can be set.</li>
+                    </ul>
+                </div>
                 <hr />
                 <div className="small-label mb-2">useful links</div>
                 <a href={kafkaEtlDocsLink} target="_blank">

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqEtlInfoHub.tsx
@@ -22,7 +22,45 @@ export function EditRabbitMqEtlInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>Text</p>
+                <p>
+                    A <strong>RabbitMQ ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
+                    that transfers data from this RavenDB database to a RabbitMQ exchange.
+                </p>
+                <ul>
+                    <li>
+                        Data is extracted from documents only.
+                        <br/>
+                        Attachments, Counters, Time series, and Revisions are not sent.
+                    </li>
+                    <li className="margin-top-xxs">
+                        The sent data can be filtered and modified by multiple transformation JavaScript scripts that
+                        are added to the task.
+                    </li>
+                    <li className="margin-top-xxs">
+                        Each script specifies the RavenDB source collection(s) and the destination Exchange(s).
+                    </li>
+                    <li className="margin-top-xxs">
+                        The scripts are executed whenever documents in the source database are created or modified
+                        (excluding deletes).
+                    </li>
+                    <li className="margin-top-xxs">
+                        You can test each script in this view to preview the messages that will be sent by the ETL
+                        task to the destination.
+                    </li>
+                </ul>
+                <hr/>
+                <div>
+                    Task definition includes:
+                    <ul>
+                        <li>A connection string to the RabbitMQ exchange server.</li>
+                        <li>The transformation scripts definitions.</li>
+                        <li>Per queue, select whether processed documents will be deleted from your RavenDB database.
+                        </li>
+                        <li>When defining the RabbitMQ Exchanges, Queues & Bindings manually, 
+                            you can request to skip their automatic creation.</li>
+                        <li>A responsible node to handle this task can be set.</li>
+                    </ul>
+                </div>
                 <hr />
                 <div className="small-label mb-2">useful links</div>
                 <a href={rabbitMqEtlDocsLink} target="_blank">

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSqlEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSqlEtlInfoHub.tsx
@@ -24,7 +24,7 @@ export function EditSqlEtlInfoHub() {
             >
                 <p>
                     A <strong>SQL ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from documents from this RavenDB database to a relational database.
+                    that transfers data from this RavenDB database to a relational database.
                 </p>
                 <ul>
                     <li>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/queueSinkSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/queueSinkSyntax.ts
@@ -6,7 +6,7 @@ import { highlight, languages } from "prismjs";
 class queueSinkSyntax extends dialogViewModelBase {
     
     view = require("views/database/tasks/queueSinkSyntax.html"); 
-    patchSyntaxFunctionsView = require("views/database/patch/patchSyntaxFunctions.html");
+    scriptFunctionsSyntaxView = require("views/database/patch/scriptFunctionsSyntax.html");
 
     dialogContainer: Element;
     clientVersion = viewModelBase.clientVersion;

--- a/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
@@ -37,8 +37,8 @@ export function CertificatesInfoHub() {
                     <strong>Server certificates</strong>:
                     <ul>
                         <li className="margin-top-xxs">
-                            The server certificate can be exported in order to upload it by another server for
-                            establishing a secure connection between the servers.
+                            The server certificate can be exported for the purpose of uploading it to another server,
+                            in order to establish a secure connection between the servers.
                         </li>
                         <li className="margin-top-xxs">
                             The server certificate can be replaced as needed - this will apply to all cluster nodes.

--- a/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/CertificatesInfoHub.tsx
@@ -4,9 +4,12 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
+import {useRavenLink} from "hooks/useRavenLink";
+import {Icon} from "components/common/Icon";
 
 export function CertificatesInfoHub() {
     const hasReadOnlyCertificates = useAppSelector(licenseSelectors.statusValue("HasReadOnlyCertificates"));
+    const certificatesDocsLink = useRavenLink({ hash: "S3G2T1" });
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -27,9 +30,48 @@ export function CertificatesInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
+                <p>
+                    Manage your server and client certificates from this view.
+                </p>
                 <div>
-                    Text
+                    <strong>Server certificates</strong>:
+                    <ul>
+                        <li className="margin-top-xxs">
+                            The server certificate can be exported in order to upload it by another server for
+                            establishing a secure connection between the servers.
+                        </li>
+                        <li className="margin-top-xxs">
+                            The server certificate can be replaced as needed - this will apply to all cluster nodes.
+                        </li>
+                    </ul>
                 </div>
+                <div>
+                    <strong>Client certificates:</strong>
+                    <ul>
+                        <li className="margin-top-xxs">
+                            An admin can generate client certificates with an optional passphrase, and an expiration
+                            period,
+                            specifying the security clearance (Cluster Admin / Operator / User)
+                        </li>
+                        <li className="margin-top-xxs">
+                            With the User security clearance, different access permissions
+                            <br/>
+                            (Admin / Read-Write / Read-Only) can be granted per database.
+                        </li>
+                        <li className="margin-top-xxs">
+                            You can upload a client certificate that was exported from another server,
+                            allowing access to users with existing certificates.
+                        </li>
+                        <li className="margin-top-xxs">
+                            RavenDB does not keep track of the client certificate&apos;s private key.
+                        </li>
+                    </ul>
+                </div>
+                <hr/>
+                <div className="small-label mb-2">useful links</div>
+                <a href={certificatesDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Manage Certificates
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
                 isUnlimited={hasReadOnlyCertificates}

--- a/src/Raven.Studio/wwwroot/App/views/database/patch/patchSyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/patch/patchSyntax.html
@@ -15,7 +15,7 @@
                     <div class="text-left margin-top">
                         <div>The following functions can be used under <code>update</code> in the patch script:</div>
                         <small>See RavenDB online documentation for the full list.</small>
-                        <div data-bind="compose: $root.patchSyntaxFunctionsView"></div>
+                        <div data-bind="compose: $root.scriptFunctionsSyntaxView"></div>
                     </div>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/patch/scriptFunctionsSyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/patch/scriptFunctionsSyntax.html
@@ -14,8 +14,8 @@
     General:
     <li><code>output(message)</code> - output debug info when testing</li>
     <li>
-        <small title="Go to Patch documentation">
-            <a target="_blank" data-bind="attr: { href: 'https://ravendb.net/l/92U6B5/' + clientVersion() }">
+        <small title="Go to script functions documentation">
+            <a target="_blank" data-bind="attr: { href: 'https://ravendb.net/l/TF56GL/' + clientVersion() }">
                 <i class="icon-link"></i><span>Syntax tutorial</span>
             </a>
         </small>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/queueSinkSyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/queueSinkSyntax.html
@@ -15,7 +15,7 @@
                     <div class="text-left margin-top">
                         <div>The following functions can be used in the script:</div>
                         <small>See RavenDB online documentation for the full list.</small>
-                        <div data-bind="compose: $root.patchSyntaxFunctionsView"></div>
+                        <div data-bind="compose: $root.scriptFunctionsSyntaxView"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21235/Write-About-this-view-texts

### Additional description

1. Added text for:

      - Kafka ETL
      - RabbitMQ ETL
      - Edit Index View
      - Certificates View
      - Time Series Settings

2. @ml054  I fixed the **syntax-tutorial-link** for these views:
    Kafka Sink, RabbitMQ Sink, Patch
    so now it goes to a common article and not to the 'patch tutorial'

### Type of change
- Task

### How risky is the change?
- Low 

### Backward compatibility
- Not relevant

### Is it platform platform-specific issue?
- No

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed