### PR TITLE
RavenDB-17997 When we read a page from a scratch file we need to use the pager state that we already acquired. Otherwise we might attempt to use already released pager if we have AllocateMorePages() calls meanwhile.

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -30,6 +30,7 @@ using Voron.Data;
 using Voron.Exceptions;
 using Voron.Impl.FileHeaders;
 using Voron.Impl.Paging;
+using Voron.Impl.Scratch;
 using Voron.Util;
 using Constants = Voron.Global.Constants;
 using NativeMemory = Sparrow.Utils.NativeMemory;
@@ -1476,9 +1477,10 @@ namespace Voron.Impl.Journal
                                 var scratchNumber = pagePosition.ScratchNumber;
                                 if (scratchPagerStates.TryGetValue(scratchNumber, out var pagerState) == false)
                                 {
-                                    pagerState = scratchBufferPool.GetPagerState(scratchNumber);
-                                    pagerState.AddRef();
-
+                                    // we're not under write transaction now, we need to acquire the pager state and use it for reading
+                                    var scratchBuffer = scratchBufferPool.GetScratchBufferFile(scratchNumber);
+                                    pagerState = scratchBuffer.File.Pager.GetPagerStateAndAddRefAtomically();
+                                   
                                     scratchPagerStates.Add(scratchNumber, pagerState);
                                 }
 
@@ -1486,7 +1488,7 @@ namespace Voron.Impl.Journal
                                 {
                                     using (tempTx) // release any resources, we just wanted to validate things
                                     {
-                                        var page = (PageHeader*)scratchBufferPool.AcquirePagePointerWithOverflowHandling(tempTx, scratchNumber, pagePosition.ScratchPage);
+                                        var page = (PageHeader*)scratchBufferPool.AcquirePagePointerWithOverflowHandling(tempTx, scratchNumber, pagePosition.ScratchPage, pagerState);
                                         var checksum = StorageEnvironment.CalculatePageChecksum((byte*)page, page->PageNumber, out var expectedChecksum);
                                         if (checksum != expectedChecksum)
                                             ThrowInvalidChecksumOnPageFromScratch(scratchNumber, pagePosition, page, checksum, expectedChecksum);
@@ -1833,7 +1835,7 @@ namespace Voron.Impl.Journal
             var pagesEncountered = 0;
             foreach (var txPage in txPages)
             {
-                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointerWithOverflowHandling(tx, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
+                var scratchPage = tx.Environment.ScratchBufferPool.AcquirePagePointerWithOverflowHandling(tx, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer, pagerState: null);
                 var pageHeader = (PageHeader*)scratchPage;
 
                 // When encryption is off, we do validation by checksum

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -308,9 +308,9 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte* AcquirePagePointerWithOverflowHandling(IPagerLevelTransactionState tx, long p)
+        public byte* AcquirePagePointerWithOverflowHandling(IPagerLevelTransactionState tx, long p, PagerState pagerState)
         {
-            return _scratchPager.AcquirePagePointerWithOverflowHandling(tx, p);
+            return _scratchPager.AcquirePagePointerWithOverflowHandling(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -205,12 +205,6 @@ namespace Voron.Impl.Scratch
 
             return item;
         }
-        public PagerState GetPagerState(int scratchNumber)
-        {
-            // Not thread-safe but only called by a single writer.
-            var bufferFile = _scratchBuffers[scratchNumber].File;
-            return bufferFile.PagerState;
-        }
 
         public PageFromScratchBuffer Allocate(LowLevelTransaction tx, int numberOfPages)
         {
@@ -413,12 +407,12 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte* AcquirePagePointerWithOverflowHandling(IPagerLevelTransactionState tx, int scratchNumber, long p)
+        public byte* AcquirePagePointerWithOverflowHandling(IPagerLevelTransactionState tx, int scratchNumber, long p, PagerState pagerState)
         {
             var item = GetScratchBufferFile(scratchNumber);
 
             ScratchBufferFile bufferFile = item.File;
-            return bufferFile.AcquirePagePointerWithOverflowHandling(tx, p);
+            return bufferFile.AcquirePagePointerWithOverflowHandling(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/SlowTests/Voron/Issues/RavenDB_17997.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17997.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl;
+using Voron.Impl.Paging;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public unsafe class RavenDB_17997 : StorageTest
+{
+    public RavenDB_17997(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustNotReadFromUnmappedAllocation()
+    {
+        var dataPager = Env.Options.DataPager;
+
+        using (var tempTx = new TempPagerTransaction())
+        {
+            PagerState stateUsedDuringAcquirePagePointer;
+            byte* ptr;
+
+            {
+                // the below code show the wrong usage that we had in ApplyPagesToDataFileFromScratch() where we're not under write tx
+                // if we don't pass pager state to AcquirePagePointer() then it will use the one from the pager instance which might get released because of AllocateMorePages() calls
+
+                /*
+                var state = dataPager.PagerState;
+                state.AddRef();
+
+                dataPager.AllocateMorePages(4 * 1024 * 1024);
+                dataPager.AllocateMorePages(8 * 1024 * 1024);
+
+                stateUsedDuringAcquirePagePointer = dataPager.PagerState; 
+
+                ptr = dataPager.AcquirePagePointer(tempTx, 0);
+                */
+            }
+
+            {
+                // correct usage should be to increment reference count of pager state and use that pager in AcquirePagePointer()
+                stateUsedDuringAcquirePagePointer = dataPager.GetPagerStateAndAddRefAtomically();
+
+                dataPager.AllocateMorePages(4 * 1024 * 1024);
+                dataPager.AllocateMorePages(8 * 1024 * 1024);
+
+                ptr = dataPager.AcquirePagePointer(tempTx, 0, stateUsedDuringAcquirePagePointer);
+            }
+
+            dataPager.AllocateMorePages(16 * 1024 * 1024);
+
+            if (ptr == stateUsedDuringAcquirePagePointer.MapBase && stateUsedDuringAcquirePagePointer._released)
+            {
+                throw new InvalidOperationException("Cannot read from already unmapped allocation of memory mapped file");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17997

### Additional description

https://issues.hibernatingrhinos.com/issue/RavenDB-17997/Occasional-AVE-on-BackgroundFlushWritesToDataFile-when-running-SlowTests-on-Jenkins#focus=Comments-67-965276.0-0

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- No UI work is needed
