### PR TITLE
RavenDB-21435 Clone index button should be disabled when limit for indexes is reached

### DIFF
--- a/src/Raven.Server/Commercial/LicenseLimitsUsage.cs
+++ b/src/Raven.Server/Commercial/LicenseLimitsUsage.cs
@@ -2,6 +2,31 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Commercial
 {
+    public sealed class DatabaseLicenseLimitsUsage : IDynamicJson
+    {
+        public int NumberOfStaticIndexes { get; set; }
+
+        public int NumberOfAutoIndexes { get; set; }
+
+        public int NumberOfCustomSorters { get; set; }
+
+        public int NumberOfAnalyzers { get; set; }
+
+        public long NumberOfSubscriptions { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(NumberOfStaticIndexes)] = NumberOfStaticIndexes,
+                [nameof(NumberOfAutoIndexes)] = NumberOfAutoIndexes,
+                [nameof(NumberOfCustomSorters)] = NumberOfCustomSorters,
+                [nameof(NumberOfAnalyzers)] = NumberOfAnalyzers,
+                [nameof(NumberOfSubscriptions)] = NumberOfSubscriptions
+            };
+        }
+    }
+
     public sealed class LicenseLimitsUsage : IDynamicJson
     {
         public int NumberOfStaticIndexesInCluster { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioStatsHandlerProcessorForGetLicenseLimitsUsage.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioStatsHandlerProcessorForGetLicenseLimitsUsage.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Commercial;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Studio;
+
+internal sealed class StudioStatsHandlerProcessorForGetLicenseLimitsUsage<TOperationContext> : AbstractDatabaseHandlerProcessor<AbstractDatabaseRequestHandler<TOperationContext>, TOperationContext>
+    where TOperationContext : JsonOperationContext
+{
+    public StudioStatsHandlerProcessorForGetLicenseLimitsUsage([NotNull] AbstractDatabaseRequestHandler<TOperationContext> requestHandler)
+        : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+        {
+            using (context.OpenReadTransaction())
+            {
+                var limits = new DatabaseLicenseLimitsUsage();
+
+                var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
+
+                using (var database = ServerStore.Cluster.ReadRawDatabaseRecord(context, RequestHandler.DatabaseName))
+                {
+                    limits.NumberOfStaticIndexes += database.CountOfStaticIndexes;
+                    limits.NumberOfAutoIndexes += database.CountOfAutoIndexes;
+                    limits.NumberOfCustomSorters += database.CountOfSorters;
+                    limits.NumberOfAnalyzers += database.CountOfAnalyzers;
+                    limits.NumberOfSubscriptions += ClusterStateMachine.GetSubscriptionsCountForDatabase(context.Allocator, items, database.DatabaseName);
+                }
+
+                context.Write(writer, limits.ToJson());
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioStatsHandlerProcessorForGetLicenseLimitsUsage.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioStatsHandlerProcessorForGetLicenseLimitsUsage.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.Commercial;
-using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
@@ -22,18 +21,7 @@ internal sealed class StudioStatsHandlerProcessorForGetLicenseLimitsUsage<TOpera
         {
             using (context.OpenReadTransaction())
             {
-                var limits = new DatabaseLicenseLimitsUsage();
-
-                var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
-
-                using (var database = ServerStore.Cluster.ReadRawDatabaseRecord(context, RequestHandler.DatabaseName))
-                {
-                    limits.NumberOfStaticIndexes += database.CountOfStaticIndexes;
-                    limits.NumberOfAutoIndexes += database.CountOfAutoIndexes;
-                    limits.NumberOfCustomSorters += database.CountOfSorters;
-                    limits.NumberOfAnalyzers += database.CountOfAnalyzers;
-                    limits.NumberOfSubscriptions += ClusterStateMachine.GetSubscriptionsCountForDatabase(context.Allocator, items, database.DatabaseName);
-                }
+                var limits = DatabaseLicenseLimitsUsage.CreateFor(context, ServerStore, RequestHandler.DatabaseName);
 
                 context.Write(writer, limits.ToJson());
             }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioStatsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioStatsHandler.cs
@@ -1,7 +1,9 @@
 ﻿extern alias NGC;
 using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Studio;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers
 {
@@ -14,6 +16,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
             {
                 await processor.ExecuteAsync();
             }
+        }
+
+        [RavenShardedAction("/databases/*/studio/license/limits-usage", "GET")]
+        public async Task GetLicenseLimitsUsage()
+        {
+            using (var processor = new StudioStatsHandlerProcessorForGetLicenseLimitsUsage<TransactionOperationContext>(this))
+                await processor.ExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -186,13 +186,15 @@ namespace Raven.Server.Web.Studio
                     var limits = new LicenseLimitsUsage();
                     var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
 
-                    foreach (var database in ServerStore.Cluster.GetAllRawDatabases(context))
+                    foreach (var databaseRecord in ServerStore.Cluster.GetAllRawDatabases(context))
                     {
-                        limits.NumberOfStaticIndexesInCluster += database.CountOfStaticIndexes;
-                        limits.NumberOfAutoIndexesInCluster += database.CountOfAutoIndexes;
-                        limits.NumberOfCustomSortersInCluster += database.CountOfSorters;
-                        limits.NumberOfAnalyzersInCluster += database.CountOfAnalyzers;
-                        limits.NumberOfSubscriptionsInCluster += ClusterStateMachine.GetSubscriptionsCountForDatabase(context.Allocator, items, database.DatabaseName);
+                        var databaseLimits = DatabaseLicenseLimitsUsage.CreateFor(context, databaseRecord);
+
+                        limits.NumberOfStaticIndexesInCluster += databaseLimits.NumberOfStaticIndexes;
+                        limits.NumberOfAutoIndexesInCluster += databaseLimits.NumberOfAutoIndexes;
+                        limits.NumberOfCustomSortersInCluster += databaseLimits.NumberOfCustomSorters;
+                        limits.NumberOfAnalyzersInCluster += databaseLimits.NumberOfAnalyzers;
+                        limits.NumberOfSubscriptionsInCluster += databaseLimits.NumberOfSubscriptions;
                     }
 
                     context.Write(writer, limits.ToJson());

--- a/src/Raven.Server/Web/Studio/StudioStatsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioStatsHandler.cs
@@ -2,6 +2,7 @@
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Web.Studio
 {
@@ -14,6 +15,13 @@ namespace Raven.Server.Web.Studio
             {
                 await processor.ExecuteAsync();
             }
+        }
+
+        [RavenAction("/databases/*/studio/license/limits-usage", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task GetLicenseLimitsUsage()
+        {
+            using (var processor = new StudioStatsHandlerProcessorForGetLicenseLimitsUsage<DocumentsOperationContext>(this))
+                await processor.ExecuteAsync();
         }
     }
 }

--- a/src/Raven.Studio/typescript/commands/licensing/getClusterLicenseLimitsUsage.ts
+++ b/src/Raven.Studio/typescript/commands/licensing/getClusterLicenseLimitsUsage.ts
@@ -1,7 +1,7 @@
 import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
 
-class getLicenseLimitsUsage extends commandBase {
+class getClusterLicenseLimitsUsage extends commandBase {
 
     execute(): JQueryPromise<Raven.Server.Commercial.LicenseLimitsUsage> {
         const url = endpoints.global.license.licenseLimitsUsage;
@@ -11,4 +11,4 @@ class getLicenseLimitsUsage extends commandBase {
     }
 }
 
-export = getLicenseLimitsUsage;
+export = getClusterLicenseLimitsUsage;

--- a/src/Raven.Studio/typescript/commands/licensing/getDatabaseLicenseLimitsUsage.ts
+++ b/src/Raven.Studio/typescript/commands/licensing/getDatabaseLicenseLimitsUsage.ts
@@ -1,0 +1,22 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+import database = require("models/resources/database");
+
+class getDatabaseLicenseLimitsUsage extends commandBase {
+
+    private readonly db: database;
+
+    constructor(db: database) {
+        super();
+        this.db = db;
+    }
+
+    execute(): JQueryPromise<Raven.Server.Commercial.DatabaseLicenseLimitsUsage> {
+        const url = endpoints.databases.studioStats.studioLicenseLimitsUsage;
+        
+        return this.query<Raven.Server.Commercial.DatabaseLicenseLimitsUsage>(url, null, this.db)
+            .fail((response: JQueryXHR) => this.reportError("Failed to get license limits usage", response.responseText));
+    }
+}
+
+export = getDatabaseLicenseLimitsUsage;

--- a/src/Raven.Studio/typescript/components/common/shell/setup.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/setup.ts
@@ -38,7 +38,9 @@ function updateReduxCollectionsTracker() {
 }
 
 export const throttledUpdateLicenseLimitsUsage = _.throttle(() => {
-    services.licenseService.getLimitsUsage().then((dto) => globalDispatch(licenseActions.limitsUsageLoaded(dto)));
+    services.licenseService
+        .getClusterLimitsUsage()
+        .then((dto) => globalDispatch(licenseActions.limitsUsageLoaded(dto)));
 }, 200);
 
 function initRedux() {

--- a/src/Raven.Studio/typescript/components/services/LicenseService.ts
+++ b/src/Raven.Studio/typescript/components/services/LicenseService.ts
@@ -1,7 +1,7 @@
-import getLicenseLimitsUsage from "commands/licensing/getLicenseLimitsUsage";
+import getClusterLicenseLimitsUsage from "commands/licensing/getClusterLicenseLimitsUsage";
 
 export default class LicenseService {
-    async getLimitsUsage() {
-        return new getLicenseLimitsUsage().execute();
+    async getClusterLimitsUsage() {
+        return new getClusterLicenseLimitsUsage().execute();
     }
 }

--- a/src/Raven.Studio/typescript/test/mocks/services/MockLicenseService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockLicenseService.ts
@@ -8,6 +8,6 @@ export default class MockLicenseService extends AutoMockService<LicenseService> 
     }
 
     withLimitsUsage(dto?: MockedValue<Raven.Server.Commercial.LicenseLimitsUsage>) {
-        return this.mockResolvedValue(this.mocks.getLimitsUsage, dto, LicenseStubs.limitsUsage());
+        return this.mockResolvedValue(this.mocks.getClusterLimitsUsage, dto, LicenseStubs.limitsUsage());
     }
 }

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -17,7 +17,14 @@
                         <a data-bind="attr: { href: indexesUrl }" class="btn btn-default" title="Return to list of indexes">
                             <i class="icon-cancel"></i><span>Cancel</span>
                         </a>
-                        <button class="btn btn-default" data-bind="click: cloneIndex, visible: isEditingExistingIndex, requiredAccess: 'DatabaseReadWrite'" title="Clone this index">
+                        <button
+                            class="btn btn-default"
+                            data-bind="click: cloneIndex,
+                                visible: isEditingExistingIndex,
+                                disable: $root.databaseLimitStatus() === 'limitReached' || $root.clusterLimitStatus() === 'limitReached',
+                                requiredAccess: 'DatabaseReadWrite',
+                                attr: { title: $root.cloneButtonTitle }"
+                        >
                             <i class="icon-clone"></i><span>Clone</span>
                         </button>
                         <div data-bind="if: showIndexHistory" style="margin: unset">

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -419,6 +419,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(LicenseConfiguration));
             scripter.AddType(typeof(LicenseHandler.ConnectivityToLicenseServer));
             scripter.AddType(typeof(LicenseLimitsUsage));
+            scripter.AddType(typeof(DatabaseLicenseLimitsUsage));
 
             // feedback form
             scripter.AddType(typeof(FeedbackForm));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21435

### Additional description

Clone is blocked when database or cluster limit is reached.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/1fe44a10-2cc7-41de-ada8-1b5a1f9d116b)

