### PR TITLE
RavenDB-21395 Better explanation on button when license is not sufficient

### DIFF
--- a/src/Raven.Studio/typescript/components/common/FeatureNotAvailableInYourLicensePopover.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureNotAvailableInYourLicensePopover.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { UncontrolledPopover } from "reactstrap";
+import { useRavenLink } from "hooks/useRavenLink";
+
+interface FeatureNotAvailableInYourLicensePopoverProps {
+    target: string;
+}
+export default function FeatureNotAvailableInYourLicensePopover(props: FeatureNotAvailableInYourLicensePopoverProps) {
+    const { target } = props;
+    const upgradeLicenseLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
+
+    return (
+        <UncontrolledPopover trigger="hover" target={target} placement="top" className="bs5">
+            <div className="p-3 text-center">
+                Your current license does not support this feature.
+                <br />
+                <a href={upgradeLicenseLink} target="_blank">
+                    Upgrade your plan
+                </a>{" "}
+                to access.
+            </div>
+        </UncontrolledPopover>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -27,6 +27,7 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 interface ClientDatabaseConfigurationProps {
     db: database;
@@ -51,8 +52,8 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
     const loadBalancingLink = useRavenLink({ hash: "GYJ8JA" });
     const clientConfigurationLink = useRavenLink({ hash: "TS7SGF" });
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasClientConfiguration"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasClientConfiguration = useAppSelector(licenseSelectors.statusValue("HasClientConfiguration"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasClientConfiguration);
 
     const globalConfig = useMemo(() => {
         const globalConfigResult = asyncGetClientGlobalConfiguration.result;
@@ -104,10 +105,10 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                         <AboutViewHeading
                             icon="database-client-configuration"
                             title="Client Configuration"
-                            licenseBadgeText={isFeatureInLicense ? null : "Professional +"}
+                            licenseBadgeText={hasClientConfiguration ? null : "Professional +"}
                         />
                         <div className="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-3">
-                            <div>
+                            <div id="saveClientConfiguration" className="w-fit-content">
                                 <Button
                                     type="submit"
                                     color="primary"
@@ -121,6 +122,9 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                                     Save
                                 </Button>
                             </div>
+                            {!hasClientConfiguration && (
+                                <FeatureNotAvailableInYourLicensePopover target="saveClientConfiguration" />
+                            )}
 
                             {canNavigateToServerSettings() && (
                                 <small title="Navigate to the server-wide Client Configuration View">
@@ -131,7 +135,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                                 </small>
                             )}
                         </div>
-                        <div className={isFeatureInLicense ? "" : "item-disabled pe-none"}>
+                        <div className={hasClientConfiguration ? "" : "item-disabled pe-none"}>
                             {globalConfig && (
                                 <div className="mt-4 mb-3">
                                     <div className="hstack justify-content-center">
@@ -573,7 +577,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                         </div>
                     </Col>
                     <Col sm={12} md={4}>
-                        <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                        <AboutViewAnchored defaultOpen={hasClientConfiguration ? null : "licensing"}>
                             <AccordionItemWrapper
                                 icon="about"
                                 color="info"
@@ -622,7 +626,7 @@ export default function ClientDatabaseConfiguration({ db }: ClientDatabaseConfig
                             </AccordionItemWrapper>
 
                             <FeatureAvailabilitySummaryWrapper
-                                isUnlimited={isFeatureInLicense}
+                                isUnlimited={hasClientConfiguration}
                                 data={featureAvailability}
                             />
                         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
@@ -26,6 +26,7 @@ import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useEnterpriseLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function DataArchival({ db }: NonShardedViewProps) {
     const { databasesService } = useServices();
@@ -42,8 +43,8 @@ export default function DataArchival({ db }: NonShardedViewProps) {
     const { reportEvent } = useEventsCollector();
     const { isAdminAccessOrAbove } = useAccessManager();
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasDataArchival"));
-    const featureAvailability = useEnterpriseLicenseAvailability(isFeatureInLicense);
+    const hasDataArchival = useAppSelector(licenseSelectors.statusValue("HasDataArchival"));
+    const featureAvailability = useEnterpriseLicenseAvailability(hasDataArchival);
 
     useEffect(() => {
         if (!formValues.isArchiveFrequencyEnabled && formValues.archiveFrequency !== null) {
@@ -80,8 +81,6 @@ export default function DataArchival({ db }: NonShardedViewProps) {
         return <LoadError error="Unable to load data archival" refresh={asyncGetDataArchivalConfiguration.execute} />;
     }
 
-    todo("Feature", "Damian", "Add the missing logic");
-    todo("Other", "Danielle", "Text for About this view");
     todo("Feature", "Damian", "Render you do not have permission to this view");
 
     return (
@@ -93,19 +92,22 @@ export default function DataArchival({ db }: NonShardedViewProps) {
                             <AboutViewHeading
                                 title="Data Archival"
                                 icon="data-archival"
-                                licenseBadgeText={isFeatureInLicense ? null : "Enterprise"}
+                                licenseBadgeText={hasDataArchival ? null : "Enterprise"}
                             />
-                            <ButtonWithSpinner
-                                type="submit"
-                                color="primary"
-                                className="mb-3"
-                                icon="save"
-                                disabled={!formState.isDirty || !isAdminAccessOrAbove}
-                                isSpinning={formState.isSubmitting}
-                            >
-                                Save
-                            </ButtonWithSpinner>
-                            <Col className={isFeatureInLicense ? "" : "item-disabled pe-none"}>
+                            <div id="saveDataArchival" className="w-fit-content">
+                                <ButtonWithSpinner
+                                    type="submit"
+                                    color="primary"
+                                    className="mb-3"
+                                    icon="save"
+                                    disabled={!formState.isDirty || !isAdminAccessOrAbove}
+                                    isSpinning={formState.isSubmitting}
+                                >
+                                    Save
+                                </ButtonWithSpinner>
+                            </div>
+                            {!hasDataArchival && <FeatureNotAvailableInYourLicensePopover target="saveDataArchival" />}
+                            <Col className={hasDataArchival ? "" : "item-disabled pe-none"}>
                                 <Card>
                                     <CardBody>
                                         <div className="vstack gap-2">
@@ -145,7 +147,7 @@ export default function DataArchival({ db }: NonShardedViewProps) {
                         </Form>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                        <AboutViewAnchored defaultOpen={hasDataArchival ? null : "licensing"}>
                             <AccordionItemWrapper
                                 targetId="about"
                                 icon="about"
@@ -187,7 +189,7 @@ export default function DataArchival({ db }: NonShardedViewProps) {
                                 </a>
                             </AccordionItemWrapper>
                             <FeatureAvailabilitySummaryWrapper
-                                isUnlimited={isFeatureInLicense}
+                                isUnlimited={hasDataArchival}
                                 data={featureAvailability}
                             />
                         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/studioConfiguration/StudioDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/studioConfiguration/StudioDatabaseConfiguration.tsx
@@ -24,6 +24,7 @@ import { useAppSelector } from "components/store";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps) {
     const { databasesService } = useServices();
@@ -49,8 +50,8 @@ export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps)
     const studioConfigurationDocsLink = useRavenLink({ hash: "HIR1VP" });
     const { reportEvent } = useEventsCollector();
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasStudioConfiguration"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasStudioConfiguration = useAppSelector(licenseSelectors.statusValue("HasStudioConfiguration"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasStudioConfiguration);
 
     const onSave: SubmitHandler<StudioDatabaseConfigurationFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -79,20 +80,25 @@ export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps)
                     <AboutViewHeading
                         icon="database-studio-configuration"
                         title="Studio Configuration"
-                        licenseBadgeText={isFeatureInLicense ? null : "Professional +"}
+                        licenseBadgeText={hasStudioConfiguration ? null : "Professional +"}
                     />
                     <Form onSubmit={handleSubmit(onSave)} autoComplete="off">
                         <div className="d-flex align-items-center justify-content-between">
-                            <ButtonWithSpinner
-                                type="submit"
-                                color="primary"
-                                className="mb-3"
-                                icon="save"
-                                disabled={!formState.isDirty}
-                                isSpinning={formState.isSubmitting}
-                            >
-                                Save
-                            </ButtonWithSpinner>
+                            <div id="saveStudioConfiguration" className="w-fit-content">
+                                <ButtonWithSpinner
+                                    type="submit"
+                                    color="primary"
+                                    className="mb-3"
+                                    icon="save"
+                                    disabled={!formState.isDirty}
+                                    isSpinning={formState.isSubmitting}
+                                >
+                                    Save
+                                </ButtonWithSpinner>
+                            </div>
+                            {!hasStudioConfiguration && (
+                                <FeatureNotAvailableInYourLicensePopover target="saveStudioConfiguration" />
+                            )}
                             <small title="Navigate to the server-wide Client Configuration View">
                                 <a target="_blank" href={appUrl.forGlobalStudioConfiguration()}>
                                     <Icon icon="link" />
@@ -100,7 +106,7 @@ export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps)
                                 </a>
                             </small>
                         </div>
-                        <div className={isFeatureInLicense ? "" : "item-disabled pe-none"}>
+                        <div className={hasStudioConfiguration ? "" : "item-disabled pe-none"}>
                             <Card id="popoverContainer">
                                 <CardBody className="d-flex flex-center flex-column flex-wrap gap-4">
                                     <InputGroup className="gap-1 flex-wrap flex-column">
@@ -164,7 +170,7 @@ export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps)
                     </Form>
                 </Col>
                 <Col sm={12} md={4}>
-                    <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                    <AboutViewAnchored defaultOpen={hasStudioConfiguration ? null : "licensing"}>
                         <AccordionItemWrapper
                             icon="about"
                             color="info"
@@ -184,7 +190,7 @@ export default function StudioDatabaseConfiguration({ db }: NonShardedViewProps)
                             </a>
                         </AccordionItemWrapper>
                         <FeatureAvailabilitySummaryWrapper
-                            isUnlimited={isFeatureInLicense}
+                            isUnlimited={hasStudioConfiguration}
                             data={featureAvailability}
                         />
                     </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
@@ -23,6 +23,7 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function ClientGlobalConfiguration() {
     const { manageServerService } = useServices();
@@ -49,8 +50,8 @@ export default function ClientGlobalConfiguration() {
 
     useDirtyFlag(formState.isDirty);
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasClientConfiguration"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasClientConfiguration = useAppSelector(licenseSelectors.statusValue("HasClientConfiguration"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasClientConfiguration);
 
     const onSave: SubmitHandler<ClientConfigurationFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -78,13 +79,22 @@ export default function ClientGlobalConfiguration() {
                         <AboutViewHeading
                             icon="database-client-configuration"
                             title="Client Configuration"
-                            licenseBadgeText={isFeatureInLicense ? null : "Professional +"}
+                            licenseBadgeText={hasClientConfiguration ? null : "Professional +"}
                         />
-                        <Button type="submit" color="primary" disabled={formState.isSubmitting || !formState.isDirty}>
-                            {formState.isSubmitting ? <Spinner size="sm" className="me-1" /> : <Icon icon="save" />}
-                            Save
-                        </Button>
-                        <div className={isFeatureInLicense ? "" : "item-disabled pe-none"}>
+                        <div id="saveClientConfiguration" className="w-fit-content">
+                            <Button
+                                type="submit"
+                                color="primary"
+                                disabled={formState.isSubmitting || !formState.isDirty}
+                            >
+                                {formState.isSubmitting ? <Spinner size="sm" className="me-1" /> : <Icon icon="save" />}
+                                Save
+                            </Button>
+                        </div>
+                        {!hasClientConfiguration && (
+                            <FeatureNotAvailableInYourLicensePopover target="saveClientConfiguration" />
+                        )}
+                        <div className={hasClientConfiguration ? "" : "item-disabled pe-none"}>
                             <Card className="card flex-column p-3 my-3">
                                 <div className="d-flex flex-grow-1">
                                     <div className="md-label">
@@ -295,7 +305,7 @@ export default function ClientGlobalConfiguration() {
                         </div>
                     </Col>
                     <Col sm={12} md={4}>
-                        <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                        <AboutViewAnchored defaultOpen={hasClientConfiguration ? null : "licensing"}>
                             <AccordionItemWrapper
                                 icon="about"
                                 color="info"
@@ -340,7 +350,7 @@ export default function ClientGlobalConfiguration() {
                                 </a>
                             </AccordionItemWrapper>
                             <FeatureAvailabilitySummaryWrapper
-                                isUnlimited={isFeatureInLicense}
+                                isUnlimited={hasClientConfiguration}
                                 data={featureAvailability}
                             />
                         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzers.tsx
@@ -13,17 +13,17 @@ import AnalyzersList from "./ServerWideCustomAnalyzersList";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function ServerWideCustomAnalyzers() {
     const { manageServerService } = useServices();
     const asyncGetAnalyzers = useAsync(manageServerService.getServerWideCustomAnalyzers, []);
 
     const { appUrl } = useAppUrls();
-    const upgradeLicenseLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
     const customAnalyzersDocsLink = useRavenLink({ hash: "VWCQPI" });
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasServerWideAnalyzers"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasServerWideCustomAnalyzers = useAppSelector(licenseSelectors.statusValue("HasServerWideAnalyzers"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasServerWideCustomAnalyzers);
 
     const resultsCount = asyncGetAnalyzers.result?.length ?? null;
 
@@ -36,30 +36,18 @@ export default function ServerWideCustomAnalyzers() {
                         <div id="newServerWideCustomAnalyzer" className="w-fit-content">
                             <a
                                 href={appUrl.forEditServerWideCustomAnalyzer()}
-                                className={classNames("btn btn-primary mb-3", { disabled: !isFeatureInLicense })}
+                                className={classNames("btn btn-primary mb-3", {
+                                    disabled: !hasServerWideCustomAnalyzers,
+                                })}
                             >
                                 <Icon icon="plus" />
                                 Add a server-wide custom analyzer
                             </a>
                         </div>
-                        {!isFeatureInLicense && (
-                            <UncontrolledPopover
-                                trigger="hover"
-                                target="newServerWideCustomAnalyzer"
-                                placement="top"
-                                className="bs5"
-                            >
-                                <div className="p-3 text-center">
-                                    Your current license does not support this feature.
-                                    <br />
-                                    <a href={upgradeLicenseLink} target="_blank">
-                                        Upgrade your plan
-                                    </a>{" "}
-                                    to access.
-                                </div>
-                            </UncontrolledPopover>
+                        {!hasServerWideCustomAnalyzers && (
+                            <FeatureNotAvailableInYourLicensePopover target="newServerWideCustomAnalyzer" />
                         )}
-                        <div className={isFeatureInLicense ? null : "item-disabled pe-none"}>
+                        <div className={hasServerWideCustomAnalyzers ? null : "item-disabled pe-none"}>
                             <HrHeader count={resultsCount}>Server-wide custom analyzers</HrHeader>
                             <AnalyzersList
                                 fetchStatus={asyncGetAnalyzers.status}
@@ -69,7 +57,7 @@ export default function ServerWideCustomAnalyzers() {
                         </div>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                        <AboutViewAnchored defaultOpen={hasServerWideCustomAnalyzers ? null : "licensing"}>
                             <AccordionItemWrapper
                                 targetId="1"
                                 icon="about"
@@ -120,7 +108,7 @@ export default function ServerWideCustomAnalyzers() {
                                 </a>
                             </AccordionItemWrapper>
                             <FeatureAvailabilitySummaryWrapper
-                                isUnlimited={isFeatureInLicense}
+                                isUnlimited={hasServerWideCustomAnalyzers}
                                 data={featureAvailability}
                             />
                         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.tsx
@@ -13,17 +13,17 @@ import SortersList from "./ServerWideCustomSortersList";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function ServerWideCustomSorters() {
     const { manageServerService } = useServices();
     const asyncGetSorters = useAsync(manageServerService.getServerWideCustomSorters, []);
 
     const { appUrl } = useAppUrls();
-    const upgradeLicenseLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
     const customSortersDocsLink = useRavenLink({ hash: "LGUJH8" });
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasServerWideCustomSorters"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasServerWideCustomSorters = useAppSelector(licenseSelectors.statusValue("HasServerWideCustomSorters"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasServerWideCustomSorters);
 
     const resultsCount = asyncGetSorters.result?.length ?? null;
 
@@ -36,30 +36,18 @@ export default function ServerWideCustomSorters() {
                         <div id="newServerWideCustomSorter" className="w-fit-content">
                             <a
                                 href={appUrl.forEditServerWideCustomSorter()}
-                                className={classNames("btn btn-primary mb-3", { disabled: !isFeatureInLicense })}
+                                className={classNames("btn btn-primary mb-3", {
+                                    disabled: !hasServerWideCustomSorters,
+                                })}
                             >
                                 <Icon icon="plus" />
                                 Add a server-wide custom sorter
                             </a>
                         </div>
-                        {!isFeatureInLicense && (
-                            <UncontrolledPopover
-                                trigger="hover"
-                                target="newServerWideCustomSorter"
-                                placement="top"
-                                className="bs5"
-                            >
-                                <div className="p-3 text-center">
-                                    Your current license does not support this feature.
-                                    <br />
-                                    <a href={upgradeLicenseLink} target="_blank">
-                                        Upgrade your plan
-                                    </a>{" "}
-                                    to access.
-                                </div>
-                            </UncontrolledPopover>
+                        {!hasServerWideCustomSorters && (
+                            <FeatureNotAvailableInYourLicensePopover target="newServerWideCustomSorter" />
                         )}
-                        <div className={isFeatureInLicense ? null : "item-disabled pe-none"}>
+                        <div className={hasServerWideCustomSorters ? null : "item-disabled pe-none"}>
                             <HrHeader count={resultsCount}>Server-wide custom sorters</HrHeader>
                             <SortersList
                                 fetchStatus={asyncGetSorters.status}
@@ -69,7 +57,7 @@ export default function ServerWideCustomSorters() {
                         </div>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                        <AboutViewAnchored defaultOpen={hasServerWideCustomSorters ? null : "licensing"}>
                             <AccordionItemWrapper
                                 targetId="1"
                                 icon="about"
@@ -116,7 +104,7 @@ export default function ServerWideCustomSorters() {
                                 </a>
                             </AccordionItemWrapper>
                             <FeatureAvailabilitySummaryWrapper
-                                isUnlimited={isFeatureInLicense}
+                                isUnlimited={hasServerWideCustomSorters}
                                 data={featureAvailability}
                             />
                         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
@@ -22,6 +22,7 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import { useProfessionalOrAboveLicenseAvailability } from "components/utils/licenseLimitsUtils";
+import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 
 export default function StudioGlobalConfiguration() {
     const asyncGlobalSettings = useAsyncCallback<StudioGlobalConfigurationFormData>(async () => {
@@ -46,8 +47,8 @@ export default function StudioGlobalConfiguration() {
     const clientConfigurationDocsLink = useRavenLink({ hash: "TS7SGF" });
     const { reportEvent } = useEventsCollector();
 
-    const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasStudioConfiguration"));
-    const featureAvailability = useProfessionalOrAboveLicenseAvailability(isFeatureInLicense);
+    const hasStudioConfiguration = useAppSelector(licenseSelectors.statusValue("HasStudioConfiguration"));
+    const featureAvailability = useProfessionalOrAboveLicenseAvailability(hasStudioConfiguration);
 
     const onSave: SubmitHandler<StudioGlobalConfigurationFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -83,20 +84,25 @@ export default function StudioGlobalConfiguration() {
                     <AboutViewHeading
                         icon="studio-configuration"
                         title="Studio Configuration"
-                        licenseBadgeText={isFeatureInLicense ? null : "Professional +"}
+                        licenseBadgeText={hasStudioConfiguration ? null : "Professional +"}
                     />
                     <Form onSubmit={handleSubmit(onSave)} autoComplete="off">
-                        <ButtonWithSpinner
-                            type="submit"
-                            color="primary"
-                            className="mb-3"
-                            icon="save"
-                            disabled={!formState.isDirty}
-                            isSpinning={formState.isSubmitting}
-                        >
-                            Save
-                        </ButtonWithSpinner>
-                        <div className={isFeatureInLicense ? null : "item-disabled pe-none"}>
+                        <div id="saveStudioConfiguration" className="w-fit-content">
+                            <ButtonWithSpinner
+                                type="submit"
+                                color="primary"
+                                className="mb-3"
+                                icon="save"
+                                disabled={!formState.isDirty}
+                                isSpinning={formState.isSubmitting}
+                            >
+                                Save
+                            </ButtonWithSpinner>
+                        </div>
+                        {!hasStudioConfiguration && (
+                            <FeatureNotAvailableInYourLicensePopover target="saveStudioConfiguration" />
+                        )}
+                        <div className={hasStudioConfiguration ? null : "item-disabled pe-none"}>
                             <Card id="popoverContainer">
                                 <CardBody className="d-flex flex-center flex-column flex-wrap gap-4">
                                     <InputGroup className="gap-1 flex-wrap flex-column">
@@ -179,7 +185,7 @@ export default function StudioGlobalConfiguration() {
                     </Form>
                 </Col>
                 <Col sm={12} md={4}>
-                    <AboutViewAnchored defaultOpen={isFeatureInLicense ? null : "licensing"}>
+                    <AboutViewAnchored defaultOpen={hasStudioConfiguration ? null : "licensing"}>
                         <AccordionItemWrapper
                             icon="about"
                             color="info"
@@ -205,7 +211,7 @@ export default function StudioGlobalConfiguration() {
                             </a>
                         </AccordionItemWrapper>
                         <FeatureAvailabilitySummaryWrapper
-                            isUnlimited={isFeatureInLicense}
+                            isUnlimited={hasStudioConfiguration}
                             data={featureAvailability}
                         />
                     </AboutViewAnchored>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21395

### Additional description
Moved the explanation popover to a separate component

### Type of change
- New feature

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
