### PR TITLE
RavenDB-21374 Indexing details for Corax dictionary training

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -253,6 +253,8 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
                 if (itemEnumerator.MoveNext(_docsContext, out var mapResults, out _) == false)
                     break;
 
+                _indexingStatsScope.RecordMapAttempt();
+                
                 var doc = (Document)itemEnumerator.Current.Item;
 
                 foreach (var result in mapResults)
@@ -263,8 +265,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
                     foreach (var item in builder.Buffer)
                         yield return item;
                 }
-
-                _indexingStatsScope.RecordMapAttempt();
+                
                 _indexingStatsScope.RecordMapSuccess();
                 _indexingStatsScope.RecordDocumentSize(doc.Data.Size);
                 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -131,7 +131,7 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
         var documentStorage = _index.DocumentDatabase.DocumentsStorage;
         
         using var scope = indexingStatsAggregator.CreateScope();
-        using var _ = scope.For(IndexingOperation.Corax.DictionaryTraining);
+        using var indexingStatsScope = scope.For(IndexingOperation.Corax.DictionaryTraining);
         using var __ = CultureHelper.EnsureInvariantCulture();
         using var ___ = contextPool.AllocateOperationContext(out TransactionOperationContext indexContext);
         using var queryContext = QueryOperationContext.Allocate(_index.DocumentDatabase, _index);
@@ -148,7 +148,7 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             var converter = CreateConverter(_index);
             converter.IgnoreComplexObjectsDuringIndex = true; // for training, we don't care
             
-            var enumerator = new CoraxDocumentTrainEnumerator(indexContext, converter, _index, _index.Type, documentStorage, queryContext.Documents, _index.Collections, token, _index.Configuration.DocumentsLimitForCompressionDictionaryCreation);
+            var enumerator = new CoraxDocumentTrainEnumerator(indexContext, converter, _index, _index.Type, documentStorage, queryContext.Documents, _index.Collections, token, indexingStatsScope, _index.Configuration.DocumentsLimitForCompressionDictionaryCreation);
 
             var llt = tx.InnerTransaction.LowLevelTransaction;
             var defaultDictionaryId = PersistentDictionary.CreateDefault(llt);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21374/Corax-Indexing-details-are-empty-for-dictionary-training-phase

### Additional description

Filling indexing details for Corax dictionary training

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
