### PR TITLE
RavenDB-21525 / RavenDB-21537 Invalid TotalResults in order by queries with paging

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
@@ -51,7 +51,6 @@ namespace Corax.Querying.Matches
         }
 
         string DebugView => Inspect().ToString();
- //       public bool RequireSorting => _inner.DoNotSortResults()
 
         internal sealed class FunctionTable
         {

--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -112,6 +112,7 @@ namespace Raven.Client.Documents.Linq
         public IRavenQueryable<T> Statistics(out QueryStatistics stats)
         {
             stats = _queryStats;
+            stats.RequestedByUser = true;
             return this;
         }
 
@@ -210,7 +211,8 @@ namespace Raven.Client.Documents.Linq
                 _isMapReduce,
                 _provider.OriginalQueryType,
                 _conventions,
-                _provider.IsProjectInto);
+                _provider.IsProjectInto,
+                _queryStats);
         }
 
         public string IndexName => _indexName;

--- a/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProvider.cs
@@ -315,7 +315,8 @@ namespace Raven.Client.Documents.Linq
                 _isMapReduce,
                 OriginalQueryType,
                 _conventions,
-                IsProjectInto);
+                IsProjectInto,
+                _queryStatistics);
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -52,6 +52,7 @@ namespace Raven.Client.Documents.Linq
         internal readonly LinqPathProvider LinqPathProvider;
         private readonly Action<QueryResult> _afterQueryExecuted;
         private readonly LinqQueryHighlightings _highlightings;
+        private readonly QueryStatistics _queryStatistics;
         private bool _chainedWhere;
         private int _insideWhere;
         private int _insideFilter;
@@ -132,7 +133,8 @@ namespace Raven.Client.Documents.Linq
             bool isMapReduce,
             Type originalType,
             DocumentConventions conventions,
-            bool isProjectInto)
+            bool isProjectInto,
+            QueryStatistics queryStatistics)
         {
             FieldsToFetch = fieldsToFetch;
             _newExpressionType = typeof(T);
@@ -146,6 +148,7 @@ namespace Raven.Client.Documents.Linq
             _originalQueryType = originalType ?? throw new ArgumentNullException(nameof(originalType));
             _conventions = conventions;
             _isProjectInto = isProjectInto;
+            _queryStatistics = queryStatistics;
             LinqPathProvider = new LinqPathProvider(queryGenerator.Conventions);
             _jsProjectionNames = new List<string>();
             _loadAliasesMovedToOutputFunction = new HashSet<string>();
@@ -3917,14 +3920,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true));
+                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true)
+                {
+                    QueryStatistics = _queryStatistics
+                });
             }
 
             var (fields, projections) = GetProjections();
 
             return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(fields, projections, FromAlias, null, _loadTokens)
             {
-                IsProjectInto = _isProjectInto
+                IsProjectInto = _isProjectInto,
+                QueryStatistics = _queryStatistics
             });
         }
 
@@ -3966,14 +3973,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true));
+                return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true)
+                {
+                    QueryStatistics = _queryStatistics
+                });
             }
 
             var (fields, projections) = GetProjections();
 
             return asyncDocumentQuery.CreateDocumentQueryInternal<T>(new QueryData(fields, projections, FromAlias, null, _loadTokens)
             {
-                IsProjectInto = _isProjectInto
+                IsProjectInto = _isProjectInto,
+                QueryStatistics = _queryStatistics
             });
         }
 

--- a/src/Raven.Client/Documents/Queries/QueryData.cs
+++ b/src/Raven.Client/Documents/Queries/QueryData.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Tokens;
 
 namespace Raven.Client.Documents.Queries
@@ -27,6 +28,8 @@ namespace Raven.Client.Documents.Queries
         public bool IsMapReduce { get; set; }
 
         internal bool IsProjectInto { get; set; }
+
+        internal QueryStatistics QueryStatistics { get; set; }
 
         public ProjectionBehavior? ProjectionBehavior { get; set; }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -171,8 +171,6 @@ namespace Raven.Client.Documents.Session
 
         private string _includesAlias;
 
-        private bool _statsRequested;
-
         private TimeSpan DefaultTimeout
         {
             get
@@ -1183,7 +1181,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
         public void Statistics(out QueryStatistics stats)
         {
             stats = QueryStats;
-            _statsRequested = true;
+            stats.RequestedByUser = true;
         }
 
         /// <summary>
@@ -1219,7 +1217,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 QueryParameters = QueryParameters,
                 DisableCaching = DisableCaching,
                 ProjectionBehavior = ProjectionBehavior,
-                SkipStatistics = _statsRequested == false
+                SkipStatistics = QueryStats.RequestedByUser == false
             };
 
             return indexQuery;

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1067,7 +1067,7 @@ namespace Raven.Client.Documents.Session
                 FilterModeStack = new Stack<bool>(FilterModeStack),
                 Start = Start,
                 Timeout = Timeout,
