### PR TITLE
RavenDB-21425: Setup wizard should throw if using a 5.4 license

### DIFF
--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Web.System
                 if (licenseStatus.Version.Major < 6)
                 {
                     throw new LicenseLimitException(
-                        $"Your license ('{licenseStatus.Id}') version '{licenseStatus.Version}' doesn't allow you to use server version '{RavenVersionAttribute.Instance.FullVersion}'. " +
+                        $"Your license ('{licenseStatus.Id}') version '{licenseStatus.Version}' doesn't allow you to set up a server of version '{RavenVersionAttribute.Instance.FullVersion}'. " +
                         $"Please proceed to the https://ravendb.net/l/8O2YU1 website to perform the license upgrade first.");
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21425

### Additional description

The setup wizard should throw if using a 5.4 license due to new license limitations for v6.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed (?!)

![image](https://github.com/ravendb/ravendb/assets/7088748/a8623cde-666a-4aa2-8bfc-73c63b3471b5)
