### PR TITLE
RavenDB-20724 Adding an unrecognized index configuration option shouldn't trigger the replacement process

### DIFF
--- a/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
@@ -395,7 +395,7 @@ namespace Raven.Server.Config.Categories
             throw new InvalidOperationException($"The {nameof(DefaultValueAttribute)} is missing for '{property.Name}' property.");
         }
 
-        public List<ConfigurationProperty> GetConfigurationProperties()
+        protected List<ConfigurationProperty> GetConfigurationProperties()
         {
             var configurationProperties = _configurationPropertiesCache.GetOrAdd(GetType(), GetConfigurationPropertiesInternal);
 

--- a/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategory.cs
@@ -395,7 +395,7 @@ namespace Raven.Server.Config.Categories
             throw new InvalidOperationException($"The {nameof(DefaultValueAttribute)} is missing for '{property.Name}' property.");
         }
 
-        protected List<ConfigurationProperty> GetConfigurationProperties()
+        public List<ConfigurationProperty> GetConfigurationProperties()
         {
             var configurationProperties = _configurationPropertiesCache.GetOrAdd(GetType(), GetConfigurationPropertiesInternal);
 

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Raven.Client;
@@ -13,6 +14,7 @@ using Raven.Server.Documents.Indexes.Analysis;
 using Raven.Server.Documents.Indexes.Configuration;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 using Raven.Server.Utils.Features;
 using Sparrow;
 using Sparrow.Platform;
@@ -28,6 +30,8 @@ namespace Raven.Server.Config.Categories
         private readonly RavenConfiguration _root;
 
         private PathSetting _indexStoragePath;
+
+        public static readonly Lazy<HashSet<string>> ValidIndexingConfigurationKeys = new Lazy<HashSet<string>>(GetValidIndexingConfigurationKeys);
 
         public IndexingConfiguration(RavenConfiguration root)
         {
@@ -70,6 +74,11 @@ namespace Raven.Server.Config.Categories
             
             EncryptedTransactionSizeLimit = defaultEncryptedTransactionSizeLimit;
             MaxAllocationsAtDictionaryTraining = defaultMaxAllocationsAtDictionaryTraining;
+        }
+        
+        private static HashSet<string> GetValidIndexingConfigurationKeys()
+        {
+            return RavenConfiguration.AllConfigurationEntries.Value.Where(configurationEntry => configurationEntry.Category == ConfigurationCategoryType.Indexing.GetDescription()).SelectMany(configurationEntry => configurationEntry.Keys).ToHashSet();
         }
 
         [DefaultValue(false)]
@@ -577,6 +586,6 @@ namespace Raven.Server.Config.Categories
             Immediate,
             Pause,
             Delay
+        }
     }
-}
 }

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -26,14 +26,11 @@ namespace Raven.Server.Documents.Indexes;
 
 public abstract class AbstractIndexCreateController
 {
-    private readonly HashSet<string> _validConfigurationKeys;
-    
     protected readonly ServerStore ServerStore;
 
     protected AbstractIndexCreateController([NotNull] ServerStore serverStore)
     {
         ServerStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
-        _validConfigurationKeys = GetValidConfigurationKeys();
     }
 
     protected abstract string GetDatabaseName();
@@ -231,27 +228,18 @@ public abstract class AbstractIndexCreateController
         }
     }
     
-    private void ValidateConfiguration(IndexDefinition definition)
+    private static void ValidateConfiguration(IndexDefinition definition)
     {
         if (definition.Configuration == null)
             return;
         
         foreach (var kvp in definition.Configuration)
         {
-            if (_validConfigurationKeys.Contains(kvp.Key) == false)
+            if (IndexingConfiguration.ValidIndexingConfigurationKeys.Value.Contains(kvp.Key) == false)
             {
                 throw new IndexCreationException($"Could not create index '{definition.Name}' because the configuration option key '{kvp.Key}' is not recognized");
             }
         }
-    }
-
-    private static HashSet<string> GetValidConfigurationKeys()
-    {
-        var allConfigurationEntries = RavenConfiguration.AllConfigurationEntries.Value;
-        
-        var validPerIndexConfigurationKeys = allConfigurationEntries.Where(configurationEntry => configurationEntry.Category == "Indexing").SelectMany(configurationEntry => configurationEntry.Keys).ToHashSet();
-
-        return validPerIndexConfigurationKeys;
     }
 
     private bool NeedToCheckIfCollectionEmpty(IndexDefinition definition, RavenConfiguration databaseConfiguration)

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -245,11 +245,11 @@ public abstract class AbstractIndexCreateController
         }
     }
 
-    private HashSet<string> GetValidConfigurationKeys()
+    private static HashSet<string> GetValidConfigurationKeys()
     {
-        var configurationProperties = ServerStore.Configuration.Indexing.GetConfigurationProperties();
+        var allConfigurationEntries = RavenConfiguration.AllConfigurationEntries.Value;
         
-        var validPerIndexConfigurationKeys = configurationProperties.SelectMany(configurationProperty => configurationProperty.ConfigurationEntryAttributes.Select(configurationEntryAttribute => configurationEntryAttribute.Key)).ToHashSet();
+        var validPerIndexConfigurationKeys = allConfigurationEntries.Where(configurationEntry => configurationEntry.Category == "Indexing").SelectMany(configurationEntry => configurationEntry.Keys).ToHashSet();
 
         return validPerIndexConfigurationKeys;
     }

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -13,6 +13,7 @@ using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
@@ -227,58 +228,18 @@ public abstract class AbstractIndexCreateController
         }
     }
     
