### PR TITLE
RavenDB-21518 In case of moving key in Lookup between pages increase TermReferenceCounter to avoid unintentionally removing necessary data.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -57,8 +57,6 @@ namespace Corax.Indexing
         private Token[] _tokensBufferHandler;
         private byte[] _encodingBufferHandler;
         private byte[] _utf8ConverterBufferHandler;
-        
-       
 
         private bool _hasSuggestions;
         private readonly IndexedField[] _knownFieldsTerms;
@@ -415,8 +413,7 @@ namespace Corax.Indexing
             }
         }
 
-        internal static ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value,
-            out Slice slice)
+        internal static ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value, out Slice slice)
         {
             if (value.Length <= Constants.Terms.MaxLength)
                 return Slice.From(context, value, ByteStringType.Mutable, out slice);
@@ -468,8 +465,7 @@ namespace Corax.Indexing
             }
         }
         
-        private void RecordTermDeletionsForEntry(Container.Item entryTerms, LowLevelTransaction llt, Dictionary<long, IndexedField> fieldsByRootPage, HashSet<long> nullTermMarkers, long dicId,
-            long entryToDelete, int termsPerEntryIndex)
+        private void RecordTermDeletionsForEntry(Container.Item entryTerms, LowLevelTransaction llt, Dictionary<long, IndexedField> fieldsByRootPage, HashSet<long> nullTermMarkers, long dicId, long entryToDelete, int termsPerEntryIndex)
         {
             var reader = new EntryTermsReader(llt, nullTermMarkers, entryTerms.Address, entryTerms.Length, dicId);
             reader.Reset();

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -164,6 +164,11 @@ public sealed partial class CompactTree : IPrepareForCommit
             DecrementTermReferenceCount(parent.Llt, ContainerId, ref parent.State);
         }
 
+        public void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+        { 
+            IncrementTermReferenceCount(parent.Llt, ContainerId);
+        }
+
         public string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
             return GetKey(parent).ToString();

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -78,6 +78,10 @@ public struct DoubleLookupKey : ILookupKey
     {
     }
 
+    public void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+    }
+
     public string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey
     {
         return ToString();

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -24,6 +24,8 @@ public interface ILookupKey
     void OnNewKeyAddition<T>(Lookup<T> parent) where T : struct, ILookupKey;
 
     void OnKeyRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey;
-
+    
+    void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey;
+    
     string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey;
 }

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -77,6 +77,10 @@ public struct Int64LookupKey : ILookupKey
     {
     }
 
+    public void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+    }
+
     public string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey
     {
         return ToString();

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -407,6 +407,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         Debug.Assert(state.Header->Upper - state.Header->Lower >= 0);
         Debug.Assert(state.Header->FreeSpace <= Constants.Storage.PageSize - PageHeader.SizeOf);
         Debug.Assert(k == key.ToLong(), "k == key.ToLong()");
+        
         key.OnKeyRemoval(this);
         entriesOffsets[(pos + 1)..].CopyTo(entriesOffsets[pos..]);
     }
@@ -468,9 +469,13 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             return false; // nothing to be done here, we cannot fully merge, so abort
         
         // now copy from the temp buffer to the actual page
+        // additionally we've to increase term references counter to avoid removal of term container
+        
         Debug.Assert(_llt.IsDirty(destinationState.Page.PageNumber));
         Memory.Copy(destinationState.Page.Pointer, temp.Ptr, Constants.Storage.PageSize);
-
+        var keyData = GetKeyData(ref parent, parent.LastSearchPosition + 1);
+        var siblingKey = TLookupKey.FromLong<TLookupKey>(keyData);
+        siblingKey.IncreaseReferenceCount(this);
         // We update the entries offsets on the source page, now that we have moved the entries.
         parent.LastSearchPosition++;
         FreePageFor(ref destinationState, ref sourceState, ref parent);
@@ -583,13 +588,18 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             FreePageFor(ref sourceState, ref destinationState, ref parent);
             return;
         }
-
+        
         // if we are removing the leftmost item, we need to maintain the smallest entry, just copy the sibling's contents
+        // additionally we've to increase term references counter to avoid removal of term container
+        var siblingKeyData = GetKeyData(ref parent, position);
+        var siblingKey = TLookupKey.FromLong<TLookupKey>(siblingKeyData);
+        siblingKey.IncreaseReferenceCount(this);
+        
         long pageNum = destinationState.Page.PageNumber;
         Debug.Assert(_llt.IsDirty(destinationState.Page.PageNumber));
         Memory.Copy(destinationState.Page.Pointer, sourceState.Page.Pointer, Constants.Storage.PageSize);
         destinationState.Page.PageNumber = pageNum;
