### PR TITLE
RavenDB-21460 Override label text for Cloud

### DIFF
--- a/src/Raven.Studio/typescript/components/common/LicenseRestrictedBadge.tsx
+++ b/src/Raven.Studio/typescript/components/common/LicenseRestrictedBadge.tsx
@@ -1,6 +1,8 @@
 ﻿import { Badge } from "reactstrap";
 import React from "react";
 import classNames from "classnames";
+import { useAppSelector } from "components/store";
+import { licenseSelectors } from "./shell/licenseSlice";
 
 export type LicenseBadgeText = "Professional +" | "Enterprise";
 
@@ -10,14 +12,22 @@ interface LicenseRestrictedBadgeProps {
 }
 
 export default function LicenseRestrictedBadge({ className, licenseRequired }: LicenseRestrictedBadgeProps) {
+    const isCloud = useAppSelector(licenseSelectors.statusValue("IsCloud"));
+
     return (
-        <Badge className={classNames("ms-2 license-restricted-badge", className, getClassName(licenseRequired))}>
-            {licenseRequired}
+        <Badge
+            className={classNames("ms-2 license-restricted-badge", className, getClassName(licenseRequired, isCloud))}
+        >
+            {isCloud ? "Production" : licenseRequired}
         </Badge>
     );
 }
 
-function getClassName(licenseBadgeText: LicenseBadgeText) {
+function getClassName(licenseBadgeText: LicenseBadgeText, isCloud: boolean): "enterprise" | "professional" {
+    if (isCloud) {
+        return "enterprise";
+    }
+
     switch (licenseBadgeText) {
         case "Enterprise":
             return "enterprise";


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21460

### Additional description
Override license label text for Cloud

### Type of change
- Optimization

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
