### PR TITLE
RavenDB-20485: connect DocumentDatabase token with ServerStore token

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1504,7 +1504,7 @@ namespace Raven.Server.Documents.Replication
             }
             catch (Exception e)
             {
-                if (_server.ServerShutdown.IsCancellationRequested || _shutdownToken.IsCancellationRequested)
+                if (_shutdownToken.IsCancellationRequested)
                     return null;
 
                 // will try to fetch it again later


### PR DESCRIPTION
The _serverStore cancellation token is canceled before documentDatabase cancellation token, need to check _serverStore cancellation token and throw DatabaseShutdownException in such case (which is expected exception)

https://github.com/ravendb/ravendb/pull/17510