### PR TITLE
RavenDB-20747 - Revert revisions After Resharding

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -448,9 +448,7 @@ namespace Raven.Server.Documents
 
             var changeVectorList = new List<ChangeVector>
             {
-                documentChangeVector,
-                context.GetChangeVector(context.LastDatabaseChangeVector ?? GetDatabaseChangeVector(context)),
-                context.GetChangeVector(ChangeVectorUtils.NewChangeVector(_documentDatabase, newEtag, context)),
+                documentChangeVector
             };
 
             foreach (var conflictChangeVector in result.ChangeVectors)
@@ -459,7 +457,9 @@ namespace Raven.Server.Documents
             }
 
             var merged = ChangeVector.Merge(changeVectorList, context);
-
+            merged = ChangeVector.MergeWithDatabaseChangeVector(context, merged);
+            merged = merged.MergeOrderWith(ChangeVectorUtils.NewChangeVector(_documentDatabase, newEtag, context), context);
+          
             return (merged, result.NonPersistentFlags);
         }
 

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1008,7 +1008,7 @@ namespace Raven.Server.Documents
                             }
                         }
 
-                        var changeVectorToSave = ChangeVector.MergeChangeVectors(putCountersData.ChangeVector, changeVector, context);
+                        var changeVectorToSave = ChangeVector.Merge(putCountersData.ChangeVector, changeVector, context);
 
                         using (Slice.External(context.Allocator, kvp.Key, out var countersGroupKey))
                         {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -38,7 +38,6 @@ using Voron.Data.Fixed;
 using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl;
-using Voron.Impl.Paging;
 using static Raven.Server.Documents.Schemas.Collections;
 using static Raven.Server.Documents.Schemas.Documents;
 using static Raven.Server.Documents.Schemas.Tombstones;
@@ -2530,10 +2529,7 @@ namespace Raven.Server.Documents
 
             if (fromReplication == false)
             {
-                context.LastDatabaseChangeVector ??= GetDatabaseChangeVector(context);
-                oldChangeVector = oldChangeVector == null
-                    ? context.LastDatabaseChangeVector
-                    : oldChangeVector.MergeWith(context.LastDatabaseChangeVector, context);
+                oldChangeVector = ChangeVector.MergeWithDatabaseChangeVector(context, oldChangeVector);
             }
 
             changeVector = SetDocumentChangeVectorForLocalChange(context, lowerId, oldChangeVector, newEtag);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -399,7 +399,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
                 var writeTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
 
                 var newEtag = GenerateNextEtag();
-                var cv = ChangeVector.Merge(context.LastDatabaseChangeVector, tombstoneChangeVector, context);
+                var cv = ChangeVector.MergeWithDatabaseChangeVector(context, tombstoneChangeVector);
                 var flags = tombstone.Flags | DocumentFlags.Artificial | DocumentFlags.FromResharding;
 
                 using (Slice.From(context.Allocator, cv, out var cvSlice))

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -950,7 +950,7 @@ namespace Raven.Server.Documents.TimeSeries
                     return ChangeVector.MergeWithNewDatabaseChangeVector(_context, ReadOnlyChangeVector, _currentEtag);
                 }
 
-                ChangeVector mergedChangeVector = ChangeVector.MergeChangeVectors(ReadOnlyChangeVector, ChangeVectorFromReplication, _context);
+                ChangeVector mergedChangeVector = ChangeVector.Merge(ReadOnlyChangeVector, ChangeVectorFromReplication, _context);
                 return ChangeVectorUtils.GetConflictStatus(ChangeVectorFromReplication, ReadOnlyChangeVector) switch
                 {
                     ConflictStatus.Update => mergedChangeVector,

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -183,7 +183,6 @@ public sealed class ChangeVector
         if (changeVector == null)
             return databaseChangeVector;
 
-        context.LastDatabaseChangeVector = databaseChangeVector.MergeOrderWith(changeVector, context);
         return changeVector.MergeOrderWith(context.LastDatabaseChangeVector, context);
     }
 
@@ -203,6 +202,13 @@ public sealed class ChangeVector
 
         if (changeVector == null)
             return databaseChangeVector;
