### PR TITLE
RavenDB-21528 added support for brotli and zstd compression

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <NoWarn>CS0419,CS1591,CS1572,CS1573,CS1574,CS1723</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_BROTLI_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_BROTLI_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IsAnyOS>true</IsAnyOS>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <NoWarn>CS0419,CS1591,CS1572,CS1573,CS1574,CS1723</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_BROTLI_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IsAnyOS>true</IsAnyOS>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <NoWarn>CS0419,CS1591,CS1572,CS1573,CS1574,CS1723</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_BROTLI_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IsAnyOS>true</IsAnyOS>

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -69,6 +69,8 @@ namespace Raven.Client
 
             public const string ContentEncoding = "Content-Encoding";
 
+            public const string AcceptEncoding = "Accept-Encoding";
+
             public const string ContentDisposition = "Content-Disposition";
 
             public const string ContentType = "Content-Type";

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -97,9 +97,15 @@ namespace Raven.Client
 
                 public const string Gzip = "gzip";
 
+#if FEATURE_BROTLI_SUPPORT
                 public const string Brotli = "br";
+#endif
 
                 public const string Deflate = "deflate";
+
+#if FEATURE_ZSTD_SUPPORT
+                public const string Zstd = "zstd";
+#endif
             }
         }
 
@@ -193,7 +199,7 @@ namespace Raven.Client
             {
                 internal const string IndexingStaticSearchEngineType = "Indexing.Static.SearchEngineType";
             }
-            
+
             public const string ClientId = "Configuration/Client";
 
             public const string StudioId = "Configuration/Studio";
@@ -280,7 +286,7 @@ namespace Raven.Client
                 public const string Refresh = "@refresh";
 
                 public const string ArchiveAt = "@archive-at";
-                
+
                 public const string Archived = "@archived";
 
                 public const string HasValue = "HasValue";
@@ -364,15 +370,15 @@ namespace Raven.Client
                         private JavaScript()
                         {
                         }
-                        
+
                         public const string ValuePropertyName = "$value";
-                        
+
                         public const string OptionsPropertyName = "$options";
-                        
+
                         public const string NamePropertyName = "$name";
-                        
+
                         public const string SpatialPropertyName = "$spatial";
-                        
+
                         public const string BoostPropertyName = "$boost";
                     }
                 }

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -88,6 +88,19 @@ namespace Raven.Client
             public const string AttachmentSize = "Attachment-Size";
 
             internal const string DatabaseMissing = "Database-Missing";
+
+            internal class Encodings
+            {
+                private Encodings()
+                {
+                }
+
+                public const string Gzip = "gzip";
+
+                public const string Brotli = "br";
+
+                public const string Deflate = "deflate";
+            }
         }
 
         public sealed class Platform

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -417,21 +417,7 @@ namespace Raven.Client.Documents.BulkInsert
         protected override async Task EnsureStreamAsync()
         {
             if (CompressionLevel != CompressionLevel.NoCompression)
-            {
-                switch (_requestExecutor.Conventions.HttpCompressionAlgorithm)
-                {
-                    case HttpCompressionAlgorithm.Gzip:
-                        _writer.StreamExposer.Headers.ContentEncoding.Add("gzip");
-                        break;
-#if FEATURE_BROTLI_SUPPORT
-                    case HttpCompressionAlgorithm.Brotli:
-                        _writer.StreamExposer.Headers.ContentEncoding.Add("br");
-                        break;
-#endif
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
+                _writer.StreamExposer.Headers.ContentEncoding.Add(_requestExecutor.Conventions.HttpCompressionAlgorithm.GetContentEncoding());
 
             var bulkCommand = new BulkInsertCommand(
                 OperationId,

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -423,7 +423,7 @@ namespace Raven.Client.Documents.BulkInsert
                     case HttpCompressionAlgorithm.Gzip:
                         _writer.StreamExposer.Headers.ContentEncoding.Add("gzip");
                         break;
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
                     case HttpCompressionAlgorithm.Brotli:
                         _writer.StreamExposer.Headers.ContentEncoding.Add("br");
                         break;

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -146,7 +146,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
                 case HttpCompressionAlgorithm.Gzip:
                     stream = new GZipStream(stream, compressionLevel, leaveOpen: true);
                     break;
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
                     stream = new BrotliStream(stream, compressionLevel, leaveOpen: true);
                     break;

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Client.Http;
 using Sparrow.Json;
 using Sparrow.Threading;
+using Sparrow.Utils;
 
 namespace Raven.Client.Documents.BulkInsert;
 
@@ -149,6 +150,11 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 #if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
                     stream = new BrotliStream(stream, compressionLevel, leaveOpen: true);
+                    break;
+#endif
+#if FEATURE_ZSTD_SUPPORT
+                case HttpCompressionAlgorithm.Zstd:
+                    stream = ZstdStream.Compress(stream);
                     break;
 #endif
                 default:

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -154,7 +154,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    stream = ZstdStream.Compress(stream, leaveOpen: true);
+                    stream = ZstdStream.Compress(stream, level: 1, leaveOpen: true);
                     break;
 #endif
                 default:

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -154,7 +154,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    stream = ZstdStream.Compress(stream);
+                    stream = ZstdStream.Compress(stream, leaveOpen: true);
                     break;
 #endif
                 default:

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -154,7 +154,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    stream = ZstdStream.Compress(stream, level: 1, leaveOpen: true);
+                    stream = ZstdStream.Compress(stream, compressionLevel, leaveOpen: true);
                     break;
 #endif
                 default:

--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents.Commands
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
             Result = new StreamResult
             {

--- a/src/Raven.Client/Documents/Commands/StreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/StreamCommand.cs
@@ -29,7 +29,7 @@ namespace Raven.Client.Documents.Commands
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
             Result = new StreamResult
             {

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -311,6 +311,9 @@ namespace Raven.Client.Documents.Conventions
             _disposeCertificate = true;
 
             _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+            #if NET6_0_OR_GREATER
+            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Brotli;
+            #endif
         }
 
         private bool _frozen;

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -309,6 +309,8 @@ namespace Raven.Client.Documents.Conventions
             _createHttpClient = handler => new HttpClient(handler);
 
             _disposeCertificate = true;
+
+            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
         }
 
         private bool _frozen;
@@ -356,6 +358,7 @@ namespace Raven.Client.Documents.Conventions
         private Size _maxHttpCacheSize;
         private bool? _useHttpDecompression;
         private bool? _useHttpCompression;
+        private HttpCompressionAlgorithm _httpCompressionAlgorithm;
         private Func<MemberInfo, string> _propertyNameConverter;
         private Func<Type, bool> _typeIsKnownServerSide = _ => false;
         private Func<MemberInfo, bool> _shouldApplyPropertyNameConverter;
@@ -612,6 +615,16 @@ namespace Raven.Client.Documents.Conventions
             }
         }
 
+        public HttpCompressionAlgorithm HttpCompressionAlgorithm
+        {
+            get => _httpCompressionAlgorithm;
+            set
+            {
+                AssertNotFrozen();
+                _httpCompressionAlgorithm = value;
+            }
+        }
+
         /// <summary>
         /// Use gzip compression when sending content of HTTP request
         /// </summary>
@@ -628,7 +641,7 @@ namespace Raven.Client.Documents.Conventions
         internal bool HasExplicitlySetDecompressionUsage => _useHttpDecompression.HasValue;
 
         /// <summary>
-        /// Can accept compressed HTTP response content and will use gzip/deflate decompression methods
+        /// Can accept compressed HTTP response content and will use brotli/gzip/deflate decompression methods
         /// </summary>
         public bool UseHttpDecompression
         {

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -215,6 +215,22 @@ namespace Raven.Client.Documents.Conventions
 
                 DefaultForServer.HttpVersion = httpVersion;
             }
+
+            var httpCompressionAlgorithmAsString = Environment.GetEnvironmentVariable("RAVEN_COMPRESSION_ALGORITHM");
+            if (httpCompressionAlgorithmAsString != null)
+            {
+                HttpCompressionAlgorithm httpCompressionAlgorithm;
+                try
+                {
+                    httpCompressionAlgorithm = Enum.Parse<HttpCompressionAlgorithm>(httpCompressionAlgorithmAsString, ignoreCase: true);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException($"Could not parse 'RAVEN_COMPRESSION_ALGORITHM' env variable with value '{httpCompressionAlgorithmAsString}'.", e);
+                }
+
+                DefaultForServer.HttpCompressionAlgorithm = httpCompressionAlgorithm;
+            }
 #endif
 
 #if NETCOREAPP3_1_OR_GREATER

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -661,7 +661,7 @@ namespace Raven.Client.Documents.Conventions
         internal bool HasExplicitlySetDecompressionUsage => _useHttpDecompression.HasValue;
 
         /// <summary>
-        /// Can accept compressed HTTP response content and will use brotli/gzip/deflate decompression methods
+        /// Can accept compressed HTTP response content and will use zstd/gzip/deflate decompression methods
         /// </summary>
         public bool UseHttpDecompression
         {

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -311,6 +311,9 @@ namespace Raven.Client.Documents.Conventions
             _disposeCertificate = true;
 
             _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+#if FEATURE_BROTLI_SUPPORT
+            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Brotli; // temp
+#endif
         }
 
         private bool _frozen;

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -312,7 +312,7 @@ namespace Raven.Client.Documents.Conventions
 
             _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
 #if FEATURE_BROTLI_SUPPORT
-            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Brotli; // temp
+            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Zstd; // temp
 #endif
         }
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -46,6 +46,8 @@ namespace Raven.Client.Documents.Conventions
         internal static TimeSpan? DefaultHttpPooledConnectionIdleTimeout;
 #endif
 
+        internal static HttpCompressionAlgorithm DefaultHttpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+
         internal static readonly DocumentConventions Default = new();
 
         internal static readonly DocumentConventions DefaultForServer = new()
@@ -229,6 +231,8 @@ namespace Raven.Client.Documents.Conventions
                     throw new InvalidOperationException($"Could not parse 'RAVEN_COMPRESSION_ALGORITHM' env variable with value '{httpCompressionAlgorithmAsString}'.", e);
                 }
 
