### PR TITLE
RavenDB-21557 Fix projecting empty array from Corax index

### DIFF
--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -170,11 +170,12 @@ namespace Raven.Server.Documents.Patch
              
                 while (reader.FindNextStored(fieldRootPage))
                 {
-                    if (reader.IsList && // stored value is an array 
-                        value is null)   // and we haven't initialized it yet 
+                    // check if stored value is an array and we haven't initialized it yet
+                    if (reader.IsList)
                     {
-                        value = new JsArray(_parent.Engine);
+                        value ??= new JsArray(_parent.Engine);
                     }
+
                     if (reader.StoredField == null)
                     {
                         SetValue(ref value, Null);
@@ -184,7 +185,10 @@ namespace Raven.Server.Documents.Patch
                     var span = reader.StoredField.Value;
                     if (span.Length == 0)
                     {
-                        SetValue(ref value, string.Empty);
+                        if (reader.IsList == false)
+                        {
+                            SetValue(ref value, string.Empty);
+                        }
                         continue;
                     }
 

--- a/test/FastTests/Issues/RavenDB_21557.cs
+++ b/test/FastTests/Issues/RavenDB_21557.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_21557 : RavenTestBase
+{
+    public RavenDB_21557(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void Can_project_role_names_from_user_without_roles(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            new UserIndex().Execute(store);
+
+            User userWithoutRoles;
+            User userWithRole;
+
+            using (var session = store.OpenSession())
+            {
+                var role = new Role
+                {
+                    Id = "roles/1", Name = "Admin"
+                };
+                session.Store(role);
+
+                userWithoutRoles = new User
+                {
+                    Id = "users/1", Roles = Array.Empty<UserRole>()
+                };
+                session.Store(userWithoutRoles);
+
+                userWithRole = new User
+                {
+                    Id = "users/2", Roles = new UserRole[]{ new() { RoleId = role.Id } }
+                };
+                session.Store(userWithRole);
+
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                string[] QueryUserRoleNames(string userId)
+                {
+                    var data = session.Query<UserIndex.Result, UserIndex>()
+                        .Where(x => x.Deleted == false && x.Id == userId)
+                        .Select(x => new
+                        {
+                            user = x,
+                            roles = RavenQuery.Load<Role>(x.Roles.Select(r => r.RoleId).Distinct())
+                        })
+                        .Select(x => new
+                        {
+                            Roles =x.roles.Select(r => r.Name).ToArray()
+                        })
+                        .SingleOrDefault();
+
+                    return data.Roles;
+                }
+
+                var user1RoleNames = QueryUserRoleNames(userWithoutRoles.Id);
+                Assert.Empty(user1RoleNames);
+
+                var user2RoleNames = QueryUserRoleNames(userWithRole.Id);
+
+                Assert.Equal(1, user2RoleNames.Length);
+                Assert.Equal("Admin", user2RoleNames[0]);
+            }
+        }
+    }
+
+    private class UserIndex : AbstractIndexCreationTask<User, UserIndex.Result>
+    {
+        public class Result
+        {
+            public string Id { get; set; }
+            public UserRoleResult[] Roles { get; set; }
+            public bool Deleted { get; set; }
+        }
+
+        public class UserRoleResult
+        {
+            public string RoleId { get; set; }
+        }
+
+        public UserIndex()
+        {
+            Map = users => from user in users
+                select new Result
+                {
+                    Id = user.Id,
+                    Roles = user.Roles
+                        .Select(x => new UserRoleResult
+                        {
+                            RoleId = x.RoleId
+                        })
+                        .ToArray(),
+                    Deleted = false
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class Role
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+        public UserRole[] Roles { get; set; }
+    }
+
+    private class UserRole
+    {
+        public string RoleId { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21557

### Additional description

Corax extraction logic would insert empty string when list was started, should not do that for list start entries.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
