### PR TITLE
RavenDB-21335 - Add command to the server tx merger (in Leader.Run)

### DIFF
--- a/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Jint;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands;
+
+public sealed class LowestIndexUpdateCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly Leader _leader;
+
+    private readonly RachisConsensus _engine;
+
+    private long _lowestIndexInEntireCluster;
+
+
+    public LowestIndexUpdateCommand([NotNull] Leader leader, [NotNull] RachisConsensus engine, long lowestIndexInEntireCluster)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _leader = leader;
+        _lowestIndexInEntireCluster = lowestIndexInEntireCluster;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        _engine.TruncateLogBefore(context, _lowestIndexInEntireCluster);
+        context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += (tx) =>
+        {
+            _leader.LowestIndexInEntireCluster = _lowestIndexInEntireCluster;
+        };
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}
+

--- a/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
@@ -30,10 +30,6 @@ public sealed class LowestIndexUpdateCommand : MergedTransactionCommand<ClusterO
     protected override long ExecuteCmd(ClusterOperationContext context)
     {
         _engine.TruncateLogBefore(context, _lowestIndexInEntireCluster);
-        context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += (tx) =>
-        {
-            _leader.LowestIndexInEntireCluster = _lowestIndexInEntireCluster;
-        };
         return 1;
     }
 

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -363,6 +363,7 @@ namespace Raven.Server.Rachis
                         {
                             var cmd = new LowestIndexUpdateCommand(leader: this, engine: _engine, lowestIndexInEntireCluster: lowestIndexInEntireCluster);
                             _engine.TxMerger.EnqueueSync(cmd);
+                            LowestIndexInEntireCluster = _lowestIndexInEntireCluster;
                         }
                     }
                     catch (Exception ex)

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -361,13 +361,8 @@ namespace Raven.Server.Rachis
 
                         if (lowestIndexInEntireCluster > lastTruncated)
                         {
-                            using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-                            using (context.OpenWriteTransaction())
-                            {
-                                _engine.TruncateLogBefore(context, lowestIndexInEntireCluster);
-                                LowestIndexInEntireCluster = lowestIndexInEntireCluster;
-                                context.Transaction.Commit();
-                            }
+                            var cmd = new LowestIndexUpdateCommand(leader: this, engine: _engine, lowestIndexInEntireCluster: lowestIndexInEntireCluster);
+                            _engine.TxMerger.EnqueueSync(cmd);
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21335/Add-commands-to-the-server-tx-merger

### Additional description

Add commands to the server tx merger

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
