### PR TITLE
RavenDB-18884: Removed the virtual calls used to implement the original solution.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -287,7 +287,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        private static void WriteMemoryStats(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, bool includeThreads, bool includeMappings)
+        private static void WriteMemoryStats<TWriter>(TWriter writer, JsonOperationContext context, bool includeThreads, bool includeMappings)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 
@@ -367,7 +368,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             writer.WriteEndObject();
         }
 
-        private static void WriteThreads(bool includeThreads, AsyncBlittableJsonTextWriter writer, JsonOperationContext context)
+        private static void WriteThreads<TWriter>(bool includeThreads, TWriter writer, JsonOperationContext context)
+            where TWriter : IBlittableJsonTextWriter
         {
             if (includeThreads == false)
                 return;
@@ -412,8 +414,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        private static void WriteMappings(bool includeMappings, AsyncBlittableJsonTextWriter writer, JsonOperationContext context,
+        private static void WriteMappings<TWriter>(bool includeMappings, TWriter writer, JsonOperationContext context,
             Dictionary<string, long> fileMappingSizesByDir, Dictionary<string, Dictionary<string, ConcurrentDictionary<IntPtr, long>>> fileMappingByDir)
+            where TWriter : IBlittableJsonTextWriter
         {
             if (includeMappings == false)
                 return;

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -205,7 +205,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        private void WriteAllEnvs(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context)
+        private void WriteAllEnvs<TWriter>(TWriter writer, DocumentsOperationContext context)
+            where TWriter : IBlittableJsonTextWriter
         {
             var envs = Database.GetAllStoragesEnvironment();
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
             }
         }
 
-        internal static void WriteGetAllResult(AsyncBlittableJsonTextWriter writer, IEnumerable<SubscriptionState> subscriptions, ClusterOperationContext context)
+        internal static void WriteGetAllResult(AsyncBlittableJsonTextWriterForDebug writer, IEnumerable<SubscriptionState> subscriptions, ClusterOperationContext context)
         {
             writer.WriteStartObject();
             writer.WriteArray(context, "Results", subscriptions.Select(SubscriptionStateAsJson), (w, c, subscription) => c.Write(w, subscription));

--- a/src/Raven.Server/Documents/Queries/ExecutingQueryInfo.cs
+++ b/src/Raven.Server/Documents/Queries/ExecutingQueryInfo.cs
@@ -38,7 +38,8 @@ namespace Raven.Server.Documents.Queries
             Token = token;
         }
 
-        public void Write(AsyncBlittableJsonTextWriter writer, JsonOperationContext context)
+        public void Write<TWriter>(TWriter writer, JsonOperationContext context)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -173,7 +173,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteEtlTaskProgress(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<EtlTaskProgress> progress)
+        public static void WriteEtlTaskProgress<TWriter>(this TWriter writer, JsonOperationContext context, IEnumerable<EtlTaskProgress> progress)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
             writer.WriteArray(context, "Results", progress, (w, c, taskStats) =>
@@ -967,7 +968,8 @@ namespace Raven.Server.Json
             writer.WriteObject(context.ReadObject(djv, "subscriptionConnection/performance"));
         }
 
-        public static void WriteIndexQuery(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IIndexQuery query)
+        public static void WriteIndexQuery<TWriter>(this TWriter writer, JsonOperationContext context, IIndexQuery query)
+            where TWriter : IBlittableJsonTextWriter
         {
             var indexQuery = query as IndexQueryServerSide;
             if (indexQuery != null)
@@ -979,7 +981,8 @@ namespace Raven.Server.Json
             throw new NotSupportedException($"Not supported query type: {query.GetType()}");
         }
 
-        private static void WriteIndexQuery(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IndexQueryServerSide query)
+        private static void WriteIndexQuery<TWriter>(this TWriter writer, JsonOperationContext context, IndexQueryServerSide query)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 
@@ -1044,7 +1047,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteEssentialDatabaseStatistics(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, EssentialDatabaseStatistics statistics)
+        public static void WriteEssentialDatabaseStatistics<TWriter>(this TWriter writer, JsonOperationContext context, EssentialDatabaseStatistics statistics)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 
@@ -1053,7 +1057,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteDatabaseStatistics(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, DatabaseStatistics statistics)
+        public static void WriteDatabaseStatistics<TWriter>(this TWriter writer, JsonOperationContext context, DatabaseStatistics statistics)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 
@@ -1062,7 +1067,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        private static void WriteDatabaseStatisticsInternal(AbstractBlittableJsonTextWriter writer, DatabaseStatistics statistics)
+        private static void WriteDatabaseStatisticsInternal<TWriter>(this TWriter writer, DatabaseStatistics statistics)
+            where TWriter : IBlittableJsonTextWriter
         {
             WriteEssentialDatabaseStatisticsInternal(writer, statistics);
             writer.WriteComma();
@@ -1142,8 +1148,9 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        private static void WriteEssentialDatabaseStatisticsInternal<TIndexInformation>(AbstractBlittableJsonTextWriter writer, AbstractDatabaseStatistics<TIndexInformation> statistics)
+        private static void WriteEssentialDatabaseStatisticsInternal<TIndexInformation, TWriter>(this TWriter writer, AbstractDatabaseStatistics<TIndexInformation> statistics)
             where TIndexInformation : EssentialIndexInformation
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(nameof(statistics.CountOfIndexes));
             writer.WriteInteger(statistics.CountOfIndexes);
@@ -1206,7 +1213,7 @@ namespace Raven.Server.Json
 
             writer.WriteEndArray();
 
-            void WriteIndexInformation(AbstractBlittableJsonTextWriter w, IndexInformation index)
+            void WriteIndexInformation(TWriter w, IndexInformation index)
             {
                 w.WriteStartObject();
 
@@ -1231,7 +1238,7 @@ namespace Raven.Server.Json
                 w.WriteEndObject();
             }
 
-            void WriteBasicIndexInformation(AbstractBlittableJsonTextWriter w, EssentialIndexInformation index)
+            void WriteBasicIndexInformation(TWriter w, EssentialIndexInformation index)
             {
                 w.WriteStartObject();
 
@@ -1260,7 +1267,7 @@ namespace Raven.Server.Json
                 w.WriteEndObject();
             }
 
-            static void WriteBasicIndexInformationInternal(AbstractBlittableJsonTextWriter w, TIndexInformation index)
+            static void WriteBasicIndexInformationInternal(TWriter w, TIndexInformation index)
             {
                 w.WritePropertyName(nameof(index.Name));
                 w.WriteString(index.Name);
@@ -1548,7 +1555,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteIndexesStats(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IndexStats[] indexesStats)
+        public static void WriteIndexesStats<TWriter>(this TWriter writer, JsonOperationContext context, IndexStats[] indexesStats)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 
@@ -1590,7 +1598,8 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static void WriteIndexErrors(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<IndexErrors> indexErrors)
+        public static void WriteIndexErrors<TWriter>(this TWriter writer, JsonOperationContext context, IEnumerable<IndexErrors> indexErrors)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
             writer.WriteArray(context, "Results", indexErrors, (w, c, index) =>

--- a/src/Raven.Server/Rachis/Json/Sync/RachisBlittableJsonTextWriter.cs
+++ b/src/Raven.Server/Rachis/Json/Sync/RachisBlittableJsonTextWriter.cs
@@ -1,17 +1,26 @@
 ﻿using System;
 using System.IO;
 using Sparrow.Json;
-using Sparrow.Json.Sync;
 
 namespace Raven.Server.Rachis.Json.Sync
 {
-    internal sealed class RachisBlittableJsonTextWriter : BlittableJsonTextWriter
+    internal sealed class RachisBlittableJsonTextWriter : AbstractBlittableJsonTextWriter, IDisposable
     {
         private readonly Action _afterFlush;
 
         public RachisBlittableJsonTextWriter(JsonOperationContext context, Stream stream, Action afterFlush) : base(context, stream)
         {
             _afterFlush = afterFlush;
+        }
+
+        public void Dispose()
+        {
+            DisposeInternal();
+        }
+
+        public void Flush()
+        {
+            FlushInternal();
         }
 
         protected override bool FlushInternal()

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -70,7 +70,8 @@ namespace Raven.Server.ServerWide
             LastRequestTimePerCertificate = newLastRequestTimePerCertificate;
         }
 
-        public void WriteTo(AbstractBlittableJsonTextWriter writer)
+        public void WriteTo<TWriter>(TWriter writer)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartObject();
 

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -1,62 +1,181 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Server.ServerWide;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.Utils
 {
-    public sealed class AsyncBlittableJsonTextWriterForDebug : AsyncBlittableJsonTextWriter
+    public sealed class AsyncBlittableJsonTextWriterForDebug : IBlittableJsonTextWriter, IAsyncDisposable
     {
         private readonly ServerStore _serverStore;
         private bool _isFirst = true;
         private bool _isOnlyWrite;
+        private readonly AsyncBlittableJsonTextWriter _inner;
 
-        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream) : base(context, stream)
+        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream, CancellationToken cancellationToken = default)
         {
+            _isFirst = true;
             _serverStore = serverStore;
+            _inner = new AsyncBlittableJsonTextWriter(context, stream, cancellationToken: cancellationToken);
         }
-        
-        public override void WriteStartObject()
+
+        public void WriteStartObject()
         {
-            base.WriteStartObject();
+            _inner.WriteStartObject();
 
             if (_isFirst)
             {
                 _isFirst = false;
 
-                WritePropertyName(Constants.Documents.Metadata.Key);
-                WriteStartObject();
-                WritePropertyName(nameof(DateTime));
-                WriteDateTime(DateTime.UtcNow, true);
-                WriteComma();
-                WritePropertyName(nameof(_serverStore.Server.WebUrl));
-                WriteString(_serverStore.Server.WebUrl);
-                WriteComma();
-                WritePropertyName(nameof(_serverStore.NodeTag));
-                WriteString(_serverStore.NodeTag);
-
-                WriteEndObject();
+                _inner.WritePropertyName(Constants.Documents.Metadata.Key);
+                _inner.WriteStartObject();
+                _inner.WritePropertyName(nameof(DateTime));
+                _inner.WriteDateTime(DateTime.UtcNow, true);
+                _inner.WriteComma();
+                _inner.WritePropertyName(nameof(_serverStore.Server.WebUrl));
+                _inner.WriteString(_serverStore.Server.WebUrl);
+                _inner.WriteComma();
+                _inner.WritePropertyName(nameof(_serverStore.NodeTag));
+                _inner.WriteString(_serverStore.NodeTag);
+                _inner.WriteEndObject();
 
                 _isOnlyWrite = true;
             }
         }
 
-        protected override void EnsureBuffer(int len)
+        public void WriteEndObject()
         {
-            base.EnsureBuffer(len);
+            _isOnlyWrite = false;
+            _inner.WriteEndObject();
+        }
 
+        public void WriteObject(BlittableJsonReaderObject obj)
+        {
             if (_isOnlyWrite)
             {
                 _isOnlyWrite = false;
                 WriteComma();
             }
+            _inner.WriteObject(obj);
         }
 
-        public override void WriteEndObject()
+        public void WriteValue(BlittableJsonToken token, object val)
         {
-            _isOnlyWrite = false;
-            base.WriteEndObject();
+            _inner.WriteValue(token, val);
+        }
+
+        public int WriteDateTime(DateTime? value, bool isUtc)
+        {
+            return _inner.WriteDateTime(value, isUtc);
+        }
+
+        public int WriteDateTime(DateTime value, bool isUtc)
+        {
+            return _inner.WriteDateTime(value, isUtc);
+        }
+
+        public void WriteString(string str, bool skipEscaping = false)
+        {
+            _inner.WriteString(str, skipEscaping);
+        }
+
+        public void WriteString(LazyStringValue str, bool skipEscaping = false)
+        {
+            _inner.WriteString(str, skipEscaping);
+        }
+
+        public void WriteString(LazyCompressedStringValue str)
+        {
+            _inner.WriteString(str);
+        }
+
+        public void WriteStartArray()
+        {
+            _inner.WriteStartArray(); 
+        }
+
+        public void WriteEndArray()
+        {
+            _inner.WriteEndArray();
+        }
+
+        public void WriteNull()
+        {
+            _inner.WriteNull();
+        }
+
+        public void WriteBool(bool val)
+        {
+            _inner.WriteBool(val);
+        }
+
+        public void WriteComma()
+        {
+            _inner.WriteComma();
+        }
+
+        public void WriteInteger(long val)
+        {
+            _inner.WriteInteger(val);
+        }
+
+        public void WriteDouble(LazyNumberValue val)
+        {
+            _inner.WriteDouble(val);
+        }
+
+        public void WriteDouble(double val)
+        {
+            _inner.WriteDouble(val);
+        }
+
+        public void WriteNewLine()
+        {
+            _inner.WriteNewLine();
+        }
+
+        public void WritePropertyName(ReadOnlySpan<byte> prop)
+        {
+            if (_isOnlyWrite)
+            {
+                _isOnlyWrite = false;
+                WriteComma();
+            }
+            _inner.WritePropertyName(prop);
+        }
+
+        public void WritePropertyName(string prop)
+        {
+            if (_isOnlyWrite)
+            {
+                _isOnlyWrite = false;
+                WriteComma();
+            }
+            _inner.WritePropertyName(prop);
+        }
+
+        public void WritePropertyName(StringSegment prop)
+        {
+            if (_isOnlyWrite)
+            {
+                _isOnlyWrite = false;
+                WriteComma();
+            }
+            _inner.WritePropertyName(prop);
+        }
+
+        public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
+        {
+            return _inner.MaybeFlushAsync(token);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return _inner.DisposeAsync();
         }
     }
 }

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -3,11 +3,12 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Sparrow.Extensions;
 
 namespace Sparrow.Json
 {
-    public abstract unsafe class AbstractBlittableJsonTextWriter
+    public abstract unsafe class AbstractBlittableJsonTextWriter : IBlittableJsonTextWriter
     {
         protected readonly JsonOperationContext _context;
         protected readonly Stream _stream;
@@ -446,6 +447,20 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteRawString(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.Length < JsonOperationContext.MemoryBuffer.DefaultSize)
+            {
+                EnsureBuffer(buffer.Length);
+                Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(_buffer + _pos), ref MemoryMarshal.GetReference(buffer), (uint)buffer.Length);
+                _pos += buffer.Length;
+                return;
+            }
+
+            UnlikelyWriteLargeRawString(buffer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteRawString(byte* buffer, int size)
         {
             if (size < JsonOperationContext.MemoryBuffer.DefaultSize)
@@ -457,6 +472,25 @@ namespace Sparrow.Json
             }
 
             UnlikelyWriteLargeRawString(buffer, size);
+        }
+
+        private void UnlikelyWriteLargeRawString(ReadOnlySpan<byte> buffer)
+        {
+            // need to do this in pieces
+            var posInStr = 0;
+            while (posInStr < buffer.Length)
+            {
+                var amountToCopy = Math.Min(buffer.Length - posInStr, JsonOperationContext.MemoryBuffer.DefaultSize);
+                FlushInternal();
+
+                Unsafe.CopyBlockUnaligned(
+                    ref Unsafe.AsRef<byte>(_buffer), 
+                    ref Unsafe.AddByteOffset( ref MemoryMarshal.GetReference(buffer), (uint)posInStr ),
+                    (uint)buffer.Length);
+
+                posInStr += amountToCopy;
+                _pos = amountToCopy;
+            }
         }
 
         private void UnlikelyWriteLargeRawString(byte* buffer, int size)
@@ -474,7 +508,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void WriteStartObject()
+        public void WriteStartObject()
         {
             EnsureBuffer(1);
             _buffer[_pos++] = StartObject;
@@ -495,15 +529,15 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void WriteEndObject()
+        public void WriteEndObject()
         {
             EnsureBuffer(1);
             _buffer[_pos++] = EndObject;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected virtual void EnsureBuffer(int len)
-        {
+        protected void EnsureBuffer(int len)
+        { 
             if (len >= JsonOperationContext.MemoryBuffer.DefaultSize)
                 ThrowValueTooBigForBuffer(len);
             if (_pos + len < JsonOperationContext.MemoryBuffer.DefaultSize)
@@ -564,6 +598,14 @@ namespace Sparrow.Json
             EnsureBuffer(1);
             _buffer[_pos++] = Comma;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WritePropertyName(ReadOnlySpan<byte> prop)
+        {
+            EnsureBuffer(prop.Length);
+            WriteRawString(prop);
+        }
+
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WritePropertyName(LazyStringValue prop)
@@ -671,6 +713,11 @@ namespace Sparrow.Json
         }
 
         public void WriteBufferFor(byte[] buffer)
+        {
+            WriteBufferFor(buffer.AsSpan());
+        }
+
+        public void WriteBufferFor(ReadOnlySpan<byte> buffer)
         {
             EnsureBuffer(buffer.Length);
             for (int i = 0; i < buffer.Length; i++)

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Sparrow.Json
 {
-    public class AsyncBlittableJsonTextWriter : AbstractBlittableJsonTextWriter, IAsyncDisposable
+    public sealed class AsyncBlittableJsonTextWriter : AbstractBlittableJsonTextWriter, IAsyncDisposable
     {
         private readonly Stream _outputStream;
         private readonly CancellationToken _cancellationToken;

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -10,8 +10,9 @@ namespace Sparrow.Json
     internal static class BlittableJsonTextWriterExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray<T>(this AbstractBlittableJsonTextWriter writer, JsonOperationContext context, string name, IEnumerable<T> items,
-            Action<AbstractBlittableJsonTextWriter, JsonOperationContext, T> onWrite)
+        public static void WriteArray<TWriter, T>(this TWriter writer, JsonOperationContext context, string name, IEnumerable<T> items,
+            Action<TWriter, JsonOperationContext, T> onWrite)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -31,7 +32,8 @@ namespace Sparrow.Json
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArrayValue(this AbstractBlittableJsonTextWriter writer, IEnumerable<string> items)
+        public static void WriteArrayValue<TWriter>(this TWriter writer, IEnumerable<string> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WriteStartArray();
             var first = true;
@@ -49,7 +51,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, Memory<double> items)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, Memory<double> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -84,7 +87,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, IEnumerable<LazyStringValue> items)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, IEnumerable<LazyStringValue> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -102,7 +106,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, IEnumerable<string> items)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, IEnumerable<string> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -126,7 +131,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, IEnumerable<DynamicJsonValue> items, JsonOperationContext context)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, IEnumerable<DynamicJsonValue> items, JsonOperationContext context)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -144,7 +150,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 
@@ -200,7 +207,8 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray(this AbstractBlittableJsonTextWriter writer, string name, IEnumerable<long> items)
+        public static void WriteArray<TWriter>(this TWriter writer, string name, IEnumerable<long> items)
+            where TWriter : IBlittableJsonTextWriter
         {
             writer.WritePropertyName(name);
 

--- a/src/Sparrow/Json/IBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/IBlittableJsonTextWriter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Sparrow.Json;
+
+public interface IBlittableJsonTextWriter
+{
+    void WriteObject(BlittableJsonReaderObject obj);
+    void WriteValue(BlittableJsonToken token, object val);
+    int WriteDateTime(DateTime? value, bool isUtc);
+    int WriteDateTime(DateTime value, bool isUtc);
+    void WriteString(string str, bool skipEscaping = false);
+    void WriteString(LazyStringValue str, bool skipEscaping = false);
+    void WriteString(LazyCompressedStringValue str);
+
+    void WriteStartObject();
+    void WriteEndObject();
+
+    void WriteStartArray();
+    void WriteEndArray();
+
+    
+
+    void WriteNull();
+    void WriteBool(bool val);
+    void WritePropertyName(ReadOnlySpan<byte> prop);
+
+    void WritePropertyName(string prop);
+    void WritePropertyName(StringSegment prop);
+
+    void WriteInteger(long val);
+    void WriteDouble(LazyNumberValue val);
+    void WriteDouble(double val);
+
+    void WriteNewLine();
+    void WriteComma();
+}

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -457,13 +457,13 @@ namespace Sparrow.Json
             using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
             {
 #endif
-                EnsureNotDisposed();
-                LazyStringValue value = GetLazyString(key, longLived: true);
-                _fieldNames[key.Value] = value;
+            EnsureNotDisposed();
+            LazyStringValue value = GetLazyString(key, longLived: true);
+            _fieldNames[key.Value] = value;
 
-                //sanity check, in case the 'value' is manually disposed outside of this function
-                Debug.Assert(value.IsDisposed == false);
-                return value;
+            //sanity check, in case the 'value' is manually disposed outside of this function
+            Debug.Assert(value.IsDisposed == false);
+            return value;
 #if DEBUG || VALIDATE
             }
 #endif
@@ -978,13 +978,15 @@ namespace Sparrow.Json
             }
         }
 
-        public void Write(AbstractBlittableJsonTextWriter writer, BlittableJsonReaderObject json)
+        public void Write<TWriter>(TWriter writer, BlittableJsonReaderObject json)
+            where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
             WriteInternal(writer, json);
         }
 
-        private void WriteInternal(AbstractBlittableJsonTextWriter writer, object json)
+        private void WriteInternal<TWriter>(TWriter writer, object json)
+            where TWriter : IBlittableJsonTextWriter
         {
             _jsonParserState.Reset();
             _objectJsonParser.Reset(json);
@@ -996,13 +998,15 @@ namespace Sparrow.Json
             _objectJsonParser.Reset(null);
         }
 
-        public void Write(AbstractBlittableJsonTextWriter writer, DynamicJsonValue json)
+        public void Write<TWriter>(TWriter writer, DynamicJsonValue json)
+            where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
             WriteInternal(writer, json);
         }
 
-        public void Write(AbstractBlittableJsonTextWriter writer, DynamicJsonArray json)
+        public void Write<TWriter>(TWriter writer, DynamicJsonArray json)
+            where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
             _jsonParserState.Reset();
@@ -1015,7 +1019,8 @@ namespace Sparrow.Json
             _objectJsonParser.Reset(null);
         }
 
-        public void WriteObject(AbstractBlittableJsonTextWriter writer, JsonParserState state, ObjectJsonParser parser)
+        public void WriteObject<TWriter>(TWriter writer, JsonParserState state, ObjectJsonParser parser)
+            where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
             if (state.CurrentTokenType != JsonParserToken.StartObject)
@@ -1053,7 +1058,9 @@ namespace Sparrow.Json
             writer.WriteEndObject();
         }
 
-        private void WriteValue(AbstractBlittableJsonTextWriter writer, JsonParserState state, ObjectJsonParser parser)
+
+        private void WriteValue<TWriter>(TWriter writer, JsonParserState state, ObjectJsonParser parser)
+            where TWriter: IBlittableJsonTextWriter
         {
             switch (state.CurrentTokenType)
             {
@@ -1119,7 +1126,8 @@ namespace Sparrow.Json
             }
         }
 
-        public void WriteArray(AbstractBlittableJsonTextWriter writer, JsonParserState state, ObjectJsonParser parser)
+        public void WriteArray<TWriter>( TWriter writer, JsonParserState state, ObjectJsonParser parser)
+            where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
             if (state.CurrentTokenType != JsonParserToken.StartArray)

--- a/src/Sparrow/Json/Sync/BlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/Sync/BlittableJsonTextWriter.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Sparrow.Json.Sync
 {
-    internal class BlittableJsonTextWriter : AbstractBlittableJsonTextWriter, IDisposable
+    internal sealed class BlittableJsonTextWriter : AbstractBlittableJsonTextWriter, IDisposable
     {
         public BlittableJsonTextWriter(JsonOperationContext context, Stream stream) : base(context, stream)
         {
@@ -15,7 +15,6 @@ namespace Sparrow.Json.Sync
             DisposeInternal();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Flush()
         {
             FlushInternal();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-18884

### Additional description

Original implementation changed the BlittableJsonTextWriter to have a virtual call whenever a new object was created and when `EnsureBuffer` was called. This is a very costly operation that has to be avoided at all cost. This alternative implementation uses generic calls that are very likely to be devirtualized by the JIT therefore while it aint pretty, it is effective in the general use case. 

### Type of change
- Regression bug fix

### How risky is the change?
- Moderate 

### Backward compatibility
- Non breaking change