### PR TITLE
RavenDB-21476 Replicas selectors overflow the create database modal

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/createDatabase.html
@@ -670,8 +670,8 @@
         <div class="help-block" data-bind="validationMessage: orchestrators"></div>
     </div>
     
-    <div>
-        <table class="table table-striped">
+    <div class="table-responsive">
+        <table class="table table-striped m-0">
             <thead>
                 <tr>
                     <th>&nbsp;</th>
@@ -709,9 +709,9 @@
             <!-- /ko -->
             </tbody>
         </table>
-        <div data-bind="validationElement: shardTopology">
-            <div class="help-block" data-bind="validationMessage: shardTopology"></div>
-        </div>
+    </div>
+    <div data-bind="validationElement: shardTopology">
+        <div class="help-block" data-bind="validationMessage: shardTopology"></div>
     </div>
 </script>
 

--- a/src/Raven.Studio/wwwroot/Content/css/modals.less
+++ b/src/Raven.Studio/wwwroot/Content/css/modals.less
@@ -151,7 +151,7 @@
 
         .modal-settings-panel-slideout {
             display: block;
-            background-color: @panel-bg-2;
+            border: 1px solid @panel-bg-2;
 
             .panel-body {
                 box-shadow: inset 0 0 0 1px @gray-dark;
@@ -161,7 +161,9 @@
             .fadeindelay-style;
 
             @media (min-width: @screen-sm) {
-                width: (@modal-lg / 3 * 2);
+                width: 500px;
+                flex-grow: 1;
+                flex-shrink: 0;
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21476/Replicas-selectors-overflow-the-create-database-modal

### Additional description

added table-responsive to manual shard creator minor style fixes to make scroll visible.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
