### PR TITLE
RavenDB-21457 Integrations View - the screen is empty when error occured

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/settings/integrations.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/integrations.ts
@@ -17,6 +17,7 @@ class integrations extends shardViewModelBase {
 
     view = require("views/database/settings/integrations.html");
     
+    isDataFetched = ko.observable<boolean>(false);
     postgreSqlCredentials = ko.observableArray<string>([]);
     
     editedPostgreSqlCredentials = ko.observable<postgreSqlCredentialsModel>(null);
@@ -61,7 +62,7 @@ class integrations extends shardViewModelBase {
         });
     }
 
-    activate(args: any) {
+    async activate(args: any) {
         super.activate(args);
 
         if (!this.canUseIntegrations) {
@@ -76,9 +77,14 @@ class integrations extends shardViewModelBase {
             return ;
         }  
         
-        return $.when<any>(this.getAllIntegrationsCredentials(), this.getPostgreSqlSupportStatus());
+        try {
+            await Promise.all([this.getAllIntegrationsCredentials(), this.getPostgreSqlSupportStatus()]);
+            this.isDataFetched(true);
+        } catch (_) {
+            this.isDataFetched(false);
+        }
     }
-    
+
     private getPostgreSqlSupportStatus(): JQueryPromise<Raven.Server.Integrations.PostgreSQL.Handlers.PostgreSqlServerStatus> {
         return new getIntegrationsPostgreSqlSupportCommand(this.db)
             .execute()

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/integrations.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/integrations.html
@@ -28,13 +28,13 @@
             </div>
         </div>
     </div>
-    <div class="row flex-row flex-grow flex-stretch-items">
+    <div class="row flex-row flex-grow flex-stretch-items" data-bind="visible: canUseIntegrations">
         <div class="col-sm-12 col-lg-6 flex-vertical">
             <div class="scroll flex-grow">
                 <div class="hr-title on-base-background margin-top">
                     <h5><strong>PostgreSQL</strong> protocol credentials</h5><hr>
                     <button class="btn btn-sm btn-primary" title="Add new credentials"
-                            data-bind="click: onAddPostgreSqlCredentials, requiredAccess: 'DatabaseAdmin'">
+                            data-bind="click: onAddPostgreSqlCredentials, disable: !isDataFetched(), requiredAccess: 'DatabaseAdmin'">
                         <i class="icon-plus"></i><span>Add</span>
                     </button> 
                 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21457/Integrations-View-the-screen-is-empty-when-error-occured

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/1b3834d6-2c73-44a5-b8dc-b30d586d8d04)
![image](https://github.com/ravendb/ravendb/assets/47967925/143ec319-cd19-4444-b9a6-4e1169fadfba)