+                DefaultHttpCompressionAlgorithm = httpCompressionAlgorithm;
+                Default.HttpCompressionAlgorithm = httpCompressionAlgorithm;
                 DefaultForServer.HttpCompressionAlgorithm = httpCompressionAlgorithm;
             }
 #endif
@@ -326,7 +330,7 @@ namespace Raven.Client.Documents.Conventions
 
             _disposeCertificate = true;
 
-            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+            _httpCompressionAlgorithm = DefaultHttpCompressionAlgorithm;
         }
 
         private bool _frozen;

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -311,9 +311,6 @@ namespace Raven.Client.Documents.Conventions
             _disposeCertificate = true;
 
             _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
-            #if NET6_0_OR_GREATER
-            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Brotli;
-            #endif
         }
 
         private bool _frozen;

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -218,7 +218,7 @@ namespace Raven.Client.Documents.Conventions
                 DefaultForServer.HttpVersion = httpVersion;
             }
 
-            var httpCompressionAlgorithmAsString = Environment.GetEnvironmentVariable("RAVEN_COMPRESSION_ALGORITHM");
+            var httpCompressionAlgorithmAsString = Environment.GetEnvironmentVariable("RAVEN_HTTP_COMPRESSION_ALGORITHM");
             if (httpCompressionAlgorithmAsString != null)
             {
                 HttpCompressionAlgorithm httpCompressionAlgorithm;
@@ -228,7 +228,7 @@ namespace Raven.Client.Documents.Conventions
                 }
                 catch (Exception e)
                 {
-                    throw new InvalidOperationException($"Could not parse 'RAVEN_COMPRESSION_ALGORITHM' env variable with value '{httpCompressionAlgorithmAsString}'.", e);
+                    throw new InvalidOperationException($"Could not parse 'RAVEN_HTTP_COMPRESSION_ALGORITHM' env variable with value '{httpCompressionAlgorithmAsString}'.", e);
                 }
 
                 DefaultHttpCompressionAlgorithm = httpCompressionAlgorithm;

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -327,9 +327,6 @@ namespace Raven.Client.Documents.Conventions
             _disposeCertificate = true;
 
             _httpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
-#if FEATURE_BROTLI_SUPPORT
-            _httpCompressionAlgorithm = HttpCompressionAlgorithm.Zstd; // temp
-#endif
         }
 
         private bool _frozen;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -114,7 +114,7 @@ namespace Raven.Client.Documents.Operations.Attachments
                     DocumentId = _documentId
                 };
 
-                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
                 var streamReader = new StreamWithTimeout(responseStream);
                 var stream = new AttachmentStream(response, streamReader);
 

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
                 var state = new JsonParserState();
-                Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                Stream stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
                 using (context.GetMemoryBuffer(out var buffer))
                 using (var parser = new UnmanagedJsonParser(context, state, "attachments/receive"))

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -362,7 +362,7 @@ namespace Raven.Client.Documents.Smuggler
 
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
-                using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
                 {
                     await _handleStreamResponse(stream).ConfigureAwait(false);
                 }

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -79,7 +79,11 @@ namespace Raven.Client.Exceptions
             if (response == null)
                 throw new ArgumentNullException(nameof(response));
 
+#if NETSTANDARD2_0
             using (var stream = await RequestExecutor.ReadAsStreamUncompressedAsync(response).ConfigureAwait(false))
+#else
+            await using (var stream = await RequestExecutor.ReadAsStreamUncompressedAsync(response).ConfigureAwait(false))
+#endif
             using (var json = await GetJson(context, response, stream).ConfigureAwait(false))
             {
                 var schema = GetExceptionSchema(response.StatusCode, json);

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -1,4 +1,10 @@
 using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Utils;
 
 namespace Raven.Client.Http;
 
@@ -6,7 +12,10 @@ public enum HttpCompressionAlgorithm
 {
     Gzip,
 #if FEATURE_BROTLI_SUPPORT
-    Brotli
+    Brotli,
+#endif
+#if FEATURE_ZSTD_SUPPORT
+    Zstd
 #endif
 }
 
@@ -22,8 +31,74 @@ internal static class HttpCompressionAlgorithmExtensions
             case HttpCompressionAlgorithm.Brotli:
                 return Constants.Headers.Encodings.Brotli;
 #endif
+#if FEATURE_ZSTD_SUPPORT
+            case HttpCompressionAlgorithm.Zstd:
+                return Constants.Headers.Encodings.Zstd;
+#endif
             default:
                 throw new ArgumentOutOfRangeException(nameof(compressionAlgorithm), compressionAlgorithm, null);
         }
     }
