### PR TITLE
RavenDB-21530 Fixing detection of the secured channel usage for Kafka and RabbitMQ ETLs

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -41,16 +41,15 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
             switch (BrokerType)
             {
                 case QueueBrokerType.Kafka:
-                    if (Connection.KafkaConnectionSettings.ConnectionOptions.ContainsKey("SecurityProtocol"))
+                    if (Connection.KafkaConnectionSettings.ConnectionOptions.TryGetValue("security.protocol", out string protocol))
                     {
-                        string protocol = Connection.KafkaConnectionSettings.ConnectionOptions["SecurityProtocol"];
-                        return protocol.ToLower() == "ssl";
+                        return protocol.ToLower().Contains("ssl");
                     }
                     break;
                 case QueueBrokerType.RabbitMq:
-                    return Connection.RabbitMqConnectionSettings.ConnectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase);
+                    return Connection.RabbitMqConnectionSettings.ConnectionString.StartsWith("amqps", StringComparison.OrdinalIgnoreCase);
                 default:
-                    return false;
+                    throw new NotSupportedException($"Unknown broker type: {BrokerType}");
             }
 
             return false;

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -350,24 +350,23 @@ namespace Raven.Server.Documents.ETL
 
             if (_databaseRecord.Encrypted && config.UsingEncryptedCommunicationChannel() == false && config.AllowEtlOnNonEncryptedChannel == false)
             {
-                LogConfigurationError(config,
-                    new List<string>
-                    {
-                        $"{_database.Name} is encrypted, but connection to ETL destination {config.GetDestination()} does not use encryption, so ETL is not allowed. " +
-                        $"You can change this behavior by setting {nameof(config.AllowEtlOnNonEncryptedChannel)} when creating the ETL configuration"
-                    });
-                return false;
-            }
+                if (config.AllowEtlOnNonEncryptedChannel == false)
+                {
+                    LogConfigurationError(config,
+                        new List<string>
+                        {
+                            $"{_database.Name} is encrypted, but connection to ETL destination {config.GetDestination()} does not use encryption, so ETL is not allowed. " +
+                            $"You can change this behavior by setting {nameof(config.AllowEtlOnNonEncryptedChannel)} when creating the ETL configuration"
+                        });
+                    return false;
+                }
 
-            if (_databaseRecord.Encrypted && config.UsingEncryptedCommunicationChannel() == false && config.AllowEtlOnNonEncryptedChannel)
-            {
                 LogConfigurationWarning(config,
                     new List<string>
                     {
                         $"{_database.Name} is encrypted and connection to ETL destination {config.GetDestination()} does not use encryption, " +
                         $"but {nameof(config.AllowEtlOnNonEncryptedChannel)} is set to true, so ETL is allowed"
                     });
-                return true;
             }
 
             if (_databaseRecord.Encrypted && config is ElasticSearchEtlConfiguration esConfig && esConfig.Connection.Authentication == null)
@@ -377,7 +376,6 @@ namespace Raven.Server.Documents.ETL
                     {
                         $"{_database.Name} is encrypted and connection to ETL destination {config.GetDestination()} does not use authentication, but ETL is allowed."
                     });
-                return true;
             }
 
             if (uniqueNames.Add(config.Name) == false)

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21530.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21530.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Tests.Infrastructure;
+using Tests.Infrastructure.ConnectionString;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.Queue;
+
+public class RavenDB_21530 : QueueEtlTestBase
+{
+    public RavenDB_21530(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void Can_check_kafka_connection_string_against_secured_channel()
+    {
+        var c = new QueueEtlConfiguration
+        {
+            BrokerType = QueueBrokerType.Kafka,
+            Connection = new QueueConnectionString
+            {
+                Name = "Test",
+                BrokerType = QueueBrokerType.Kafka,
+                KafkaConnectionSettings = new KafkaConnectionSettings()
+                {
+                    ConnectionOptions = new Dictionary<string, string>()
+                    {
+                        {"security.protocol", "SASL_SSL"}
+                    },
+                    BootstrapServers = "localhost:29290"
+                }
+            }
+        };
+
+        Assert.True(c.UsingEncryptedCommunicationChannel());
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void Can_check_rabbitmq_connection_string_against_secured_channel()
+    {
+        var c = new QueueEtlConfiguration
+        {
+            BrokerType = QueueBrokerType.RabbitMq,
+            Connection = new QueueConnectionString
+            {
+                Name = "Test",
+                BrokerType = QueueBrokerType.RabbitMq,
+                RabbitMqConnectionSettings = new RabbitMqConnectionSettings() { ConnectionString = "amqps://guest:guest@localhost:5672/" }
+            }
+        };
+
+        Assert.True(c.UsingEncryptedCommunicationChannel());
+    }
+}


### PR DESCRIPTION
Fixing the validation - we don't want to return true immediately, we should check other conditions as well.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21530

### Additional description

We should not raise a warning if the connection is secured.

### Type of change

- Validation fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
