### PR TITLE
RavenDB-21443 Info Hub on Document Revisions is warning-colored even though license contains everything

### DIFF
--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -251,7 +251,7 @@ namespace Raven.Server.Commercial
         public int? MaxNumberOfRevisionAgeToKeepInDays => GetValue<int?>(LicenseAttribute.MaxNumberOfRevisionAgeToKeepInDays, agplValue: 45);
 
         public int? MinPeriodForExpirationInHours => GetValue<int?>(LicenseAttribute.MinPeriodForExpirationInHours, agplValue: 36);
-        
+
         public int? MinPeriodForRefreshInHours => GetValue<int?>(LicenseAttribute.MinPeriodForRefreshInHours, agplValue: 36);
 
         public int? MaxReplicationFactorForSharding => GetValue<int?>(LicenseAttribute.MaxReplicationFactorForSharding, agplValue: 1);
@@ -272,7 +272,7 @@ namespace Raven.Server.Commercial
 
         public int? MaxNumberOfCustomSortersPerCluster => GetValue<int?>(LicenseAttribute.MaxNumberOfCustomSortersPerCluster, agplValue: 5);
 
-        public int? MaxNumberOfCustomAnalyzersPerDatabase => GetValue<int?>(LicenseAttribute.MaxNumberOfCustomAnalyzersPerDatabase, agplValue: 1) ;
+        public int? MaxNumberOfCustomAnalyzersPerDatabase => GetValue<int?>(LicenseAttribute.MaxNumberOfCustomAnalyzersPerDatabase, agplValue: 1);
 
         public int? MaxNumberOfCustomAnalyzersPerCluster => GetValue<int?>(LicenseAttribute.MaxNumberOfCustomAnalyzersPerCluster, agplValue: 5);
 
@@ -351,6 +351,7 @@ namespace Raven.Server.Commercial
                 [nameof(MaxNumberOfCustomSortersPerCluster)] = MaxNumberOfCustomSortersPerCluster,
                 [nameof(MaxNumberOfCustomAnalyzersPerDatabase)] = MaxNumberOfCustomAnalyzersPerDatabase,
                 [nameof(MaxNumberOfCustomAnalyzersPerCluster)] = MaxNumberOfCustomAnalyzersPerCluster,
+                [nameof(CanSetupDefaultRevisionsConfiguration)] = CanSetupDefaultRevisionsConfiguration,
             };
         }
     }

--- a/src/Raven.Studio/typescript/components/utils/licenseLimitsUtils.tsx
+++ b/src/Raven.Studio/typescript/components/utils/licenseLimitsUtils.tsx
@@ -33,29 +33,13 @@ export function getLicenseAvailabilityType(licenseType: Raven.Server.Commercial.
             return "community";
         case "Professional":
             return "professional";
+        case "Developer":
         case "Enterprise":
             return "enterprise";
         default:
             return null;
     }
 }
-// // TODO remove + run webpack
-// export const featureAvailabilityProfessionalOrAbove: FeatureAvailabilityData[] = [
-//     {
-//         community: { value: false },
-//         professional: { value: true },
-//         enterprise: { value: true },
-//     },
-// ];
-
-// // TODO remove + run webpack
-// export const featureAvailabilityEnterprise: FeatureAvailabilityData[] = [
-//     {
-//         community: { value: false },
-//         professional: { value: false },
-//         enterprise: { value: true },
-//     },
-// ];
 
 function useLicenseAvailability(
     featureAvailabilityData: FeatureAvailabilityData[],


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21443

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
