### PR TITLE
RavenDB-21550 - Missing overload for ToArray

### DIFF
--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -996,6 +996,11 @@ namespace Sparrow.Json
             return StartsWith(value.ToString());
         }
 
+        public char[] ToArray()
+        {
+            return ToString().ToArray();
+        }
+
         public char[] ToCharArray()
         {
             return ToString().ToCharArray();

--- a/test/FastTests/Issues/RavenDB_21550.cs
+++ b/test/FastTests/Issues/RavenDB_21550.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_21550 : RavenTestBase
+    {
+        public RavenDB_21550(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_Handle_ToArray()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await new Index().ExecuteAsync(store);
+
+                const string name = "Grisha";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = name });
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var result = await session.Query<User, Index>()
+                        .ProjectInto<Index.Result>()
+                        .FirstOrDefaultAsync();
+
+                    Assert.NotNull(result);
+                    Assert.Equal(name.ToArray(), result.Array);
+                }
+            }
+        }
+
+        public class Index : AbstractIndexCreationTask<User>
+        {
+            public class Result
+            {
+                public char[] Array { get; set; }
+            }
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Maps = { @"from user in docs.Users
+select new { Array = user.Name.ToArray() }" },
+                    Fields =
+                    {
+                        {
+                            nameof(Result.Array), new IndexFieldOptions()
+                            {
+                                Storage = FieldStorage.Yes
+                            }
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/test/FastTests/Issues/RavenDB_21550.cs
+++ b/test/FastTests/Issues/RavenDB_21550.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +16,7 @@ namespace FastTests.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task Should_Handle_ToArray()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21550/Missing-overload-for-ToArray

### Additional description

Add a missing overload for `ToArray`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works