### PR TITLE
RavenDB-21471 Vectorized And will check memory boundaries before loading values into vector.

### DIFF
--- a/src/Corax/Queries/Meta/MergeHelper.cs
+++ b/src/Corax/Queries/Meta/MergeHelper.cs
@@ -59,7 +59,7 @@ namespace Corax.Queries.Meta
                 largerEndPtr = left + leftLength;
                 applyVectorization = leftLength > N && rightLength > 0;
             }
-            
+
             if (applyVectorization)
             {
                 while (true)
@@ -86,6 +86,9 @@ namespace Corax.Queries.Meta
 
                         continue;
                     }
+
+                    if (largerEndPtr - largerPtr < N)
+                        break; //In case when block is smaller than N we've to use scalar version.
 
                     Vector256<ulong> value = Vector256.Create((ulong)*smallerPtr);
                     Vector256<ulong> blockValues = Avx.LoadVector256((ulong*)largerPtr);

--- a/src/Corax/Queries/TermMatch.cs
+++ b/src/Corax/Queries/TermMatch.cs
@@ -453,6 +453,9 @@ namespace Corax.Queries
                                     continue;
                                 }
 
+                                if (largerEndPtr - largerPtr < N)
+                                    break; // boundary guardian for vector load.
+                                
                                 Vector256<ulong> value = Vector256.Create((ulong)*smallerPtr);
                                 Vector256<ulong> blockValues = Avx.LoadVector256((ulong*)largerPtr);
 

--- a/test/FastTests/Corax/Bugs/RavenDB-21471.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21471.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Corax.Queries.Meta;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs
+{
+    public class RavenDB_21471 : RavenTestBase
+    {
+        public RavenDB_21471(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void VectorizedAndWillNotAccessMemoryOutOfRange()
+        {
+            const int size = 6;
+            var buffer = new byte[3 * sizeof(long) * size];
+            var longBuffer = MemoryMarshal.Cast<byte, long>(buffer);
+
+            var left = longBuffer.Slice(size, size);
+            left[0] = 5708;
+            left[1] = 5709;
+
+            var right = longBuffer.Slice(0, size);
+            (new long[] {763, 764, 941, 942, 946, 966}).AsSpan().CopyTo(right);
+            var outputBuffer = longBuffer.Slice(2 * size, size);
+
+            var common = MergeHelper.And(outputBuffer, left.Slice(0,2), right);
+            
+            Assert.Equal(0, common);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21471 

### Additional description

In the case of contiguous memory, we accessed another array with a vector load.

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
