### PR TITLE
RavenDB-21523 switched backup compression algorithm to zstd with the configuration option to switch to previous gzip

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerExportOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerExportOptions.cs
@@ -2,9 +2,11 @@
 {
     public class DatabaseSmugglerExportOptions : DatabaseSmugglerOptions, IDatabaseSmugglerExportOptions
     {
+        public ExportCompressionAlgorithm? CompressionAlgorithm { get; set; }
     }
 
     internal interface IDatabaseSmugglerExportOptions : IDatabaseSmugglerOptions
     {
+        ExportCompressionAlgorithm? CompressionAlgorithm { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -87,4 +87,10 @@ namespace Raven.Client.Documents.Smuggler
         int MaxStepsForTransformScript { get; set; }
         List<string> Collections { get; set; }
     }
+
+    public enum ExportCompressionAlgorithm
+    {
+        Zstd,
+        Gzip
+    }
 }

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.Azure.Legacy", ConfigurationEntryScope.ServerWideOnly)]
         public bool AzureLegacy { get; set; }
 
-        [Description("Compression algorithm that is used to perform backups and exports.")]
+        [Description("Compression algorithm that is used to perform backups (does not apply to snapshot backups) and exports.")]
         [DefaultValue(BackupCompressionAlgorithm.Zstd)]
         [ConfigurationEntry("Backup.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public BackupCompressionAlgorithm CompressionAlgorithm { get; set; }

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -63,10 +63,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.Azure.Legacy", ConfigurationEntryScope.ServerWideOnly)]
         public bool AzureLegacy { get; set; }
 
-        [Description("Compression algorithm that is used to perform backups (does not apply to snapshot backups) and exports.")]
-        [DefaultValue(BackupCompressionAlgorithm.Zstd)]
+        [Description("Compression algorithm that is used to perform backups (does not apply to snapshot backups).")]
+        [DefaultValue(ExportCompressionAlgorithm.Zstd)]
         [ConfigurationEntry("Backup.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public BackupCompressionAlgorithm CompressionAlgorithm { get; set; }
+        public ExportCompressionAlgorithm CompressionAlgorithm { get; set; }
 
         public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
         {
@@ -152,7 +152,7 @@ namespace Raven.Server.Config.Categories
         }
     }
 
-    public enum BackupCompressionAlgorithm
+    public enum ExportCompressionAlgorithm
     {
         Zstd,
         Gzip

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -8,7 +8,6 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide;
-using Sparrow;
 
 namespace Raven.Server.Config.Categories
 {
@@ -64,7 +63,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.Azure.Legacy", ConfigurationEntryScope.ServerWideOnly)]
         public bool AzureLegacy { get; set; }
 
-        [Description("Compression algorithm that is used to perform backups.")]
+        [Description("Compression algorithm that is used to perform backups and exports.")]
         [DefaultValue(BackupCompressionAlgorithm.Zstd)]
         [ConfigurationEntry("Backup.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public BackupCompressionAlgorithm CompressionAlgorithm { get; set; }
@@ -98,7 +97,7 @@ namespace Raven.Server.Config.Categories
                 throw new ArgumentException($"The backup path '{LocalRootPath.FullPath}' defined in the configuration under '{RavenConfiguration.GetKey(x => x.Backup.LocalRootPath)}' doesn't exist.");
             }
         }
-        
+
         internal void ValidateAllowedDestinations()
         {
             if (AllowedDestinations == null)
@@ -155,8 +154,7 @@ namespace Raven.Server.Config.Categories
 
     public enum BackupCompressionAlgorithm
     {
-        None,
-        Gzip,
-        Zstd
+        Zstd,
+        Gzip
     }
 }

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide;
@@ -150,11 +151,5 @@ namespace Raven.Server.Config.Categories
 
             throw new ArgumentException($"The selected backup destination '{dest}' is not allowed in this RavenDB server. Contact the administrator for more information. Allowed backup destinations: {string.Join(", ", AllowedDestinations)}");
         }
-    }
-
-    public enum ExportCompressionAlgorithm
-    {
-        Zstd,
-        Gzip
     }
 }

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -64,6 +64,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.Azure.Legacy", ConfigurationEntryScope.ServerWideOnly)]
         public bool AzureLegacy { get; set; }
 
+        [Description("Compression algorithm that is used to perform backups.")]
+        [DefaultValue(BackupCompressionAlgorithm.Zstd)]
+        [ConfigurationEntry("Backup.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public BackupCompressionAlgorithm CompressionAlgorithm { get; set; }
+
         public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
         {
             base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
@@ -146,5 +151,12 @@ namespace Raven.Server.Config.Categories
 
             throw new ArgumentException($"The selected backup destination '{dest}' is not allowed in this RavenDB server. Contact the administrator for more information. Allowed backup destinations: {string.Join(", ", AllowedDestinations)}");
         }
+    }
+
+    public enum BackupCompressionAlgorithm
+    {
+        None,
+        Gzip,
+        Zstd
     }
 }

--- a/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
@@ -36,6 +36,8 @@ namespace Raven.Server.Config.Categories
         TransactionMerger,
         Updates,
         [Description("Traffic Watch")]
-        TrafficWatch
+        TrafficWatch,
+        [Description("Export & Import")]
+        ExportImport
     }
 }

--- a/src/Raven.Server/Config/Categories/ExportImportConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ExportImportConfiguration.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+using Raven.Server.Config.Attributes;
+
+namespace Raven.Server.Config.Categories
+{
+    [ConfigurationCategory(ConfigurationCategoryType.ExportImport)]
+    public class ExportImportConfiguration : ConfigurationCategory
+    {
+        [Description("Compression algorithm that is used to perform exports.")]
+        [DefaultValue(Categories.ExportCompressionAlgorithm.Zstd)]
+        [ConfigurationEntry("Export.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public ExportCompressionAlgorithm CompressionAlgorithm { get; set; }
+    }
+}

--- a/src/Raven.Server/Config/Categories/ExportImportConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ExportImportConfiguration.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Config.Attributes;
 
 namespace Raven.Server.Config.Categories
@@ -7,7 +8,7 @@ namespace Raven.Server.Config.Categories
     public class ExportImportConfiguration : ConfigurationCategory
     {
         [Description("Compression algorithm that is used to perform exports.")]
-        [DefaultValue(Categories.ExportCompressionAlgorithm.Zstd)]
+        [DefaultValue(ExportCompressionAlgorithm.Zstd)]
         [ConfigurationEntry("Export.Compression.Algorithm", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public ExportCompressionAlgorithm CompressionAlgorithm { get; set; }
     }

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -103,6 +103,8 @@ namespace Raven.Server.Config
 
         public TrafficWatchConfiguration TrafficWatch { get; }
 
+        public ExportImportConfiguration ExportImport { get; }
+
         internal string ConfigPath => _customConfigPath
                        ?? Path.Combine(AppContext.BaseDirectory, "settings.json");
 
@@ -153,6 +155,7 @@ namespace Raven.Server.Config
             Migration = new MigrationConfiguration();
             TrafficWatch = new TrafficWatchConfiguration();
             Integrations = new IntegrationsConfiguration();
+            ExportImport = new ExportImportConfiguration();
         }
 
         private void AddJsonConfigurationVariables(string customConfigPath = null)
@@ -214,6 +217,7 @@ namespace Raven.Server.Config
             Migration.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             TrafficWatch.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Integrations.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
+            ExportImport.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
 
             PostInit();
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1214,7 +1214,7 @@ namespace Raven.Server.Documents
                         var smugglerSource = new DatabaseSource(this, 0, 0, _logger);
                         using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
                         {
-                            var smugglerDestination = new StreamDestination(outputStream, documentsContext, smugglerSource);
+                            var smugglerDestination = new StreamDestination(outputStream, documentsContext, smugglerSource, Configuration.Backup);
                             var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide
                             {
                                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1214,7 +1214,7 @@ namespace Raven.Server.Documents
                         var smugglerSource = new DatabaseSource(this, 0, 0, _logger);
                         using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
                         {
-                            var smugglerDestination = new StreamDestination(outputStream, documentsContext, smugglerSource, Configuration.Backup);
+                            var smugglerDestination = new StreamDestination(outputStream, documentsContext, smugglerSource, Configuration.Backup.CompressionAlgorithm);
                             var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide
                             {
                                 AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -759,7 +759,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value, startRaftIndex.Value, _logger);
-                var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource);
+                var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, _database.Configuration.Backup);
                 var smuggler = new DatabaseSmuggler(_database,
                     smugglerSource,
                     smugglerDestination,

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -759,7 +759,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
                 var smugglerSource = new DatabaseSource(_database, startDocumentEtag.Value, startRaftIndex.Value, _logger);
-                var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, _database.Configuration.Backup);
+                var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, _database.Configuration.Backup.CompressionAlgorithm);
                 var smuggler = new DatabaseSmuggler(_database,
                     smugglerSource,
                     smugglerDestination,

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -908,7 +908,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             await using (var fileStream = await GetStream(filePath))
             await using (var inputStream = GetInputStream(fileStream, database.MasterKey))
-            await using (var gzipStream = RavenServerBackupUtils.GetDecompressionStream(inputStream))
+            await using (var gzipStream = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
             using (var source = new StreamSource(gzipStream, context, database))
             {
                 var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,
@@ -956,7 +956,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     {
                         await using (var input = entry.Open())
                         await using (var inputStream = GetSnapshotInputStream(input, database.Name))
-                        await using (var uncompressed = RavenServerBackupUtils.GetDecompressionStream(inputStream))
+                        await using (var uncompressed = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
                         {
                             var source = new StreamSource(uncompressed, context, database);
                             var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -908,7 +908,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             await using (var fileStream = await GetStream(filePath))
             await using (var inputStream = GetInputStream(fileStream, database.MasterKey))
-            await using (var gzipStream = new GZipStream(inputStream, CompressionMode.Decompress))
+            await using (var gzipStream = RavenServerBackupUtils.GetDecompressionStream(inputStream))
             using (var source = new StreamSource(gzipStream, context, database))
             {
                 var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,
@@ -956,7 +956,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     {
                         await using (var input = entry.Open())
                         await using (var inputStream = GetSnapshotInputStream(input, database.Name))
-                        await using (var uncompressed = new GZipStream(inputStream, CompressionMode.Decompress))
+                        await using (var uncompressed = RavenServerBackupUtils.GetDecompressionStream(inputStream))
                         {
                             var source = new StreamSource(uncompressed, context, database);
                             var smuggler = new Smuggler.Documents.DatabaseSmuggler(database, source, destination,

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Routing;

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -15,6 +15,8 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         public bool SkipRevisionCreation { get; set; }
 
+        public ExportCompressionAlgorithm? CompressionAlgorithm { get; set; }
+
         public static DatabaseSmugglerOptionsServerSide Create(HttpContext httpContext)
         {
             var result = new DatabaseSmugglerOptionsServerSide();

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex, Logger);
                 await using (var outputStream = GetOutputStream(ResponseBodyStream(), options))
                 {
-                    var destination = new StreamDestination(outputStream, context, source, Database.Configuration.ExportImport.CompressionAlgorithm);
+                    var destination = new StreamDestination(outputStream, context, source, options.CompressionAlgorithm ?? Database.Configuration.ExportImport.CompressionAlgorithm);
                     var smuggler = new DatabaseSmuggler(Database, source, destination, Database.Time, options, onProgress: onProgress, token: token.Token);
                     return await smuggler.ExecuteAsync();
                 }

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -239,7 +239,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             {
                 var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
 
-                await using (var stream = BackupUtils.GetDecompressionStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte)))
+                await using (var stream = await BackupUtils.GetDecompressionStreamAsync(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte)))
                 using (var token = CreateHttpRequestBoundOperationToken())
                 using (var source = new StreamSource(stream, context, Database))
                 {
@@ -318,7 +318,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
 
                         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         await using (var file = await getFile())
-                        await using (var stream = Utils.BackupUtils.GetDecompressionStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
+                        await using (var stream = await BackupUtils.GetDecompressionStreamAsync(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
                         using (var source = new StreamSource(stream, context, Database))
                         {
                             var destination = new DatabaseDestination(Database);
@@ -720,7 +720,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                                     ApplyBackwardCompatibility(options);
 
                                     var inputStream = GetInputStream(section.Body, options);
-                                    var stream = BackupUtils.GetDecompressionStream(inputStream);
+                                    var stream = await BackupUtils.GetDecompressionStreamAsync(inputStream);
                                     await DoImportInternalAsync(context, stream, options, result, onProgress, token);
                                 }
                             }

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -43,6 +43,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Utils;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
 
 namespace Raven.Server.Smuggler.Documents.Handlers
 {
@@ -200,7 +201,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex, Logger);
                 await using (var outputStream = GetOutputStream(ResponseBodyStream(), options))
                 {
-                    var destination = new StreamDestination(outputStream, context, source);
+                    var destination = new StreamDestination(outputStream, context, source, Database.Configuration.Backup);
                     var smuggler = new DatabaseSmuggler(Database, source, destination, Database.Time, options, onProgress: onProgress, token: token.Token);
                     return await smuggler.ExecuteAsync();
                 }
@@ -238,7 +239,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             {
                 var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
 
-                await using (var stream = new GZipStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
+                await using (var stream = BackupUtils.GetDecompressionStream(new BufferedStream(await GetImportStream(), 128 * Voron.Global.Constants.Size.Kilobyte)))
                 using (var token = CreateHttpRequestBoundOperationToken())
                 using (var source = new StreamSource(stream, context, Database))
                 {
@@ -317,7 +318,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
 
                         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         await using (var file = await getFile())
-                        await using (var stream = new GZipStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte), CompressionMode.Decompress))
+                        await using (var stream = Utils.BackupUtils.GetDecompressionStream(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
                         using (var source = new StreamSource(stream, context, Database))
                         {
                             var destination = new DatabaseDestination(Database);
@@ -719,7 +720,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                                     ApplyBackwardCompatibility(options);
 
                                     var inputStream = GetInputStream(section.Body, options);
-                                    var stream = new GZipStream(inputStream, CompressionMode.Decompress);
+                                    var stream = BackupUtils.GetDecompressionStream(inputStream);
                                     await DoImportInternalAsync(context, stream, options, result, onProgress, token);
                                 }
                             }

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                 var source = new DatabaseSource(Database, startDocumentEtag, startRaftIndex, Logger);
                 await using (var outputStream = GetOutputStream(ResponseBodyStream(), options))
                 {
-                    var destination = new StreamDestination(outputStream, context, source, Database.Configuration.Backup);
+                    var destination = new StreamDestination(outputStream, context, source, Database.Configuration.ExportImport.CompressionAlgorithm);
                     var smuggler = new DatabaseSmuggler(Database, source, destination, Database.Time, options, onProgress: onProgress, token: token.Token);
                     return await smuggler.ExecuteAsync();
                 }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client;
@@ -40,30 +39,33 @@ using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
 
 namespace Raven.Server.Smuggler.Documents
 {
     public class StreamDestination : ISmugglerDestination
     {
         private readonly Stream _stream;
-        private GZipStream _gzipStream;
+        private Stream _outputStream;
         private readonly DocumentsOperationContext _context;
         private readonly DatabaseSource _source;
+        private readonly Raven.Server.Config.Categories.BackupConfiguration _configuration;
         private AsyncBlittableJsonTextWriter _writer;
         private DatabaseSmugglerOptionsServerSide _options;
         private Func<LazyStringValue, bool> _filterMetadataProperty;
 
-        public StreamDestination(Stream stream, DocumentsOperationContext context, DatabaseSource source)
+        public StreamDestination(Stream stream, DocumentsOperationContext context, DatabaseSource source, Raven.Server.Config.Categories.BackupConfiguration configuration)
         {
             _stream = stream;
             _context = context;
             _source = source;
+            _configuration = configuration;
         }
 
         public IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
         {
-            _gzipStream = new GZipStream(_stream, CompressionMode.Compress, leaveOpen: true);
-            _writer = new AsyncBlittableJsonTextWriter(_context, _gzipStream);
+            _outputStream = BackupUtils.GetCompressionStream(_stream, _configuration);
+            _writer = new AsyncBlittableJsonTextWriter(_context, _outputStream);
             _options = options;
 
             SetupMetadataFilterMethod(_context);
@@ -77,7 +79,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 _writer.WriteEndObject();
                 await _writer.DisposeAsync();
-                await _gzipStream.DisposeAsync();
+                await _outputStream.DisposeAsync();
             });
         }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -27,6 +27,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.PeriodicBackup;
@@ -49,22 +50,22 @@ namespace Raven.Server.Smuggler.Documents
         private Stream _outputStream;
         private readonly DocumentsOperationContext _context;
         private readonly DatabaseSource _source;
-        private readonly Raven.Server.Config.Categories.BackupConfiguration _configuration;
+        private readonly ExportCompressionAlgorithm _compressionAlgorithm;
         private AsyncBlittableJsonTextWriter _writer;
         private DatabaseSmugglerOptionsServerSide _options;
         private Func<LazyStringValue, bool> _filterMetadataProperty;
 
-        public StreamDestination(Stream stream, DocumentsOperationContext context, DatabaseSource source, Raven.Server.Config.Categories.BackupConfiguration configuration)
+        public StreamDestination(Stream stream, DocumentsOperationContext context, DatabaseSource source, ExportCompressionAlgorithm compressionAlgorithm)
         {
             _stream = stream;
             _context = context;
             _source = source;
-            _configuration = configuration;
+            _compressionAlgorithm = compressionAlgorithm;
         }
 
         public IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
         {
-            _outputStream = BackupUtils.GetCompressionStream(_stream, _configuration);
+            _outputStream = BackupUtils.GetCompressionStream(_stream, _compressionAlgorithm);
             _writer = new AsyncBlittableJsonTextWriter(_context, _outputStream);
             _options = options;
 

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Smuggler.Migration
             }
 
             await using (var responseStream = await response.Content.ReadAsStreamAsync())
-            await using (var stream = BackupUtils.GetDecompressionStream(responseStream))
+            await using (var stream = await BackupUtils.GetDecompressionStreamAsync(responseStream))
             using (Parameters.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var source = new StreamSource(stream, context, Parameters.Database))
             {

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -20,6 +20,7 @@ using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Utils;
 using Sparrow.Json;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
 
 namespace Raven.Server.Smuggler.Migration
 {
@@ -171,7 +172,7 @@ namespace Raven.Server.Smuggler.Migration
             }
 
             await using (var responseStream = await response.Content.ReadAsStreamAsync())
-            await using (var stream = new GZipStream(responseStream, mode: CompressionMode.Decompress))
+            await using (var stream = BackupUtils.GetDecompressionStream(responseStream))
             using (Parameters.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var source = new StreamSource(stream, context, Parameters.Database))
             {

--- a/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
@@ -319,7 +319,7 @@ namespace Raven.Server.Smuggler.Migration
             }
 
             await using (var responseStream = await response.Content.ReadAsStreamAsync())
-            await using (var stream = BackupUtils.GetDecompressionStream(responseStream))
+            await using (var stream = await BackupUtils.GetDecompressionStreamAsync(responseStream))
             using (Parameters.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var source = new StreamSource(stream, context, Parameters.Database))
             {

--- a/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
@@ -15,6 +15,7 @@ using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
 using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
 
 namespace Raven.Server.Smuggler.Migration
@@ -318,7 +319,7 @@ namespace Raven.Server.Smuggler.Migration
             }
 
             await using (var responseStream = await response.Content.ReadAsStreamAsync())
-            await using (var stream = new GZipStream(responseStream, mode: CompressionMode.Decompress))
+            await using (var stream = BackupUtils.GetDecompressionStream(responseStream))
             using (Parameters.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var source = new StreamSource(stream, context, Parameters.Database))
             {

--- a/src/Raven.Server/Utils/BackupStream.cs
+++ b/src/Raven.Server/Utils/BackupStream.cs
@@ -1,0 +1,100 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace Raven.Server.Utils;
+
+public sealed class BackupStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly byte _b;
+    private bool _hasRead;
+
+    public BackupStream(Stream inner, byte b)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _b = b;
+    }
+
+    public override void Flush()
+    {
+        _inner.Flush();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_hasRead == false)
+        {
+            _hasRead = true;
+            buffer[offset] = _b;
+            return 1;
+        }
+
+        return _inner.Read(buffer, offset, count);
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (_hasRead == false)
+        {
+            _hasRead = true;
+            buffer[offset] = _b;
+            return Task.FromResult(1);
+        }
+
+        return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (_hasRead == false)
+        {
+            _hasRead = true;
+            buffer.Span[0] = _b;
+            return ValueTask.FromResult(1);
+        }
+
+        return _inner.ReadAsync(buffer, cancellationToken);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get
+        {
+            return _hasRead ? _inner.Position : 0;
+        }
+
+        set { throw new NotSupportedException(); }
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        return _inner.DisposeAsync();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _inner.Dispose();
+    }
+}

--- a/src/Raven.Server/Utils/BackupStream.cs
+++ b/src/Raven.Server/Utils/BackupStream.cs
@@ -19,7 +19,19 @@ public sealed class BackupStream : Stream
 
     public override void Flush()
     {
-        _inner.Flush();
+        throw new NotSupportedException();
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        if (_hasRead == false)
+        {
+            _hasRead = true;
+            buffer[0] = _b;
+            return 1;
+        }
+
+        return _inner.Read(buffer);
     }
 
     public override int Read(byte[] buffer, int offset, int count)

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -50,7 +50,7 @@ internal static class BackupUtils
             {
                 31 => new GZipStream(backupStream, CompressionMode.Decompress),
                 40 => ZstdStream.Decompress(backupStream),
-                _ => throw new NotSupportedException()
+                _ => throw new NotSupportedException($"Unknown stream format ({buffer[0]})")
             };
         }
         finally

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -11,6 +11,7 @@ using NCrontab.Advanced;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Smuggler;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -44,18 +44,19 @@ internal static class BackupUtils
             if (read == 0)
                 throw new InvalidOperationException("Empty stream");
 
+            var backupStream = new BackupStream(stream, buffer[0]);
+
             return buffer[0] switch
             {
-                31 => new GZipStream(new BackupStream(stream, buffer[0]), CompressionMode.Decompress),
-                40 => ZstdStream.Decompress(new BackupStream(stream, buffer[0])),
-                _ => throw new NotSupportedException()
+                31 => new GZipStream(backupStream, CompressionMode.Decompress),
+                40 => ZstdStream.Decompress(backupStream),
+                _ => backupStream
             };
         }
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
         }
-
     }
 
     internal static Stream GetCompressionStream(Stream stream, Raven.Server.Config.Categories.BackupConfiguration configuration)

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -50,7 +50,7 @@ internal static class BackupUtils
             {
                 31 => new GZipStream(backupStream, CompressionMode.Decompress),
                 40 => ZstdStream.Decompress(backupStream),
-                _ => backupStream
+                _ => throw new NotSupportedException()
             };
         }
         finally
@@ -63,9 +63,6 @@ internal static class BackupUtils
     {
         switch (configuration.CompressionAlgorithm)
         {
-            case BackupCompressionAlgorithm.None:
-                return stream;
-                break;
             case BackupCompressionAlgorithm.Gzip:
                 return new GZipStream(stream, CompressionMode.Compress, leaveOpen: true);
             case BackupCompressionAlgorithm.Zstd:

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -59,13 +59,13 @@ internal static class BackupUtils
         }
     }
 
-    internal static Stream GetCompressionStream(Stream stream, Raven.Server.Config.Categories.BackupConfiguration configuration)
+    internal static Stream GetCompressionStream(Stream stream, ExportCompressionAlgorithm compressionAlgorithm)
     {
-        switch (configuration.CompressionAlgorithm)
+        switch (compressionAlgorithm)
         {
-            case BackupCompressionAlgorithm.Gzip:
+            case ExportCompressionAlgorithm.Gzip:
                 return new GZipStream(stream, CompressionMode.Compress, leaveOpen: true);
-            case BackupCompressionAlgorithm.Zstd:
+            case ExportCompressionAlgorithm.Zstd:
                 return ZstdStream.Compress(stream);
             default:
                 throw new ArgumentOutOfRangeException();

--- a/src/Raven.Server/Web/Studio/SampleDataHandler.cs
+++ b/src/Raven.Server/Web/Studio/SampleDataHandler.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Web.Studio
                 await using (var sampleData = typeof(SampleDataHandler).Assembly
                     .GetManifestResourceStream("Raven.Server.Web.Studio.EmbeddedData.Northwind.ravendbdump"))
                 {
-                    await using (var stream = Raven.Server.Utils.BackupUtils.GetDecompressionStream(sampleData))
+                    await using (var stream = await Raven.Server.Utils.BackupUtils.GetDecompressionStreamAsync(sampleData))
                     using (var source = new StreamSource(stream, context, Database))
                     {
                         var destination = new DatabaseDestination(Database);

--- a/src/Raven.Server/Web/Studio/SampleDataHandler.cs
+++ b/src/Raven.Server/Web/Studio/SampleDataHandler.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Web.Studio
                 await using (var sampleData = typeof(SampleDataHandler).Assembly
                     .GetManifestResourceStream("Raven.Server.Web.Studio.EmbeddedData.Northwind.ravendbdump"))
                 {
-                    await using (var stream = new GZipStream(sampleData, CompressionMode.Decompress))
+                    await using (var stream = Raven.Server.Utils.BackupUtils.GetDecompressionStream(sampleData))
                     using (var source = new StreamSource(stream, context, Database))
                     {
                         var destination = new DatabaseDestination(Database);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1367,7 +1367,7 @@ namespace Raven.Server.Web.System
                                 onProgress(overallProgress);
                                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                                 await using (var reader = File.OpenRead(configuration.OutputFilePath))
-                                await using (var stream = BackupUtils.GetDecompressionStream(reader))
+                                await using (var stream = await BackupUtils.GetDecompressionStreamAsync(reader))
                                 using (var source = new StreamSource(stream, context, database))
                                 {
                                     var destination = new DatabaseDestination(database);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -53,6 +53,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Voron.Util.Settings;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
 using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
 using Index = Raven.Server.Documents.Indexes.Index;
 using Size = Sparrow.Size;
@@ -1366,7 +1367,7 @@ namespace Raven.Server.Web.System
                                 onProgress(overallProgress);
                                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                                 await using (var reader = File.OpenRead(configuration.OutputFilePath))
-                                await using (var stream = new GZipStream(reader, CompressionMode.Decompress))
+                                await using (var stream = BackupUtils.GetDecompressionStream(reader))
                                 using (var source = new StreamSource(stream, context, database))
                                 {
                                     var destination = new DatabaseDestination(database);

--- a/test/SlowTests/Issues/RavenDB_21523.cs
+++ b/test/SlowTests/Issues/RavenDB_21523.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Orders;
+using Org.BouncyCastle.Bcpg.Sig;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Utils;
@@ -28,7 +32,9 @@ public class RavenDB_21523 : RavenTestBase
     public async Task CanExportImport(BackupCompressionAlgorithm algorithm)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
+        IOExtensions.DeleteDirectory(backupPath);
         var exportFile = Path.Combine(backupPath, "export.ravendbdump");
+
         using (var store = GetDocumentStore(new Options
         {
             ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Backup.CompressionAlgorithm)] = algorithm.ToString()
@@ -77,6 +83,90 @@ public class RavenDB_21523 : RavenTestBase
 
                 Assert.NotNull(company);
                 Assert.Equal("HR", company.Name);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.BackupExportImport)]
+    [InlineData(BackupCompressionAlgorithm.Gzip, BackupType.Backup)]
+    [InlineData(BackupCompressionAlgorithm.Zstd, BackupType.Backup)]
+    //[InlineData(BackupCompressionAlgorithm.Gzip, BackupType.Snapshot)]
+    //[InlineData(BackupCompressionAlgorithm.Zstd, BackupType.Snapshot)]
+    public async Task CanBackupRestore(BackupCompressionAlgorithm algorithm, BackupType backupType)
+    {
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        IOExtensions.DeleteDirectory(backupPath);
+
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Backup.CompressionAlgorithm)] = algorithm.ToString()
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Company { Name = "HR" }, "companies/1");
+                await session.SaveChangesAsync();
+            }
+
+            var config = Backup.CreateBackupConfiguration(backupPath, backupType);
+            await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+            var databaseName = GetDatabaseName() + "restore";
+
+            var backupDirectory = Directory.GetDirectories(backupPath).First();
+            var files = Directory.GetFiles(backupDirectory)
+                .Where(Raven.Client.Documents.Smuggler.BackupUtils.IsFullBackupOrSnapshot)
+                .OrderBackups()
+                .ToArray();
+
+            var lastFile = files.Last();
+
+            Assert.True(File.Exists(lastFile));
+
+            await using (var fileStream = File.OpenRead(lastFile))
+            await using (var backupStream = await BackupUtils.GetDecompressionStreamAsync(fileStream))
+            {
+                var buffer = new byte[1024];
+                var read = await backupStream.ReadAsync(buffer, 0, buffer.Length); // validates if we picked appropriate decompression algorithm
+                Assert.True(read > 0);
+
+                switch (algorithm)
+                {
+                    case BackupCompressionAlgorithm.Gzip:
+                        Assert.IsType<GZipStream>(backupStream);
+                        break;
+                    case BackupCompressionAlgorithm.Zstd:
+                        Assert.IsType<ZstdStream>(backupStream);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null);
+                }
+            }
+
+            var restoreConfig = new RestoreBackupConfiguration()
+            {
+                BackupLocation = backupDirectory,
+                DatabaseName = databaseName,
+                LastFileNameToRestore = lastFile
+            };
+
+            var restoreOperation = new RestoreBackupOperation(restoreConfig);
+            var operation = await store.Maintenance.Server.SendAsync(restoreOperation);
+            await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+            using (var store2 = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                ModifyDatabaseName = s => databaseName
+            }))
+            {
+                using (var session = store2.OpenAsyncSession())
+                {
+                    var company = await session.LoadAsync<Company>("companies/1");
+
+                    Assert.NotNull(company);
+                    Assert.Equal("HR", company.Name);
+                }
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_21523.cs
+++ b/test/SlowTests/Issues/RavenDB_21523.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Orders;
-using Org.BouncyCastle.Bcpg.Sig;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;
@@ -27,9 +26,9 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
-    [InlineData(BackupCompressionAlgorithm.Gzip)]
-    [InlineData(BackupCompressionAlgorithm.Zstd)]
-    public async Task CanExportImport(BackupCompressionAlgorithm algorithm)
+    [InlineData(ExportCompressionAlgorithm.Gzip)]
+    [InlineData(ExportCompressionAlgorithm.Zstd)]
+    public async Task CanExportImport(ExportCompressionAlgorithm algorithm)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
         IOExtensions.DeleteDirectory(backupPath);
@@ -37,7 +36,7 @@ public class RavenDB_21523 : RavenTestBase
 
         using (var store = GetDocumentStore(new Options
         {
-            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Backup.CompressionAlgorithm)] = algorithm.ToString()
+            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.ExportImport.CompressionAlgorithm)] = algorithm.ToString()
         }))
         {
             using (var session = store.OpenAsyncSession())
@@ -60,10 +59,10 @@ public class RavenDB_21523 : RavenTestBase
 
                 switch (algorithm)
                 {
-                    case BackupCompressionAlgorithm.Gzip:
+                    case ExportCompressionAlgorithm.Gzip:
                         Assert.IsType<GZipStream>(backupStream);
                         break;
-                    case BackupCompressionAlgorithm.Zstd:
+                    case ExportCompressionAlgorithm.Zstd:
                         Assert.IsType<ZstdStream>(backupStream);
                         break;
                     default:
@@ -88,11 +87,11 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
-    [InlineData(BackupCompressionAlgorithm.Gzip, BackupType.Backup)]
-    [InlineData(BackupCompressionAlgorithm.Zstd, BackupType.Backup)]
+    [InlineData(ExportCompressionAlgorithm.Gzip, BackupType.Backup)]
+    [InlineData(ExportCompressionAlgorithm.Zstd, BackupType.Backup)]
     //[InlineData(BackupCompressionAlgorithm.Gzip, BackupType.Snapshot)]
     //[InlineData(BackupCompressionAlgorithm.Zstd, BackupType.Snapshot)]
-    public async Task CanBackupRestore(BackupCompressionAlgorithm algorithm, BackupType backupType)
+    public async Task CanBackupRestore(ExportCompressionAlgorithm algorithm, BackupType backupType)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
         IOExtensions.DeleteDirectory(backupPath);
@@ -132,10 +131,10 @@ public class RavenDB_21523 : RavenTestBase
 
                 switch (algorithm)
                 {
-                    case BackupCompressionAlgorithm.Gzip:
+                    case ExportCompressionAlgorithm.Gzip:
                         Assert.IsType<GZipStream>(backupStream);
                         break;
-                    case BackupCompressionAlgorithm.Zstd:
+                    case ExportCompressionAlgorithm.Zstd:
                         Assert.IsType<ZstdStream>(backupStream);
                         break;
                     default:

--- a/test/SlowTests/Issues/RavenDB_21523.cs
+++ b/test/SlowTests/Issues/RavenDB_21523.cs
@@ -23,7 +23,6 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
-    [InlineData(BackupCompressionAlgorithm.None)]
     [InlineData(BackupCompressionAlgorithm.Gzip)]
     [InlineData(BackupCompressionAlgorithm.Zstd)]
     public async Task CanExportImport(BackupCompressionAlgorithm algorithm)
@@ -55,9 +54,6 @@ public class RavenDB_21523 : RavenTestBase
 
                 switch (algorithm)
                 {
-                    case BackupCompressionAlgorithm.None:
-                        Assert.IsType<BackupStream>(backupStream);
-                        break;
                     case BackupCompressionAlgorithm.Gzip:
                         Assert.IsType<GZipStream>(backupStream);
                         break;

--- a/test/SlowTests/Issues/RavenDB_21523.cs
+++ b/test/SlowTests/Issues/RavenDB_21523.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server.Config;
+using Raven.Server.Config.Categories;
+using Raven.Server.Utils;
+using Sparrow.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21523 : RavenTestBase
+{
+    public RavenDB_21523(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.BackupExportImport)]
+    [InlineData(BackupCompressionAlgorithm.None)]
+    [InlineData(BackupCompressionAlgorithm.Gzip)]
+    [InlineData(BackupCompressionAlgorithm.Zstd)]
+    public async Task CanExportImport(BackupCompressionAlgorithm algorithm)
+    {
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        var exportFile = Path.Combine(backupPath, "export.ravendbdump");
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Backup.CompressionAlgorithm)] = algorithm.ToString()
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Company { Name = "HR" }, "companies/1");
+                await session.SaveChangesAsync();
+            }
+
+            var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportFile);
+            await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
+
+            Assert.True(File.Exists(exportFile));
+
+            await using (var fileStream = File.OpenRead(exportFile))
+            await using (var backupStream = await BackupUtils.GetDecompressionStreamAsync(fileStream))
+            {
+                var buffer = new byte[1024];
+                var read = await backupStream.ReadAsync(buffer, 0, buffer.Length); // validates if we picked appropriate decompression algorithm
+                Assert.True(read > 0);
+
+                switch (algorithm)
+                {
+                    case BackupCompressionAlgorithm.None:
+                        Assert.IsType<BackupStream>(backupStream);
+                        break;
+                    case BackupCompressionAlgorithm.Gzip:
+                        Assert.IsType<GZipStream>(backupStream);
+                        break;
+                    case BackupCompressionAlgorithm.Zstd:
+                        Assert.IsType<ZstdStream>(backupStream);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null);
+                }
+            }
+        }
+
+        using (var store = GetDocumentStore())
+        {
+            var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), exportFile);
+            await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var company = await session.LoadAsync<Company>("companies/1");
+
+                Assert.NotNull(company);
+                Assert.Equal("HR", company.Name);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -18,6 +18,7 @@ using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Sparrow.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1500,7 +1501,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 using (FileStream fs = file.OpenRead())
                 {
                     using (var stream = new MemoryStream())
-                    using (var gz = new GZipStream(fs, CompressionMode.Decompress))
+                    using (var gz = ZstdStream.Decompress(fs))
                     {
                         gz.CopyTo(stream);
                         stream.Position = 0;

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 8072;
+            const int numberToTolerate = 6452;
             if (array.Length == numberToTolerate)
                 return;
 
@@ -103,27 +103,30 @@ namespace SlowTests.Tests
 
             static bool Filter(MethodInfo method)
             {
-                var factAttributes = method.GetCustomAttribute(typeof(FactAttribute), false);
-
-                if (factAttributes != null)
+                var factAttribute = method.GetCustomAttribute(typeof(FactAttribute), false);
+                if (factAttribute != null)
                 {
-                    if (factAttributes.GetType() == typeof(RavenFactAttribute))
+                    if (ValidNamespace(factAttribute.GetType().Namespace))
                         return false;
 
                     return true;
                 }
 
-                var theoryAttributes = method.GetCustomAttribute(typeof(TheoryAttribute), false);
-
-                if (theoryAttributes != null)
+                var theoryAttribute = method.GetCustomAttribute(typeof(TheoryAttribute), false);
+                if (theoryAttribute != null)
                 {
-                    if (theoryAttributes.GetType() == typeof(RavenTheoryAttribute))
+                    if (ValidNamespace(theoryAttribute.GetType().Namespace))
                         return false;
 
                     return true;
                 }
 
                 return false;
+            }
+
+            static bool ValidNamespace(string @namespace)
+            {
+                return @namespace == null || @namespace.StartsWith("FastTests") || @namespace.StartsWith("SlowTests") || @namespace.StartsWith("Tests.Infrastructure");
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21523

### Type of change

- Optimization
- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
