### PR TITLE
RavenDB-21573 Do not change analyzer when field has time during QueryBuilder phase instead do it in CoraxBooleanItem.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
@@ -134,6 +134,7 @@ public sealed class CoraxOrQueries : CoraxBooleanQueryBase
                 }
                 else
                 {
+                    
                     AddToQueryTree(IndexSearcher.InQuery(field, terms));
                 }
             }

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -540,11 +540,10 @@ public static class QueryBuilderHelper
             if (fieldName is "score" or "score()")
                 return default;
         }
-
-        var shouldTurnOffAnalyzersForTime = index.IndexFieldsPersistence.HasTimeValues(fieldName) && isSorting == false;
+        
         if (indexMapping.TryGetByFieldName(allocator, fieldName, out var indexFinding))
         {
-            if (exact || shouldTurnOffAnalyzersForTime) //When field has exact let's change the analyzer to do nothing
+            if (exact) //When field has exact let's change the analyzer to do nothing
                 metadata = indexFinding.Metadata.ChangeAnalyzer(FieldIndexingMode.Exact);
             else if (indexFinding.FieldIndexingMode is FieldIndexingMode.Search) // in case of search
                 metadata = handleSearch
@@ -560,7 +559,7 @@ public static class QueryBuilderHelper
             if (hasDynamics == false)
                 ThrowNotFoundInIndex();
 
-            var mode = shouldTurnOffAnalyzersForTime || exact
+            var mode = exact
                 ? FieldIndexingMode.Exact
                 : FieldIndexingMode.Normal;
             metadata = FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, indexMapping.DefaultAnalyzer, hasBoost: hasBoost);

--- a/test/SlowTests/Corax/RavenDB_21573.cs
+++ b/test/SlowTests/Corax/RavenDB_21573.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using FastTests;
+using Lucene.Net.Analysis.Standard;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21573 : RavenTestBase
+{
+    public RavenDB_21573(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void WhenFieldHasDatesWeStillCanUseAnalyzerToFindOtherValues(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        new DtoIndex().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(new Dto("MyMessageType", null, new object[] { TimeSpan.FromSeconds(5), "SomeEndpoint Send MyMessageType" }));
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+        int count = session.Query<Dto, DtoIndex>().Search(x => x.Name, "MyMessageType").Count();
+        Assert.Equal(1, count);
+
+        count = session.Query<Dto, DtoIndex>().Count(x => x.Name == "MyMessageType");
+        Assert.Equal(1, count);
+    }
+
+    private record Dto(string Name, string Id, object[] OtherValues);
+
+    private class DtoIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DtoIndex()
+        {
+            Map = dtos =>
+                from dto in dtos
+                select new {Name = new string[] {dto.Name}.Union(dto.OtherValues), dto.Id};
+            Index(x => x.Name, FieldIndexing.Search);
+            Analyze(x => x.Name, typeof(StandardAnalyzer).AssemblyQualifiedName);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21573

### Additional description

We moved the mechanism of detecting dates into CoraxBooleanItem instead of the QueryBuilder phase.

### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
