### PR TITLE
RavenDB-21506 Periodic backup is missing "Backup now" button on Cloud Free tier - Community license

### DIFF
--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -4,7 +4,6 @@ import activeDatabase = require("common/shell/activeDatabaseTracker");
 import router = require("plugins/router");
 import messagePublisher = require("common/messagePublisher");
 import { DatabaseSharedInfo } from "components/models/databases";
-import { EditPeriodicBackupTaskSourceView } from "components/models/common";
 
 class appUrl {
 
@@ -597,7 +596,7 @@ class appUrl {
         return "#databases/tasks/editReplicationSinkTask?" + databasePart + taskPart;
     }
 
-    static forEditPeriodicBackupTask(db: database, sourceView: EditPeriodicBackupTaskSourceView,taskId?: number): string {
+    static forEditPeriodicBackupTask(db: database, sourceView: EditPeriodicBackupTaskSourceView, taskId?: number): string {
         const databasePart = appUrl.getEncodedDbPart(db);
         const sourceViewPart = "&sourceView=" + sourceView;
         const taskPart = taskId ? "&taskId=" + taskId : "";

--- a/src/Raven.Studio/typescript/components/models/common.d.ts
+++ b/src/Raven.Studio/typescript/components/models/common.d.ts
@@ -53,5 +53,3 @@ export interface NonShardedViewProps {
 export interface ShardedViewProps extends NonShardedViewProps {
     location?: databaseLocationSpecifier;
 }
-
-export type EditPeriodicBackupTaskSourceView = "Backups" | "OngoingTasks";

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -382,6 +382,7 @@ export function BackupsPage(props: BackupsPageProps) {
                                 <>
                                     {backups.map((x) => (
                                         <PeriodicBackupPanel
+                                            sourceView="Backups"
                                             forceReload={reload}
                                             allowSelect={false}
                                             {...sharedPanelProps}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -600,6 +600,7 @@ export function OngoingTasksPage(props: OngoingTasksPageProps) {
 
                             {backups.map((x) => (
                                 <PeriodicBackupPanel
+                                    sourceView="OngoingTasks"
                                     forceReload={reload}
                                     allowSelect
                                     {...sharedPanelProps}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -28,11 +28,11 @@ import classNames from "classnames";
 import notificationCenter from "common/notifications/notificationCenter";
 import backupNow = require("viewmodels/database/tasks/backupNow");
 import app from "durandal/app";
-import clusterTopologyManager from "common/shell/clusterTopologyManager";
 import backupNowPeriodicCommand from "commands/database/tasks/backupNowPeriodicCommand";
 import { Badge, Collapse, Input } from "reactstrap";
 import { Icon } from "components/common/Icon";
-import useBoolean from "components/hooks/useBoolean";
+import { useAppSelector } from "components/store";
+import { clusterSelectors } from "components/common/shell/clusterSlice";
 
 interface PeriodicBackupPanelProps extends BaseOngoingTaskPanelProps<OngoingTaskPeriodicBackupInfo> {
     forceReload: () => void;
@@ -68,10 +68,8 @@ function findBackupNowBlockReason(data: OngoingTaskPeriodicBackupInfo, runningOn
     return null;
 }
 
-function Details(props: PeriodicBackupPanelProps & { canEdit: boolean }) {
-    const { data, canEdit, db, forceReload } = props;
-
-    const { value: isCurrentNodeResponsible, setValue: setIsCurrentNodeResponsible } = useBoolean(false);
+function Details(props: PeriodicBackupPanelProps) {
+    const { data, db, forceReload } = props;
 
     const backupDestinationsHumanized = data.shared.backupDestinations.length
         ? data.shared.backupDestinations.join(", ")
@@ -103,9 +101,10 @@ function Details(props: PeriodicBackupPanelProps & { canEdit: boolean }) {
         return `in ${formatDuration} (${backupTypeText}) ${originalDateText}`;
     }, [data.shared]);
 
+    const localNodeTag = useAppSelector(clusterSelectors.localNodeTag);
+
     const onGoingBackup = data.nodesInfo.map((x) => x.details?.onGoingBackup).find((x) => x);
-    const runningOnAnotherNode =
-        onGoingBackup && data.shared.responsibleNodeTag !== clusterTopologyManager.default.localNodeTag();
+    const runningOnAnotherNode = onGoingBackup && data.shared.responsibleNodeTag !== localNodeTag;
 
     const onGoingBackupHumanized = useMemo(() => {
         if (!onGoingBackup) {
@@ -133,8 +132,10 @@ function Details(props: PeriodicBackupPanelProps & { canEdit: boolean }) {
 
     const backupNowInProgress = !!onGoingBackup;
     const neverBackedUp = !data.shared.lastFullBackup;
-    const backupNowVisible =
-        (!data.shared.serverWide || canEdit) && !(backupNowInProgress && !isCurrentNodeResponsible);
+
+    const { isAdminAccessOrAbove } = useAccessManager();
+
+    const backupNowVisible = !(!data.shared.serverWide && !isAdminAccessOrAbove(db));
 
     const onBackupNow = () => {
         if (onGoingBackup && onGoingBackup.RunningBackupTaskId) {
@@ -156,10 +157,7 @@ function Details(props: PeriodicBackupPanelProps & { canEdit: boolean }) {
                     (backupNowResult: Raven.Client.Documents.Operations.Backups.StartBackupOperationResult) => {
                         forceReload();
 
-                        const isCurrentNodeResponsibleResult =
-                            clusterTopologyManager.default.localNodeTag() === backupNowResult.ResponsibleNode;
-
-                        setIsCurrentNodeResponsible(isCurrentNodeResponsibleResult);
+                        const isCurrentNodeResponsibleResult = localNodeTag === backupNowResult.ResponsibleNode;
 
                         if (backupNowResult && isCurrentNodeResponsibleResult) {
                             // running on this node
@@ -285,7 +283,7 @@ export function PeriodicBackupPanel(props: PeriodicBackupPanelProps) {
                 </RichPanelActions>
             </RichPanelHeader>
             <Collapse isOpen={detailsVisible}>
-                <Details canEdit={canEdit} {...props} />
+                <Details {...props} />
             </Collapse>
         </RichPanel>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -135,7 +135,7 @@ function Details(props: PeriodicBackupPanelProps) {
 
     const { isAdminAccessOrAbove } = useAccessManager();
 
-    const backupNowVisible = !(!data.shared.serverWide && !isAdminAccessOrAbove(db));
+    const backupNowVisible = data.shared.serverWide || isAdminAccessOrAbove(db);
 
     const onBackupNow = () => {
         if (onGoingBackup && onGoingBackup.RunningBackupTaskId) {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -37,6 +37,7 @@ import useBoolean from "components/hooks/useBoolean";
 interface PeriodicBackupPanelProps extends BaseOngoingTaskPanelProps<OngoingTaskPeriodicBackupInfo> {
     forceReload: () => void;
     allowSelect: boolean;
+    sourceView: EditPeriodicBackupTaskSourceView;
 }
 
 const neverBackedUpText = "Never backed up";
@@ -228,13 +229,23 @@ function BackupEncryption(props: { encrypted: boolean }) {
 }
 
 export function PeriodicBackupPanel(props: PeriodicBackupPanelProps) {
-    const { db, data, allowSelect, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
+    const {
+        db,
+        data,
+        allowSelect,
+        toggleSelection,
+        isSelected,
+        onTaskOperation,
+        isDeleting,
+        isTogglingState,
+        sourceView,
+    } = props;
 
     const { isAdminAccessOrAbove } = useAccessManager();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = isAdminAccessOrAbove(db) && !data.shared.serverWide;
-    const editUrl = forCurrentDatabase.editPeriodicBackupTask(data.shared.taskId)();
+    const editUrl = forCurrentDatabase.editPeriodicBackupTask(sourceView, data.shared.taskId)();
 
     const { detailsVisible, toggleDetails, onEdit } = useTasksOperations(editUrl, props);
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
@@ -107,12 +107,18 @@ export function OngoingTaskResponsibleNode(props: { task: OngoingTaskInfo }) {
 }
 
 export function OngoingTaskName(props: { task: OngoingTaskInfo; canEdit: boolean; editUrl: string }) {
-    const { task, editUrl } = props;
+    const { task, editUrl, canEdit } = props;
     return (
         <RichPanelName>
-            <a href={editUrl} title={"Task name: " + task.shared.taskName}>
-                {task.shared.taskName}
-            </a>
+            {canEdit ? (
+                <a href={editUrl} title={"Task name: " + task.shared.taskName}>
+                    {task.shared.taskName}
+                </a>
+            ) : (
+                <span className="text-primary" color="link">
+                    {task.shared.taskName}
+                </span>
+            )}
         </RichPanelName>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
@@ -115,9 +115,7 @@ export function OngoingTaskName(props: { task: OngoingTaskInfo; canEdit: boolean
                     {task.shared.taskName}
                 </a>
             ) : (
-                <span className="text-primary" color="link">
-                    {task.shared.taskName}
-                </span>
+                <span className="text-primary">{task.shared.taskName}</span>
             )}
         </RichPanelName>
     );

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -16,7 +16,6 @@ import database from "models/resources/database";
 import licenseModel from "models/auth/licenseModel";
 import { EditPeriodicBackupTaskInfoHub } from "./EditPeriodicBackupTaskInfoHub";
 import { EditManualBackupTaskInfoHub } from "./EditManualBackupTaskInfoHub";
-import { EditPeriodicBackupTaskSourceView } from "components/models/common";
 
 type backupConfigurationClass = manualBackupConfiguration | periodicBackupConfiguration;
 

--- a/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
+++ b/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
@@ -1,3 +1,6 @@
+
+type EditPeriodicBackupTaskSourceView = "Backups" | "OngoingTasks";
+
 // Interface
 interface computedAppUrls {
     adminSettingsCluster: KnockoutComputed<string>;
@@ -19,7 +22,7 @@ interface computedAppUrls {
     editExternalReplication: (taskId?: number) => KnockoutComputed<string>;
     editReplicationHub: (taskId?: number) => KnockoutComputed<string>;
     editReplicationSink: (taskId?: number) => KnockoutComputed<string>;
-    editPeriodicBackupTask: (sourceView: PeriodicBackupSourceView, taskId?: number) => KnockoutComputed<string>;
+    editPeriodicBackupTask: (sourceView: EditPeriodicBackupTaskSourceView, taskId?: number) => KnockoutComputed<string>;
     editSubscription: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editRavenEtl: (taskId?: number, taskName?: string) => KnockoutComputed<string>;
     editSqlEtl: (taskId?: number, taskName?: string) => KnockoutComputed<string>;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21506/Periodic-backup-is-missing-Backup-now-button-on-Cloud-Free-tier-Community-license

### Additional description

- Fix source view link for periodic backup
- Hide the "Backup now" button only for database backups if access is below the database admin.
- Disable task link, when can't edit

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

Disabled link for server wide bakcup:
![image](https://github.com/ravendb/ravendb/assets/47967925/cd86e6f6-44bc-414c-98aa-d47251dc8415)

