### PR TITLE
RavenDB-19301 - Attachment stream doesn't exist for document when sol…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_19301.cs
+++ b/test/SlowTests/Issues/RavenDB_19301.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.ServerWide;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19301 : ReplicationTestBase
+    {
+        public RavenDB_19301(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Replication)]
+        public async Task ConflictOfAttachmentAndDocument_ManualResolution()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record => record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false }
+            };
+
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                await SetupReplicationAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store1);
+
+                var b1 = await BreakReplication(Server.ServerStore, store1.Database);
+                var b2 = await BreakReplication(Server.ServerStore, store2.Database);
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>("users/1");
+                    u.Age = 30;
+                    await session.SaveChangesAsync();
+                }
+
+                b1.Mend();
+                b2.Mend();
+
+                Assert.Equal(2, WaitUntilHasConflict(store1, "users/1").Length);
+                Assert.Equal(2, WaitUntilHasConflict(store2, "users/1").Length);
+
+                var config = new ConflictSolver { ResolveToLatest = true };
+                await UpdateConflictResolver(store1, config.ResolveByCollection, config.ResolveToLatest);
+                await UpdateConflictResolver(store2, config.ResolveByCollection, config.ResolveToLatest);
+
+                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store2, store1);
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment.Stream);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
+                }
+
+                using (var session = store2.OpenAsyncSession())
+                {
+                    var attachment = await session.Advanced.Attachments.GetAsync("users/1", "foo/bar");
+                    Assert.NotNull(attachment);
+                    Assert.NotNull(attachment.Stream);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ving conflict manually

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19301/Attachment-stream-doesnt-exist-for-document-when-solving-conflict-manually

### Additional description

(https://issues.hibernatingrhinos.com/issue/RavenDB-19301/Attachment-stream-doesnt-exist-for-document-when-solving-conflict-manually#focus=Comments-67-396728.0-0)

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
