### PR TITLE
RavenDB-21480 Corax dictionary training shouldn't stop when processing document that throws an exception

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.Unicode;
 using System.Threading;
 using Corax;
@@ -10,7 +8,6 @@ using Corax.Mappings;
 using Corax.Pipeline;
 using Corax.Utils;
 using Raven.Client.Documents.Indexes;
-using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils.Enumerators;
 using Sparrow;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -282,13 +282,14 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
 
                     builder.Reset();
                     _converter.SetDocument(doc.LowerId, null, enumerator.Current, _indexContext, builder);
+                    
+                    _indexingStatsScope.RecordMapSuccess();
 
                     foreach (var item in builder.Buffer)
                         yield return item;
                 } 
                 while (true);
 
-                _indexingStatsScope.RecordMapSuccess();
                 _indexingStatsScope.RecordDocumentSize(doc.Data.Size);
                 
                 // Check if we have already hit the threshold allocations.

--- a/test/SlowTests/Issues/RavenDB-21480.cs
+++ b/test/SlowTests/Issues/RavenDB-21480.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Assert = Xunit.Assert;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21480 : RavenTestBase
+{
+    public RavenDB_21480(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CheckIndexingStatsForDictionaryTraining(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() { Name = "Name1", Score = 1 };
+                var d2 = new Dto() { Name = "Name2", Score = 1 };
+                var d3 = new Dto() { Name = "Name3", Score = 1 };
+                var d4 = new Dto() { Name = "Name4", Score = 1 };
+                var d5 = new Dto() { Name = "Name5", Score = 1 };
+                
+                session.Store(d1);
+                session.Store(d2);
+                session.Store(d3);
+                session.Store(d4);
+                session.Store(d5);
+                
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+
+                var dictionaryTrainingStats = indexInstance
+                    .GetIndexingPerformance().First(indexingPerformanceStats => indexingPerformanceStats.Details.Operations.Any(indexingPerformanceOperation => indexingPerformanceOperation.Name == "Corax/DictionaryTraining"));
+                
+                Assert.Equal(10, dictionaryTrainingStats.InputCount);
+                Assert.Equal(10, dictionaryTrainingStats.SuccessCount);
+                Assert.Equal(0, dictionaryTrainingStats.FailedCount);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CheckIndexingStatsForDictionaryTrainingOnErroredIndex(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() { Name = "Name1", Score = 1 };
+                var d2 = new Dto() { Name = "Name2", Score = 1 };
+                var d3 = new Dto() { Name = "Name3", Score = 0 };
+                var d4 = new Dto() { Name = "Name4", Score = 1 };
+                var d5 = new Dto() { Name = "Name5", Score = 1 };
+                
+                session.Store(d1);
+                session.Store(d2);
+                session.Store(d3);
+                session.Store(d4);
+                session.Store(d5);
+                
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+                
+                var dictionaryTrainingStats = indexInstance
+                    .GetIndexingPerformance().First(indexingPerformanceStats => indexingPerformanceStats.Details.Operations.Any(indexingPerformanceOperation => indexingPerformanceOperation.Name == "Corax/DictionaryTraining"));
+
+                Assert.Equal(10, dictionaryTrainingStats.InputCount);
+                Assert.Equal(8, dictionaryTrainingStats.SuccessCount);
+                Assert.Equal(2, dictionaryTrainingStats.FailedCount);
+            }
+        }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = dtos =>
+                from dto in dtos
+                select new Dto() { Name = dto.Name, Score = 1 / dto.Score };
+        }
+    }
+    
+    private class Dto
+    {
+        public string Name { get; set; }
+        public int Score { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21480/Corax-Dictionary-training-stops-after-encountering-item-that-throws-an-error

### Additional description

We want to continue dictionary training and just skip problematic document. Before these changes training stopped immediately after encountering a problematic document.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
