### PR TITLE
RavenDB-21558 Removing default dictionary / accounting root container in storagereport.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -57,8 +57,6 @@ namespace Corax.Indexing
         private Token[] _tokensBufferHandler;
         private byte[] _encodingBufferHandler;
         private byte[] _utf8ConverterBufferHandler;
-        
-       
 
         private bool _hasSuggestions;
         private readonly IndexedField[] _knownFieldsTerms;
@@ -415,8 +413,7 @@ namespace Corax.Indexing
             }
         }
 
-        internal static ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value,
-            out Slice slice)
+        internal static ByteStringContext<ByteStringMemoryCache>.InternalScope CreateNormalizedTerm(ByteStringContext context, ReadOnlySpan<byte> value, out Slice slice)
         {
             if (value.Length <= Constants.Terms.MaxLength)
                 return Slice.From(context, value, ByteStringType.Mutable, out slice);
@@ -468,8 +465,7 @@ namespace Corax.Indexing
             }
         }
         
-        private void RecordTermDeletionsForEntry(Container.Item entryTerms, LowLevelTransaction llt, Dictionary<long, IndexedField> fieldsByRootPage, HashSet<long> nullTermMarkers, long dicId,
-            long entryToDelete, int termsPerEntryIndex)
+        private void RecordTermDeletionsForEntry(Container.Item entryTerms, LowLevelTransaction llt, Dictionary<long, IndexedField> fieldsByRootPage, HashSet<long> nullTermMarkers, long dicId, long entryToDelete, int termsPerEntryIndex)
         {
             var reader = new EntryTermsReader(llt, nullTermMarkers, entryTerms.Address, entryTerms.Length, dicId);
             reader.Reset();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1119,7 +1119,7 @@ namespace Voron
                         {
                             case RootObjectType.VariableSizeTree:
                                 var tree = tx.ReadTree(currentKey);
-                                RegisterPages(tree.AllPages(), name);
+                                RegisterPages(tree.AllPages(), name + " (VST)");
                                 if (tree.State.Flags.HasFlag(TreeFlags.CompactTrees) ||
                                     tree.State.Flags.HasFlag(TreeFlags.Lookups))
                                 {
@@ -1133,7 +1133,7 @@ namespace Voron
                                             {
                                                 case RootObjectType.Lookup:
                                                     var lookup = tree.LookupFor<Int64LookupKey>(it.CurrentKey);
-                                                    RegisterLookup(lookup, name);
+                                                    RegisterLookup(lookup, name + $"/{it.CurrentKey}");
                                                     break;
                                                 case RootObjectType.EmbeddedFixedSizeTree:
                                                     continue; // already accounted for
@@ -1275,6 +1275,7 @@ namespace Voron
 
             void RegisterContainer(long container, string name)
             {
+                r.Add(container, name);
                 var overflowName = $"{name}/OverflowPage";
                 var (allPages, freePages) = Container.GetPagesFor(tx.LowLevelTransaction, container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21558 
### Additional description
 Removing default dictionary / accounting root container in storagereport.

### Type of change


- Regression bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