+
+        if (changeVector.IsSingle == false)
+        {
+            var version = MergeWithDatabaseChangeVector(context, changeVector.Version);
+            var order = changeVector.Order.MergeOrderWith(databaseChangeVector, context);
+            return new ChangeVector(version, order);
+        }
 
         return MergeWithDatabaseChangeVector(context, changeVector);
     }

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -164,36 +164,27 @@ public sealed class ChangeVector
             return context.GetChangeVector(result);
         }
 
-        var orderMerge = ChangeVectorUtils.MergeVectors(cv1.Order._changeVector, cv2.Order._changeVector);
-        var versionMerge = ChangeVectorUtils.MergeVectors(cv1.Version._changeVector, cv2.Version._changeVector);
-        return context.GetChangeVector(versionMerge, orderMerge);
-    }
-
-    public static ChangeVector MergeChangeVectors(ChangeVector cv1, ChangeVector cv2, IChangeVectorOperationContext context)
-    {
-        if (cv1.IsNullOrEmpty)
-            return cv2;
-
-        if (cv2.IsNullOrEmpty)
-            return cv1;
-
-        if (cv1.IsSingle && cv2.IsSingle || cv1.IsSingle == false && cv2.IsSingle == false)
-            return Merge(cv1, cv2, context);
+        if (cv1.IsSingle == false && cv2.IsSingle == false)
+        {
+            var orderMerge = ChangeVectorUtils.MergeVectors(cv1.Order._changeVector, cv2.Order._changeVector);
+            var versionMerge = ChangeVectorUtils.MergeVectors(cv1.Version._changeVector, cv2.Version._changeVector);
+            return context.GetChangeVector(versionMerge, orderMerge);
+        }
 
         // we are keeping the existing order without merging it with the version of the single change vector
         var mergedOrder = cv2.IsSingle ? cv1.Order : cv2.Order;
-        var mergedVersion = Merge(cv1.Version, cv2.Version, context);
+        var mergedVersion = ChangeVectorUtils.MergeVectors(cv1.Version._changeVector, cv2.Version._changeVector);
         return context.GetChangeVector(mergedVersion, mergedOrder);
     }
 
-
-    public static void MergeWithDatabaseChangeVector(DocumentsOperationContext context, ChangeVector changeVector)
+    public static ChangeVector MergeWithDatabaseChangeVector(DocumentsOperationContext context, ChangeVector changeVector)
     {
+        var databaseChangeVector = context.LastDatabaseChangeVector ??= DocumentsStorage.GetDatabaseChangeVector(context);
         if (changeVector == null)
-            return;
+            return databaseChangeVector;
 
-        var databaseChangeVector = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
         context.LastDatabaseChangeVector = databaseChangeVector.MergeOrderWith(changeVector, context);
+        return changeVector.MergeOrderWith(context.LastDatabaseChangeVector, context);
     }
 
     public static void MergeWithDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
@@ -213,11 +204,7 @@ public sealed class ChangeVector
         if (changeVector == null)
             return databaseChangeVector;
 
-        if (changeVector.IsSingle)
-            return changeVector.MergeOrderWith(databaseChangeVector, context);
-
-        var mergedChangeVector = changeVector.MergeWith(databaseChangeVector, context);
-        return context.GetChangeVector(mergedChangeVector.Version, databaseChangeVector);
+        return MergeWithDatabaseChangeVector(context, changeVector);
     }
 
     public static ChangeVector MergeWithNewDatabaseChangeVector(DocumentsOperationContext context, string changeVector)

--- a/test/SlowTests/Issues/RavenDB-16614.cs
+++ b/test/SlowTests/Issues/RavenDB-16614.cs
@@ -134,13 +134,7 @@ namespace SlowTests.Issues
                 var arava = await session2.LoadAsync<User>("users/arava");
                 var cv = session2.Advanced.GetChangeVectorFor(arava);
                 var cti = cv.ToChangeVectorList().Where(x => x.NodeTag == ChangeVectorParser.TrxnInt).ToList();
-                if (options.DatabaseMode == RavenDatabaseMode.Single)
-                    Assert.Equal(2, cti.Count);
-                else
-                {
-                    // for sharded we have the following TRXN:12-aaa, RAFT:12-bbb | TRXN:12-aaa, RAFT:12-bbb, TRXN:44-xxx, RAFT:44-yyyy
-                    Assert.Equal(3, cti.Count);
-                }
+                Assert.Equal(2, cti.Count);
                 Assert.Equal("Arava", arava.Name);
             }
         }