+
+    internal static async Task<string> ReadAsStringWithZstdSupportAsync(this HttpContent httpContent, CancellationToken cancellationToken = default)
+    {
+#if FEATURE_ZSTD_SUPPORT
+        if (IsContentEncodingZstd(httpContent))
+        {
+            await using (var contentStream = await httpContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+            await using (var zstdStream = ZstdStream.Decompress(contentStream))
+            using (var streamReader = new StreamReader(zstdStream))
+            {
+#if NET6_0
+                return await streamReader.ReadToEndAsync().ConfigureAwait(false);
+#else
+                return await streamReader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#endif
+            }
+        }
+#endif
+
+#if NET6_0_OR_GREATER
+        return await httpContent.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        return await httpContent.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+    }
+
+    internal static async Task<Stream> ReadAsStreamWithZstdSupportAsync(this HttpContent httpContent)
+    {
+        var contentStream = await httpContent.ReadAsStreamAsync().ConfigureAwait(false);
+        var contentStreamType = contentStream.GetType();
+#if FEATURE_BROTLI_SUPPORT
+        if (contentStreamType == typeof(BrotliStream))
+            return contentStream;
+#endif
+        if (contentStreamType == typeof(GZipStream))
+            return contentStream;
+
+#if FEATURE_ZSTD_SUPPORT
+        if (IsContentEncodingZstd(httpContent))
+            return ZstdStream.Decompress(contentStream);
+
+        return contentStream;
+#else
+        return contentStream;
+#endif
+    }
+
+#if FEATURE_ZSTD_SUPPORT
+    internal static bool IsContentEncodingZstd(HttpContent httpContent)
+    {
+        if (httpContent.Headers.TryGetValues(Constants.Headers.ContentEncoding, out var values) == false)
+            return false;
+
+        foreach (var value in values)
+        {
+            if (value == Constants.Headers.Encodings.Zstd)
+                return true;
+        }
+
+        return false;
+    }
+#endif
 }

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -3,7 +3,7 @@ namespace Raven.Client.Http;
 public enum HttpCompressionAlgorithm
 {
     Gzip,
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
     Brotli
 #endif
 }

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -1,0 +1,9 @@
+namespace Raven.Client.Http;
+
+public enum HttpCompressionAlgorithm
+{
+    Gzip,
+#if NET6_0_OR_GREATER
+    Brotli
+#endif
+}

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -17,10 +17,10 @@ internal static class HttpCompressionAlgorithmExtensions
         switch (compressionAlgorithm)
         {
             case HttpCompressionAlgorithm.Gzip:
-                return "gzip";
+                return Constants.Headers.Encodings.Gzip;
 #if FEATURE_BROTLI_SUPPORT
             case HttpCompressionAlgorithm.Brotli:
-                return "br";
+                return Constants.Headers.Encodings.Brotli;
 #endif
             default:
                 throw new ArgumentOutOfRangeException(nameof(compressionAlgorithm), compressionAlgorithm, null);

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Raven.Client.Http;
 
 public enum HttpCompressionAlgorithm
@@ -6,4 +8,22 @@ public enum HttpCompressionAlgorithm
 #if FEATURE_BROTLI_SUPPORT
     Brotli
 #endif
+}
+
+internal static class HttpCompressionAlgorithmExtensions
+{
+    internal static string GetContentEncoding(this HttpCompressionAlgorithm compressionAlgorithm)
+    {
+        switch (compressionAlgorithm)
+        {
+            case HttpCompressionAlgorithm.Gzip:
+                return "gzip";
+#if FEATURE_BROTLI_SUPPORT
+            case HttpCompressionAlgorithm.Brotli:
+                return "br";
+#endif
+            default:
+                throw new ArgumentOutOfRangeException(nameof(compressionAlgorithm), compressionAlgorithm, null);
+        }
+    }
 }

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -142,7 +142,7 @@ namespace Raven.Client.Http
             if (ResponseType == RavenCommandResponseType.Empty || response.StatusCode == HttpStatusCode.NoContent)
                 return ResponseDisposeHandling.Automatic;
 
-            using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
             {
                 if (ResponseType == RavenCommandResponseType.Object)
                 {

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1668,7 +1668,7 @@ namespace Raven.Client.Http
             var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
             if (encoding != null && encoding.Contains("gzip"))
                 return new GZipStream(stream, CompressionMode.Decompress);
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
             if (encoding != null && encoding.Contains("br"))
                 return new BrotliStream(stream, CompressionMode.Decompress);
 #endif

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1670,6 +1670,10 @@ namespace Raven.Client.Http
                 return new GZipStream(stream, CompressionMode.Decompress);
             if (encoding != null && encoding.Contains("deflate"))
                 return new DeflateStream(stream, CompressionMode.Decompress);
+#if NET6_0_OR_GREATER
+            if (encoding != null && encoding.Contains("br"))
+                return new BrotliStream(stream, CompressionMode.Decompress);
+#endif
 
             return serverStream;
         }
@@ -2072,7 +2076,11 @@ namespace Raven.Client.Http
             {
                 httpMessageHandler.AutomaticDecompression =
                     useHttpDecompression ?
-                        DecompressionMethods.GZip | DecompressionMethods.Deflate
+                        DecompressionMethods.GZip
+                        | DecompressionMethods.Deflate
+#if NET6_0_OR_GREATER
+                        | DecompressionMethods.Brotli
+#endif
                         : DecompressionMethods.None;
             }
             else if (useHttpDecompression && hasExplicitlySetDecompressionUsage)

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1672,18 +1672,24 @@ namespace Raven.Client.Http
             var serverStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             var stream = serverStream;
             var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
-            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Gzip))
-                return new GZipStream(stream, CompressionMode.Decompress);
+            if (encoding != null)
+            {
+                switch (encoding)
+                {
+                    case Constants.Headers.Encodings.Gzip:
+                        return new GZipStream(stream, CompressionMode.Decompress);
 #if FEATURE_BROTLI_SUPPORT
-            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Brotli))
-                return new BrotliStream(stream, CompressionMode.Decompress);
+                    case Constants.Headers.Encodings.Brotli:
+                        return new BrotliStream(stream, CompressionMode.Decompress);
 #endif
 #if FEATURE_ZSTD_SUPPORT
-            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Zstd))
-                return ZstdStream.Decompress(stream);
+                    case Constants.Headers.Encodings.Zstd:
+                        return ZstdStream.Decompress(stream);
 #endif
-            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Deflate))
-                return new DeflateStream(stream, CompressionMode.Decompress);
+                    case Constants.Headers.Encodings.Deflate:
+                        return new DeflateStream(stream, CompressionMode.Decompress);
+                }
+            }
 
             return serverStream;
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1666,13 +1666,13 @@ namespace Raven.Client.Http
             var serverStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             var stream = serverStream;
             var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
-            if (encoding != null && encoding.Contains("gzip"))
+            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Gzip))
                 return new GZipStream(stream, CompressionMode.Decompress);
 #if FEATURE_BROTLI_SUPPORT
-            if (encoding != null && encoding.Contains("br"))
+            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Brotli))
                 return new BrotliStream(stream, CompressionMode.Decompress);
 #endif
-            if (encoding != null && encoding.Contains("deflate"))
+            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Deflate))
                 return new DeflateStream(stream, CompressionMode.Decompress);
 
             return serverStream;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2088,7 +2088,7 @@ namespace Raven.Client.Http
                     useHttpDecompression ?
                         DecompressionMethods.GZip
                         | DecompressionMethods.Deflate
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
                         | DecompressionMethods.Brotli
 #endif
                         : DecompressionMethods.None;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1668,12 +1668,12 @@ namespace Raven.Client.Http
             var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
             if (encoding != null && encoding.Contains("gzip"))
                 return new GZipStream(stream, CompressionMode.Decompress);
-            if (encoding != null && encoding.Contains("deflate"))
-                return new DeflateStream(stream, CompressionMode.Decompress);
 #if NET6_0_OR_GREATER
             if (encoding != null && encoding.Contains("br"))
                 return new BrotliStream(stream, CompressionMode.Decompress);
 #endif
