### PR TITLE
RavenDB-21574 Fix SearchEngineType not being transferred via all index creation methods

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Operations.Attachments;
-using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
@@ -247,12 +246,6 @@ namespace Raven.Client.Documents.Indexes
                 if (DeploymentMode.HasValue)
                     indexDefinition.DeploymentMode = DeploymentMode.Value;
 
-                if (SearchEngineType.HasValue)
-                {
-                    indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Value.ToString();
-                }
-
-                
                 return store.Maintenance.ForDatabase(database).SendAsync(new PutIndexesOperation(indexDefinition), token);
             }
             finally
@@ -302,7 +295,7 @@ namespace Raven.Client.Documents.Indexes
             if (Conventions == null)
                 Conventions = new DocumentConventions();
 
-            var indexDefinition = new IndexDefinitionBuilder<TDocument, TReduceResult>(IndexName)
+            IndexDefinitionBuilder<TDocument, TReduceResult> builder = new(IndexName)
             {
                 Indexes = Indexes,
                 IndexesStrings = IndexesStrings,
@@ -330,7 +323,14 @@ namespace Raven.Client.Documents.Indexes
                 CompoundFieldsStrings = CompoundFieldsStrings,
                 CompoundFields = CompoundFields,
                 ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
-            }.ToIndexDefinition(Conventions);
+            };
+
+            if (SearchEngineType.HasValue)
+            {
+                builder.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Value.ToString();
+            }
+
+            var indexDefinition = builder.ToIndexDefinition(Conventions);
 
             return indexDefinition;
         }

--- a/src/Raven.Client/Documents/Indexes/AbstractJavaScriptIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractJavaScriptIndexCreationTask.cs
@@ -74,6 +74,12 @@ namespace Raven.Client.Documents.Indexes
             _definition.State = State;
             _definition.DeploymentMode = DeploymentMode;
             _definition.CompoundFields = CompoundFieldsStrings;
+
+            if (SearchEngineType.HasValue)
+            {
+                _definition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Value.ToString();
+            }
+
             var definition = new IndexDefinition();
             _definition.CopyTo(definition);
 

--- a/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -72,7 +72,7 @@ namespace Raven.Client.Documents.Indexes
             if (Conventions == null)
                 Conventions = new DocumentConventions();
 
-            var indexDefinition = new IndexDefinitionBuilder<object, TReduceResult>(IndexName)
+            IndexDefinitionBuilder<object,TReduceResult> builder = new(IndexName)
             {
                 Indexes = Indexes,
                 Analyzers = Analyzers,
@@ -99,7 +99,14 @@ namespace Raven.Client.Documents.Indexes
                 CompoundFields = CompoundFields,
                 CompoundFieldsStrings = CompoundFieldsStrings,
                 ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
-            }.ToIndexDefinition(Conventions, validateMap: false);
+            };
+
+            if (SearchEngineType.HasValue)
+            {
+                builder.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Value.ToString();
+            }
+
+            var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
             foreach (var map in _maps.Select(generateMap => generateMap()))
             {

--- a/test/SlowTests/Issues/RavenDB-21574.cs
+++ b/test/SlowTests/Issues/RavenDB-21574.cs
@@ -7,6 +7,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -74,7 +75,7 @@ public class RavenDB_21574 : RavenTestBase
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Indexes)]
     public async Task Setting_Index_SearchEngineType_Should_Work()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB-21574.cs
+++ b/test/SlowTests/Issues/RavenDB-21574.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21574 : RavenTestBase
+{
+    public RavenDB_21574(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class CompanyIndex : AbstractIndexCreationTask<Company>
+    {
+        public CompanyIndex()
+        {
+            Map = companies => from company in companies
+                select new
+                {
+                    company.Name
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class CompanyIndex_MultiMap : AbstractMultiMapIndexCreationTask<CompanyIndex_MultiMap.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+        }
+
+        public CompanyIndex_MultiMap()
+        {
+            AddMap<Company>(companies => from company in companies
+                select new
+                {
+                    company.Name
+                });
+
+            Reduce = results => from result in results
+                group result by result.Name
+                into g
+                select new
+                {
+                    Name = g.Key
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class CompanyIndex_JavaScript : AbstractJavaScriptIndexCreationTask
+    {
+        public override string IndexName => "Companies/JavaScript";
+
+        public CompanyIndex_JavaScript()
+        {
+            Maps = new HashSet<string>
+            {
+                "map('Companies', function(company) { return { Name: company.Name } });"
+            };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    [Fact]
+    public async Task Setting_Index_SearchEngineType_Should_Work()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await ValidateSearchEngineType<CompanyIndex>(store);
+            await ValidateSearchEngineType<CompanyIndex_MultiMap>(store);
+            await ValidateSearchEngineType<CompanyIndex_JavaScript>(store);
+        }
+    }
+
+    private async Task ValidateSearchEngineType<T>(DocumentStore store) where T : AbstractIndexCreationTask, new()
+    {
+        var index = new T();
+        await IndexCreation.CreateIndexesAsync(new List<AbstractIndexCreationTask> { index }, store);
+        Indexes.WaitForIndexing(store);
+
+        var indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
+        var indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.Equal(nameof(SearchEngineType.Corax), indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+        Assert.Equal(SearchEngineType.Corax, indexStats.SearchEngineType);
+
+        index.SearchEngineType = SearchEngineType.Lucene;
+
+        await IndexCreation.CreateIndexesAsync(new List<AbstractIndexCreationTask> { index }, store);
+        Indexes.WaitForIndexing(store);
+
+        indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
+        indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.Equal(nameof(SearchEngineType.Lucene), indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+        Assert.Equal(SearchEngineType.Lucene, indexStats.SearchEngineType);
+
+        index.SearchEngineType = SearchEngineType.Corax;
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
+        indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.Equal(nameof(SearchEngineType.Corax), indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+        Assert.Equal(SearchEngineType.Corax, indexStats.SearchEngineType);
+
+        index.SearchEngineType = SearchEngineType.Lucene;
+        store.ExecuteIndex(index);
+        Indexes.WaitForIndexing(store);
+
+        indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
+        indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.Equal(nameof(SearchEngineType.Lucene), indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+        Assert.Equal(SearchEngineType.Lucene, indexStats.SearchEngineType);
+
+        index = new T();
+        indexDefinition = index.CreateIndexDefinition();
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+        Indexes.WaitForIndexing(store);
+
+        indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
+        indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.Equal(nameof(SearchEngineType.Corax), indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+        Assert.Equal(SearchEngineType.Corax, indexStats.SearchEngineType);
+    }
+}


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21574

### Additional description

Only `new MyIndex().Execute` transferred the information (like documented), but as `IndexCreation` is a convenient way to deploy indexes would be nice if it worked too when custom `SearchEngineType` is set in index constructor.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
