### PR TITLE
RavenDB-21384 Prevent UI break for high number of nodes in database creation input

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
+++ b/src/Raven.Studio/typescript/models/resources/creation/databaseCreationModel.ts
@@ -22,6 +22,7 @@ const defaultReplicationFactor = 2;
 class databaseCreationModel {
 
     static readonly shardsLimit = 100;
+    static readonly nodesLimit = 100;
     static storageExporterPathKeyName = storageKeyProvider.storageKeyFor("storage-exporter-path");
 
     readonly configurationSections: Array<availableConfigurationSection> = [
@@ -274,6 +275,10 @@ class databaseCreationModel {
         const shardCount = this.replicationAndSharding.numberOfShards();
 
         // prevent UI break
+        if (factor > databaseCreationModel.nodesLimit) {
+            return;
+        }
+        
         if (shardCount > databaseCreationModel.shardsLimit) {
             return;
         }
@@ -428,6 +433,10 @@ class databaseCreationModel {
                     validator: (val: number) => val <= maxReplicationFactor,
                     message: `Max available nodes: {0}`,
                     params: maxReplicationFactor
+                },
+                {
+                    validator: (val: number) => val < databaseCreationModel.nodesLimit,
+                    message: `Replication factor must be less than ${databaseCreationModel.nodesLimit}.`
                 }
             ],
             digit: true

--- a/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
@@ -30,6 +30,8 @@ class createDatabase extends dialogViewModelBase {
     
     static readonly shardsLimit = databaseCreationModel.shardsLimit; 
     
+    static readonly nodesLimit = databaseCreationModel.nodesLimit;
+    
     static readonly legacyKeySizes = [128, 192, 256];
 
     static readonly defaultSection: availableConfigurationSectionId = "replicationAndSharding";

--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -654,7 +654,7 @@
             <thead>
                 <tr>
                     <th>&nbsp;</th>
-                    <!-- ko foreach: new Array(replicationFactor()) -->
+                    <!-- ko foreach: new Array(Math.min(replicationFactor(), $root.constructor.nodesLimit)) -->
                     <th>Replica <span data-bind="text: $index() + 1"></span></th>
                     <!-- /ko -->
                 </tr>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21384/Database-creation-Trying-to-input-high-number-of-nodes-or-shards-results-in-studio-freeze

### Additional description

Prevent UI break when user tries to input high number of nodes

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