+            if (encoding != null && encoding.Contains("deflate"))
+                return new DeflateStream(stream, CompressionMode.Decompress);
 
             return serverStream;
         }

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
+using Sparrow.Utils;
 
 namespace Raven.Client.Json
 {
@@ -48,6 +49,14 @@ namespace Raven.Client.Json
                     await using (var brotliStream = new BrotliStream(stream, CompressionLevel.Fastest, leaveOpen: true))
                     {
                         await _asyncTaskWriter(brotliStream).ConfigureAwait(false);
+                    }
+                    break;
+#endif
+#if FEATURE_ZSTD_SUPPORT
+                case HttpCompressionAlgorithm.Zstd:
+                    await using (var zstdStream = ZstdStream.Compress(stream))
+                    {
+                        await _asyncTaskWriter(zstdStream).ConfigureAwait(false);
                     }
                     break;
 #endif

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Json
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    await using (var zstdStream = ZstdStream.Compress(stream, leaveOpen: true))
+                    await using (var zstdStream = ZstdStream.Compress(stream, level: 1, leaveOpen: true))
                     {
                         await _asyncTaskWriter(zstdStream).ConfigureAwait(false);
                     }

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -20,21 +20,7 @@ namespace Raven.Client.Json
             _conventions = conventions;
 
             if (_conventions.UseHttpCompression)
-            {
-                switch (_conventions.HttpCompressionAlgorithm)
-                {
-                    case HttpCompressionAlgorithm.Gzip:
-                        Headers.ContentEncoding.Add("gzip");
-                        break;
-#if FEATURE_BROTLI_SUPPORT
-                    case HttpCompressionAlgorithm.Brotli:
-                        Headers.ContentEncoding.Add("br");
-                        break;
-#endif
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
+                Headers.ContentEncoding.Add(_conventions.HttpCompressionAlgorithm.GetContentEncoding());
         }
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.Json
                     case HttpCompressionAlgorithm.Gzip:
                         Headers.ContentEncoding.Add("gzip");
                         break;
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
                     case HttpCompressionAlgorithm.Brotli:
                         Headers.ContentEncoding.Add("br");
                         break;
@@ -57,7 +57,7 @@ namespace Raven.Client.Json
                         await _asyncTaskWriter(gzipStream).ConfigureAwait(false);
                     }
                     break;
-#if NET6_0_OR_GREATER
+#if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
                     await using (var brotliStream = new BrotliStream(stream, CompressionLevel.Fastest, leaveOpen: true))
                     {

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Json
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    await using (var zstdStream = ZstdStream.Compress(stream))
+                    await using (var zstdStream = ZstdStream.Compress(stream, leaveOpen: true))
                     {
                         await _asyncTaskWriter(zstdStream).ConfigureAwait(false);
                     }

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -63,8 +63,6 @@ namespace Raven.Client.Json
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
-
         }
 
         protected override bool TryComputeLength(out long length)

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -46,7 +46,7 @@ namespace Raven.Client.Json
                     break;
 #if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
-                    await using (var brotliStream = new BrotliStream(stream, CompressionLevel.Fastest, leaveOpen: true))
+                    await using (var brotliStream = new BrotliStream(stream, CompressionLevel.Optimal, leaveOpen: true))
                     {
                         await _asyncTaskWriter(brotliStream).ConfigureAwait(false);
                     }
@@ -54,7 +54,7 @@ namespace Raven.Client.Json
 #endif
 #if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
-                    await using (var zstdStream = ZstdStream.Compress(stream, level: 1, leaveOpen: true))
+                    await using (var zstdStream = ZstdStream.Compress(stream, CompressionLevel.Fastest, leaveOpen: true))
                     {
                         await _asyncTaskWriter(zstdStream).ConfigureAwait(false);
                     }

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -225,8 +225,10 @@ namespace Raven.Client.Util
         protected override void Dispose(bool disposing)
         {
             GC.SuppressFinalize(this);
-            base.Dispose(disposing);
+
             _stream.Dispose();
+            base.Dispose(disposing);
+
             _readCts?.Dispose();
             _writeCts?.Dispose();
         }
@@ -243,8 +245,8 @@ namespace Raven.Client.Util
 #else
             GC.SuppressFinalize(this);
 
-            await base.DisposeAsync().ConfigureAwait(false);
             await _stream.DisposeAsync().ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
 
             _readCts?.Dispose();
             _writeCts?.Dispose();

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -10,7 +10,7 @@ namespace Raven.Client.Util
         private static readonly TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
         internal static TimeSpan DefaultReadTimeout { get; } = TimeSpan.FromSeconds(120);
 
-        private readonly Stream _stream;
+        internal readonly Stream _stream;
         private int _writeTimeout;
         private int _readTimeout;
         private bool _canBaseStreamTimeoutOnWrite;

--- a/src/Raven.Server/Commercial/FeedbackSender.cs
+++ b/src/Raven.Server/Commercial/FeedbackSender.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Raven.Client.Http;
 using Raven.Server.Documents.Studio;
 
 namespace Raven.Server.Commercial
@@ -15,7 +16,7 @@ namespace Raven.Server.Commercial
                     new StringContent(JsonConvert.SerializeObject(feedback), Encoding.UTF8, "application/json"))
                 .ConfigureAwait(false);
 
-            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
             if (response.IsSuccessStatusCode == false)
             {
                 throw new InvalidOperationException(responseString);

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Raven.Client;
+using Raven.Client.Http;
 using Raven.Server.Config;
 using Raven.Server.Https;
 using Raven.Server.ServerWide;
@@ -146,7 +147,7 @@ public sealed class LetsEncryptSimulationHelper
                         {
                             response = await client.GetAsync("/are-you-there?", cts.Token);
                             response.EnsureSuccessStatusCode();
-                            result = await response.Content.ReadAsStringAsync(cts.Token);
+                            result = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token);
                             if (result != guid)
                             {
                                 throw new InvalidOperationException($"Expected result guid: {guid} but got {result}.");

--- a/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Raven.Client.Http;
 using Raven.Server.Utils;
 using Sparrow.Logging;
 
@@ -84,7 +85,7 @@ public sealed class RavenDnsRecordHelper
                 throw new InvalidOperationException("Registration request to api.ravendb.net failed for: " + serializeObject, e);
             }
 
-            var responseString = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode == false)
             {
@@ -121,7 +122,7 @@ public sealed class RavenDnsRecordHelper
                         throw new InvalidOperationException("Registration-result request to api.ravendb.net failed.", e); //add the object we tried to send to error
                     }
 
-                    responseString = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+                    responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
 
                     if (response.IsSuccessStatusCode == false)
                     {
@@ -171,7 +172,7 @@ public sealed class RavenDnsRecordHelper
             {
                 var response = await client.GetAsync($"/resolve?name={hostname}", cts.Token);
 
-                var responseString = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+                var responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode == false)
                     throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
                                                                $"Request failed with status {response.StatusCode}.{Environment.NewLine}{responseString}");
@@ -274,7 +275,7 @@ public sealed class RavenDnsRecordHelper
                 throw new InvalidOperationException("Registration request to api.ravendb.net failed for: " + serializeObject, e);
             }
 
-            var responseString = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode == false)
             {
@@ -298,7 +299,7 @@ public sealed class RavenDnsRecordHelper
                         throw new InvalidOperationException("Registration-result request to api.ravendb.net failed.", e); //add the object we tried to send to error
                     }
 
