### PR TITLE
RavenDB-20065 Upgrade Elasticsearch client to v8

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Sparrow.Json.Parsing;
@@ -12,7 +13,8 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         public Authentication Authentication;
 
         public override ConnectionStringType Type => ConnectionStringType.ElasticSearch;
-
+        
+        [Obsolete("Elasticsearch compatibility isn't required anymore to connect with Elasticsearch server v8.x.")]
         public bool EnableCompatibilityMode { get; set; }
 
         protected override void ValidateImpl(ref List<string> errors)

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -72,7 +72,8 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
                 [nameof(Authentication.ApiKey)] = Authentication.ApiKey == null ? null : new DynamicJsonValue()
                 {
                     [nameof(Authentication.ApiKey.ApiKeyId)] = Authentication?.ApiKey?.ApiKeyId,
-                    [nameof(Authentication.ApiKey.ApiKey)] = Authentication?.ApiKey?.ApiKey
+                    [nameof(Authentication.ApiKey.ApiKey)] = Authentication?.ApiKey?.ApiKey,
+                    [nameof(Authentication.ApiKey.EncodedApiKey)] = Authentication?.ApiKey?.EncodedApiKey
                 },
                 [nameof(Authentication.Certificate)] = Authentication.Certificate == null ? null : new DynamicJsonValue()
                 {
@@ -105,6 +106,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         public string ApiKeyId { get; set; }
         
         public string ApiKey { get; set; }
+        public string EncodedApiKey { get; set; }
     }
     
     public sealed class BasicAuthentication

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -61,7 +61,9 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         {
             DynamicJsonValue json = base.ToJson();
             json[nameof(Nodes)] = new DynamicJsonArray(Nodes);
+#pragma warning disable CS0618 // Type or member is obsolete
             json[nameof(EnableCompatibilityMode)] = EnableCompatibilityMode;
+#pragma warning restore CS0618 // Type or member is obsolete
             json[nameof(Authentication)] = Authentication == null ? null : new DynamicJsonValue()
             {
                 [nameof(Authentication.Basic)] = Authentication.Basic == null ? null : new DynamicJsonValue()
@@ -88,7 +90,9 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         {
             DynamicJsonValue json = base.ToAuditJson();
             json[nameof(Nodes)] = new DynamicJsonArray(Nodes);
+#pragma warning disable CS0618 // Type or member is obsolete
             json[nameof(EnableCompatibilityMode)] = EnableCompatibilityMode;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return json;
         }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Sync;
+
+namespace Raven.Server.Documents.ETL.Providers.ElasticSearch;
+
+internal class BlittableJsonElasticSerializer : Serializer
+{
+    public DocumentsOperationContext Context { private get; set; }
+
+    public override void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.None)
+    {
+        if (data is not BlittableJsonReaderObject json)
+        {
+            throw new NotImplementedException();
+        }
+        
+        using (var writer = new BlittableJsonTextWriter(Context, stream))
+        {
+            writer.WriteObject(json);
+        }
+    }
+
+    public override Task SerializeAsync<T>(T data, Stream stream,
+        SerializationFormatting formatting = SerializationFormatting.None, CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+        
+    public override object Deserialize(Type type, Stream stream) =>
+        throw new NotImplementedException();
+    
+    public override T Deserialize<T>(Stream stream) =>
+        throw new NotImplementedException();
+
+    public override ValueTask<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+
+    public override ValueTask<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
@@ -9,15 +9,30 @@ using Sparrow.Json.Sync;
 
 namespace Raven.Server.Documents.ETL.Providers.ElasticSearch;
 
-internal class BlittableJsonElasticSerializer : Serializer
+internal class BlittableJsonElasticSerializer : Serializer, IDisposable
 {
-    public DocumentsOperationContext Context { private get; set; }
+    private DocumentsOperationContext Context { get; set; }
+
+    public BlittableJsonElasticSerializer SetContext(DocumentsOperationContext context)
+    {
+        Context = context;
+        return this;
+    }
+    
+    public void Dispose()
+    {
+        Context = null;
+    }
 
     public override void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.None)
     {
+        if (Context is null)
+        {
+            throw new InvalidOperationException("Context cannot be null");
+        }
         if (data is not BlittableJsonReaderObject json)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
         
         using (var writer = new BlittableJsonTextWriter(Context, stream))
@@ -28,17 +43,17 @@ internal class BlittableJsonElasticSerializer : Serializer
 
     public override Task SerializeAsync<T>(T data, Stream stream,
         SerializationFormatting formatting = SerializationFormatting.None, CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
         
     public override object Deserialize(Type type, Stream stream) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     
     public override T Deserialize<T>(Stream stream) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
 
     public override ValueTask<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
 
     public override ValueTask<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -124,8 +124,10 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
     
                     var bulkRequestDescriptor = new BulkRequestDescriptor().Index(indexName).Refresh(Elastic.Clients.Elasticsearch.Refresh.WaitFor);
                     var toDispose = new List<BlittableJsonReaderObject>();
-                    foreach (var insert in index.Inserts.Where(insert => insert.TransformationResult != null))
+                    foreach (var insert in index.Inserts)
                     {
+                        if (insert.TransformationResult == null)
+                            continue;
                         var json = EnsureLowerCasedIndexIdProperty(context, insert.TransformationResult, index);
                         toDispose.Add(json);
                         bulkRequestDescriptor.Create(json);

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
@@ -35,9 +35,17 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                 }
                 else if (connectionString.Authentication.ApiKey != null)
                 {
-                    var apiKeyMergedBytes = Encodings.Utf8.GetBytes($"{connectionString.Authentication.ApiKey.ApiKeyId}:{connectionString.Authentication.ApiKey.ApiKey}");
-                    var encodedApiKey = Convert.ToBase64String(apiKeyMergedBytes);
-                    settings.Authentication(new ApiKey(encodedApiKey));
+                    if (connectionString.Authentication.ApiKey.EncodedApiKey != null)
+                    {
+                        settings.Authentication(new ApiKey(connectionString.Authentication.ApiKey.EncodedApiKey));
+                    }
+                    else
+                    { 
+                        var apiKeyMergedBytes = Encodings.Utf8.GetBytes($"{connectionString.Authentication.ApiKey.ApiKeyId}:{connectionString.Authentication.ApiKey.ApiKey}");
+                        var encodedApiKey = Convert.ToBase64String(apiKeyMergedBytes);
+                        settings.Authentication(new ApiKey(encodedApiKey));    
+                    }
+                    
                 }
                 else if (connectionString.Authentication.Certificate != null)
                 {

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchHelper.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Transport;
+using NetTopologySuite.Utilities;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+using Sparrow;
 using BasicAuthentication = Elastic.Transport.BasicAuthentication;
 
 namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
@@ -18,7 +20,6 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
             var settings = useCustomBlittableSerializer
                 ? new ElasticsearchClientSettings(pool, sourceSerializer: (@in, values) => new BlittableJsonElasticSerializer())
                 : new ElasticsearchClientSettings(pool);
-                
 
             if (requestTimeout != null)
                 settings.RequestTimeout(requestTimeout.Value);
@@ -34,7 +35,9 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
                 }
                 else if (connectionString.Authentication.ApiKey != null)
                 {
-                    settings.Authentication(new ApiKey(connectionString.Authentication.ApiKey.ApiKey)); //connectionString.Authentication.ApiKey.ApiKeyId ??
+                    var apiKeyMergedBytes = Encodings.Utf8.GetBytes($"{connectionString.Authentication.ApiKey.ApiKeyId}:{connectionString.Authentication.ApiKey.ApiKey}");
+                    var encodedApiKey = Convert.ToBase64String(apiKeyMergedBytes);
+                    settings.Authentication(new ApiKey(encodedApiKey));
                 }
                 else if (connectionString.Authentication.Certificate != null)
                 {

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/Handlers/Processors/ElasticSearchEtlConnectionHandlerForTestConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/Handlers/Processors/ElasticSearchEtlConnectionHandlerForTestConnection.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
 using JetBrains.Annotations;
-using Nest;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Server.Documents.Handlers.Processors;
@@ -29,11 +29,11 @@ internal sealed class ElasticSearchEtlConnectionHandlerForTestConnection<TOperat
             string authenticationJson = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
             Authentication authentication = JsonConvert.DeserializeObject<Authentication>(authenticationJson);
 
-            ElasticClient client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = new[] { url }, Authentication = authentication });
+            ElasticsearchClient client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = new[] { url }, Authentication = authentication });
 
             PingResponse pingResult = await client.PingAsync();
 
-            if (pingResult.IsValid)
+            if (pingResult.IsValidResponse)
             {
                 DynamicJsonValue result = new() { [nameof(NodeConnectionTestResult.Success)] = true, [nameof(NodeConnectionTestResult.TcpServerUrl)] = url, };
 

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -164,7 +164,6 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="DasMulli.Win32.ServiceUtils.Signed" Version="1.1.0" />
     <PackageReference Include="FluentFTP" Version="48.0.0" />
-    <PackageReference Include="FluentFTP" Version="47.1.0" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -164,6 +164,8 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="DasMulli.Win32.ServiceUtils.Signed" Version="1.1.0" />
     <PackageReference Include="FluentFTP" Version="48.0.0" />
+    <PackageReference Include="FluentFTP" Version="47.1.0" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -185,7 +187,6 @@
     <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="MySqlConnector" Version="2.2.7" />
     <PackageReference Include="NCrontab.Advanced" Version="1.3.28" />
-    <PackageReference Include="NEST" Version="7.17.5" />
     <PackageReference Include="Npgsql" Version="5.0.16" />
     <PackageReference Include="NuGet.Commands" Version="6.7.0" Alias="NGC" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringElasticSearch.html
@@ -77,6 +77,14 @@
             </div>
         </div>
     </div>
+    <div data-bind="collapse: authMethodUsed() === 'encodedApiKey'">
+        <div class="form-group" data-bind="validationElement: encodedApiKey">
+            <label class="control-label">Encoded API Key <i class="required"></i></label>
+            <div class="flex-grow">
+                <input class="form-control" data-bind="textInput: encodedApiKey" placeholder="Enter Encoded API Key" />
+            </div>
+        </div>
+    </div>
     <div data-bind="collapse: authMethodUsed() === 'certificate'">
         <div class="input-group file-input">
             <input type="file" id="elasticCertificateFilePicker" data-bind="event: { change: _.partial(uploadElasticCertificate, $element) }" />
@@ -123,25 +131,6 @@
                 </div>
             </div>
         </div>
-    </div>
-</div>
-<div class="form-group margin-bottom-sm">
-    <label class="control-label">&nbsp;</label>
-    <div class="text-warning bg-warning padding padding-sm margin-top flex-horizontal">
-        <div class="flex-start"><small><i class="icon-warning"></i></small></div>
-        <div>
-            <small>
-            In order to use the latest <strong>7.x</strong> Elasticsearch client with an <strong>8.x</strong> Elasticsearch server, you must enable the compatibility mode below.<br />
-            This will set <strong>EnableApiVersioningHeader</strong> on the Elasticsearch connection string.
-            </small>
-        </div>
-    </div>
-</div>
-<div class="form-group">
-    <label class="control-label">&nbsp;</label>
-    <div class="toggle">
-        <input id="toggle-elastic-compatibility-mode" type="checkbox" data-bind="checked: enableCompatibilityMode">
-        <label for="toggle-elastic-compatibility-mode">Enable compatibility mode</label>
     </div>
 </div>
 <div data-bind="if: !nodesUrls.isValid()">

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -61,7 +61,7 @@ loadToOrders" + IndexSuffix + @"(orderData);";
         };
 
         protected ElasticSearchEtlConfiguration SetupElasticEtl(DocumentStore store, string script, IEnumerable<ElasticSearchIndex> indexes, IEnumerable<string> collections, bool applyToAllDocuments = false,
-            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, string configurationName = null, string transformationName = null, string[] nodes = null, bool enableCompatibilityMode = false)
+            global::Raven.Client.Documents.Operations.ETL.ElasticSearch.Authentication authentication = null, string configurationName = null, string transformationName = null, string[] nodes = null)
         {
             var connectionStringName = $"{store.Database}@{store.Urls.First()} to ELASTIC";
 
@@ -93,7 +93,6 @@ loadToOrders" + IndexSuffix + @"(orderData);";
                     Name = connectionStringName,
                     Nodes = nodes ?? ElasticSearchTestNodes.Instance.VerifiedNodes.Value,
                     Authentication = authentication,
-                    EnableCompatibilityMode = enableCompatibilityMode
                 });
 
             return config;

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -938,60 +938,6 @@ output('test output')"
             }
         }
 
