### PR TITLE
RavenDB-21469 System.ArgumentException: at AuthenticateConnection.Can…

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1507,10 +1507,10 @@ namespace Raven.Server
                 // worried about race conditions here if we move to HTTP 2.0 at some point. At that point,
                 // we'll probably want to handle this concurrently, and the cost of adding it in this manner
                 // is pretty small for most cases anyway
-                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases)
-                {
-                    {database, mode}
-                };
+                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
+                if (_caseSensitiveAuthorizedDatabases.TryAdd(database,mode) == false)
+                    return CheckAccess(mode, requireAdmin, requireWrite);
+
 
                 return CheckAccess(mode, requireAdmin, requireWrite);
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1503,14 +1503,10 @@ namespace Raven.Server
                 if (AuthorizedDatabases.TryGetValue(ShardHelper.ToDatabaseName(database), out mode) == false)
                     return false;
 
-                // Technically speaking, since this is per connection, this is single threaded. But I'm
-                // worried about race conditions here if we move to HTTP 2.0 at some point. At that point,
-                // we'll probably want to handle this concurrently, and the cost of adding it in this manner
-                // is pretty small for most cases anyway
-                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
-                if (_caseSensitiveAuthorizedDatabases.TryAdd(database,mode) == false)
-                    return CheckAccess(mode, requireAdmin, requireWrite);
+                var authorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
+                authorizedDatabases.TryAdd(database, mode);
 
+                _caseSensitiveAuthorizedDatabases = authorizedDatabases;
 
                 return CheckAccess(mode, requireAdmin, requireWrite);
 


### PR DESCRIPTION
…Access()

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21469
### Additional description

we had an exception at AuthenticateConnection.CanAccess when adding the same DBname to the Dictionary.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