-                    responseString = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+                    responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
 
                     if (response.IsSuccessStatusCode == false)
                     {

--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Utils;
 using Sparrow.Platform;
@@ -158,13 +159,13 @@ namespace Raven.Server.Commercial
 
             if (response.Content.Headers.ContentType.MediaType == "application/problem+json")
             {
-                var problemJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var problemJson = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
                 var problem = JsonConvert.DeserializeObject<Problem>(problemJson);
                 problem.RawJson = problemJson;
                 throw new LetsEncryptException(problem, response);
             }
 
-            var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
 
             if (typeof(TResult) == typeof(string)
                 && response.Content.Headers.ContentType.MediaType == "application/pem-certificate-chain")
@@ -233,7 +234,7 @@ namespace Raven.Server.Commercial
 
                 if (response.Content.Headers.ContentType.MediaType == "application/problem+json")
                 {
-                    var problemJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var problemJson = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
 
                     if (retries-- > 0)
                     {

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -575,7 +575,7 @@ namespace Raven.Server.Commercial
 
         public static async Task<LeasedLicense> ConvertResponseToLeasedLicense(HttpResponseMessage httpResponseMessage)
         {
-            var leasedLicenseAsStream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var leasedLicenseAsStream = await httpResponseMessage.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
             using (var context = JsonOperationContext.ShortTermSingleUse())
             {
                 var json = await context.ReadForMemoryAsync(leasedLicenseAsStream, "leased license info");
@@ -678,7 +678,7 @@ namespace Raven.Server.Commercial
                     if (license != null)
                         return license;
 
-                    var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
                     AddLeaseLicenseError($"status code: {response.StatusCode}, response: {responseString}");
                     return null;
                 }
@@ -782,7 +782,7 @@ namespace Raven.Server.Commercial
                     new StringContent(JsonConvert.SerializeObject(license), Encoding.UTF8, "application/json"))
                 .ConfigureAwait(false);
 
-            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
             if (response.IsSuccessStatusCode == false)
                 throw new InvalidOperationException($"Failed to renew license, error: {responseString}");
 
@@ -1842,7 +1842,7 @@ namespace Raven.Server.Commercial
 
                     if (response.IsSuccessStatusCode == false)
                     {
-                        var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        var responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
 
                         var message = $"Couldn't get license support info, response: {responseString}, status code: {response.StatusCode}";
                         if (_skipLeasingErrorsLogging == false && Logger.IsInfoEnabled)
@@ -1851,7 +1851,7 @@ namespace Raven.Server.Commercial
                         return GetDefaultLicenseSupportInfo();
                     }
 
-                    var licenseSupportStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    var licenseSupportStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
                     using (var context = JsonOperationContext.ShortTermSingleUse())
                     {
                         var json = await context.ReadForMemoryAsync(licenseSupportStream, "license support info");

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -82,6 +82,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Http.BrotliResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
         public CompressionLevel BrotliResponseCompressionLevel { get; set; }
 
+        [Description("Compression level to be used when compressing HTTP responses with Zstd")]
+        [DefaultValue(1)]
+        [ConfigurationEntry("Http.ZstdResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
+        public int ZstdResponseCompressionLevel { get; set; }
+
         [Description("Compression level to be used when compressing static files")]
         [DefaultValue(CompressionLevel.Optimal)]
         [ConfigurationEntry("Http.StaticFilesResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -78,14 +78,14 @@ namespace Raven.Server.Config.Categories
         public CompressionLevel DeflateResponseCompressionLevel { get; set; }
 
         [Description("Compression level to be used when compressing HTTP responses with Brotli")]
-        [DefaultValue(CompressionLevel.Fastest)]
+        [DefaultValue(CompressionLevel.Optimal)]
         [ConfigurationEntry("Http.BrotliResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
         public CompressionLevel BrotliResponseCompressionLevel { get; set; }
 
         [Description("Compression level to be used when compressing HTTP responses with Zstd")]
-        [DefaultValue(1)]
+        [DefaultValue(CompressionLevel.Fastest)]
         [ConfigurationEntry("Http.ZstdResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
-        public int ZstdResponseCompressionLevel { get; set; }
+        public CompressionLevel ZstdResponseCompressionLevel { get; set; }
 
         [Description("Compression level to be used when compressing static files")]
         [DefaultValue(CompressionLevel.Optimal)]

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -77,6 +77,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Http.DeflateResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
         public CompressionLevel DeflateResponseCompressionLevel { get; set; }
 
+        [Description("Compression level to be used when compressing HTTP responses with Brotli")]
+        [DefaultValue(CompressionLevel.Fastest)]
+        [ConfigurationEntry("Http.BrotliResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]
+        public CompressionLevel BrotliResponseCompressionLevel { get; set; }
+
         [Description("Compression level to be used when compressing static files")]
         [DefaultValue(CompressionLevel.Optimal)]
         [ConfigurationEntry("Http.StaticFilesResponseCompressionLevel", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Commands.Streaming
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
             Result = new StreamResult
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Exceptions.Security;
+using Raven.Client.Http;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Handlers;
 using Raven.Server.Utils;
@@ -66,7 +67,7 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
                     {
                         Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(HttpContext.Request.ContentType) }
                     });
-                return await msg.Content.ReadAsStreamAsync();
+                return await msg.Content.ReadAsStreamWithZstdSupportAsync();
             }
 
             return await SmugglerHandler.HttpClient.GetStreamAsync(url);

--- a/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TransactionsRecordingHandler.cs
@@ -68,14 +68,8 @@ namespace Raven.Server.Documents.Handlers
 
                                 if (MultipartRequestHelper.HasFileContentDisposition(contentDisposition))
                                 {
-                                    if (section.Headers.ContainsKey(Constants.Headers.ContentEncoding) && section.Headers[Constants.Headers.ContentEncoding] == "gzip")
-                                    {
-                                        await using (var gzipStream = new GZipStream(section.Body, CompressionMode.Decompress))
-                                        {
-                                            return await DoReplayAsync(progress, gzipStream, token.Token);
-                                        }
-                                    }
-                                    return await DoReplayAsync(progress, section.Body, token.Token);
+                                    await using (var stream = GetDecompressedStream(section.Body, section.Headers))
+                                        return await DoReplayAsync(progress, stream, token.Token);
                                 }
                             }
 

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -107,7 +107,7 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
 
         foreach(var writer in _writers.Values)
         {
-            await writer.EnsureStreamAsync(CompressionLevel);
+            await writer.EnsureStreamAsync(HttpCompressionAlgorithm.Gzip, CompressionLevel);
         }
     }
 

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -96,18 +96,7 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
     {
         if (CompressionLevel != CompressionLevel.NoCompression)
         {
-            string contentEncoding;
-            switch (DocumentConventions.DefaultForServer.HttpCompressionAlgorithm)
-            {
-                case HttpCompressionAlgorithm.Gzip:
-                    contentEncoding = "gzip";
-                    break;
-                case HttpCompressionAlgorithm.Brotli:
-                    contentEncoding = "br";
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            var contentEncoding = DocumentConventions.DefaultForServer.HttpCompressionAlgorithm.GetContentEncoding();
 
             foreach (var shardNumber in _databaseContext.ShardsTopology.Keys)
             {

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -110,7 +110,7 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
 
         foreach (var writer in _writers.Values)
         {
-            await writer.EnsureStreamAsync(HttpCompressionAlgorithm.Gzip, CompressionLevel);
+            await writer.EnsureStreamAsync(DocumentConventions.DefaultForServer.HttpCompressionAlgorithm, CompressionLevel);
         }
     }
 

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -16,6 +16,7 @@
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
     <TieredPGO>false</TieredPGO>
+    <DefineConstants>$(DefineConstants);FEATURE_BROTLI_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Compile Include="..\CommonAssemblyInfo.Windows.cs" Link="Properties\CommonAssemblyInfo.Windows.cs" />

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -16,7 +16,6 @@
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
     <TieredPGO>false</TieredPGO>
-    <DefineConstants>$(DefineConstants);FEATURE_BROTLI_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Compile Include="..\CommonAssemblyInfo.Windows.cs" Link="Properties\CommonAssemblyInfo.Windows.cs" />

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -247,6 +247,7 @@ namespace Raven.Server
                             services.Configure<ResponseCompressionOptions>(options =>
                             {
                                 options.EnableForHttps = Configuration.Http.AllowResponseCompressionOverHttps;
+                                options.Providers.Add(typeof(BrotliCompressionProvider));
                                 options.Providers.Add(typeof(GzipCompressionProvider));
                                 options.Providers.Add(typeof(DeflateCompressionProvider));
                             });
@@ -254,6 +255,8 @@ namespace Raven.Server
                             services.Configure<GzipCompressionProviderOptions>(options => { options.Level = Configuration.Http.GzipResponseCompressionLevel; });
 
                             services.Configure<DeflateCompressionProviderOptions>(options => { options.Level = Configuration.Http.DeflateResponseCompressionLevel; });
+
+                            services.Configure<BrotliCompressionProviderOptions>(options => { options.Level = Configuration.Http.BrotliResponseCompressionLevel; });
 
                             services.AddResponseCompression();
                         }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -258,7 +258,7 @@ namespace Raven.Server
                             });
 
 #if FEATURE_ZSTD_SUPPORT
-                            services.Configure<ZstdCompressionProviderOptions>(options => { });
+                            services.Configure<ZstdCompressionProviderOptions>(options => { options.Level = Configuration.Http.ZstdResponseCompressionLevel; });
 #endif
 
 #if FEATURE_BROTLI_SUPPORT

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -247,9 +247,8 @@ namespace Raven.Server
                             services.Configure<ResponseCompressionOptions>(options =>
                             {
                                 options.EnableForHttps = Configuration.Http.AllowResponseCompressionOverHttps;
-#if FEATURE_ZSTD_SUPPORT
+
                                 options.Providers.Add(typeof(ZstdCompressionProvider));
-#endif
 #if FEATURE_BROTLI_SUPPORT
                                 options.Providers.Add(typeof(BrotliCompressionProvider));
 #endif
@@ -257,9 +256,7 @@ namespace Raven.Server
                                 options.Providers.Add(typeof(DeflateCompressionProvider));
                             });
 
-#if FEATURE_ZSTD_SUPPORT
                             services.Configure<ZstdCompressionProviderOptions>(options => { options.Level = Configuration.Http.ZstdResponseCompressionLevel; });
-#endif
 
 #if FEATURE_BROTLI_SUPPORT
                             services.Configure<BrotliCompressionProviderOptions>(options => { options.Level = Configuration.Http.BrotliResponseCompressionLevel; });

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -20,6 +20,7 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors.Smuggler;
@@ -71,7 +72,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
         {
             var url = GetQueryStringValueAndAssertIfSingleAndNotEmpty("url");
             var result = await HttpClient.GetAsync(url);
-            var dirTextXml = await result.Content.ReadAsStringAsync();
+            var dirTextXml = await result.Content.ReadAsStringWithZstdSupportAsync();
             var filesListing = XElement.Parse(dirTextXml);
             var ns = XNamespace.Get("http://s3.amazonaws.com/doc/2006-03-01/");
             var urls = from content in filesListing.Elements(ns + "Contents")
@@ -81,8 +82,8 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                           var response = await HttpClient.GetAsync(requestUri);
                           if (response.IsSuccessStatusCode == false)
                               throw new InvalidOperationException("Request failed on " + requestUri + " with " +
-                                                                  await response.Content.ReadAsStreamAsync());
-                          return await response.Content.ReadAsStreamAsync();
+                                                                  await response.Content.ReadAsStreamWithZstdSupportAsync());
+                          return await response.Content.ReadAsStreamWithZstdSupportAsync();
                       });
 
             var files = new BlockingCollection<Func<Task<Stream>>>(new ConcurrentQueue<Func<Task<Stream>>>(urls));

--- a/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
+++ b/src/Raven.Server/Smuggler/Migration/ApiKey/Authenticator.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Server.Extensions;
 using Raven.Server.Utils;
 
@@ -120,8 +121,8 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
                 httpClient.DefaultRequestHeaders.TryAddWithoutValidation("grant_type", "client_credentials");
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json") { CharSet = "UTF-8" });
 
-                httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("deflate"));
-                httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+                httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue(Constants.Headers.Encodings.Deflate));
+                httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue(Constants.Headers.Encodings.Gzip));
 
                 if (string.IsNullOrEmpty(apiKey) == false)
                     httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);

--- a/src/Raven.Server/Smuggler/Migration/ApiKey/WebResponseExtensions.cs
+++ b/src/Raven.Server/Smuggler/Migration/ApiKey/WebResponseExtensions.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Raven.Client;
 
 namespace Raven.Server.Smuggler.Migration.ApiKey
 {
@@ -17,9 +18,9 @@ namespace Raven.Server.Smuggler.Migration.ApiKey
         {
             var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             var encoding = response.Content.Headers.ContentEncoding.FirstOrDefault();
-            if (encoding != null && encoding.Contains("gzip"))
+            if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Gzip))
                 stream = new GZipStream(stream, CompressionMode.Decompress);
-            else if (encoding != null && encoding.Contains("deflate"))
+            else if (encoding != null && encoding.Contains(Constants.Headers.Encodings.Deflate))
                 stream = new DeflateStream(stream, CompressionMode.Decompress);
             return stream;
         }

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -154,10 +154,8 @@ namespace Raven.Server.Web
                 case HttpCompressionAlgorithm.Brotli:
                     return new BrotliStream(stream, CompressionMode.Decompress);
 #endif
-#if FEATURE_ZSTD_SUPPORT
                 case HttpCompressionAlgorithm.Zstd:
                     return ZstdStream.Decompress(stream);
-#endif
                 case null:
                     return stream;
                 default:
@@ -196,10 +194,8 @@ namespace Raven.Server.Web
             {
                 switch (encoding)
                 {
-#if FEATURE_ZSTD_SUPPORT
                     case Constants.Headers.Encodings.Zstd:
                         return HttpCompressionAlgorithm.Zstd;
-#endif
 #if FEATURE_BROTLI_SUPPORT
                     case Constants.Headers.Encodings.Brotli:
                         return HttpCompressionAlgorithm.Brotli;

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Web
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Stream GetDecompressedStream(Stream stream, IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers)
+        internal Stream GetDecompressedStream(Stream stream, IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers)
         {
             var httpCompressionAlgorithm = GetHttpCompressionAlgorithmFromHeaders(headers, Constants.Headers.ContentEncoding);
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -194,18 +194,19 @@ namespace Raven.Server.Web
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var encoding in acceptedContentEncodings)
             {
+                switch (encoding)
+                {
 #if FEATURE_ZSTD_SUPPORT
-                if (encoding.Contains(Constants.Headers.Encodings.Zstd))
-                    return HttpCompressionAlgorithm.Zstd;
+                    case Constants.Headers.Encodings.Zstd:
+                        return HttpCompressionAlgorithm.Zstd;
 #endif
-
 #if FEATURE_BROTLI_SUPPORT
-                if (encoding.Contains(Constants.Headers.Encodings.Brotli))
-                    return HttpCompressionAlgorithm.Brotli;
+                    case Constants.Headers.Encodings.Brotli:
+                        return HttpCompressionAlgorithm.Brotli;
 #endif
-
-                if (encoding.Contains(Constants.Headers.Encodings.Gzip))
-                    return HttpCompressionAlgorithm.Gzip;
+                    case Constants.Headers.Encodings.Gzip:
+                        return HttpCompressionAlgorithm.Gzip;
+                }
             }
 
             return null;

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -39,6 +39,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Utils;
 
 namespace Raven.Server.Web
 {
@@ -149,8 +150,14 @@ namespace Raven.Server.Web
             {
                 case HttpCompressionAlgorithm.Gzip:
                     return GetGzipStream(stream, CompressionMode.Decompress);
+#if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
                     return new BrotliStream(stream, CompressionMode.Decompress);
+#endif
+#if FEATURE_ZSTD_SUPPORT
+                case HttpCompressionAlgorithm.Zstd:
+                    return ZstdStream.Decompress(stream);
+#endif
                 case null:
                     return stream;
                 default:
@@ -187,8 +194,15 @@ namespace Raven.Server.Web
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var encoding in acceptedContentEncodings)
             {
+#if FEATURE_ZSTD_SUPPORT
+                if (encoding.Contains(Constants.Headers.Encodings.Zstd))
+                    return HttpCompressionAlgorithm.Zstd;
+#endif
+
+#if FEATURE_BROTLI_SUPPORT
                 if (encoding.Contains(Constants.Headers.Encodings.Brotli))
                     return HttpCompressionAlgorithm.Brotli;
+#endif
 
                 if (encoding.Contains(Constants.Headers.Encodings.Gzip))
                     return HttpCompressionAlgorithm.Gzip;

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -187,10 +187,10 @@ namespace Raven.Server.Web
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var encoding in acceptedContentEncodings)
             {
-                if (encoding.Contains("br"))
+                if (encoding.Contains(Constants.Headers.Encodings.Brotli))
                     return HttpCompressionAlgorithm.Brotli;
 
-                if (encoding.Contains("gzip"))
+                if (encoding.Contains(Constants.Headers.Encodings.Gzip))
                     return HttpCompressionAlgorithm.Gzip;
             }
 

--- a/src/Raven.Server/Web/ResponseCompression/DeflateCompressionProvider.cs
+++ b/src/Raven.Server/Web/ResponseCompression/DeflateCompressionProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Options;
+using Raven.Client;
 
 namespace Raven.Server.Web.ResponseCompression
 {
@@ -25,7 +26,7 @@ namespace Raven.Server.Web.ResponseCompression
             return new DeflateStream(outputStream, Options.Level, true);
         }
 
-        public string EncodingName => "deflate";
+        public string EncodingName => Constants.Headers.Encodings.Deflate;
         public bool SupportsFlush => false;
     }
 }

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Options;
+using Raven.Client;
+using Sparrow.Utils;
+
+namespace Raven.Server.Web.ResponseCompression
+{
+#if FEATURE_ZSTD_SUPPORT
+    public sealed class ZstdCompressionProvider : ICompressionProvider
+    {
+        public ZstdCompressionProvider(IOptions<ZstdCompressionProviderOptions> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            Options = options.Value;
+        }
+
+        private ZstdCompressionProviderOptions Options { get; }
+
+        public Stream CreateStream(Stream outputStream)
+        {
+            return ZstdStream.Compress(outputStream);
+        }
+
+        public string EncodingName => Constants.Headers.Encodings.Zstd;
+        public bool SupportsFlush => true;
+    }
+#endif
+}

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Web.ResponseCompression
 
         public Stream CreateStream(Stream outputStream)
         {
-            return ZstdStream.Compress(outputStream);
+            return ZstdStream.Compress(outputStream, Options.Level);
         }
 
         public string EncodingName => Constants.Headers.Encodings.Zstd;

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProvider.cs
@@ -8,7 +8,6 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Web.ResponseCompression
 {
-#if FEATURE_ZSTD_SUPPORT
     public sealed class ZstdCompressionProvider : ICompressionProvider
     {
         public ZstdCompressionProvider(IOptions<ZstdCompressionProviderOptions> options)
@@ -31,5 +30,4 @@ namespace Raven.Server.Web.ResponseCompression
         public string EncodingName => Constants.Headers.Encodings.Zstd;
         public bool SupportsFlush => true;
     }
-#endif
 }

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Raven.Server.Web.ResponseCompression
+{
+#if FEATURE_ZSTD_SUPPORT
+    /// <summary>
+    /// Options for the ZstdCompressionProvider
+    /// </summary>
+    public sealed class ZstdCompressionProviderOptions : IOptions<ZstdCompressionProviderOptions>
+    {
+        /// <inheritdoc />
+        ZstdCompressionProviderOptions IOptions<ZstdCompressionProviderOptions>.Value => this;
+    }
+#endif
+}

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System.IO.Compression;
+using Microsoft.Extensions.Options;
 
 namespace Raven.Server.Web.ResponseCompression
 {
@@ -8,6 +9,8 @@ namespace Raven.Server.Web.ResponseCompression
     /// </summary>
     public sealed class ZstdCompressionProviderOptions : IOptions<ZstdCompressionProviderOptions>
     {
+        public int Level { get; set; } = 1;
+
         /// <inheritdoc />
         ZstdCompressionProviderOptions IOptions<ZstdCompressionProviderOptions>.Value => this;
     }

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Web.ResponseCompression
     /// </summary>
     public sealed class ZstdCompressionProviderOptions : IOptions<ZstdCompressionProviderOptions>
     {
-        public int Level { get; set; } = 1;
+        public CompressionLevel Level { get; set; } = CompressionLevel.Fastest;
 
         /// <inheritdoc />
         ZstdCompressionProviderOptions IOptions<ZstdCompressionProviderOptions>.Value => this;

--- a/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
+++ b/src/Raven.Server/Web/ResponseCompression/ZstdCompressionProviderOptions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Options;
 
 namespace Raven.Server.Web.ResponseCompression
 {
-#if FEATURE_ZSTD_SUPPORT
     /// <summary>
     /// Options for the ZstdCompressionProvider
     /// </summary>
@@ -14,5 +13,4 @@ namespace Raven.Server.Web.ResponseCompression
         /// <inheritdoc />
         ZstdCompressionProviderOptions IOptions<ZstdCompressionProviderOptions>.Value => this;
     }
-#endif
 }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -203,7 +203,7 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
 
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
-                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
                 Result = new StreamResult
                 {

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Exceptions.Security;
+using Raven.Client.Http;
 using Raven.Client.Properties;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
@@ -61,7 +62,7 @@ namespace Raven.Server.Web.System
                         var response = await ApiHttpClient.Instance.PostAsync("/api/v1/dns-n-cert/" + action, content).ConfigureAwait(false);
 
                         HttpContext.Response.StatusCode = (int)response.StatusCode;
-                        responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
 
                         if ((int)response.StatusCode >= 500 && (int)response.StatusCode <= 599)
                         {
@@ -149,7 +150,7 @@ namespace Raven.Server.Web.System
                         var response = await ApiHttpClient.Instance.PostAsync("/api/v1/dns-n-cert/user-domains", content).ConfigureAwait(false);
 
                         HttpContext.Response.StatusCode = (int)response.StatusCode;
-                        responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        responseString = await response.Content.ReadAsStringWithZstdSupportAsync().ConfigureAwait(false);
 
                         if (response.IsSuccessStatusCode == false)
                         {

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -442,7 +442,7 @@ namespace Raven.Server.Web.System
             byte[] contentsToServe;
             if (ClientAcceptsGzipResponse() && metadata.CompressedContents != null)
             {
-                HttpContext.Response.Headers[Constants.Headers.ContentEncoding] = "gzip";
+                HttpContext.Response.Headers[Constants.Headers.ContentEncoding] = Constants.Headers.Encodings.Gzip;
                 contentsToServe = metadata.CompressedContents;
             }
             else

--- a/src/Sparrow/Utils/ReadWriteCompressedStream.cs
+++ b/src/Sparrow/Utils/ReadWriteCompressedStream.cs
@@ -40,8 +40,8 @@ namespace Sparrow.Utils
             }
 
             _inner = innerInput ?? throw new ArgumentNullException(nameof(inner));
-            _input = ZstdStream.Decompress(inner);
-            _output = ZstdStream.Compress(inner);
+            _input = ZstdStream.Decompress(inner, leaveOpen: true);
+            _output = ZstdStream.Compress(inner, leaveOpen: true);
             _dispose = new DisposeOnce<SingleAttempt>(DisposeInternal);
         }
 

--- a/test/SlowTests/Issues/RavenDB-19852.cs
+++ b/test/SlowTests/Issues/RavenDB-19852.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Session;
 using Raven.Client.Http;
+using Raven.Client.Util;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Xunit;
@@ -53,8 +54,10 @@ public class RavenDB_19852 : RavenTestBase
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            // Automatic decompression clears info about content-encodings. We've to assert by ContentType.
-            Assert.Contains("GZip", response.Content.GetType().Name);
+            var streamWithTimeout = (StreamWithTimeout)stream;
+            var innerStream = streamWithTimeout._stream;
+            var contentTypeName = innerStream.GetType().Name;
+            Assert.True(contentTypeName.Contains("GZip") || contentTypeName.Contains("Brotli") || contentTypeName.Contains("Zstd"), $"{contentTypeName}.Contains('GZip') || {contentTypeName}.Contains('Brotli') || {contentTypeName}.Contains('Zstd')");
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-19852.cs
+++ b/test/SlowTests/Issues/RavenDB-19852.cs
@@ -22,7 +22,9 @@ public class RavenDB_19852 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.ClientApi)]
     [InlineData(HttpCompressionAlgorithm.Gzip)]
+#if FEATURE_BROTLI_SUPPORT
     [InlineData(HttpCompressionAlgorithm.Brotli)]
+#endif
     [InlineData(HttpCompressionAlgorithm.Zstd)]
     public void ResponseFromMultiGetIsCompressed(HttpCompressionAlgorithm compressionAlgorithm)
     {
@@ -69,11 +71,13 @@ public class RavenDB_19852 : RavenTestBase
             switch (_compressionAlgorithm)
             {
                 case HttpCompressionAlgorithm.Gzip:
-                    Assert.True(contentTypeName.Contains("Brotli"), $"{contentTypeName}.Contains('Brotli')"); // we are picking the best one based on the order of compression providers in the RavenServer
+                    Assert.True(contentTypeName.Contains("GZip"), $"{contentTypeName}.Contains('GZip')");
                     break;
+#if FEATURE_BROTLI_SUPPORT
                 case HttpCompressionAlgorithm.Brotli:
                     Assert.True(contentTypeName.Contains("Brotli"), $"{contentTypeName}.Contains('Brotli')");
                     break;
+#endif
                 case HttpCompressionAlgorithm.Zstd:
                     Assert.True(contentTypeName.Contains("Zstd"), $"{contentTypeName}.Contains('Zstd')");
                     break;

--- a/test/SlowTests/Issues/RavenDB-19852.cs
+++ b/test/SlowTests/Issues/RavenDB-19852.cs
@@ -1,13 +1,14 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using FastTests;
 using Raven.Client.Documents.Commands.MultiGet;
-using Raven.Client.Documents.Session;
 using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,22 +20,31 @@ public class RavenDB_19852 : RavenTestBase
     {
     }
 
-    [Fact]
-    public void ResponseFromMultiGetIsCompressed()
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [InlineData(HttpCompressionAlgorithm.Gzip)]
+    [InlineData(HttpCompressionAlgorithm.Brotli)]
+    [InlineData(HttpCompressionAlgorithm.Zstd)]
+    public void ResponseFromMultiGetIsCompressed(HttpCompressionAlgorithm compressionAlgorithm)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = s => s.Conventions.HttpCompressionAlgorithm = compressionAlgorithm
+        });
+
         const string docs = "/docs";
 
         using (var session = store.OpenSession())
         {
-            session.Store(new Company() {Name = new string('a', 10), Id = "doc/1"}, id: "doc/1");
+            session.Store(new Company() { Name = new string('a', 10), Id = "doc/1" }, id: "doc/1");
             session.SaveChanges();
         }
 
         using (var commands = store.Commands())
         {
-            using var firstCommand = new MultiGetCommandForCompressionTest(commands.RequestExecutor,
-                new List<GetRequest> {new GetRequest {Url = docs, Query = "?id=doc/1"}});
+            using var firstCommand = new MultiGetCommandForCompressionTest(
+                compressionAlgorithm,
+                commands.RequestExecutor,
+                new List<GetRequest> { new GetRequest { Url = docs, Query = "?id=doc/1" } });
 
             commands.RequestExecutor.Execute(firstCommand, commands.Context);
         }
@@ -42,14 +52,12 @@ public class RavenDB_19852 : RavenTestBase
 
     private class MultiGetCommandForCompressionTest : MultiGetCommand
     {
-        public MultiGetCommandForCompressionTest(RequestExecutor requestExecutor, List<GetRequest> commands) : base(requestExecutor, commands)
-        {
-            ResponseType = RavenCommandResponseType.Raw;
-        }
+        private readonly HttpCompressionAlgorithm _compressionAlgorithm;
 
-        internal MultiGetCommandForCompressionTest(RequestExecutor requestExecutor, List<GetRequest> commands, SessionInfo sessionInfo) : base(requestExecutor, commands,
-            sessionInfo)
+        public MultiGetCommandForCompressionTest(HttpCompressionAlgorithm compressionAlgorithm, RequestExecutor requestExecutor, List<GetRequest> commands) : base(requestExecutor, commands)
         {
+            _compressionAlgorithm = compressionAlgorithm;
+            ResponseType = RavenCommandResponseType.Raw;
         }
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
@@ -57,7 +65,21 @@ public class RavenDB_19852 : RavenTestBase
             var streamWithTimeout = (StreamWithTimeout)stream;
             var innerStream = streamWithTimeout._stream;
             var contentTypeName = innerStream.GetType().Name;
-            Assert.True(contentTypeName.Contains("GZip") || contentTypeName.Contains("Brotli") || contentTypeName.Contains("Zstd"), $"{contentTypeName}.Contains('GZip') || {contentTypeName}.Contains('Brotli') || {contentTypeName}.Contains('Zstd')");
+
+            switch (_compressionAlgorithm)
+            {
+                case HttpCompressionAlgorithm.Gzip:
+                    Assert.True(contentTypeName.Contains("Brotli"), $"{contentTypeName}.Contains('Brotli')"); // we are picking the best one based on the order of compression providers in the RavenServer
+                    break;
+                case HttpCompressionAlgorithm.Brotli:
+                    Assert.True(contentTypeName.Contains("Brotli"), $"{contentTypeName}.Contains('Brotli')");
+                    break;
+                case HttpCompressionAlgorithm.Zstd:
+                    Assert.True(contentTypeName.Contains("Zstd"), $"{contentTypeName}.Contains('Zstd')");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
     }
 }

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4654;
+            const int numberToTolerate = 4653;
 
             if (array.Length == numberToTolerate)
                 return;

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -105,6 +105,10 @@ namespace FastTests
             //DocumentConventions.DefaultHttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
             //DefaultHttpProtocols = HttpProtocols.Http2;
 
+            Console.WriteLine($"Default HTTP Compression Algorithm: {DocumentConventions.DefaultHttpCompressionAlgorithm}");
+            Console.WriteLine($"Default HTTP Pooled Connection Idle Timeout: {DocumentConventions.DefaultHttpPooledConnectionIdleTimeout}");
+            Console.WriteLine($"Default HTTP Version Policy: {DocumentConventions.DefaultHttpVersionPolicy}");
+
             Lucene.Net.Util.UnmanagedStringArray.Segment.AllocateMemory = NativeMemory.AllocateMemory;
             Lucene.Net.Util.UnmanagedStringArray.Segment.FreeMemory = NativeMemory.Free;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21528 

### Type of change

- New feature

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