--- a/test/SlowTests/Sharding/Issues/RavenDB_20747.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_20747.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_20747 : ReplicationTestBase
+    {
+        public RavenDB_20747(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Sharding)]
+        public async Task RevertRevisionsAfterResharding()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+                var id = "users/shiran";
+                DateTime last;
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, id);
+                    session.SaveChanges();
+                    last = DateTime.UtcNow;
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>(id);
+                    Assert.NotNull(user);
+                    user.Name = "Shiran2";
+                    session.SaveChanges();
+                }
+
+                var db0 = await GetDocumentDatabaseInstanceForAsync(store, RavenDatabaseMode.Sharded, id);
+
+                RevertResult result;
+                using (var token = new OperationCancelToken(db0.Configuration.Databases.OperationTimeout.AsTimeSpan, db0.DatabaseShutdown, CancellationToken.None))
+                {
+                    result = (RevertResult)await db0.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                Assert.Equal(2, result.ScannedRevisions);
+                Assert.Equal(1, result.ScannedDocuments);
+                Assert.Equal(1, result.RevertedDocuments);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var userRevisions = await session.Advanced.Revisions.GetForAsync<User>(id);
+                    Assert.Equal(3, userRevisions.Count);
+
+                    Assert.Equal("Shiran", userRevisions[0].Name);
+                    Assert.Equal("Shiran2", userRevisions[1].Name);
+                    Assert.Equal("Shiran", userRevisions[2].Name);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store, id, toShard: 1);
+
+                var db1 = await GetDocumentDatabaseInstanceForAsync(store, RavenDatabaseMode.Sharded, id);
+
+                using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
+                {
+                    await db1.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store, id, toShard: 0);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete(id);
+                    session.SaveChanges();
+                }
+
+                using (var token = new OperationCancelToken(db0.Configuration.Databases.OperationTimeout.AsTimeSpan, db0.DatabaseShutdown, CancellationToken.None))
+                {
+                    await db0.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store, id, toShard: 1);
+
+                await Sharding.EnsureNoDatabaseChangeVectorLeakAsync(store.Database);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Revisions | RavenTestCategory.Sharding)]
+        [RavenExternalReplication(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
+        [RavenExternalReplication(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
+        public async Task RevertRevisionsWithReplicationAndResharding(Options sourceOptions, Options destinationOptions)
+        {
+            using (var store1 = GetDocumentStore(sourceOptions))
+            using (var store2 = GetDocumentStore(destinationOptions))
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store1, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+                var id = "users/shiran";
+                DateTime last;
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Shiran" }, id);
+                    session.SaveChanges();
+                    last = DateTime.UtcNow;
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store1);
+
+                await EnsureReplicatingAsync(store1, store2);
+
+                using (var session = store2.OpenSession())
+                {
+                    var user = session.Load<User>(id);
+                    Assert.NotNull(user);
+                    user.Name = "Shiran2";
+                    session.SaveChanges();
+                }
+
+                await EnsureReplicatingAsync(store2, store1);
+
+                var db1 = await GetDocumentDatabaseInstanceForAsync(store1, sourceOptions.DatabaseMode, id);
+
+                using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
+                {
+                    await db1.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store1, id, toShard: 1);
+
+                var db2 = await GetDocumentDatabaseInstanceForAsync(store2, destinationOptions.DatabaseMode, id);
+
+                using (var token = new OperationCancelToken(db2.Configuration.Databases.OperationTimeout.AsTimeSpan, db2.DatabaseShutdown, CancellationToken.None))
+                {
+                    await db2.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store1, id, toShard: 0);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Delete(id);
+                    session.SaveChanges();
+                }
+
+                using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
+                {
+                    await db1.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null,
+                        token: token);
+                }
+
+                await Sharding.Resharding.MoveShardForId(store1, id, toShard: 1);
+
+                await Sharding.EnsureNoDatabaseChangeVectorLeakAsync(store1.Database);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20747/Revert-revisions-After-Resharding

### Additional info

Overall, seems like Revert Revisions after Resharding works as expected. The only issue we found was a database change vector leak in shards. It happened because we were using `ChangeVector.Merge` / `ChangeVector.MergeWith` methods which aren't handling differently in the case one change vector is single, and the other is not. 

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
