### PR TITLE
RavenDB-20485: fix Failed to digest change of type 'RecordChanged' for database

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1327,7 +1327,7 @@ namespace Raven.Server.Documents
             {
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e);
 
-                if (_databaseShutdown.IsCancellationRequested)
+                if (_serverStore.ServerShutdown.IsCancellationRequested || _databaseShutdown.IsCancellationRequested)
                     ThrowDatabaseShutdown();
 
                 throw;
@@ -1365,7 +1365,7 @@ namespace Raven.Server.Documents
             {
                 DatabaseDisabledException throwShutDown = null;
 
-                if (_databaseShutdown.IsCancellationRequested && e is DatabaseDisabledException == false)
+                if ((_serverStore.ServerShutdown.IsCancellationRequested || _databaseShutdown.IsCancellationRequested) && e is DatabaseDisabledException == false) 
                     e = throwShutDown = CreateDatabaseShutdownException(e);
 
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1491,7 +1491,7 @@ namespace Raven.Server.Documents.Replication
             }
             catch (Exception e)
             {
-                if (_shutdownToken.IsCancellationRequested)
+                if (_server.ServerShutdown.IsCancellationRequested || _shutdownToken.IsCancellationRequested)
                     return null;
 
                 // will try to fetch it again later


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20485

### Additional description

The `_serverStore` cancellation token is canceled before `documentDatabase` cancellation token, need to check `_serverStore` cancellation token and throw `DatabaseShutdownException` in such case (which is expected exception)

### Type of change

- Bug fix

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
