### PR TITLE
RavenDB-21459 Remove sharded/nonsharded from db selector

### DIFF
--- a/src/Raven.Studio/typescript/components/models/databases.d.ts
+++ b/src/Raven.Studio/typescript/components/models/databases.d.ts
@@ -66,12 +66,7 @@ export interface ShardedDatabaseSharedInfo extends DatabaseSharedInfo {
     shards: DatabaseSharedInfo[];
 }
 
-export type DatabaseFilterByStateOption =
-    | Exclude<MergedDatabaseState, "Partially Online">
-    | "Sharded"
-    | "NonSharded"
-    | "Local"
-    | "Remote";
+export type DatabaseFilterByStateOption = Exclude<MergedDatabaseState, "Partially Online"> | "Local" | "Remote";
 
 export interface DatabaseFilterCriteria {
     name: string;

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
@@ -74,8 +74,6 @@ const selectFilterByStateOptions = (store: RootState): InputItem<DatabaseFilterB
         { value: "Offline", label: "Offline", count: offline },
         { value: "Error", label: "Errored", count: error },
         { value: "Disabled", label: "Disabled", count: disabled },
-        { value: "Sharded", label: "Sharded", count: sharded, verticalSeparatorLine: true },
-        { value: "NonSharded", label: "Non Sharded", count: nonSharded },
         {
             value: "Local",
             label: `Local (Node ${localNodeTag})`,

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewSelectors.ts
@@ -20,8 +20,6 @@ const selectFilterByStateOptions = (store: RootState): InputItem<DatabaseFilterB
         offline = 0,
         disabled = 0,
         online = 0,
-        sharded = 0,
-        nonSharded = 0,
         local = 0,
         remote = 0;
 
@@ -52,12 +50,6 @@ const selectFilterByStateOptions = (store: RootState): InputItem<DatabaseFilterB
                 break;
             default:
                 assertUnreachable(state);
-        }
-
-        if (db.sharded) {
-            sharded++;
-        } else {
-            nonSharded++;
         }
 
         if (perNodeState.some((x) => x.location.nodeTag === localNodeTag)) {
@@ -110,15 +102,6 @@ const isDatabaseInFilterState = (
     db: DatabaseSharedInfo,
     filterStates: DatabaseFilterByStateOption[]
 ): boolean => {
-    const matchesSharding =
-        !filterStates.some((x) => ["Sharded", "NonSharded"].includes(x)) ||
-        (filterStates.includes("Sharded") && db.sharded) ||
-        (filterStates.includes("NonSharded") && !db.sharded);
-
-    if (!matchesSharding) {
-        return false;
-    }
-
     const perNodeStates = selectDatabaseState(db.name)(store);
     const databaseState = DatabaseUtils.getDatabaseState(db, perNodeStates);
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21459

### Additional description
Removed sharded/nonsharded from the filtering selector

### Type of change
- Optimization

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
