### PR TITLE
RavenDB-17656 Server Wide Tasks: Add disabled info in the database Ongoing Tasks View

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/backups.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/backups.html
@@ -108,7 +108,7 @@
                                     <small title="Backup is not encrypted" data-bind="visible: !isBackupEncrypted()"><i class="icon-unlock text-gray"></i></small>
                                 </div>
                                 <div class="node" data-bind="template: { name: 'responsible-node-template' }"></div>
-                                <div class="status" data-bind="visible: !isServerWide(), template: { name: 'state-template' }"></div>
+                                <div class="status" data-bind="template: { name: 'state-template' }"></div>
                                 <div data-bind="template: { name: 'backup-actions-template' }"></div>
                             </div>
                         </div>
@@ -195,7 +195,7 @@
 
 <script type="text/html" id="state-template">
     <div class="btn-group">
-        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false" data-bind="requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false" data-bind="disable: isServerWide(), requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
             <!--set-size-->
             <span data-bind="text: stateText()"></span><span class="caret"></span>
         </button>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
@@ -93,7 +93,7 @@
                                     </div>
                                     <div class="panel-name flex-grow" data-bind="template: { name: 'name-template-admin' }"></div>
                                     <div class="node" data-bind="template: { name: 'responsible-node-template' }"></div>
-                                    <div class="status" data-bind="visible: !isServerWide(), template: { name: 'state-template' }"></div>
+                                    <div class="status" data-bind="template: { name: 'state-template' }"></div>
                                     <div data-bind="template: { name: 'actions-template-admin' }"></div>
                                 </div>
                             </div>
@@ -451,7 +451,7 @@
                                         <small title="Backup is not encrypted" data-bind="visible: !isBackupEncrypted()"><i class="icon-unlock text-gray"></i></small>
                                     </div>
                                     <div class="node" data-bind="template: { name: 'responsible-node-template' }"></div>
-                                    <div class="status" data-bind="visible: !isServerWide(), template: { name: 'state-template' }"></div>
+                                    <div class="status" data-bind="template: { name: 'state-template' }"></div>
                                     <div data-bind="template: { name: 'actions-template-admin' }"></div>
                                 </div>
                             </div>
@@ -805,7 +805,7 @@
 <script type="text/html" id="state-template">
     <div class="btn-group">
         <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false" 
-                data-bind="requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+                data-bind="disable: isServerWide(), requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
             <!--set-size-->
             <span data-bind="text: stateText()"></span><span class="caret"></span>
         </button>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17656/Server-Wide-Tasks-Add-disabled-info-in-the-database-Ongoing-Tasks-View

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/f18e565d-fce8-4fa8-9ea0-90214e4bcfa9)
![image](https://github.com/ravendb/ravendb/assets/47967925/aa2e6b8f-d02b-4c87-85bd-696dd5c38efb)

