### PR TITLE
RavenDB-7070 Skipping tests with rvn setup on Linux. They have never run before because of the issue with env variable casing.

### DIFF
--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -31,7 +31,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     {
     }
 
-    [LicenseRequiredFact]
+    [MultiplatformFact(RavenPlatform.Windows, LicenseRequired = true)]
     public async Task Should_Create_Secured_Cluster_Generating_Self_Singed_Cert_And_Setup_Zip_File_From_Rvn_Three_Nodes()
     {
         DoNotReuseServer();
@@ -206,7 +206,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
 
     }
 
-    [LicenseRequiredFact]
+    [MultiplatformFact(RavenPlatform.Windows, LicenseRequired = true)]
     public async Task Should_Create_Secured_Cluster_Generating_Self_Singed_Cert_And_Setup_Zip_File_From_Rvn_One_Node()
     {
         DoNotReuseServer();
@@ -309,7 +309,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
 
     }
 
-    [LicenseRequiredRetryFact(delayBetweenRetriesMs: 1000)]
+    [MultiplatformFact(RavenPlatform.Windows, LicenseRequired = true)]
     public async Task Should_Create_Secured_Cluster_From_Rvn_Using_Lets_Encrypt_Mode_One_Node()
     {
         DoNotReuseServer();
@@ -437,7 +437,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             Assert.True(await WaitForValueAsync(() => server.ServerStore.GetClusterTopology().Members.Count == numberOfExpectedNodes, true));
     }
 
-    [LicenseRequiredRetryFact(delayBetweenRetriesMs: 1000)]
+    [MultiplatformFact(RavenPlatform.Windows, LicenseRequired = true)]
     public async Task Should_Create_Secured_Cluster_From_Rvn_Using_Lets_Encrypt_Mode_Three_Nodes()
     {
         DoNotReuseServer();


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21542

### Additional description



### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