-    private static readonly List<string> ValidPerIndexConfigurationKeys = new List<string>()
-    {
-        "Indexing.Analyzers.Default",
-        "Indexing.Analyzers.Exact.Default",
-        "Indexing.Analyzers.Lucene.NGram.MaxGram",
-        "Indexing.Analyzers.Lucene.NGram.MinGram",
-        "Indexing.Analyzers.Search.Default",
-        "Indexing.QueryClauseCache.Disabled",
-        "Indexing.QueryClauseCache.RepeatedQueriesTimeFrameInSec",
-        "Indexing.Encrypted.TransactionSizeLimitInMb",
-        "Indexing.IndexEmptyEntries",
-        "Indexing.IndexMissingFieldsAsNull",
-        "Indexing.Lucene.LargeSegmentSizeToMergeInMb",
-        "Indexing.ManagedAllocationsBatchSizeLimitInMb",
-        "Indexing.MapBatchSize",
-        "Indexing.MapTimeoutAfterEtagReachedInMin",
-        "Indexing.MapTimeoutInSec",
-        "Indexing.Lucene.MaximumSizePerSegmentInMb",
-        "Indexing.MaxStepsForScript",
-        "Indexing.MaxTimeForDocumentTransactionToRemainOpenInSec",
-        "Indexing.Lucene.MaxTimeForMergesToKeepRunningInSec",
-        "Indexing.Lucene.MergeFactor",
-        "Indexing.Metrics.Enabled",
-        "Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory",
-        "Indexing.NumberOfConcurrentStoppedBatchesIfRunningLowOnMemory",
-        "Indexing.Lucene.NumberOfLargeSegmentsToMergeInSingleBatch",
-        "Indexing.ScratchSpaceLimitInMb",
-        "Indexing.Throttling.TimeIntervalInMs",
-        "Indexing.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecutedInMin",
-        "Indexing.TransactionSizeLimitInMb",
-        "Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved",
-        "Indexing.Lucene.UseCompoundFileInMerging",
-        "Indexing.Lucene.IndexInputType",
-        "Indexing.MaxTimeToWaitAfterFlushAndSyncWhenReplacingSideBySideIndexInSec",
-        "Indexing.MinimumTotalSizeOfJournalsToRunFlushAndSyncWhenReplacingSideBySideIndexInMb",
-        "Indexing.OrderByTicksAutomaticallyWhenDatesAreInvolved",
-        "Query.RegexTimeoutInMs",
-        "Indexing.Lucene.ReaderTermsIndexDivisor",
-        "Indexing.Corax.IncludeDocumentScore",
-        "Indexing.Corax.IncludeSpatialDistance",
-        "Indexing.Corax.MaxMemoizationSizeInMb",
-        "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb"
-    };
-
-    private static void ValidateConfiguration(IndexDefinition definition)
+    private void ValidateConfiguration(IndexDefinition definition)
     {
         if (definition.Configuration == null)
             return;
+
+        var indexingConfigurationProperties = ServerStore.Configuration.Indexing.GetConfigurationProperties();
+
+        var validPerIndexConfigurationKeys = indexingConfigurationProperties.SelectMany(configurationProperty => configurationProperty.ConfigurationEntryAttributes.Select(configurationEntryAttribute => configurationEntryAttribute.Key).ToList());
         
         foreach (var kvp in definition.Configuration)
         {
-            if (kvp.Key.In(ValidPerIndexConfigurationKeys) == false)
+            if (kvp.Key.In(validPerIndexConfigurationKeys) == false)
             {
                 throw new IndexCreationException($"Could not create index '{definition.Name}' because the configuration option key '{kvp.Key}' is not recognized");
             }

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
@@ -128,11 +128,9 @@ namespace FastTests.Server.Documents.Indexing.Static
         [RavenExplicitData]
         public async Task CanPersist(RavenTestParameters config)
         {
-
             IndexDefinition indexDefinition1, indexDefinition2;
             string dbName;
-
-
+            
             using (CreatePersistentDocumentDatabase(NewDataPath(), out var database, modifyConfiguration: dictionary => dictionary[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = config.SearchEngine.ToString()))
             {
                 dbName = database.Name;
@@ -143,7 +141,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                     Maps = { "from user in docs.Users select new { user.Name }" },
                     Configuration =
                     {
-                        { "TestKey", "TestValue" }
+                        { "Indexing.Disable", "false" }
                     }
                 };
 

--- a/test/SlowTests/Issues/RavenDB-20724.cs
+++ b/test/SlowTests/Issues/RavenDB-20724.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_20724 : RavenTestBase
+{
+    public RavenDB_20724(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfUnrecognizedIndexConfigurationKeyThrowsException()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new DummyIndex();
+            
+            var exception = Assert.Throws<IndexCreationException>(() => index.Execute(store));
+
+            Assert.Contains($"Could not create index '{index.IndexName}' because the configuration option key 'blabla1' is not recognized", exception.Message);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { DummyValue = 1 };
+
+            Configuration = new IndexConfiguration(){ { "Indexing.Metrics.Enabled", "true" }, { "blabla1", "blabla2" } };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20724/Adding-an-unrecognized-Index-configuration-option-shouldnt-trigger-the-replacement-process.

### Additional description

We want to throw an exception when user provides index configuration option that's not recognized by server. 

### Type of change

- Behavior change

### How risky is the change?

- Moderate 

### Backward compatibility

- Breaking change
Adding unrecognized index configuration option will throw an exception.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
