### PR TITLE
RavenDB-21517: Fix for Import from SQL with a transform script results in high usage of unmanaged memory

### DIFF
--- a/src/Raven.Server/SqlMigration/JsPatcher.cs
+++ b/src/Raven.Server/SqlMigration/JsPatcher.cs
@@ -28,6 +28,7 @@ namespace Raven.Server.SqlMigration
             if (_runner == null)
                 return document;
 
+            using (document)
             using (var runner = _runner.Run(_context, _context, "execute", new object[] {document}))
             {
                 return runner.TranslateToObject(_context);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21517
Github discussion https://github.com/ravendb/ravendb/discussions/17448

### Additional description

In the case when a transform script is used, we do not dispose of the original document after performing the transformation.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed