### PR TITLE
RavenDB-21213 Support for CompoundFields for JavaScript indexes.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractGenericIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractGenericIndexCreationTask.cs
@@ -28,14 +28,9 @@ namespace Raven.Client.Documents.Indexes
             TermVectorsStrings = new Dictionary<string, FieldTermVector>();
             SpatialIndexes = new Dictionary<Expression<Func<TReduceResult, object>>, SpatialOptions>();
             SpatialIndexesStrings = new Dictionary<string, SpatialOptions>();
-            CompoundFieldsStrings = new List<string[]>();
             CompoundFields = new List<Expression<Func<TReduceResult, object>>[]>();
         }
 
-        /// <summary>
-        /// Expert: List of compound fields that Corax can use to optimize certain queries
-        /// </summary>
-        public List<string[]> CompoundFieldsStrings { get; set; }
         
         /// <summary>
         /// Expert: List of compound fields that Corax can use to optimize certain queries
@@ -222,11 +217,6 @@ namespace Raven.Client.Documents.Indexes
                 AdditionalAssemblies = new HashSet<AdditionalAssembly>();
 
             AdditionalAssemblies.Add(assembly);
-        }
-
-        protected void CompoundField(string firstField, string secondField)
-        {
-            CompoundFieldsStrings.Add(new[]{firstField, secondField});
         }
         
         protected void CompoundField(Expression<Func<TReduceResult, object>> first, Expression<Func<TReduceResult, object>> second)

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -204,7 +204,18 @@ namespace Raven.Client.Documents.Indexes
         {
             AsyncHelpers.RunSync(() => ExecuteAsync(store, conventions, database));
         }
-
+        
+        /// <summary>
+        /// Expert: List of compound fields that Corax can use to optimize certain queries
+        /// </summary>
+        public List<string[]> CompoundFieldsStrings { get; set; }
+        
+        protected void CompoundField(string firstField, string secondField)
+        {
+            CompoundFieldsStrings ??= new();
+            CompoundFieldsStrings.Add(new[]{firstField, secondField});
+        }
+        
         /// <summary>
         /// Executes the index creation against the specified document store.
         /// </summary>

--- a/src/Raven.Client/Documents/Indexes/AbstractJavaScriptIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractJavaScriptIndexCreationTask.cs
@@ -73,7 +73,7 @@ namespace Raven.Client.Documents.Indexes
             _definition.Priority = Priority;
             _definition.State = State;
             _definition.DeploymentMode = DeploymentMode;
-
+            _definition.CompoundFields = CompoundFieldsStrings;
             var definition = new IndexDefinition();
             _definition.CopyTo(definition);
 

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionBuilder.cs
@@ -165,7 +165,6 @@ namespace Raven.Client.Documents.Indexes
             SpatialIndexes = new Dictionary<Expression<Func<TReduceResult, object>>, SpatialOptions>();
             SpatialIndexesStrings = new Dictionary<string, SpatialOptions>();
             CompoundFields = new List<Expression<Func<TReduceResult, object>>[]>();
-            CompoundFieldsStrings = new List<string[]>();
             Configuration = new IndexConfiguration();
         }
 
@@ -178,7 +177,7 @@ namespace Raven.Client.Documents.Indexes
             {
                 if (Reduce != null)
                     IndexDefinitionHelper.ValidateReduce(Reduce);
-
+                CompoundFieldsStrings ??= new();
                 var indexDefinition = new TIndexDefinition
                 {
                     Name = _indexName,

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -859,9 +859,9 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public bool HasCompoundField(Slice first, Slice second, out int offset)
+        public bool HasCompoundField(Slice first, Slice second, out int bindingId)
         {
-            offset = 0;
+            bindingId = 0;
             if (_compoundFields == null)
                 return false;
             var span = CollectionsMarshal.AsSpan(_compoundFields);
@@ -871,7 +871,7 @@ namespace Raven.Server.Documents.Indexes
                 if (cur.First.AsSpan().SequenceEqual(first.AsSpan()) &&
                     cur.Second.AsSpan().SequenceEqual(second.AsSpan()))
                 {
-                    offset = span.Length - i;
+                    bindingId = 1 + Definition.IndexFields.Count - span.Length + i; // 1 is ID()/hash(key) field.
                     return true;
                 }
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -160,9 +160,9 @@ public static class CoraxQueryBuilder
 
             if (cbi.Field.Equals(SortField.Field) == false)
             {
-                if ( builderParameters.Index.HasCompoundField(cbi.Field.FieldName, SortField.Field.FieldName, out var offset))
+                if ( builderParameters.Index.HasCompoundField(cbi.Field.FieldName, SortField.Field.FieldName, out var bindingId))
                 {
-                    var indexFieldBinding = builderParameters.IndexFieldsMapping.GetByFieldId(builderParameters.IndexFieldsMapping.Count - offset);
+                    var indexFieldBinding = builderParameters.IndexFieldsMapping.GetByFieldId(bindingId);
                     CompoundField = FieldMetadata.Build(indexFieldBinding.FieldName, indexFieldBinding.FieldTermTotalSumField,
                         indexFieldBinding.FieldId, indexFieldBinding.FieldIndexingMode, indexFieldBinding.Analyzer);
                     MatchedByCompoundField = true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21213 

### Additional description

-Adding compoundField builder for javascript indexes.
-Adjusting Client API
-Changing the way of detecting compoundfield binding in query builder.

### Type of change

- Bug fix

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
