### PR TITLE
RavenDB-21332 You can name more than 32 values for TimeSeries

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/settings/timeSeries.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/timeSeries.html
@@ -238,7 +238,7 @@
                                     <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: namedValues">
                                         <div class="help-block margin-bottom" data-bind="validationMessage: namedValues"></div>
                                     </div>
-                                    <button class="btn btn-default" data-bind="click: addMapping">
+                                    <button class="btn btn-default" data-bind="click: addMapping, disable: namedValues().length > 31">
                                         <i class="icon-plus"> </i><span>Add Name</span>
                                     </button>
                                 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21332 

### Additional description

Limit time series values to 32

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

