### PR TITLE
RavenDB-21315 - Change vector with the MOVE element leaked to non-sha…

### DIFF
--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -5,6 +5,7 @@ using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Senders
@@ -26,12 +27,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected override bool ShouldSkip(DocumentsOperationContext context, ReplicationBatchItem item, OutgoingReplicationStatsScope stats, SkippedReplicationItemsInfo skippedReplicationItemsInfo)
         {
-            var changeVector = context.GetChangeVector(item.ChangeVector);
-            var changeVectorOrder = changeVector.Order.StripMoveTag(context);
-            item.ChangeVector = changeVector.IsSingle ? 
-                changeVectorOrder : 
-                context.GetChangeVector(changeVector.Version, changeVectorOrder);
-
+            item.ChangeVector = ChangeVector.StripMoveTag(item.ChangeVector, context);
             return base.ShouldSkip(context, item, stats, skippedReplicationItemsInfo);
         }
     }

--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -26,7 +26,12 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected override bool ShouldSkip(DocumentsOperationContext context, ReplicationBatchItem item, OutgoingReplicationStatsScope stats, SkippedReplicationItemsInfo skippedReplicationItemsInfo)
         {
-            item.ChangeVector = context.GetChangeVector(item.ChangeVector).Order.StripMoveTag(context);
+            var changeVector = context.GetChangeVector(item.ChangeVector);
+            var changeVectorOrder = changeVector.Order.StripMoveTag(context);
+            item.ChangeVector = changeVector.IsSingle ? 
+                changeVectorOrder : 
+                context.GetChangeVector(changeVector.Version, changeVectorOrder);
+
             return base.ShouldSkip(context, item, stats, skippedReplicationItemsInfo);
         }
     }

--- a/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ExternalReplicationDocumentSender.cs
@@ -2,6 +2,9 @@
 using System.IO;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Replication.Senders
@@ -19,6 +22,12 @@ namespace Raven.Server.Documents.Replication.Senders
 
             _parent._parent._server.LicenseManager.AssertCanDelayReplication(external.DelayReplicationFor);
             return external.DelayReplicationFor;
+        }
+
+        protected override bool ShouldSkip(DocumentsOperationContext context, ReplicationBatchItem item, OutgoingReplicationStatsScope stats, SkippedReplicationItemsInfo skippedReplicationItemsInfo)
+        {
+            item.ChangeVector = context.GetChangeVector(item.ChangeVector).Order.StripMoveTag(context);
+            return base.ShouldSkip(context, item, stats, skippedReplicationItemsInfo);
         }
     }
 }

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -317,6 +317,8 @@ public sealed class ChangeVector
 
     public ChangeVector StripMoveTag(IChangeVectorOperationContext context) => StripTags(ChangeVectorParser.MoveTag, exclude: null, context);
 
+    public static ChangeVector StripMoveTag(string changeVectorStr, IChangeVectorOperationContext context) => context.GetChangeVector(changeVectorStr).StripMoveTag(context);
+
     public ChangeVector StripTrxnTags(IChangeVectorOperationContext context) => StripTags(ChangeVectorParser.TrxnTag, exclude: null, context);
 
     public ChangeVector StripSinkTags(string exclude, IChangeVectorOperationContext context) => StripTags(ChangeVectorParser.SinkTag, exclude, context);

--- a/test/SlowTests/Sharding/Issues/RavenDB_21315.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_21315.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_21315 : ReplicationTestBase
+    {
+        public RavenDB_21315(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Sharding)]
+        public async Task ChangeVectorWithMoveTagShouldNotLeakToNonShardedAfterResharding()
+        {
+            using (var store1 = Sharding.GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                var id = "users/shiran";
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User {Name = "Shiran"}, id);
+                    await session.SaveChangesAsync();
+                }
+
+                await Sharding.Resharding.MoveShardForId(store1, id);
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var stats2 = await GetDatabaseStatisticsAsync(store2);
+                Assert.NotNull(stats2.DatabaseChangeVector);
+                Assert.False(stats2.DatabaseChangeVector.Contains("MOVE", StringComparison.OrdinalIgnoreCase));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…rded database after resharding

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21315/Change-vector-with-the-MOVE-element-leaked-to-non-sharded-database-after-resharding


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
