### PR TITLE
RavenDB-21204 Removed tracking of memory metrics over time for `/admin/debug/memory/stats` endpoint

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -296,7 +296,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             long totalUnmanagedAllocations = NativeMemory.TotalAllocatedMemory;
             var encryptionBuffers = EncryptionBuffersPool.Instance.GetStats();
             var dirtyMemoryState = MemoryInformation.GetDirtyMemoryState();
-            var memoryUsageRecords = MemoryInformation.GetMemoryUsageRecords();
 
             long totalMapping = 0;
             var fileMappingByDir = new Dictionary<string, Dictionary<string, ConcurrentDictionary<IntPtr, long>>>();
@@ -337,12 +336,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.DirtyMemory)] = Size.Humane(dirtyMemoryState.TotalDirtyInBytes),
                 [nameof(MemoryInfo.AvailableMemory)] = Size.Humane(memInfo.AvailableMemory.GetValue(SizeUnit.Bytes)),
                 [nameof(MemoryInfo.AvailableMemoryForProcessing)] = memInfo.AvailableMemoryForProcessing.ToString(),
-                [nameof(MemoryInfo.HighMemLastOneMinute)] = memoryUsageRecords.High.LastOneMinute.ToString(),
-                [nameof(MemoryInfo.LowMemLastOneMinute)] = memoryUsageRecords.Low.LastOneMinute.ToString(),
-                [nameof(MemoryInfo.HighMemLastFiveMinute)] = memoryUsageRecords.High.LastFiveMinutes.ToString(),
-                [nameof(MemoryInfo.LowMemLastFiveMinute)] = memoryUsageRecords.Low.LastFiveMinutes.ToString(),
-                [nameof(MemoryInfo.HighMemSinceStartup)] = memoryUsageRecords.High.SinceStartup.ToString(),
-                [nameof(MemoryInfo.LowMemSinceStartup)] = memoryUsageRecords.Low.SinceStartup.ToString(),
             };
             if (memInfo.Remarks != null)
             {
@@ -549,12 +542,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string DirtyMemory { get; set; }
             public string AvailableMemory { get; set; }
             public string AvailableMemoryForProcessing { get; set; }
-            public string HighMemLastOneMinute { get; set; }
-            public string LowMemLastOneMinute { get; set; }
-            public string HighMemLastFiveMinute { get; set; }
-            public string LowMemLastFiveMinute { get; set; }
-            public string HighMemSinceStartup { get; set; }
-            public string LowMemSinceStartup { get; set; }
             public MemoryInfoMappingItem[] Mappings { get; set; }
         }
 

--- a/src/Sparrow/LowMemory/MemoryInfoResult.cs
+++ b/src/Sparrow/LowMemory/MemoryInfoResult.cs
@@ -2,19 +2,6 @@
 {
     public struct MemoryInfoResult
     {
-        public class MemoryUsageIntervals
-        {
-            public Size LastOneMinute;
-            public Size LastFiveMinutes;
-            public Size SinceStartup;
-        }
-
-        public class MemoryUsageLowHigh
-        {
-            public MemoryUsageIntervals High;
-            public MemoryUsageIntervals Low;
-        }
-
         public string Remarks;
         public Size TotalCommittableMemory;
         public Size CurrentCommitCharge;

--- a/src/Sparrow/LowMemory/MemoryInfoResult.cs
+++ b/src/Sparrow/LowMemory/MemoryInfoResult.cs
@@ -1,7 +1,24 @@
-﻿namespace Sparrow.LowMemory
+﻿using System;
+
+namespace Sparrow.LowMemory
 {
     public struct MemoryInfoResult
     {
+        [Obsolete("Will be removed in next major version")]
+        public class MemoryUsageIntervals
+        {
+            public Size LastOneMinute;
+            public Size LastFiveMinutes;
+            public Size SinceStartup;
+        }
+
+        [Obsolete("Will be removed in next major version")]
+        public class MemoryUsageLowHigh
+        {
+            public MemoryUsageIntervals High;
+            public MemoryUsageIntervals Low;
+        }
+        
         public string Remarks;
         public Size TotalCommittableMemory;
         public Size CurrentCommitCharge;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21204/AssertNotAboutToRunOutOfMemory-is-too-eager-at-calling-into-GetMemoryInfo-which-can-cause-contention-in-high-concurrency

### Additional description

Concurrent queue used to gather these metrics hurts the performance a little. These metrics are rarely used for memory profiling.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change - removal of fields returned from a debug endpoint
Removal of `HighLastOneMinute`, `LowLastOneMinute`, `HighLastFiveMinutes`, `LowLastFiveMinutes`, `LowSinceStartup` and `HighSinceStartup` metrics of `/admin/debug/memory/stats` endpoint.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
