### PR TITLE
RavenDB-20708 - ArgumentNullException in ChangeVectorUtils.GetEtagById

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
@@ -256,8 +255,7 @@ namespace Raven.Server.Documents.Handlers
             if (clusterTransactionCommand.DatabaseCommandsCount > 0)
             {
                 ClusterTransactionCompletionResult reply;
-                using (var timeout = new CancellationTokenSource(ServerStore.Engine.OperationTimeout))
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, HttpContext.RequestAborted))
+                using (var cts = CreateHttpRequestBoundTimeLimitedOperationToken(ServerStore.Engine.OperationTimeout))
                 {
                     reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, cts.Token);
                 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -338,6 +338,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         database.ClusterTransactionId = databaseRecord.Topology.ClusterTransactionIdBase64;
                         database.DatabaseGroupId = databaseRecord.Topology.DatabaseTopologyIdBase64;
 
+                        database.TxMerger.Start();
+
                         result.Files.FileCount = filesToRestore.Count + (snapshotRestore ? 1 : 0);
                         
                         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/test/SlowTests/Issues/RavenDB_20708.cs
+++ b/test/SlowTests/Issues/RavenDB_20708.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Session;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20708 : ReplicationTestBase
+    {
+        public RavenDB_20708(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ShouldNotBlockClusterTransactionOnDatabaseStartup()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore(new Options { DeleteDatabaseOnDispose = false, RunInMemory = false }))
+            {
+                Cluster.SuspendObserver(Server);
+
+                var testingStuff = Server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly();
+                testingStuff.BeforeHandleClusterTransactionOnDatabaseChanged = (server) => server.DatabasesLandlord.RestartDatabase(store.Database);
+                testingStuff.DelayNotifyFeaturesAboutStateChange = () => Thread.Sleep(1000);
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user1 = new User { Name = "Karmel" };
+                    var user2 = new User { Name = "Karmel2" };
+
+                    await session.StoreAsync(user1, "users/1");
+                    await session.StoreAsync(user2, "users/2");
+
+                    await Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await session.SaveChangesAsync());
+
+                    Assert.True(await WaitForValueAsync(() => Server.ServerStore.DatabasesLandlord.IsDatabaseLoaded(store.Database),
+                        true, 10_000));
+
+                    var database = await GetDatabase(store.Database);
+                    var key = AlertRaised.GetKey(AlertType.ClusterTransactionFailure, $"{database.Name}/ClusterTransaction");
+                    Assert.False(database.NotificationCenter.Exists(key));
+
+                    var user = await session.LoadAsync<User>("users/1");
+                    Assert.Equal(user1.Name, user.Name);
+
+                    user = await session.LoadAsync<User>("users/2");
+                    Assert.Equal(user2.Name, user.Name);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_20708.cs
+++ b/test/SlowTests/Issues/RavenDB_20708.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Database;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -37,7 +38,7 @@ namespace SlowTests.Issues
                     await session.StoreAsync(user1, "users/1");
                     await session.StoreAsync(user2, "users/2");
 
-                    await Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () => await session.SaveChangesAsync());
+                    await Assert.ThrowsAsync<DatabaseDisabledException>(async () => await session.SaveChangesAsync());
 
                     Assert.True(await WaitForValueAsync(() => Server.ServerStore.DatabasesLandlord.IsDatabaseLoaded(store.Database),
                         true, 10_000));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20708/ArgumentNullException-in-ChangeVectorUtils.GetEtagById


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
