### PR TITLE
RavenDB-21449: Handle license limits in `PutSubscriptionBatchCommand` and `PutShardedSubscriptionBatchCommand`

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -191,6 +191,8 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             throw new NotImplementedException();
         }
 
+        public bool IncludesRevisions() => Query.Contains(DocumentSubscriptions.IncludeRevisionsRQL);
+
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(Query)] = Query;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21449

### Additional description

We want to handle license limits in `PutSubscriptionBatchCommand` and `PutShardedSubscriptionBatchCommand` too

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed