### PR TITLE
RavenDB-21475 If license is ISV we should display Info Hub labels for ISV

### DIFF
--- a/src/Raven.Studio/typescript/components/common/AboutView.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/AboutView.stories.tsx
@@ -23,14 +23,16 @@ interface FloatingButtonProps {
     licenseType: Raven.Server.Commercial.LicenseType;
     isCloud: boolean;
     isEnabled: boolean;
+    isIsv: boolean;
 }
 
-const FloatingButton = ({ isCloud, licenseType, isEnabled }: FloatingButtonProps) => {
+const FloatingButton = ({ isCloud, licenseType, isEnabled, isIsv }: FloatingButtonProps) => {
     const { license } = mockStore;
 
     license.with_License({
         Type: licenseType,
         IsCloud: isCloud,
+        IsIsv: isIsv,
     });
 
     const availabilityData = getLicenseAvailabilityData({
@@ -188,6 +190,7 @@ export const Floating = boundCopy(FloatingButton, {
     licenseType: "Community",
     isCloud: false,
     isEnabled: false,
+    isIsv: false,
 });
 
 export const Anchored = boundCopy(AnchoredHub, {

--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
@@ -34,6 +34,7 @@ export function FeatureAvailabilitySummary(props: FeatureAvailabilitySummaryProp
 
     const currentLicense = useAppSelector(licenseSelectors.licenseType);
     const isCloud = useAppSelector(licenseSelectors.statusValue("IsCloud"));
+    const isIsv = useAppSelector(licenseSelectors.statusValue("IsIsv"));
 
     const buyLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
 
@@ -62,9 +63,14 @@ export function FeatureAvailabilitySummary(props: FeatureAvailabilitySummaryProp
                         <tr>
                             <th className="p-0"></th>
                             {licenseTypes.map((licenseType) => {
-                                if (currentLicense === "Essential" && licenseType === "Community") {
+                                if (isIsv && licenseType === "Community") {
                                     return (
-                                        <th key="Essential" className="community current bg-faded-primary">
+                                        <th
+                                            key="Essential"
+                                            className={classNames("community", {
+                                                "current bg-faded-primary": currentLicense === "Essential",
+                                            })}
+                                        >
                                             <Icon icon="circle-filled" className="license-dot" /> Essential
                                         </th>
                                     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21475/If-license-is-ISV-we-should-display-Info-Hub-labels-for-ISV

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