-                QueryStats = QueryStats,
+                QueryStats = queryData?.QueryStatistics ?? QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,
                 DocumentIncludes = new HashSet<string>(DocumentIncludes),

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1053,7 +1053,7 @@ namespace Raven.Client.Documents.Session
                 FilterModeStack = new Stack<bool>(FilterModeStack),
                 Start = Start,
                 Timeout = Timeout,
-                QueryStats = QueryStats,
+                QueryStats = queryData?.QueryStatistics ?? QueryStats,
                 TheWaitForNonStaleResults = TheWaitForNonStaleResults,
                 Negate = Negate,
                 DocumentIncludes = new HashSet<string>(DocumentIncludes),

--- a/src/Raven.Client/Documents/Session/QueryStatistics.cs
+++ b/src/Raven.Client/Documents/Session/QueryStatistics.cs
@@ -87,5 +87,7 @@ namespace Raven.Client.Documents.Session
             ResultEtag = qr.ResultEtag;
             NodeTag = qr.NodeTag;
         }
+
+        internal bool RequestedByUser { get; set; }
     }
 }

--- a/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Debug.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
+using Sparrow;
 
 namespace Voron.Data.CompactTrees;
 
@@ -12,17 +14,44 @@ unsafe partial class CompactTree
         public static void WriteCommit(CompactTree tree)
         {
 #if ENABLE_COMPACT_DUMPER
-            using var writer = File.AppendText(tree.Name.ToString());
+            using var writer = File.AppendText(tree._inner.Name.ToString());
             writer.WriteLine("###");
 #endif
         }
 
         [Conditional("ENABLE_COMPACT_DUMPER")]
-        public static void WriteAddition(CompactTree tree, ReadOnlySpan<byte> key, long value)
+        public static void WriteAddition(CompactTree tree, ref CompactKeyLookup lookup, long value)
         {
 #if ENABLE_COMPACT_DUMPER
-            using var writer = File.AppendText(tree.Name.ToString());
-            writer.WriteLine($"+{Encodings.Utf8.GetString(key)}|{value}");
+            using var writer = File.AppendText(tree._inner.Name.ToString());
+            writer.WriteLine($"+{Encodings.Utf8.GetString(lookup.Key.Decoded())}|{value}");
+#endif
+        }
+
+        [Conditional("ENABLE_COMPACT_DUMPER")]
+        public static void WriteBulkSet(CompactTree tree, ref CompactKeyLookup lookup, long value)
+        {
+#if ENABLE_COMPACT_DUMPER
+            using var writer = File.AppendText(tree._inner.Name.ToString());
+            writer.WriteLine($"*{Encodings.Utf8.GetString(lookup.Key.Decoded())}|{value}");
+#endif
+        }
+
+        [Conditional("ENABLE_COMPACT_DUMPER")]
+        public static void WriteRemoval(CompactTree tree, ref CompactKeyLookup lookup, long oldValue)
+        {
+#if ENABLE_COMPACT_DUMPER
+            using var writer = File.AppendText(tree._inner.Name.ToString());
+            writer.WriteLine($"-{Encodings.Utf8.GetString(lookup.Key.Decoded())}|{oldValue}");
+#endif
+        }
+
+        [Conditional("ENABLE_COMPACT_DUMPER")]
+        public static void WriteBulkRemoval(CompactTree tree, ref CompactKeyLookup lookup, long oldValue)
+        {
+#if ENABLE_COMPACT_DUMPER
+            using var writer = File.AppendText(tree._inner.Name.ToString());
+            writer.WriteLine($"/{Encodings.Utf8.GetString(lookup.Key.Decoded())}|{oldValue}");
 #endif
         }
     }

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -271,6 +271,8 @@ public sealed partial class CompactTree : IPrepareForCommit
 
     public long AddAfterTryGetNext(ref CompactKeyLookup lookup, long value)
     {
+        CompactTreeDumper.WriteAddition(this, ref lookup, value);
+
         _inner.AddAfterTryGetNext(ref lookup, value);
         return lookup.ContainerId;
     }
