### PR TITLE
RavenDB-21430 Index complex object as JSON in case of AutoIndexes and warn user about it

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -21,6 +21,7 @@ namespace Corax
         public const string IndexTimeFields = "@index_time_fields";
         public const string DocumentBoost = "@document_boost";
         public const string ProjectionNullValue = "NULL_VALUE";
+        public const string JsonValue = "JSON_VALUE";
 
         public static readonly Slice NullValueSlice, ProjectionNullValueSlice, EmptyStringSlice, IndexMetadataSlice, DocumentBoostSlice, IndexTimeFieldsSlice;
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -280,6 +280,8 @@ namespace Raven.Server.Documents.Indexes
 
         public TestIndexRun TestRun;
         
+        private HashSet<string> _fieldsReportedAsComplex = new();
+        
         protected Index(IndexType type, IndexSourceType sourceType, IndexDefinitionBaseServerSide definition)
         {
             Type = type;
@@ -2545,6 +2547,17 @@ namespace Raven.Server.Documents.Indexes
             _updateReferenceLoadWarning = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SetFieldIsIndexedAsJsonViaCoraxAutoIndex(IndexField field)
+        {
+            if (Type.IsAuto() == false || _fieldsReportedAsComplex.Contains(field.OriginalName))
+                return;
+            
+            DocumentDatabase.NotificationCenter.Indexing.AddComplexFieldWarning(Name, field.OriginalName);
+            _fieldsReportedAsComplex.Add(field.OriginalName);
+        }
+        
+        
         private void HandleMismatchedReferences()
         {
             if (CurrentIndexingScope.Current.MismatchedReferencesWarningHandler == null || CurrentIndexingScope.Current.MismatchedReferencesWarningHandler.IsEmpty)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -315,7 +315,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
             case ValueType.DynamicJsonObject:
                 if (_index.Type.IsAuto())
                 {
-                    InsertRegularField(field, value.ToString(), indexContext, builder, sourceDocument, out shouldSkip);
+                    InsertRegularField(field, CoraxConstants.JsonValue, indexContext, builder, sourceDocument, out shouldSkip);
                     _index.SetFieldIsIndexedAsJsonViaCoraxAutoIndex(field);
 
                     return;
@@ -345,7 +345,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 var jsonScope = Scope.CreateJson(json, indexContext);
                 if (_index.Type.IsAuto())
                 {
-                    InsertRegularField(field, jsonScope, indexContext, builder, sourceDocument, out shouldSkip);
+                    InsertRegularField(field, CoraxConstants.JsonValue, indexContext, builder, sourceDocument, out shouldSkip);
                     _index.SetFieldIsIndexedAsJsonViaCoraxAutoIndex(field);
                     return;
                 }
@@ -437,7 +437,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         if (_index.Type.IsAuto())
         {
             _index.SetFieldIsIndexedAsJsonViaCoraxAutoIndex(field);
-            InsertRegularField(field, val.ToString(), indexContext, builder, sourceDocument, out shouldSkip);
+            InsertRegularField(field, CoraxConstants.JsonValue, indexContext, builder, sourceDocument, out shouldSkip);
             return;
         }
         

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -211,8 +211,7 @@ namespace Raven.Server.NotificationCenter
 
         private AlertRaised GetComplexFieldAlert(ComplexFieldsWarning complexFieldsWarning)
         {
-            return AlertRaised.Create(_notificationCenter.Database, $"Complex field in AutoIndex", $"We detected complex field in AutoIndex. It may result in higher resource usage since its values will be processed as JSON objects. You should consider querying on individual fields of that object or using static index.", AlertType.Indexing_CoraxComplexItem, NotificationSeverity.Warning,
-                Source, complexFieldsWarning);
+            return AlertRaised.Create(_notificationCenter.Database, $"Complex field in Corax auto index", $"We have detected a complex field in an auto index. To avoid higher resources usage when processing JSON objects, the values of these fields will be replaced with 'JSON_VALUE'. Please consider querying on individual fields of that object or using a static index.", AlertType.Indexing_CoraxComplexItem, NotificationSeverity.Warning, Source, complexFieldsWarning);
         }
 
         public void Dispose()

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/ComplexFieldsWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/ComplexFieldsWarning.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details;
+
+public sealed class ComplexFieldsWarning : INotificationDetails
+{
+    public ComplexFieldsWarning()
+    {
+        //deserialization
+    }
+
+    public ComplexFieldsWarning(ConcurrentQueue<(string indexName, string fieldName)> complexFields)
+    {
+        Fields = new();
+
+        while (complexFields.TryDequeue(out var field))
+        {
+            ref var indexFields = ref CollectionsMarshal.GetValueRefOrAddDefault(Fields, field.indexName, out var exists);
+            if (exists == false)
+                indexFields = new();
+
+            indexFields.Add(field.fieldName);
+        }
+    }
+    
+    public Dictionary<string, List<string>> Fields { get; set; }
+    
+    public DynamicJsonValue ToJson()
+    {
+        var djv = new DynamicJsonValue(GetType());
+        var listOfFields = new DynamicJsonValue();
+
+        foreach (var (indexName, indexComplexFields) in Fields)
+        {
+            var complexInIndex = new DynamicJsonArray();
+            foreach (var field in indexComplexFields)
+                complexInIndex.Add(field);
+
+            listOfFields[indexName] = complexInIndex;
+        }
+        djv[nameof(Fields)] = listOfFields;
+
+        return djv;
+    }
+}

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -64,7 +64,8 @@ import queueSinkErrorDetails
     from "viewmodels/common/notificationCenter/detailViewer/alerts/queueSinkErrorDetails";
 import conflictExceededDetails
     from "viewmodels/common/notificationCenter/detailViewer/alerts/conflictExceededDetails";
-
+import complexFieldsAlertDetails
+    from "viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails";
 interface detailsProvider {
     supportsDetailsFor(notification: abstractNotification): boolean;
     showDetailsFor(notification: abstractNotification, notificationCenter: notificationCenter): JQueryPromise<void> | void;
@@ -188,7 +189,7 @@ class notificationCenter {
             queueSinkErrorDetails,
             serverLimitsDetails,
             conflictExceededDetails,
-
+            complexFieldsAlertDetails,
             genericAlertDetails  // leave it as last item on this list - this is fallback handler for all alert types
         );
 

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails.ts
@@ -25,10 +25,9 @@ class complexFieldsAlertDetails extends abstractAlertDetails {
 
         const warning = this.alert.details() as ComplexFieldsWarning;
         
-        for (let [index, fields] of Object.entries(warning.Fields))
+        for (const [index, fields] of Object.entries(warning.Fields)) {
             this.tableItems.push({indexName: index, complexFields: fields.join(", ")});
-        
-        
+        }
     }
 
     private fetcher(): JQueryPromise<pagedResult<WarningItem>> {

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails.ts
@@ -1,0 +1,79 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import alert = require("common/notifications/models/alert");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import abstractAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/abstractAlertDetails");
+import ComplexFieldsWarning = Raven.Server.NotificationCenter.Notifications.Details.ComplexFieldsWarning;
+import genUtils from "common/generalUtils";
+
+interface WarningItem {
+    indexName: string;
+    complexFields: string;
+}
+
+class complexFieldsAlertDetails extends abstractAlertDetails {
+    view = require("views/common/notificationCenter/detailViewer/alerts/complexFieldAlertDetails.html");
+    tableItems: WarningItem[] = [];
+    private gridController = ko.observable<virtualGridController<WarningItem>>();
+    private columnPreview = new columnPreviewPlugin<WarningItem>();
+
+    constructor(alert: alert, notificationCenter: notificationCenter) {
+        super(alert, notificationCenter);
+
+        const warning = this.alert.details() as ComplexFieldsWarning;
+        
+        for (let [index, fields] of Object.entries(warning.Fields))
+            this.tableItems.push({indexName: index, complexFields: fields.join(", ")});
+        
+        
+    }
+
+    private fetcher(): JQueryPromise<pagedResult<WarningItem>> {
+        return $.Deferred<pagedResult<WarningItem>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(() => this.fetcher(), () => {
+            const indexNameColumn = new textColumn<WarningItem>(grid, x => x.indexName, "Index Name", "25%", {
+                sortable: x => x.indexName
+            });
+            const indexComplexFields = new textColumn<WarningItem>(grid, x => x.complexFields, "Fields", "25%", {
+                sortable: x => x.complexFields
+            });
+           
+            return [indexNameColumn, indexComplexFields];
+        });
+
+        this.columnPreview.install(".complexFieldsAlertDetails", ".js-complex-fields-details-tooltip",
+            (details: WarningItem,
+             column: textColumn<WarningItem>,
+             e: JQueryEventObject, onValue: (context: any, valueToCopy?: string) => void) => {
+                const value = column.getCellValue(details);
+                if (value) {
+                    onValue(genUtils.escapeHtml(value), value);
+                }
+            });
+    }
+    
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof alert) && notification.alertType() === "Indexing_CoraxComplexItem";
+    }
+
+    static showDetailsFor(alert: alert, center: notificationCenter) {
+        return app.showBootstrapDialog(new complexFieldsAlertDetails(alert, center));
+    }
+}
+
+export = complexFieldsAlertDetails;

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/complexFieldAlertDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/complexFieldAlertDetails.html
@@ -1,0 +1,23 @@
+<div class="modal-dialog modal-lg complexFieldAlertDetails" id="js-complex-field-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: alert">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: alert.message"></h3>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-complex-field-details-tooltip" style="opacity: 0">
+</div>

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/complexFieldAlertDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/complexFieldAlertDetails.html
@@ -1,4 +1,4 @@
-<div class="modal-dialog modal-lg complexFieldAlertDetails" id="js-complex-field-details" role="document">
+<div class="modal-dialog modal-lg complexFieldsAlertDetails" id="js-complex-field-details" role="document">
     <div class="modal-content force-text-wrap-word" tabindex="-1">
         <div class="modal-header">
             <button type="button" class="close" data-bind="click: close" aria-hidden="true">
@@ -19,5 +19,5 @@
         </div>
     </div>
 </div>
-<div class="tooltip json-preview js-complex-field-details-tooltip" style="opacity: 0">
+<div class="tooltip json-preview js-complex-fields-details-tooltip" style="opacity: 0">
 </div>

--- a/test/FastTests/Corax/RavenDB-21430.cs
+++ b/test/FastTests/Corax/RavenDB-21430.cs
@@ -22,15 +22,15 @@ public class RavenDB_21430 : RavenTestBase
 
         using (var session = store.OpenAsyncSession())
         {
-            await session.StoreAsync(new ComplexField(new Query.Order() {Company = "Maciej"}));
-            await session.StoreAsync(new ComplexField(null));
+            await session.StoreAsync(new ComplexField(new Query.Order() {Company = "Maciej"}, new Query.Order(){Company = "Test"}));
+            await session.StoreAsync(new ComplexField(null, null));
             await session.SaveChangesAsync();
 
             var result = await session.Query<ComplexField>()
                 .Customize(i => i.WaitForNonStaleResults())
-                .Statistics(out var stats).Where(x => x.Order != null)
+                .Statistics(out var stats).Where(x => x.Order != null && x.Field != null)
                 .ToListAsync();
-            
+            WaitForUserToContinueTheTest(store);
             Assert.False(stats.IsStale);
             
             Assert.Equal(1, result.Count);
@@ -41,5 +41,5 @@ public class RavenDB_21430 : RavenTestBase
         
     }
 
-    private sealed record ComplexField(Query.Order Order, string Id = null);
+    private sealed record ComplexField(Query.Order Order, Query.Order Field, string Id = null);
 }

--- a/test/FastTests/Corax/RavenDB-21430.cs
+++ b/test/FastTests/Corax/RavenDB-21430.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class RavenDB_21430 : RavenTestBase
+{
+    public RavenDB_21430(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public async Task CanIndexComplexFieldInAutoIndex()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new ComplexField(new Query.Order() {Company = "Maciej"}));
+            await session.StoreAsync(new ComplexField(null));
+            await session.SaveChangesAsync();
+
+            var result = await session.Query<ComplexField>()
+                .Customize(i => i.WaitForNonStaleResults())
+                .Statistics(out var stats).Where(x => x.Order != null)
+                .ToListAsync();
+            
+            Assert.False(stats.IsStale);
+            
+            Assert.Equal(1, result.Count);
+            var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { stats.IndexName }));
+            Assert.Empty(indexErrors[0].Errors);
+        }
+        
+        
+    }
+
+    private sealed record ComplexField(Query.Order Order, string Id = null);
+}

