### PR TITLE
RavenDB-21516 - fix NRE when failing to allocate a context

### DIFF
--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -797,7 +797,7 @@ namespace Raven.Server.Documents
             }
             catch
             {
-                if (current.Transaction != null)
+                if (current?.Transaction != null)
                 {
                     _recording.State?.TryRecord(current, TxInstruction.DisposeTx, current.Transaction.Disposed == false);
                     current.Transaction.Dispose();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21516/NRE-in-transaction-merger-when-failing-to-allocate-a-context

### Additional description

Fix NRE when failing to allocate a context

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Testing by Contributor

- It has been verified by manual testing