### PR TITLE
RavenDB-16201 fix leftovers from ELT in queue sink

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddQueueSink.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddQueueSink.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -27,7 +26,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
             _taskId = index;
 
-            responseJson[nameof(EtlConfiguration<ConnectionString>.TaskId)] = _taskId;
+            responseJson[nameof(QueueSinkConfiguration.TaskId)] = _taskId;
         }
 
         protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration,
@@ -60,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 raftRequestId);
         }
 
-        protected virtual void AssertCanAddOrUpdateQueueSink(ref BlittableJsonReaderObject etlConfiguration)
+        protected virtual void AssertCanAddOrUpdateQueueSink(ref BlittableJsonReaderObject queueSinkConfiguration)
         {
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddQueueSink.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForAddQueueSink.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override void AssertCanAddOrUpdateQueueSink(ref BlittableJsonReaderObject etlConfiguration)
+        protected override void AssertCanAddOrUpdateQueueSink(ref BlittableJsonReaderObject queueSinkConfiguration)
         {
             throw new NotSupportedInShardingException("Queue Sinks are currently not supported in sharding");
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16201

### Additional description

Code cleanup

### Type of change

- Code cleanup

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- Ensured. Please explain how has it been implemented?
- Breaking change
- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
