### PR TITLE
RavenDB-21277 - SlowTests.Smuggler.SmugglerConflicts.CanExportAndImpo…

### DIFF
--- a/test/SlowTests/Smuggler/SmugglerConflicts.cs
+++ b/test/SlowTests/Smuggler/SmugglerConflicts.cs
@@ -407,7 +407,10 @@ namespace SlowTests.Smuggler
             await SetupReplicationAsync(store2, store1);
 
             Assert.Equal(2, WaitUntilHasConflict(store1, "users/fitzchak").Length);
-
+            Assert.Equal(2, WaitUntilHasConflict(store1, "people/1-A").Length);
+            Assert.Equal(2, WaitUntilHasConflict(store1, "companies/1-A").Length);
+            Assert.Equal(2, WaitUntilHasConflict(store1, "people/2-A").Length);
+           
             var stats = await GetDatabaseStatisticsAsync(store1);
             Assert.Equal(3, stats.CountOfDocuments);
             Assert.Equal(4, stats.CountOfDocumentsConflicts);


### PR DESCRIPTION
…rtWithConflicts_ToTheSameDatabase(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21277/SlowTests.Smuggler.SmugglerConflicts.CanExportAndImportWithConflictsToTheSameDatabaseoptions-DatabaseMode-Sharded

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
