### PR TITLE
RavenDB-21519 Compare frequencies after quantization to avoid duplicates in posting lists.

### DIFF
--- a/src/Corax/Indexing/EntriesModifications.cs
+++ b/src/Corax/Indexing/EntriesModifications.cs
@@ -210,8 +210,7 @@ internal unsafe struct EntriesModifications
 
             //We've to delete exactly same item in additions and removals and delete those.
             //This is made for Set structure.
-            if (currentAdd.EntryId == currentRemoval.EntryId &&
-                EntryIdEncodings.FrequencyQuantization(currentAdd.Frequency) == EntryIdEncodings.FrequencyQuantization(currentRemoval.Frequency))
+            if (currentAdd.Equals(currentRemoval))
             {
                 if (Updates.TryPush(currentAdd) == false)
                 {

--- a/src/Corax/Indexing/EntriesModifications.cs
+++ b/src/Corax/Indexing/EntriesModifications.cs
@@ -210,7 +210,8 @@ internal unsafe struct EntriesModifications
 
             //We've to delete exactly same item in additions and removals and delete those.
             //This is made for Set structure.
-            if (currentAdd.EntryId == currentRemoval.EntryId && currentAdd.Frequency == currentRemoval.Frequency)
+            if (currentAdd.EntryId == currentRemoval.EntryId &&
+                EntryIdEncodings.FrequencyQuantization(currentAdd.Frequency) == EntryIdEncodings.FrequencyQuantization(currentRemoval.Frequency))
             {
                 if (Updates.TryPush(currentAdd) == false)
                 {

--- a/src/Corax/Indexing/TermInEntryModification.cs
+++ b/src/Corax/Indexing/TermInEntryModification.cs
@@ -3,7 +3,7 @@ using Corax.Utils;
 
 namespace Corax.Indexing;
 
-internal struct TermInEntryModification : IEquatable<TermInEntryModification>
+internal struct TermInEntryModification : IEquatable<TermInEntryModification>, IComparable<TermInEntryModification>
 {
     public long EntryId;
     public int TermsPerEntryIndex; 
@@ -14,5 +14,13 @@ internal struct TermInEntryModification : IEquatable<TermInEntryModification>
     public bool Equals(TermInEntryModification other)
     {
         return EntryId == other.EntryId && EntryIdEncodings.FrequencyQuantization(Frequency) == EntryIdEncodings.FrequencyQuantization(other.Frequency);
+    }
+
+    public int CompareTo(TermInEntryModification other)
+    {
+        var entryIdComparison = EntryId.CompareTo(other.EntryId);
+        if (entryIdComparison != 0)
+            return entryIdComparison;
+        return EntryIdEncodings.FrequencyQuantization(Frequency).CompareTo(EntryIdEncodings.FrequencyQuantization(other.Frequency));
     }
 }

--- a/src/Corax/Indexing/TermInEntryModification.cs
+++ b/src/Corax/Indexing/TermInEntryModification.cs
@@ -1,8 +1,9 @@
 using System;
+using Corax.Utils;
 
 namespace Corax.Indexing;
 
-internal struct TermInEntryModification : IEquatable<TermInEntryModification>, IComparable<TermInEntryModification>
+internal struct TermInEntryModification : IEquatable<TermInEntryModification>
 {
     public long EntryId;
     public int TermsPerEntryIndex; 
@@ -12,13 +13,6 @@ internal struct TermInEntryModification : IEquatable<TermInEntryModification>, I
 
     public bool Equals(TermInEntryModification other)
     {
-        return EntryId == other.EntryId && Frequency == other.Frequency;
-    }
-
-    public int CompareTo(TermInEntryModification other)
-    {
-        var entryIdComparison = EntryId.CompareTo(other.EntryId);
-        if (entryIdComparison != 0) return entryIdComparison;
-        return Frequency.CompareTo(other.Frequency);
+        return EntryId == other.EntryId && EntryIdEncodings.FrequencyQuantization(Frequency) == EntryIdEncodings.FrequencyQuantization(other.Frequency);
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Threading;
 using Corax.Querying;
 using Corax.Mappings;
-using Corax.Querying;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.SortingMatches;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxSuggestionIndexReader.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using Corax.Querying;
 using Corax.Mappings;
 using Corax.Pipeline;
-using Corax.Querying;
 using Raven.Client.Documents.Queries.Suggestions;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Suggestions;

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using Corax.Querying;
 using Corax.Mappings;
-using Corax.Querying;
 using Corax.Utils;
 using Lucene.Net.Search;
 using Lucene.Net.Store;

--- a/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapQueryResultRetriever.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using Corax.Querying;
-using Corax.Querying;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Queries.Timings;

--- a/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/MapReduceQueryResultRetriever.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using Corax.Querying;
-using Corax.Querying;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Includes;

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Corax.Querying;
-using Corax.Querying;
 using Jint;
 using Jint.Native;
 using Jint.Native.Object;

--- a/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using Corax.Querying;
-using Corax.Querying;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Patch;

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -2,7 +2,6 @@ using System.IO;
 using Corax;
 using Corax.Querying;
 using Corax.Mappings;
-using Corax.Querying;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using FastTests.Voron;

--- a/test/FastTests/Corax/EntriesModificationsTests.cs
+++ b/test/FastTests/Corax/EntriesModificationsTests.cs
@@ -30,15 +30,32 @@ public class EntriesModificationsTests : NoDisposalNeeded
         Assert.Equal(1, entries.Updates.Count);
         Assert.Equal(2, entries.Updates.ToSpan()[0].EntryId);
     }
-    private static void AssertEntriesCase(ref EntriesModifications entries)
+    private static unsafe void AssertEntriesCase(ref EntriesModifications entries)
     {
         var additions = entries.Additions;
         var removals = entries.Removals;
 
         foreach (var add in additions.ToSpan())
-            Assert.True(0 > removals.ToSpan().BinarySearch(add));
+        {
+            bool found = false;
+            for (int i = 0; i < removals.Count; i++)
+            {
+                if (add.EntryId == removals.RawItems[i].EntryId)
+                    found = true;
+            }
+            Assert.False(found);
+        }
+
 
         foreach (var removal in removals.ToSpan())
-            Assert.True(0 > additions.ToSpan().BinarySearch(removal));
+        {
+            bool found = false;
+            for (int i = 0; i < additions.Count; i++)
+            {
+                if (removal.EntryId == additions.RawItems[i].EntryId)
+                    found = true;
+            }
+            Assert.False(found);
+        }
     }
 }

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Corax;
 using Corax.Analyzers;
 using Corax.Querying;
 using Corax.Mappings;
 using Corax.Pipeline;
-using Corax.Querying;
 using FastTests.Voron;
 using Sparrow.Server;
 using Sparrow.Threading;

--- a/test/SlowTests/Corax/RavenDB-21519.cs
+++ b/test/SlowTests/Corax/RavenDB-21519.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public sealed class RavenDB_21519 : RavenTestBase
+{
+    public RavenDB_21519(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public static IEnumerable<object[]> RandomSeeds => new[] { new object[] { Random.Shared.Next() } };
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [InlineData(956465115)]
+    [MemberData(nameof(RandomSeeds))]
+    public void Fuzzy(int seed)
+    {
+        // Console.WriteLine(seed);
+        // Output.WriteLine($"{seed}");
+
+        var random = new Random(seed);
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        var operationCount = random.Next(1, 4);
+        var existingIds = new List<string>();
+
+        using (var _ = store.OpenSession())
+        {
+            var results = _.Query<User>()
+                .Search(x => x.Text, "maciej")
+                .ToList();
+        }
+
+        var totalOperations = operationCount;
+        while (operationCount-- >= 0)
+        {
+            Indexes.WaitForIndexing(store);
+            using var session = store.OpenSession();
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+
+            var updatedDoNotTouch = new HashSet<string>();
+            var users = new List<User>();
+            var docsToHandleInSession = random.Next(0, 256);
+
+
+            for (int idX = 0; idX < docsToHandleInSession; ++idX)
+            {
+                var action = (Action)(random.Next() % 3 + 1);
+                switch (action)
+                {
+                    case Action.Add:
+                        var user = new User(TextGen(random.Next(0, 128)));
+                        users.Add(user);
+                        session.Store(user);
+                        break;
+                    case Action.Remove:
+                        {
+                            if (existingIds.Count == 0)
+                                break;
+                            var index = random.Next(existingIds.Count);
+                            var toDelete = existingIds[index];
+
+                            var doc = session.Load<User>(toDelete);
+
+                            session.Delete(doc);
+                            existingIds.RemoveAt(index);
+                            break;
+                        }
+                    case Action.Update:
+                        {
+                            if (existingIds.Count == 0)
+                                break;
+
+                            var index = random.Next(existingIds.Count);
+                            var toUpdate = existingIds[index];
+
+                            if (updatedDoNotTouch.Contains(toUpdate))
+                                break;
+
+                            var doc = session.Load<User>(toUpdate);
+                            doc.Text = TextGen(random.Next(0, 128));
+                            session.Store(doc);
+                            updatedDoNotTouch.Add(toUpdate);
+                            break;
+                        }
+
+                }
+            }
+
+            if (totalOperations - operationCount == 2)
+            {
+                WaitForUserToContinueTheTest(store);
+                Debugger.Break();
+            }
+
+            //     Console.WriteLine($"Operation no {totalOperations - operationCount} executed.");
+            //          Output.WriteLine($"Operation no {totalOperations - operationCount} executed.");
+            //     iterationRequired = totalOperations - operationCount;
+            session.SaveChanges();
+            foreach (var newUsers in users)
+                existingIds.Add(newUsers.Id);
+
+            Indexes.WaitForIndexing(store);
+
+            var currentCount = session.Query<User>()
+                .Search(x => x.Text, "maciej")
+                .Count();
+        }
+
+        string TextGen(int count) => string.Join(" ", Enumerable.Range(0, count).Select(_ => "Maciej"));
+    }
+
+    private enum Action : byte
+    {
+        Add = 1,
+        Remove = 2,
+        Update = 3
+    }
+
+    internal class User
+    {
+        public User()
+        {
+        }
+
+        public User(string text)
+        {
+            Text = text;
+        }
+
+        public string Id;
+        public string Text;
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-21519.cs
+++ b/test/SlowTests/Corax/RavenDB-21519.cs
@@ -160,7 +160,9 @@ public sealed class RavenDB_21519 : RavenTestBase
             Text = text;
         }
 
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
         public string Id;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
         public string Text;
     }
 }

--- a/test/StressTests/Corax/Bugs/RavenDB_21519.cs
+++ b/test/StressTests/Corax/Bugs/RavenDB_21519.cs
@@ -70,7 +70,9 @@ public class RavenDB_21519 : RavenTestBase
             Text = text;
         }
 
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
         public string Id;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
         public string Text;
     }
 }

--- a/test/StressTests/Corax/Bugs/RavenDB_21519.cs
+++ b/test/StressTests/Corax/Bugs/RavenDB_21519.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Corax.Bugs;
+
+public class RavenDB_21519 : RavenTestBase
+{
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void PostingListUpdateDocumentWithBiggerFrequencyButTheSameAsAlreadyIndexedAfterQuantization(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<User>()
+                .Search(x => x.Text, "maciej")
+                .ToList();
+            session.Store(new User(TextGen(10)), "doc1");
+            session.Store(new User(TextGen(100)), "doc2");
+            session.SaveChanges();
+        }
+
+        using (var bulkInsert = store.BulkInsert())
+        {
+            foreach (var i in Enumerable.Range(0, 20_000))
+                bulkInsert.Store(new User("maciej"), $"doc{i + 4}");
+        }
+
+        Indexes.WaitForIndexing(store);
+        
+        using (var session = store.OpenSession())
+        {
+            var prevUser = session.Load<User>("doc2");
+            prevUser.Text = TextGen(101); //changing reference, there will be update
+            session.Store(new User(TextGen(10)), "doc3");
+            session.SaveChanges();
+        }        
+        
+        Indexes.WaitForIndexing(store);
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<User>()
+                .Search(x => x.Text, "maciej")
+                .Count();
+            
+            Assert.Equal(20_00_3, results);
+        }
+        
+        
+        string TextGen(int count) => string.Join(" ", Enumerable.Range(0, count).Select(_ => "Maciej"));
+    }
+
+    public RavenDB_21519(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private class User
+    {
+        public User()
+        {
+        }
+
+        public User(string text)
+        {
+            Text = text;
+        }
+
+        public string Id;
+        public string Text;
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Tests.Infrastructure;
 using Raven.Server.Utils;
+using SlowTests.Corax;
 using SlowTests.Sharding.Cluster;
 using Xunit;
 
@@ -28,10 +29,10 @@ public static class Program
             {
                 TryRemoveDatabasesFolder();
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ShardedClusterObserverTests(testOutputHelper))
+                using (var test = new RavenDB_21519(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.ClusterObserverWillSkipCommandIfChangingTheSameDatabaseRecordTwiceInOneIteration();
+                    test.Fuzzy(956465115);
                 }
             }
             catch (Exception e)

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -29,10 +29,10 @@ public static class Program
             {
                 TryRemoveDatabasesFolder();
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new RavenDB_21519(testOutputHelper))
+                using (var test = new ShardedClusterObserverTests(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    test.Fuzzy(956465115);
+                    await test.ClusterObserverWillSkipCommandIfChangingTheSameDatabaseRecordTwiceInOneIteration();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21519 

### Additional description

In case of an update of term frequency, we have to compare frequency by quantized value to properly detect duplicates in EntriesModification.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
