### PR TITLE
RavenDB-21448 Tag 6.0 Docker images with *latest tags

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -35,8 +35,8 @@ function GetUbuntuImageTags($repo, $version, $arch) {
     switch ($arch) {
         "x64" { 
             return @(
-                # "$($repo):latest",
-                # "$($repo):ubuntu-latest",
+                "$($repo):latest",
+                "$($repo):ubuntu-latest",
                 "$($repo):6.0-ubuntu-latest",
                 "$($repo):$($version)-ubuntu.22.04-x64"
             )
@@ -44,7 +44,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm32v7" {
             return @(
-                # "$($repo):ubuntu-arm32v7-latest",
+                "$($repo):ubuntu-arm32v7-latest",
                 "$($repo):6.0-ubuntu-arm32v7-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm32v7"
             )
@@ -52,7 +52,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm64v8" {
             return @(
-                # "$($repo):ubuntu-arm64v8-latest",
+                "$($repo):ubuntu-arm64v8-latest",
                 "$($repo):6.0-ubuntu-arm64v8-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm64v8"
                 )
@@ -70,7 +70,7 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         "1809" {
             return @(
                 "$($repo):$($version)-windows-1809",
-                # "$($repo):windows-1809-latest",
+                "$($repo):windows-1809-latest",
                 "$($repo):6.0-windows-1809-latest"
             )
             break;
@@ -78,7 +78,7 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         "ltsc2022" {
              return @(
                 "$($repo):$($version)-windows-ltsc2022",
-                # "$($repo):windows-ltsc2022-latest",
+                "$($repo):windows-ltsc2022-latest",
                 "$($repo):6.0-windows-ltsc2022-latest"
             )
             break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21448/Check-docker-tags-for-6.0-release
