### PR TITLE
RavenDB-20608-2 - handle replicated attachments

### DIFF
--- a/src/Raven.Server/Documents/AttachmentOrTombstone.cs
+++ b/src/Raven.Server/Documents/AttachmentOrTombstone.cs
@@ -1,0 +1,42 @@
+﻿using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Voron;
+
+namespace Raven.Server.Documents
+{
+    public class AttachmentOrTombstone
+    {
+        public Attachment Attachment;
+        public Tombstone Tombstone;
+        public bool Missing => Attachment == null && Tombstone == null;
+
+        public static AttachmentOrTombstone GetAttachmentOrTombstone(DocumentsOperationContext context, Slice attachmentKey)
+        {
+            var attachment = AttachmentsStorage.GetAttachmentByKey(context, attachmentKey);
+            if (attachment != null)
+            {
+                return new AttachmentOrTombstone
+                {
+                    Attachment = attachment
+                };
+            }
+
+            var tombstone = AttachmentsStorage.GetAttachmentTombstoneByKey(context, attachmentKey);
+            if (tombstone != null)
+            {
+                return new AttachmentOrTombstone
+                {
+                    Tombstone = tombstone
+                };
+            }
+
+            return new AttachmentOrTombstone();
+        }
+
+        public static ConflictStatus GetConflictStatus(string remoteAsString, AttachmentOrTombstone attachmentOrTombstone, out string existingChangeVector)
+        {
+            existingChangeVector = attachmentOrTombstone.Attachment?.ChangeVector ?? attachmentOrTombstone.Tombstone?.ChangeVector;
+            return ChangeVectorUtils.GetConflictStatus(remoteAsString, existingChangeVector);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/AttachmentOrTombstone.cs
+++ b/src/Raven.Server/Documents/AttachmentOrTombstone.cs
@@ -1,5 +1,4 @@
 ﻿using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Voron;
 
 namespace Raven.Server.Documents
@@ -8,7 +7,9 @@ namespace Raven.Server.Documents
     {
         public Attachment Attachment;
         public Tombstone Tombstone;
+
         public bool Missing => Attachment == null && Tombstone == null;
+        public string ChangeVector => Attachment?.ChangeVector ?? Tombstone?.ChangeVector;
 
         public static AttachmentOrTombstone GetAttachmentOrTombstone(DocumentsOperationContext context, Slice attachmentKey)
         {
@@ -31,12 +32,6 @@ namespace Raven.Server.Documents
             }
 
             return new AttachmentOrTombstone();
-        }
-
-        public static ConflictStatus GetConflictStatus(string remoteAsString, AttachmentOrTombstone attachmentOrTombstone, out string existingChangeVector)
-        {
-            existingChangeVector = attachmentOrTombstone.Attachment?.ChangeVector ?? attachmentOrTombstone.Tombstone?.ChangeVector;
-            return ChangeVectorUtils.GetConflictStatus(remoteAsString, existingChangeVector);
         }
     }
 }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -745,7 +745,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public Attachment GetAttachmentByKey(DocumentsOperationContext context, Slice key)
+        public static Attachment GetAttachmentByKey(DocumentsOperationContext context, Slice key)
         {
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
 
@@ -1168,36 +1168,6 @@ namespace Raven.Server.Documents
                 if (attachmentFoundInResolveDocument == false)
                     DeleteAttachmentDirect(context, lowerId, conflictName, conflictContentType, conflictHash, changeVector);
             }
-        }
-
-        public struct AttachmentOrTombstone
-        {
-            public Attachment Attachment;
-            public Tombstone Tombstone;
-            public bool Missing => Attachment == null && Tombstone == null;
-        }
-
-        public AttachmentOrTombstone GetAttachmentOrTombstone(DocumentsOperationContext context, Slice attachmentKey)
-        {
-            var attachment = GetAttachmentByKey(context, attachmentKey);
-            if (attachment != null)
-            {
-                return new AttachmentOrTombstone
-                {
-                    Attachment = attachment
-                };
-            }
-
-            var tombstone = GetAttachmentTombstoneByKey(context, attachmentKey);
-            if (tombstone != null)
-            {
-                return new AttachmentOrTombstone
-                {
-                    Tombstone = tombstone
-                };
-            }
-
-            return new AttachmentOrTombstone();
         }
 
         private void DeleteAttachmentDirect(DocumentsOperationContext context, Slice lowerId, LazyStringValue conflictName,

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1170,6 +1170,36 @@ namespace Raven.Server.Documents
             }
         }
 
+        public struct AttachmentOrTombstone
+        {
+            public Attachment Attachment;
+            public Tombstone Tombstone;
+            public bool Missing => Attachment == null && Tombstone == null;
+        }
+
+        public AttachmentOrTombstone GetAttachmentOrTombstone(DocumentsOperationContext context, Slice attachmentKey)
+        {
+            var attachment = GetAttachmentByKey(context, attachmentKey);
+            if (attachment != null)
+            {
+                return new AttachmentOrTombstone
+                {
+                    Attachment = attachment
+                };
+            }
+
+            var tombstone = GetAttachmentTombstoneByKey(context, attachmentKey);
+            if (tombstone != null)
+            {
+                return new AttachmentOrTombstone
+                {
+                    Tombstone = tombstone
+                };
+            }
+
+            return new AttachmentOrTombstone();
+        }
+
         private void DeleteAttachmentDirect(DocumentsOperationContext context, Slice lowerId, LazyStringValue conflictName,
             LazyStringValue conflictContentType, LazyStringValue conflictHash, string changeVector)
         {

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1157,10 +1157,10 @@ namespace Raven.Server.Documents.Replication
                                 toDispose.Add(DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.Name, out _, out Slice attachmentName));
                                 toDispose.Add(DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.ContentType, out _, out Slice contentType));
 
-                                var newChangeVector = AttachmentOrTombstone.GetConflictStatus(attachment.ChangeVector, result, out string localChangeVector) switch
+                                var newChangeVector = ChangeVectorUtils.GetConflictStatus(attachment.ChangeVector, result.ChangeVector) switch
                                 {
                                     // we don't need to worry about the *contents* of the attachments, that is handled by the conflict detection during document replication
-                                    ConflictStatus.Conflict => ChangeVectorUtils.MergeVectors(attachment.ChangeVector, localChangeVector),
+                                    ConflictStatus.Conflict => ChangeVectorUtils.MergeVectors(attachment.ChangeVector, result.ChangeVector),
                                     ConflictStatus.Update => attachment.ChangeVector,
                                     ConflictStatus.AlreadyMerged => null, // nothing to do
                                     _ => throw new ArgumentOutOfRangeException()
@@ -1176,7 +1176,7 @@ namespace Raven.Server.Documents.Replication
                             case AttachmentTombstoneReplicationItem attachmentTombstone:
                                 
                                 var attachmentOrTombstone = AttachmentOrTombstone.GetAttachmentOrTombstone(context, attachmentTombstone.Key);
-                                if (AttachmentOrTombstone.GetConflictStatus(item.ChangeVector, attachmentOrTombstone, out _) == ConflictStatus.AlreadyMerged)
+                                if (ChangeVectorUtils.GetConflictStatus(item.ChangeVector, attachmentOrTombstone.ChangeVector) == ConflictStatus.AlreadyMerged)
                                     continue;
 
                                 string documentId = CompoundKeyHelper.ExtractDocumentId(attachmentTombstone.Key); 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20608/Excessive-number-of-revisions-after-replication-from-sharded-to-non-sharded

### Additional description

Changing the behavior of `GetConflictStatus` for `Attachment` and `AttachmentTombstone.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