@@ -284,11 +286,10 @@ public sealed partial class CompactTree : IPrepareForCommit
     public long Add(CompactKey key, long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
-
-        CompactTreeDumper.WriteAddition(this, key.Decoded(), value);
-
         AssertValueAndKeySize(key, value);
+
         var lookup = new CompactKeyLookup(key);
+        CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
 
         return lookup.ContainerId;
@@ -423,12 +424,16 @@ public sealed partial class CompactTree : IPrepareForCommit
     
     public bool TryRemove(CompactKeyLookup key, out long oldValue)
     {
-        return _inner.TryRemove(key, out oldValue);
+        var result = _inner.TryRemove(key, out oldValue);
+        CompactTreeDumper.WriteRemoval(this, ref key, oldValue);
+        return result;
     }
 
     public bool TryRemoveExistingValue(ref CompactKeyLookup key, out long oldValue)
     {
-        return _inner.TryRemoveExistingValue(ref key, out oldValue);
+        var result = _inner.TryRemoveExistingValue(ref key, out oldValue);
+        CompactTreeDumper.WriteRemoval(this, ref key, oldValue);
+        return result;
     }
 
     public void InitializeStateForTryGetNextValue()
@@ -449,7 +454,8 @@ public sealed partial class CompactTree : IPrepareForCommit
     
     public void BulkUpdateSet(ref CompactKeyLookup key, long value, long pageNum, int offset, ref int adjustment)
     {
-        _inner.BulkUpdateSet(ref key, value, pageNum, offset, ref adjustment);   
+        _inner.BulkUpdateSet(ref key, value, pageNum, offset, ref adjustment);
+        CompactTreeDumper.WriteBulkSet(this, ref key, value);
     }
 
     public Lookup<CompactKeyLookup>.TreeStructureChanged CheckTreeStructureChanges()
@@ -459,7 +465,9 @@ public sealed partial class CompactTree : IPrepareForCommit
 
     public bool BulkUpdateRemove(ref CompactKeyLookup key, long pageNum, int offset, ref int adjustment, out long oldValue)
     {
-        return _inner.BulkUpdateRemove(ref key, pageNum, offset, ref adjustment, out oldValue);
+        var result = _inner.BulkUpdateRemove(ref key, pageNum, offset, ref adjustment, out oldValue);
+        CompactTreeDumper.WriteBulkRemoval(this, ref key, oldValue);
+        return result;
     }
     
     public int BulkUpdateStart(Span<CompactKeyLookup> keys, Span<long> values, Span<int> offsets, out long pageNum)

--- a/test/SlowTests/Issues/RavenDB_21525.cs
+++ b/test/SlowTests/Issues/RavenDB_21525.cs
@@ -17,12 +17,11 @@ public class RavenDB_21525 : RavenTestBase
     {
     }
 
-    [Theory]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    public async Task OrderByWithPaginationVsUnordered(Options options)
-    {
-        int size = 10_000;
 
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task OrderByWithPaginationVsUnordered(Options options, int size = 10000)
+    {
         using (var store = GetDocumentStore(options))
         {
             using (var bulkInsert = store.BulkInsert())
@@ -51,6 +50,8 @@ public class RavenDB_21525 : RavenTestBase
                         .Customize(i => i.WaitForNonStaleResults().NoCaching())
                         .ToList();
 
+                    Assert.Equal(resultsOrdered.Count, resultsUnordered.Count);
+
                     long totalOrdered = orderedStats.TotalResults;
                     long totalUnordered = unorderedStats.TotalResults;
                     Assert.Equal(totalUnordered, totalOrdered);
@@ -72,11 +73,13 @@ public class RavenDB_21525 : RavenTestBase
                         .Customize(i => i.WaitForNonStaleResults().NoCaching())
                         .ToListAsync();
 
+                    Assert.Equal(resultsOrdered.Count, resultsUnordered.Count);
+
                     long totalOrdered = orderedStats.TotalResults;
                     long totalUnordered = unorderedStats.TotalResults;
                     Assert.Equal(totalUnordered, totalOrdered);
                 }
-                
+
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_21525.cs
+++ b/test/SlowTests/Issues/RavenDB_21525.cs
@@ -1,0 +1,90 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21525 : RavenTestBase
+{
+    public RavenDB_21525(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Theory]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task OrderByWithPaginationVsUnordered(Options options)
+    {
+        int size = 10_000;
+
+        using (var store = GetDocumentStore(options))
+        {
+            using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < size; ++i)
+                {
+                    bulkInsert.Store(new Person() { Name = $"ItemNo{i}", Age = i % 100, Height = i % 200 });
+                }
+            }
+
+            for (int i = 0; i < size; i += 70)
+            {
+                // sync API
+                using (var session = store.OpenSession())
+                {
+                    var resultsOrdered = session.Query<Person>()
+                        .OrderBy(y => y.Age)
+                        .Statistics(out var orderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToList();
+
+                    var resultsUnordered = session.Query<Person>()
+                        .Statistics(out var unorderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToList();
+
+                    long totalOrdered = orderedStats.TotalResults;
+                    long totalUnordered = unorderedStats.TotalResults;
+                    Assert.Equal(totalUnordered, totalOrdered);
+                }
+
+                // async API
+                using (var session = store.OpenAsyncSession())
+                {
+                    var resultsOrdered = await session.Query<Person>()
+                        .OrderBy(y => y.Age)
+                        .Statistics(out var orderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToListAsync();
+
+                    var resultsUnordered = await session.Query<Person>()
+                        .Statistics(out var unorderedStats)
+                        .Skip(i).Take(70)
+                        .Customize(i => i.WaitForNonStaleResults().NoCaching())
+                        .ToListAsync();
+
+                    long totalOrdered = orderedStats.TotalResults;
+                    long totalUnordered = unorderedStats.TotalResults;
+                    Assert.Equal(totalUnordered, totalOrdered);
+                }
+                
+            }
+        }
+    }
+
+    private class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public int Height { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21525
https://issues.hibernatingrhinos.com/issue/RavenDB-21537

### Additional description

- Client side: We'll send `SkipStatistics: false` if they were requested via Linq API
- Server side: Fixing and issue where Limiting FillWithReader causeed wrong calculation of the stats

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
