### PR TITLE
RavenDB-21437 Rewrite alert text for Subscriptions

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -40,10 +40,10 @@ export function EditSubscriptionTaskInfoHub() {
             >
                 <p>
                     Define a <strong>Subscription Query</strong> in this view to create a subscription-task on the
-                    server to which clients can subscribe.
+                    RavenDB server to which clients can subscribe.
                 </p>
                 <p>
-                    When a client opens a connection to this task, RavenDB sends all documents{" "}
+                    When a client opens a connection to this task, the server sends all documents{" "}
                     <strong>matching the defined query</strong> to the client for processing.
                 </p>
                 <p>
@@ -59,9 +59,9 @@ export function EditSubscriptionTaskInfoHub() {
                     <li>
                         The <strong>starting point</strong> from where to send the matching documents can be configured.
                     </li>
-                    <li>
-                        You can <strong>test the subscription</strong> in this view to preview sample document results
-                        that will be sent.
+                    <li className="margin-top-xxs">
+                        You can <strong>test the subscription query</strong> in this view to preview sample document results
+                        that will be sent to the client.
                     </li>
                 </ul>
                 <hr />

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
@@ -72,7 +72,12 @@
                                     <button type="button" class="close btn-lg" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>
-                                    <small><strong class="text-warning"><i class="icon-license"></i> Your current license does not include Subscriptions Revisions</strong>.<br/>Unleash the full potential and <a href="https://ravendb.net/l/FLDLO4" target="_blank">upgrade your plan.</a></small>
+                                    <small>
+                                        <strong class="text-warning"><i class="icon-license"></i><span>Your current license does not support processing document revisions by this Subscription task</span></strong>.
+                                        <br/>
+                                        Unleash the full potential of <span><i class="icon-subscription"></i> Subscriptions</span>
+                                        by <a href="https://ravendb.net/l/FLDLO4" target="_blank">upgrading</a> your plan.
+                                    </small>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21437/Rewrite-alert-text-for-Subscriptions

### Additional description

* Fixed the alert text that shows when the license does not support a subscription with revisions
* Small fixes to the "About text"

### Type of change
- Task

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
