### PR TITLE
RavenDB-21569 - "Limit # of revisions to keep by age" doesn't working correctly

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -672,7 +672,9 @@ namespace Raven.Server.Documents.Revisions
             else
             {
                 revisionsToDelete = GetRevisionsForCollectionOrDefault(context, table, lowerIdPrefix,
-                    configuration, result.PreviousCount, result);
+                    configuration, result.PreviousCount,
+                    stopWhenReachingAge: nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration)==false, 
+                    result);
             }
 
             var deleted = DeleteRevisionsInternal(context, table, lowerIdPrefix, collectionName, changeVector, lastModifiedTicks, result.PreviousCount, revisionsToDelete, result);
@@ -824,6 +826,7 @@ namespace Raven.Server.Documents.Revisions
             Slice prefixSlice,
             RevisionsCollectionConfiguration configuration,
             long revisionsCount,
+            bool stopWhenReachingAge,
             DeleteOldRevisionsResult result)
         {
             result.HasMore = false;
@@ -874,6 +877,13 @@ namespace Raven.Server.Documents.Revisions
                         _database.Time.GetUtcNow() - revision.LastModified <= configuration.MinimumRevisionAgeToKeep.Value)
                     {
                         revision.Dispose();
+
+                        if (stopWhenReachingAge == false)
+                        {
+                            result.Skip++;
+                            ended = false;
+                        }
+
                         break;
                     }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -673,7 +673,7 @@ namespace Raven.Server.Documents.Revisions
             {
                 revisionsToDelete = GetRevisionsForCollectionOrDefault(context, table, lowerIdPrefix,
                     configuration, result.PreviousCount,
-                    stopWhenReachingAge: nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration)==false, 
+                    stopWhenReachingAge: nonPersistentFlags.Contain(NonPersistentDocumentFlags.ByEnforceRevisionConfiguration) == false,
                     result);
             }
 

--- a/test/SlowTests/Issues/RavenDB-21569.cs
+++ b/test/SlowTests/Issues/RavenDB-21569.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using static SlowTests.RavenDB_20425;
@@ -23,7 +24,7 @@ public class RavenDB_21569 : RavenTestBase
     {
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Revisions)]
     public async Task Delete_Outdated_Revisions_By_EnforceConfig_When_Revisions_Isnt_OrderedBy_LastModified()
     {
         using var store = GetDocumentStore();
@@ -67,7 +68,7 @@ public class RavenDB_21569 : RavenTestBase
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Revisions)]
     public async Task Delete_Outdated_Revisions_By_EnforceConfig_WithMaxUponUpdate_When_Revisions_Isnt_OrderedBy_LastModified()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Issues/RavenDB-21569.cs
+++ b/test/SlowTests/Issues/RavenDB-21569.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.RavenDB_20425;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21569 : RavenTestBase
+{
+    public RavenDB_21569(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task Delete_Outdated_Revisions_By_EnforceConfig_When_Revisions_Isnt_OrderedBy_LastModified()
+    {
+        using var store = GetDocumentStore();
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var configuration = new RevisionsConfiguration
+        {
+            Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+            {
+                ["Users"] = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                }
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        await CreateRevisions(store, database);
+
+
+        configuration = new RevisionsConfiguration
+        {
+            Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+            {
+                ["Users"] = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionAgeToKeep = TimeSpan.FromDays(365),
+                    PurgeOnDelete = true
+                }
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, token: token);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+            Assert.Equal(10, doc1RevCount);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_Outdated_Revisions_By_EnforceConfig_WithMaxUponUpdate_When_Revisions_Isnt_OrderedBy_LastModified()
+    {
+        using var store = GetDocumentStore();
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var configuration = new RevisionsConfiguration
+        {
+            Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+            {
+                ["Users"] = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                }
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        await CreateRevisions(store, database);
+
+
+        configuration = new RevisionsConfiguration
+        {
+            Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+            {
+                ["Users"] = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionAgeToKeep = TimeSpan.FromDays(365),
+                    MaximumRevisionsToDeleteUponDocumentUpdate = 3,
+                    PurgeOnDelete = true
+                }
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, token: token);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
+            Assert.Equal(10, doc1RevCount); // same but happens in batches
+        }
+    }
+
+    private async Task CreateRevisions(DocumentStore store, DocumentDatabase database)
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = $"New{i}" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+        }
+
+        database.Time.UtcDateTime = () => DateTime.UtcNow.AddDays(-400);
+        for (int i = 1; i <= 5; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = $"Old{i}" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+        }
+        database.Time.UtcDateTime = () => DateTime.UtcNow;
+
+        for (int i = 6; i <= 10; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = $"New{i}" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}
+

--- a/test/SlowTests/RavenDB-20425.cs
+++ b/test/SlowTests/RavenDB-20425.cs
@@ -485,8 +485,6 @@ return oldestDoc;"
             await SetupReplicationAsync(src, dst); // Conflicts resolved
             await EnsureReplicatingAsync(src, dst);
 
-            WaitForUserToContinueTheTest(dst);
-
 
             // Ensure revisions arent ordered by "last modified".
             using (var session = dst.OpenAsyncSession())
@@ -537,7 +535,7 @@ return oldestDoc;"
             using (var session = dst.OpenAsyncSession())
             {
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(3, doc1RevCount); // OLD (DELETED) , NEW, OLD, OLD
+                Assert.Equal(1, doc1RevCount); // OLD (DELETED) , NEW, OLD (DELETED), OLD (DELETED)
             }
 
             dbDst.Time.UtcDateTime = () => DateTime.UtcNow.AddHours(2);
@@ -545,7 +543,7 @@ return oldestDoc;"
             using (var session = dst.OpenAsyncSession())
             {
                 var doc1RevCount = await session.Advanced.Revisions.GetCountForAsync("Docs/1");
-                Assert.Equal(0, doc1RevCount); // OLDER (DELETED EARLIER) , OLD (DELETED), OLDER (DELETED), OLDER (DELETED)
+                Assert.Equal(0, doc1RevCount); // OLDER (DELETED EARLIER) , OLD (DELETED), OLDER (DELETED EARLIER), OLDER (DELETED EARLIER)
             }
 
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21569/Limit-of-revisions-to-keep-by-age-doesnt-working-correctly

### Additional description

The problem was that the out of date revisions cannot be deleted when the doc revisions aren't ordered by date, 
because the deleting stops when we reach "not out of date revision".
My solution was to not stop but skip "not out of date revision", but I do it only in Enforce Configuration (not in doc update) because it require passing all the doc revisions.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
