### PR TITLE
RavenDB-21528 reduce the number of allocations done by the BlittableJsonTextWriter when wrting an object

### DIFF
--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -114,7 +114,7 @@ namespace Sparrow.Json
                     }
 
                     obj.GetPropertyByIndex(buffer.Properties[i], ref prop);
-                    WritePropertyName((string)prop.Name);
+                    WritePropertyName(prop.Name);
 
                     WriteValue(prop.Token & BlittableJsonReaderBase.TypesMask, prop.Value);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21528

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