-        [RequiresElasticSearchRetryFact]
-        public void CanEnableCompatibilityMode()
-        {
-            using (var store = GetDocumentStore())
-            using (GetElasticClient(out var client))
-            {
-                var config = SetupElasticEtl(store, DefaultScript, DefaultIndexes, DefaultCollections, enableCompatibilityMode: true);
-                var etlDone = Etl.WaitForEtlToComplete(store);
-
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Order
-                    {
-                        OrderLines = new List<OrderLine>
-                        {
-                            new OrderLine {Cost = 3, Product = "Cheese", Quantity = 3}, new OrderLine {Cost = 4, Product = "Bear", Quantity = 2},
-                        }
-                    });
-                    session.SaveChanges();
-                }
-
-                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
-
-                var ordersCount = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCount = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
-
-                Assert.True(ordersCount.IsValidResponse);
-                Assert.True(orderLinesCount.IsValidResponse);
-
-                Assert.Equal(1, ordersCount.Count);
-                Assert.Equal(2, orderLinesCount.Count);
-
-                etlDone.Reset();
-
-                using (var session = store.OpenSession())
-                {
-                    session.Delete("orders/1-A");
-
-                    session.SaveChanges();
-                }
-
-                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
-
-                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
-
-                Assert.True(ordersCount.IsValidResponse);
-                Assert.True(orderLinesCount.IsValidResponse);
-
-                Assert.Equal(0, ordersCountAfterDelete.Count);
-                Assert.Equal(0, orderLinesCountAfterDelete.Count);
-            }
-        }
-
         private class Order
         {
             public Address Address { get; set; }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
 using Orders;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -67,11 +68,11 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCount = client.Count<object>(c => c.Index(OrdersIndexName));
-                var orderLinesCount = client.Count<object>(c => c.Index(OrderLinesIndexName));
+                var ordersCount = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCount = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
-                Assert.True(ordersCount.IsValid);
-                Assert.True(orderLinesCount.IsValid);
+                Assert.True(ordersCount.IsValidResponse);
+                Assert.True(orderLinesCount.IsValidResponse);
 
                 Assert.Equal(1, ordersCount.Count);
                 Assert.Equal(2, orderLinesCount.Count);
@@ -87,11 +88,11 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCountAfterDelete = client.Count<object>(c => c.Index(OrdersIndexName));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Index(OrderLinesIndexName));
+                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
-                Assert.True(ordersCount.IsValid);
-                Assert.True(orderLinesCount.IsValid);
+                Assert.True(ordersCount.IsValidResponse);
+                Assert.True(orderLinesCount.IsValidResponse);
 
                 Assert.Equal(0, ordersCountAfterDelete.Count);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -22,10 +22,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
             using (GetElasticClient(out var client))
             {
                 client.Indices.Create(OrdersIndexName, c => c
-                    .Map(m => m
-                        .Properties(p => p
-                            .MatchOnlyText(t => t
-                                .Name("Id")))));
+                    .Mappings(m => m
+                        .Properties<object>(p => p
+                            .MatchOnlyText("Id"))));
 
                 var config = SetupElasticEtl(store, @"
 var orderData = {

--- a/test/SlowTests/Sharding/Issues/RavenDB_18766.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18766.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FastTests;
-using Nest;
+using Lucene.Net.Analysis.Standard;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.MoreLikeThis;

--- a/test/SlowTests/Tests/Subscriptions.cs
+++ b/test/SlowTests/Tests/Subscriptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
-using Nest;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Subscriptions;

--- a/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
+++ b/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Nest;
+using Elastic.Clients.Elasticsearch;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Server.Documents.ETL.Providers.ElasticSearch;
 
@@ -62,8 +62,8 @@ namespace Tests.Infrastructure.ConnectionString
 
             if (TryConnect(Nodes.Value, out pingResponse))
                 return Nodes.Value;
-
-            throw new InvalidOperationException($"Can't ping Elastic Search instance. Provided urls: {string.Join(',', Nodes.Value)}", pingResponse?.OriginalException);
+            pingResponse.TryGetOriginalException(out var originalException);
+            throw new InvalidOperationException($"Can't ping Elastic Search instance. Provided urls: {string.Join(',', Nodes.Value)}", originalException);
 
 
             bool TryConnect(string[] nodes, out PingResponse response)
@@ -74,7 +74,7 @@ namespace Tests.Infrastructure.ConnectionString
 
                     response = client.Ping();
 
-                    return response.IsValid;
+                    return response.IsValidResponse;
                 }
                 catch
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20065/Upgrade-Elasticsearch-client-to-v8

### Additional description

Removed the old `Nest` (v7) client to Elasticsearch that we used to talk with Elasticsearch servers.
Upgraded to `Elastic.Clients.Elasticsearch` (v8) client that works with 7.x and 8.x servers by default, without compatibility mode.
Removed the compatibility mode references on the server side.

Added a possibility to provide Encoded API Key instead of KeyID + Raw Key 

### Type of change

- Optimization


### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
