### PR TITLE
RavenDB-19156 Switched to SslStreamCertificateContext usage instead of certificate for TCP connections for Postgres integration

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             {
                 var session = new PgSession(
                     client,
-                    _server.Certificate.Certificate,
+                    _server.Certificate,
                     identifier,
                     _processId,
                     _server.ServerStore.DatabasesLandlord,
@@ -173,6 +173,8 @@ namespace Raven.Server.Integrations.PostgreSQL
                         {
                             if (_logger.IsOperationsEnabled)
                                 _logger.Operations($"Failed to accept TCP client (port: {((IPEndPoint)tcpListener.LocalEndpoint).Port})", e);
+
+                            continue;
                         }
 
                         _connections.TryAdd(client, HandleConnection(client));


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19156/Consider-use-SslStreamCertificateContext-to-improve-SSL-authentication-speed-in-Linux

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/17511 for Postgres connections

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests will verify the fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
