### PR TITLE
RavenDB-21422 Document Revisions refresh issue

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -94,6 +94,10 @@ export default function DocumentRevisions({ db }: NonShardedViewProps) {
 
     useEffect(() => {
         dispatch(documentRevisionsActions.fetchConfigs(db));
+
+        return () => {
+            dispatch(documentRevisionsActions.reset());
+        };
     }, [db, dispatch]);
 
     const { databasesService } = useServices();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
@@ -110,6 +110,7 @@ export const documentRevisionsSlice = createSlice({
         saveConfigs: (state) => {
             configsAdapter.setAll(state.originalConfigs, configsSelectors.selectAll(state.configs));
         },
+        reset: () => initialState,
     },
     extraReducers: (builder) => {
         builder


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21422/Document-Revisions-refresh-issue

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