--- a/test/FastTests/Corax/RavenDB-21430.cs
+++ b/test/FastTests/Corax/RavenDB-21430.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.NotificationCenter.Notifications;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,27 +22,36 @@ public class RavenDB_21430 : RavenTestBase
     [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes | RavenTestCategory.Corax)]
     public async Task CanIndexComplexFieldInAutoIndex()
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
-
-        using (var session = store.OpenAsyncSession())
+        using (var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax)))
         {
-            await session.StoreAsync(new ComplexField(new Query.Order() {Company = "Maciej"}, new Query.Order(){Company = "Test"}));
-            await session.StoreAsync(new ComplexField(null, null));
-            await session.SaveChangesAsync();
+            var db = await GetDatabase(store.Database);
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new ComplexField(new Query.Order() {Company = "Maciej"}, new Query.Order() {Company = "Test"}));
+                await session.StoreAsync(new ComplexField(null, null));
+                await session.SaveChangesAsync();
 
-            var result = await session.Query<ComplexField>()
-                .Customize(i => i.WaitForNonStaleResults())
-                .Statistics(out var stats).Where(x => x.Order != null && x.Field != null)
-                .ToListAsync();
-            WaitForUserToContinueTheTest(store);
-            Assert.False(stats.IsStale);
-            
-            Assert.Equal(1, result.Count);
-            var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { stats.IndexName }));
-            Assert.Empty(indexErrors[0].Errors);
+                var result = await session.Query<ComplexField>()
+                    .Customize(i => i.WaitForNonStaleResults())
+                    .Statistics(out var stats).Where(x => x.Order != null && x.Field != null)
+                    .ToListAsync();
+                Assert.False(stats.IsStale);
+
+                Assert.Equal(1, result.Count);
+                var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {stats.IndexName}));
+                Assert.Empty(indexErrors[0].Errors);
+
+                using (db.NotificationCenter.GetStored(out var actions))
+                {
+                    var alertPersisted = actions.ToList();
+                    Assert.Equal(1, alertPersisted.Count);
+
+                    var complexFieldAlert = Raven.Server.NotificationCenter.Notifications.AlertRaised.FromJson("", alertPersisted[0].Json);
+                    Assert.Equal(AlertType.Indexing_CoraxComplexItem, complexFieldAlert.AlertType);
+                    Assert.Contains("Complex field in Corax auto index", complexFieldAlert.Title);
+                }
+            }
         }
-        
-        
     }
 
     private sealed record ComplexField(Query.Order Order, Query.Order Field, string Id = null);

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -266,6 +266,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(HugeDocumentsDetails));
             scripter.AddType(typeof(HugeDocumentInfo));
             scripter.AddType(typeof(MismatchedReferencesLoadWarning));
+            scripter.AddType(typeof(ComplexFieldsWarning));
             scripter.AddType(typeof(BlockingTombstoneDetails));
             scripter.AddType(typeof(RequestLatencyDetail));
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21430
### Additional description

We are calling `.ToString()` in case of complex object in case of autoindexes since the user has no option to do it without creating the static index. In such cases, we send an alert about it.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
