### PR TITLE
RavenDB-20955 - _waitForChanges should be always triggered by `OnChan…

### DIFF
--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents
 
         public void AddAfterCommitNotification(DocumentChange change)
         {
-            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingReplication;
+            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingInternalReplication;
 
             if (_documentNotifications == null)
                 _documentNotifications = new List<DocumentChange>();
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents
 
         public void AddAfterCommitNotification(CounterChange change)
         {
-            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingReplication;
+            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingInternalReplication;
 
             if (_counterNotifications == null)
                 _counterNotifications = new List<CounterChange>();
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents
 
         public void AddAfterCommitNotification(TimeSeriesChange change)
         {
-            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingReplication;
+            change.TriggeredByReplicationThread = IncomingReplicationHandler.IsIncomingInternalReplication;
 
             if (_timeSeriesNotifications == null)
                 _timeSeriesNotifications = new List<TimeSeriesChange>();

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1239,7 +1239,7 @@ namespace Raven.Server.Documents.Replication
         private void OnChangeInternal(bool triggeredByReplicationThread)
         {
             if (triggeredByReplicationThread &&
-                (ReplicationType != ReplicationLatestEtagRequest.ReplicationType.External ||
+                (ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal ||
                  ForTestingPurposes?.DisableWaitForChangesForExternalReplication == true))
                 return;
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1238,9 +1238,8 @@ namespace Raven.Server.Documents.Replication
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void OnChangeInternal(bool triggeredByReplicationThread)
         {
-            if (triggeredByReplicationThread &&
-                (ReplicationType == ReplicationLatestEtagRequest.ReplicationType.Internal ||
-                 ForTestingPurposes?.DisableWaitForChangesForExternalReplication == true))
+            if (triggeredByReplicationThread || 
+                ForTestingPurposes?.DisableWaitForChangesForExternalReplication == true)
                 return;
 
             _waitForChanges.Set();

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1238,8 +1238,11 @@ namespace Raven.Server.Documents.Replication
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void OnChangeInternal(bool triggeredByReplicationThread)
         {
-            if (triggeredByReplicationThread)
+            if (triggeredByReplicationThread &&
+                (ReplicationType != ReplicationLatestEtagRequest.ReplicationType.External ||
+                 ForTestingPurposes?.DisableWaitForChangesForExternalReplication == true))
                 return;
+
             _waitForChanges.Set();
         }
 
@@ -1335,6 +1338,8 @@ namespace Raven.Server.Documents.Replication
             public Action OnDocumentSenderFetchNewItem;
 
             public Action<Dictionary<Slice, AttachmentReplicationItem>> OnMissingAttachmentStream;
+
+            public bool DisableWaitForChangesForExternalReplication;
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB_20955.cs
+++ b/test/SlowTests/Issues/RavenDB_20955.cs
@@ -1,0 +1,84 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20955 : ReplicationTestBase
+    {
+        public RavenDB_20955(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task OnChangeShouldTrigger_waitForChangesForExternalReplication()
+        {
+            var sw = new Stopwatch();
+            long timeElapsed1;
+            long timeElapsed2;
+
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            using (var store3 = GetDocumentStore())
+            {
+                sw.Start();
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store3);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.SaveChanges();
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Shiran";
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(store3, "users/1", u => u.Name == "Shiran"));
+
+                sw.Stop();
+                timeElapsed2 = sw.ElapsedMilliseconds;
+            }
+
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            using (var store3 = GetDocumentStore())
+            {
+                var db2 = await GetDatabase(store2.Database);
+                db2.ReplicationLoader.ForTestingPurposesOnly().OnOutgoingReplicationStart = (o) =>
+                {
+                    if (o.Destination.Database == store3.Database)
+                        o.ForTestingPurposesOnly().DisableWaitForChangesForExternalReplication = true;
+                };
+
+                sw.Restart();
+
+                await SetupReplicationAsync(store1, store2);
+                await SetupReplicationAsync(store2, store3);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.SaveChanges();
+
+                    var user = session.Load<User>("users/1");
+                    user.Name = "Shiran";
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(store3, "users/1", u => u.Name == "Shiran"));
+              
+                sw.Stop();
+                timeElapsed1 = sw.ElapsedMilliseconds;
+            }
+
+            Assert.True(timeElapsed2 < timeElapsed1);
+        }
+    }
+}


### PR DESCRIPTION
…ge` when the destination is an external replication

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20955/waitForChanges-should-be-always-triggered-by-OnChange-when-the-destination-is-an-external-replication

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
