### PR TITLE
RavenDB-18060 don't reload indexes after collection query

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -798,14 +798,16 @@ class query extends viewModelBase {
             if (currentIndex) {
                 this.queriedIndexInfo(currentIndex);
             } else {
-                // fetch indexes since this view may not be up-to-date if index was defined outside of studio
-                this.fetchAllIndexes(this.activeDatabase())
-                    .done(() => {
-                        this.queriedIndexInfo(this.indexes() ? this.indexes().find(i => i.Name === indexName) : null);
-                    })
-                    .fail(() => {
-                        this.queriedIndexInfo(null);
-                    });
+                if (!indexName.startsWith(queryUtil.DynamicPrefix)) {
+                    // fetch indexes since this view may not be up-to-date if index was defined outside of studio
+                    this.fetchAllIndexes(this.activeDatabase())
+                        .done(() => {
+                            this.queriedIndexInfo(this.indexes() ? this.indexes().find(i => i.Name === indexName) : null);
+                        })
+                        .fail(() => {
+                            this.queriedIndexInfo(null);
+                        });
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18060 

### Additional description

Don't reload stats after collection query

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

