### PR TITLE
RavenDB-21502 cluster with a single member should use its own commands version

### DIFF
--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Rachis
                     if (clusterTopology.Members.Count == 1)
                     {
                         CastVoteForSelf(ElectionTerm + 1, "Single member cluster, natural leader");
-                        _engine.SwitchToLeaderState(ElectionTerm, _engine.CommandsVersionManager.CurrentClusterMinimalVersion,
+                        _engine.SwitchToLeaderState(ElectionTerm, ClusterCommandsVersionManager.MyCommandsVersion,
                             "I'm the only one in the cluster, so no need for elections, I rule.");
                         return;
                     }

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -1133,5 +1133,33 @@ namespace RachisTests
             var topology = cluster.Leader.ServerStore.GetClusterTopology();
             Assert.Equal(3, topology.AllNodes.Count);
         }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task UseProperCommandVersionWhenSingleMember()
+        {
+            var (_, raft1) = await CreateRaftCluster(1, shouldRunInMemory: false);
+
+            await raft1.ServerStore.AddNodeToClusterAsync("http://foo.bar", "B", validateNotInTopology: false);
+            await raft1.ServerStore.AddNodeToClusterAsync("http://foo.baz", "C", validateNotInTopology: false);
+
+            var result = await DisposeServerAndWaitForFinishOfDisposalAsync(raft1);
+
+            raft1 = Servers[0] = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    { RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), result.Url }, 
+                    { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url }
+                },
+                RunInMemory = false,
+                DeletePrevious = false,
+                DataDirectory = result.DataDirectory
+            });
+
+            using (var store = GetDocumentStore(new Options { Server = raft1, }))
+            {
+
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21502 

### Additional description

During setup wizard we can have a cluster topology of 1 Member and 2 Promotables.
This topology is a single member topology and it need to select the command version from current node. 

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
