### PR TITLE
RavenDB-16045 Comparing `LazyNumberValue` objects using their values instead of references

### DIFF
--- a/src/Sparrow/Json/LazyNumberValue.cs
+++ b/src/Sparrow/Json/LazyNumberValue.cs
@@ -161,6 +161,19 @@ namespace Sparrow.Json
             return -(decimal)y;
         }
 
+        public static bool operator !=(LazyNumberValue self, LazyNumberValue lnv) => !(self == lnv);
+        
+        public static bool operator ==(LazyNumberValue self, LazyNumberValue lnv)
+        {
+            if (ReferenceEquals(self, null))
+                return ReferenceEquals(lnv, null);
+            
+            if (ReferenceEquals(lnv, null))
+                return false;
+
+            return self.Equals(lnv);
+        }
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))

--- a/test/SlowTests/Issues/RavenDB-16045.cs
+++ b/test/SlowTests/Issues/RavenDB-16045.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_16045 : RavenTestBase
+{
+    public RavenDB_16045(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void QueryRelatedDocumentTest()
+    {
+        using var store = GetDocumentStore();
+
+        var index = new TestDocDataIndex();
+        
+        index.Execute(store);
+
+        using (var session = store.OpenSession())
+        {
+            var d1 = new Dto() { Quantity = 101 };
+
+            session.Store(d1);
+            
+            var dr1 = new DtoWithReference() { ReferenceId = d1.Id, Quantity = 101 };
+            
+            session.Store(dr1);
+            
+            session.SaveChanges();
+            
+            Indexes.WaitForIndexing(store);
+            
+            WaitForUserToContinueTheTest(store);
+
+            var queryResults = session.Query<TestDocDataIndex.IndexResult, TestDocDataIndex>().ProjectInto<TestDocDataIndex.IndexResult>().ToList();
+            
+            Assert.False(queryResults.First().HasQuantityChanged);
+            Assert.False(queryResults.First().LeftIsGreater);
+            Assert.False(queryResults.First().RightIsGreater);
+
+            Assert.True(queryResults.First().EqualQuantity);
+            Assert.True(queryResults.First().LeftIsGte);
+            Assert.True(queryResults.First().RightIsGte);
+        }
+    }
+    
+    private class Dto
+    {
+        public string Id { get; set; }
+        public decimal Quantity { get; set; }
+    }
+
+    private class DtoWithReference
+    {
+        public string Id { get; set; }
+        public string ReferenceId { get; set; }
+        public decimal Quantity { get; set; }
+    }
+    
+    private class TestDocDataIndex : AbstractIndexCreationTask<DtoWithReference>
+    {
+        public class IndexResult
+        {
+            public string Id { get; set; }
+            public bool HasQuantityChanged { get; set; }
+            public bool EqualQuantity { get; set; }
+            public bool LeftIsGreater { get; set; }
+            public bool RightIsGreater { get; set; }
+            public bool LeftIsGte { get; set; }
+            public bool RightIsGte { get; set; }
+        }
+        
+        public TestDocDataIndex()
+        {
+            Map = dtosWithReference => from dtoWithReference in dtosWithReference
+                let dto = LoadDocument<Dto>(dtoWithReference.ReferenceId)
+                select new IndexResult()
+                {
+                    HasQuantityChanged = dtoWithReference.Quantity != dto.Quantity,
+                    EqualQuantity = dtoWithReference.Quantity == dto.Quantity,
+                    LeftIsGreater = dtoWithReference.Quantity > dto.Quantity,
+                    RightIsGreater = dtoWithReference.Quantity < dto.Quantity,
+                    LeftIsGte = dtoWithReference.Quantity >= dto.Quantity,
+                    RightIsGte = dtoWithReference.Quantity <= dto.Quantity
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16045/Wrong-results-returned-when-index-definition-doesnt-have-decimal-cast

### Additional description

In case of comparison of two `LazyNumberValue` objects using `!=` or `==` operator we want to compare their values, not references.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change
Before this change comparing two `LazyNumberValue`  with `==` or `!=` operator would compare their references. Now we actually compare their values.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
