### PR TITLE
RavenDB-21483 for revision tombstone replication item the ownership of the id's LSV should be the context

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             return tempBufferPos;
         }
 
-        protected unsafe void SetLazyStringValue(DocumentsOperationContext context, ref LazyStringValue prop)
+        protected unsafe void SetLazyStringValue(JsonOperationContext context, ref LazyStringValue prop)
         {
             var size = *(int*)Reader.ReadExactly(sizeof(int));
             if (size < 0)

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -76,10 +76,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             {
                 stats.RecordRevisionTombstoneRead();
                 LastModifiedTicks = *(long*)Reader.ReadExactly(sizeof(long));
-
-                var size = *(int*)Reader.ReadExactly(sizeof(int));
-                Id = context.AllocateStringValue(null, Reader.ReadExactly(size), size);
-
+                
+                SetLazyStringValue(context, ref Id);
                 SetLazyStringValueFromString(context, out Collection);
                 Debug.Assert(Collection != null);
             }

--- a/test/SlowTests/Issues/RavenDB_20987.cs
+++ b/test/SlowTests/Issues/RavenDB_20987.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide.Context;
@@ -199,6 +203,98 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ReplicateRevisionTombstones(Options options)
+        {
+            var cluster = await CreateRaftCluster(3, watcherCluster: true);
+            
+            options.ReplicationFactor = 3;
+            options.ModifyDatabaseName = _ => "foo";
+            options.ModifyDocumentStore = s => s.Conventions = new DocumentConventions { DisableTopologyUpdates = true };
+
+            var o1 = options.Clone();
+            o1.Server = cluster.Nodes[0];
+
+            var o2 = options.Clone();
+            o2.Server = cluster.Nodes[1];
+            o2.CreateDatabase = false;
+
+            var o3 = options.Clone();
+            o3.Server = cluster.Nodes[2];
+            o3.CreateDatabase = false;
+
+            var id = $"users/1/{new string('x', 450)}";
+
+            using (var store1 = GetDocumentStore(o1))
+            using (var store2 = GetDocumentStore(o2))
+            using (var store3 = GetDocumentStore(o3))
+            using (var cts = new CancellationTokenSource())
+            {
+                var t1 = Run(store1, id, cts.Token);
+                var t2 = Run(store2, id, cts.Token);
+                var t3 = Run(store3, id, cts.Token);
+                
+                try
+                {
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        {
+                            var r = await session.Advanced.Revisions.GetCountForAsync(id);
+                            return r >= 1000;
+                        }
+                    }, true);
+
+                    await store1.Maintenance.Server.SendAsync(new ConfigureRevisionsForConflictsOperation(store1.Database,
+                        new RevisionsCollectionConfiguration { MaximumRevisionsToDeleteUponDocumentUpdate = 100, MinimumRevisionsToKeep = 10 }));
+
+                    await WaitForValueAsync(async () =>
+                    {
+                        using (var session = store1.OpenAsyncSession())
+                        {
+                            var r = await session.Advanced.Revisions.GetCountForAsync(id);
+                            return r <= 12;
+                        }
+                    }, true);
+                }
+                finally
+                {
+                    cts.Cancel();
+                }
+
+                await Task.WhenAll(t1, t2, t3);
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store3);
+                await EnsureReplicatingAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store3);
+                await EnsureReplicatingAsync(store3, store2);
+                await EnsureReplicatingAsync(store3, store1);
+            }
+        }
+
+        private static Task Run(DocumentStore store, string id, CancellationToken cancellationToken)
+        {
+            return Task.Run(async () =>
+            {
+                while (cancellationToken.IsCancellationRequested == false)
+                {
+                    try
+                    {
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User { Name = Guid.NewGuid().ToString() }, id, cancellationToken);
+                            await session.SaveChangesAsync(cancellationToken);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+            });
         }
 
         private async Task CheckData(IDocumentStore store, RavenDatabaseMode mode, string id, long expectedRevisionTombstones, long expectedAttachmentTombstones = 0)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21483

### Additional description

Move the ownership of the LSV to the context instead of the `Reader`, since the reader is simply a ring buffer to parse jsons from stream

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change, it is relevant only for 6.0


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
