### PR TITLE
RavenDB-21181 - SlowTests.Sharding.Replication.ShardedExternalReplica…

### DIFF
--- a/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
+++ b/test/SlowTests/Sharding/Replication/ShardedExternalReplicationTests.cs
@@ -614,7 +614,12 @@ namespace SlowTests.Sharding.Replication
                 await SetupReplicationAsync(src, dst);
                 await SetupReplicationAsync(dst, src);
 
-                Assert.True(WaitForDocument(dst, "users/1", 30_000));
+                Assert.True(await WaitForDocumentInClusterAsync<User>(
+                    dstNodes,
+                    dst.Database,
+                    "users/1",
+                    u => u.Name.Equals("Karmel"),
+                    TimeSpan.FromSeconds(60)));
 
                 using (var session = dst.OpenSession())
                 {


### PR DESCRIPTION
…tionTests.BidirectionalReplicationWithReshardingShouldWork(source:  DatabaseMode = Sharded, destination:  DatabaseMode = Sharded)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21181/SlowTests.Sharding.Replication.ShardedExternalReplicationTests.BidirectionalReplicationWithReshardingShouldWorksource

### Additional description

I managed to reproduce the failure by changing `dst` topology (move node from `Members` to `Rehabs`) before document `"users/1"` reached all `dstNodes`. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
