### PR TITLE
RavenDB-21369 - SlowTests.Sharding.Cluster.SubscriptionsWithReshardingTests.ContinueSubscriptionAfterReshardingInAClusterRF1WithOrchestratorFailover

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -117,7 +117,7 @@ public partial class RavenTestBase
             if (token.CanBeCanceled)
                 return null;
 
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
             token = cts.Token;
             return cts;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21369

Temporary fix. See https://issues.hibernatingrhinos.com/issue/RavenDB-21423
