### PR TITLE
RavenDB-21589 Treat LINQ `Any` call with predicate parameter as a going into subclause

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2055,12 +2055,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     }
                 case "Any":
                     {
+                        if (expression.Arguments.Count == 2 && expression.Arguments[0] is not ConstantExpression)
+                            _subClauseDepth++;
+                        
                         VisitExpression(expression.Arguments[0]);
                         if (expression.Arguments.Count == 2)
                         {
                             if (_chainedWhere)
                                 DocumentQuery.AndAlso();
                             VisitExpression(((UnaryExpression)expression.Arguments[1]).Operand);
+                            
+                            if (_subClauseDepth > 0)
+                                _subClauseDepth--;
                         }
 
                         VisitAny();

--- a/test/SlowTests/Issues/RavenDB-21589.cs
+++ b/test/SlowTests/Issues/RavenDB-21589.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21589 : RavenTestBase
+{
+    public RavenDB_21589(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void AnyWithPredicateParameterCombinedWithWhere()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 10; i++)
+                    session.Store(new Number(){ Value = i + 1 });
+                
+                session.SaveChanges();
+                
+                var ravenQueryable = session.Query<Number>();
+
+                var r1 = ravenQueryable.Where(n => n.Value < 3 || n.Value > 7).Any(n => n.Value == 4 || n.Value == 6);
+
+                var r2 = ravenQueryable.Where(n => n.Value < 3 || n.Value > 7).Where(n => n.Value == 4 || n.Value == 6).Any();
+                
+                var r3 = ravenQueryable.Any(n => n.Value == 4 || n.Value == 6);
+                
+                Assert.Equal(false, r1);
+                Assert.Equal(false, r2);
+                Assert.Equal(true, r3);
+            }
+        }
+    }
+
+    private class Number
+    {
+        public int Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21589/Parenthesis-missing-when-combining-Where-and-Any

### Additional description

We want to treat calling `Any` with predicate parameter as a going into subclause.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
