### PR TITLE
RavenDB-21525 Fixing an issue that we were sending SkipStatistics: true even though they were requsted via Linq extension method

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -112,6 +112,7 @@ namespace Raven.Client.Documents.Linq
         public IRavenQueryable<T> Statistics(out QueryStatistics stats)
         {
             stats = _queryStats;
+            stats.RequestedByUser = true;
             return this;
         }
 
@@ -210,7 +211,8 @@ namespace Raven.Client.Documents.Linq
                 _isMapReduce,
                 _provider.OriginalQueryType,
                 _conventions,
-                _provider.IsProjectInto);
+                _provider.IsProjectInto,
+                _queryStats);
         }
 
         public string IndexName => _indexName;

--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -315,7 +315,8 @@ namespace Raven.Client.Documents.Linq
                 _isMapReduce,
                 OriginalQueryType,
                 _conventions,
-                IsProjectInto);
+                IsProjectInto,
+                _queryStatistics);
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -52,6 +52,7 @@ namespace Raven.Client.Documents.Linq
         internal readonly LinqPathProvider LinqPathProvider;
         private readonly Action<QueryResult> _afterQueryExecuted;
         private readonly LinqQueryHighlightings _highlightings;
+        private readonly QueryStatistics _queryStatistics;
         private bool _chainedWhere;
         private int _insideWhere;
         private int _insideFilter;
@@ -132,7 +133,8 @@ namespace Raven.Client.Documents.Linq
             bool isMapReduce,
             Type originalType,
             DocumentConventions conventions,
-            bool isProjectInto)
+            bool isProjectInto,
+            QueryStatistics queryStatistics)
         {
             FieldsToFetch = fieldsToFetch;
             _newExpressionType = typeof(T);
@@ -146,6 +148,7 @@ namespace Raven.Client.Documents.Linq
             _originalQueryType = originalType ?? throw new ArgumentNullException(nameof(originalType));
             _conventions = conventions;
             _isProjectInto = isProjectInto;
+            _queryStatistics = queryStatistics;
             LinqPathProvider = new LinqPathProvider(queryGenerator.Conventions);
             _jsProjectionNames = new List<string>();
             _loadAliasesMovedToOutputFunction = new HashSet<string>();
@@ -3917,14 +3920,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true));
+                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true)
+                {
+                    QueryStatistics = _queryStatistics
+                });
             }
 
             var (fields, projections) = GetProjections();
 
             return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(fields, projections, FromAlias, null, _loadTokens)
             {
-                IsProjectInto = _isProjectInto
+                IsProjectInto = _isProjectInto,
+                QueryStatistics = _queryStatistics
             });
         }
 
@@ -3966,14 +3973,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true));
+                return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true)
+                {
+                    QueryStatistics = _queryStatistics
+                });
             }
 
             var (fields, projections) = GetProjections();
 
             return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(fields, projections, FromAlias, null, _loadTokens)
             {
-                IsProjectInto = _isProjectInto
+                IsProjectInto = _isProjectInto,
+                QueryStatistics = _queryStatistics
             });
         }
 

--- a/src/Raven.Client/Documents/Queries/QueryData.cs
+++ b/src/Raven.Client/Documents/Queries/QueryData.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Tokens;
 
 namespace Raven.Client.Documents.Queries
@@ -27,6 +28,8 @@ namespace Raven.Client.Documents.Queries
         public bool IsMapReduce { get; set; }
 
         internal bool IsProjectInto { get; set; }
+
+        internal QueryStatistics QueryStatistics { get; set; }
 
         public ProjectionBehavior? ProjectionBehavior { get; set; }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -171,8 +171,6 @@ namespace Raven.Client.Documents.Session
 
         private string _includesAlias;
 
-        private bool _statsRequested;
-
         private TimeSpan DefaultTimeout
         {
             get
@@ -1183,7 +1181,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         public void Statistics(out QueryStatistics stats)
         {
             stats = QueryStats;
-            _statsRequested = true;
+            stats.RequestedByUser = true;
         }
 
         /// <summary>
@@ -1219,7 +1217,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 QueryParameters = QueryParameters,
                 DisableCaching = DisableCaching,
                 ProjectionBehavior = ProjectionBehavior,
-                SkipStatistics = _statsRequested == false
+                SkipStatistics = QueryStats.RequestedByUser == false
             };
 
             return indexQuery;

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1067,7 +1067,7 @@ namespace Raven.Client.Documents.Session
                 FilterModeStack = new Stack<bool>(FilterModeStack),
                 Start = Start,
                 Timeout = Timeout,
-                QueryStats = QueryStats,
+                QueryStats = queryData?.QueryStatistics ?? QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,
                 DocumentIncludes = new HashSet<string>(DocumentIncludes),

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1053,7 +1053,7 @@ namespace Raven.Client.Documents.Session
                 FilterModeStack = new Stack<bool>(FilterModeStack),
                 Start = Start,
                 Timeout = Timeout,
-                QueryStats = QueryStats,
+                QueryStats = queryData?.QueryStatistics ?? QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,
                 DocumentIncludes = new HashSet<string>(DocumentIncludes),

--- a/src/Raven.Client/Documents/Session/QueryStatistics.cs
+++ b/src/Raven.Client/Documents/Session/QueryStatistics.cs
@@ -87,5 +87,7 @@ namespace Raven.Client.Documents.Session
             ResultEtag = qr.ResultEtag;
             NodeTag = qr.NodeTag;
         }
+
+        internal bool RequestedByUser { get; set; }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_21525.cs
+++ b/test/SlowTests/Issues/RavenDB_21525.cs
@@ -1,0 +1,90 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21525 : RavenTestBase
+{
+    public RavenDB_21525(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Theory]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task OrderByWithPaginationVsUnordered(Options options)
+    {
+        int size = 10_000;
+
+        using (var store = GetDocumentStore(options))
+        {
+            using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < size; ++i)
+                {
+                    bulkInsert.Store(new Person() { Name = $"ItemNo{i}", Age = i % 100, Height = i % 200 });
+                }
+            }
+
+            for (int i = 0; i < size; i += 70)
+            {
+                // sync API
+                using (var session = store.OpenSession())
+                {
+                    var resultsOrdered = session.Query<Person>()
+                        .OrderBy(y => y.Age)
+                        .Statistics(out var orderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToList();
+
+                    var resultsUnordered = session.Query<Person>()
+                        .Statistics(out var unorderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToList();
+
+                    long totalOrdered = orderedStats.TotalResults;
+                    long totalUnordered = unorderedStats.TotalResults;
+                    Assert.Equal(totalUnordered, totalOrdered);
+                }
+
+                // async API
+                using (var session = store.OpenAsyncSession())
+                {
+                    var resultsOrdered = await session.Query<Person>()
+                        .OrderBy(y => y.Age)
+                        .Statistics(out var orderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToListAsync();
+
+                    var resultsUnordered = await session.Query<Person>()
+                        .Statistics(out var unorderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToListAsync();
+
+                    long totalOrdered = orderedStats.TotalResults;
+                    long totalUnordered = unorderedStats.TotalResults;
+                    Assert.Equal(totalUnordered, totalOrdered);
+                }
+                
+            }
+        }
+    }
+
+    private class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public int Height { get; set; }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21525

### Additional description

This fixes the original problem just partially. Now we'll send `SkipStatistics: false` if they were requested. Still there seems to be server side problem in Corax.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
