### PR TITLE
RavenDB-21462

### DIFF
--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -47,13 +47,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(LazyStringValue obj)
         {
-            unsafe
-            {
-                //PERF: JIT will remove the corresponding line based on the target architecture using dead code removal.
-                if (IntPtr.Size == 4)
-                    return (int)Hashing.XXHash32.CalculateInline(obj.Buffer, obj.Size);
-                return (int)Hashing.XXHash64.CalculateInline(obj.Buffer, (ulong)obj.Size);
-            }
+            return obj.GetHashCode();
         }
     }
 


### PR DESCRIPTION
- GetLazyStringForFieldWithCaching in UnlikelyGetProperty is materializing LSV, because of that further lookups on _propertyNameToId dictionary will fail ending in ArgumentException (An item with the same key has already been added)
- LazyStringValueStructComparer should use built-in hashcode (same one) which takes leverage from caching inside LSV

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21462

### Type of change

- Bug fix

### How risky is the change?

- High

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works [TODO]

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
