### PR TITLE
RavenDB-21466 incoming replication should ignore any revision policy

### DIFF
--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -17,8 +17,10 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
+using Raven.Client.Json;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
@@ -3113,8 +3115,8 @@ namespace SlowTests.Client.Attachments
                 }
             }
         }
-        
-            [Fact]
+
+        [Fact]
         public async Task ConflictOfAttachmentAndDocument3StoresDifferentLastModifiedOrder_RevisionsDisabled_MissingAttachmentLoop()
         {
             var options = new Options

--- a/test/SlowTests/Client/RavenDB_21466.cs
+++ b/test/SlowTests/Client/RavenDB_21466.cs
@@ -11,7 +11,6 @@ using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using static FastTests.RavenTestBase;
 
 namespace SlowTests.Client
 {
@@ -21,7 +20,7 @@ namespace SlowTests.Client
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
         public async Task MissingRevisionTombstone()
         {
             var cluster = await CreateRaftCluster(2, watcherCluster: true);
@@ -78,7 +77,7 @@ namespace SlowTests.Client
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
         public async Task MissingTimeSeriesSnapshot()
         {
             var cluster = await CreateRaftCluster(2, watcherCluster: true);
@@ -139,7 +138,7 @@ namespace SlowTests.Client
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Counters)]
         public async Task MissingCounterSnapshot()
         {
             var cluster = await CreateRaftCluster(2, watcherCluster: true);

--- a/test/SlowTests/Client/RavenDB_21466.cs
+++ b/test/SlowTests/Client/RavenDB_21466.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Json;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static FastTests.RavenTestBase;
+
+namespace SlowTests.Client
+{
+    public class RavenDB_21466 : ReplicationTestBase
+    {
+        public RavenDB_21466(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task MissingRevisionTombstone()
+        {
+            var cluster = await CreateRaftCluster(2, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = cluster.Leader,
+                       ReplicationFactor = 1
+                   }))
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration()
+                }));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete("foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        PurgeOnDelete = true
+                    }
+                }));
+
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges();
+                    await session.StoreAsync(new User(), "foo/bar2");
+                    await session.SaveChangesAsync();
+                }
+
+                foreach (var server in Servers)
+                {
+                    var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    using(database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        var count = database.DocumentsStorage.RevisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, long.MaxValue).Count();
+                        Assert.Equal(1, count);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task MissingTimeSeriesSnapshot()
+        {
+            var cluster = await CreateRaftCluster(2, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = cluster.Leader,
+                       ReplicationFactor = 1,
+                   }))
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration()
+                }));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "foo/bar");
+                    session.TimeSeriesFor("foo/bar", "likes").Append(DateTime.UtcNow, 1);
+                    session.TimeSeriesFor("foo/bar", "views").Append(DateTime.UtcNow, 2);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete("foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+
+                await WaitAndAssertForValueAsync(async () => await GetMembersCount(store), 2);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges();
+                    await session.StoreAsync(new User(), "foo/bar2");
+                    await session.SaveChangesAsync();
+                }
+                
+                await Task.Delay(3000);
+
+                var toRemove = record.Topology.AllNodes.Contains("A") ? "A" : "B";
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: true, fromNode: toRemove));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var rv = await session.Advanced.Revisions.GetForAsync<User>( "foo/bar");
+                    // TODO: Assert.Equal(2, rv.Count);
+                    Assert.Equal(4, rv.Count);
+
+                    var metadatas = rv.Select(c => (MetadataAsDictionary)session.Advanced.GetMetadataFor(c)).ToList();
+
+                    Assert.True(metadatas[1].ContainsKey(Constants.Documents.Metadata.RevisionTimeSeries));
+                    Assert.True(metadatas[2].ContainsKey(Constants.Documents.Metadata.RevisionTimeSeries));
+                }
+
+            }
+        }
+
+        [Fact]
+        public async Task MissingCounterSnapshot()
+        {
+            var cluster = await CreateRaftCluster(2, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = cluster.Leader,
+                       ReplicationFactor = 1,
+                   }))
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration()
+                }));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "foo/bar");
+                    session.CountersFor("foo/bar").Increment("likes", 1);
+                    session.CountersFor("foo/bar").Increment("views", 1);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete("foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));
+
+                await WaitAndAssertForValueAsync(async () => await GetMembersCount(store), 2);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges();
+                    await session.StoreAsync(new User(), "foo/bar2");
+                    await session.SaveChangesAsync();
+                }
+
+                await Task.Delay(3000);
+
+                var toRemove = record.Topology.AllNodes.Contains("A") ? "A" : "B";
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: true, fromNode: toRemove));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var rv = await session.Advanced.Revisions.GetForAsync<User>( "foo/bar");
+                    // TODO: Assert.Equal(2, rv.Count);
+                    Assert.Equal(3, rv.Count);
+
+                    var metadatas = rv.Select(c => (MetadataAsDictionary)session.Advanced.GetMetadataFor(c)).ToList();
+
+                    Assert.True(metadatas[1].ContainsKey(Constants.Documents.Metadata.RevisionCounters));
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21466 

### Additional description

- When `PurgeOnDelete` is ON, we took that into account during the incoming replication and remove all revisions.
The destination shouldn't have a "say" in regards to the revision policy.
We should enforce the policy only on the node that actually to modification to the document.

- The `@counters-snapshot` & `@timeseries-snapshot` were missing in the revisions after replication

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