-
+        
         // now ask that we'll remove the _sibling_ page, not us, since we copied it
         parent.LastSearchPosition++;
         FreePageFor(ref destinationState, ref sourceState, ref parent);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1119,7 +1119,7 @@ namespace Voron
                         {
                             case RootObjectType.VariableSizeTree:
                                 var tree = tx.ReadTree(currentKey);
-                                RegisterPages(tree.AllPages(), name);
+                                RegisterPages(tree.AllPages(), name + " (VST)");
                                 if (tree.State.Flags.HasFlag(TreeFlags.CompactTrees) ||
                                     tree.State.Flags.HasFlag(TreeFlags.Lookups))
                                 {
@@ -1133,7 +1133,7 @@ namespace Voron
                                             {
                                                 case RootObjectType.Lookup:
                                                     var lookup = tree.LookupFor<Int64LookupKey>(it.CurrentKey);
-                                                    RegisterLookup(lookup, name);
+                                                    RegisterLookup(lookup, name + $"/{it.CurrentKey}");
                                                     break;
                                                 case RootObjectType.EmbeddedFixedSizeTree:
                                                     continue; // already accounted for
@@ -1275,6 +1275,7 @@ namespace Voron
 
             void RegisterContainer(long container, string name)
             {
+                r.Add(container, name);
                 var overflowName = $"{name}/OverflowPage";
                 var (allPages, freePages) = Container.GetPagesFor(tx.LowLevelTransaction, container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");

--- a/test/SlowTests/Issues/RavenDB-21399-2.cs
+++ b/test/SlowTests/Issues/RavenDB-21399-2.cs
@@ -1,4 +1,6 @@
 ﻿using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,14 +13,14 @@ public class RavenDB_21399_2 : StorageTest
     {
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public unsafe void CanHandleDeletesAndUpdatesToLeftmostLeafPage()
     {
         using var wtx = Env.WriteTransaction();
 
         var lookup = wtx.LookupFor<Int64LookupKey>("test");
         long k = 1;
-        
+
         // we are waiting until the tree structure looks like
         // * Root
         // * * Branch - min value
@@ -41,15 +43,12 @@ public class RavenDB_21399_2 : StorageTest
         {
             lookup.Add(k++, 0);
         }
-        
-        var rootState = new Lookup<Int64LookupKey>.CursorState
-        {
-            Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)
-        };
+
+        var rootState = new Lookup<Int64LookupKey>.CursorState {Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)};
 
         long keyData = Lookup<Int64LookupKey>.GetKeyData(ref rootState, rootState.Header->NumberOfEntries - 1);
         changed = lookup.CheckTreeStructureChanges();
-        
+
         // Now we remove until we have this situation:
         // * Root
         // * * Branch - min value
@@ -61,22 +60,22 @@ public class RavenDB_21399_2 : StorageTest
         {
             lookup.TryRemove(keyData++, out _);
         }
-        
+
         // Now we insert $SomeVal+8, which will go to the $SomeVal + 10 key 
-        lookup.Add(keyData-2, 0);
-        
+        lookup.Add(keyData - 2, 0);
+
         // Problem
         lookup.VerifyStructure();
     }
-    
-    [Fact]
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public unsafe void CanHandleDeletesAndUpdatesToMiddleLeafPage()
     {
         using var wtx = Env.WriteTransaction();
 
         var lookup = wtx.LookupFor<Int64LookupKey>("test");
         long k = 1;
-        
+
         // we are waiting until the tree structure looks like
         // * Root
         // * * Branch - min value
@@ -94,13 +93,10 @@ public class RavenDB_21399_2 : StorageTest
         // * * Branch - $SomeVal
         // * * Branch - $SomeVal + 100
 
-        var rootState = new Lookup<Int64LookupKey>.CursorState
-        {
-            Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)
-        };
+        var rootState = new Lookup<Int64LookupKey>.CursorState {Page = wtx.LowLevelTransaction.GetPage(lookup.State.RootPage)};
 
-        long keyData = Lookup<Int64LookupKey>.GetKeyData(ref rootState, rootState.Header->NumberOfEntries /2);
-        
+        long keyData = Lookup<Int64LookupKey>.GetKeyData(ref rootState, rootState.Header->NumberOfEntries / 2);
+
         // Now we remove until we have this situation:
         // * Root
         // * * Branch - min value
@@ -113,9 +109,28 @@ public class RavenDB_21399_2 : StorageTest
             lookup.TryRemove(keyData++, out _);
         }
 
-        lookup.Add(keyData-2, 0);
-        
+        lookup.Add(keyData - 2, 0);
+
         // Problem
         lookup.VerifyStructure();
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
+    public void CanSafelySwapLeavesWithoutRemovingTermFromDisk()
+    {
+        using var wtx = Env.WriteTransaction();
+        CompactTree tree = wtx.CompactTreeFor($"test");
+        var lookup = tree._inner;
+        long k = 1;
+        
+        while (lookup.State.BranchPages < 4)
+        {
+            tree.Add($"{k}", k++);
+        }
+
+        while (k > 0)
+        {
+            tree.TryRemove($"{--k}", out _);
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21518 
### Additional description

In case of moving key in Lookup between pages increase TermReferenceCounter to avoid unintentionally removing necessary data.

### Type of change

- Bug fix


### How risky is the change?

- Moderate 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
