### PR TITLE
RavenDB-21474 Periodic Backups - Save is not disabled for Sharded dbs

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -154,6 +154,7 @@ class editPeriodicBackupTask extends shardViewModelBase {
 
         if (this.db.isSharded()) {
             this.configuration().backupType("Backup");
+            this.dirtyFlag().reset();
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21474/Periodic-Backups-Save-is-not-disabled-for-Sharded-dbs

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
