### PR TITLE
RavenDB-21488 Fixing an issue where splitting a branch page at the 2n…

### DIFF
--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -949,6 +949,9 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             // here we insert a minimum value as the first item of the branch
             var k = TLookupKey.FromLong<TLookupKey>(separatorKey);
             RemoveEntryFromPage(ref newPageState, ref k, 0, out var pageNum);
+            var childPage = _llt.GetPage(pageNum);
+            // we need to update the separator key here...
+            (separatorKey,_) = GetFirstActualKeyAndValue((LookupPageHeader*)childPage.Pointer);
             var requiredSize = EncodeEntry(newPageState.Header, TLookupKey.MinValue, pageNum, entryBufferPtr);
             newPageState.LastSearchPosition = 0;
             AddEntryToPage(ref newPageState, requiredSize, entryBufferPtr, false);


### PR DESCRIPTION
…d level would cause us to drop the separator key, now we'll get that from the right location

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21488 
