### PR TITLE
RavenDB-14274 - uploading a backup without creating a temp file on disk

### DIFF
--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -58,6 +58,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.CloudStorageOperationTimeoutInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting CloudStorageOperationTimeout { get; set; }
 
+        [Description("Disable the direct upload to an external destination, instead use a temp file to create the backup first.")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Backup.DisableDirectUpload", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool DisableDirectUpload { get; set; }
 
         [Description("EXPERT: Indicates which library to use when doing Azure backups.")]
         [DefaultValue(false)]

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1189,7 +1189,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public SmugglerResult FullBackupTo(string backupPath, CompressionLevel compressionLevel = CompressionLevel.Optimal,
+        public SmugglerResult FullBackupTo(Stream stream, CompressionLevel compressionLevel = CompressionLevel.Optimal,
             bool excludeIndexes = false, Action<(string Message, int FilesCount)> infoNotify = null, CancellationToken cancellationToken = default)
         {
             SmugglerResult smugglerResult;
@@ -1202,8 +1202,7 @@ namespace Raven.Server.Documents
             }
 
             using (TombstoneCleaner.PreventTombstoneCleaningUpToEtag(lastTombstoneEtag))
-            using (var file = SafeFileStream.Create(backupPath, FileMode.Create))
-            using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
+            using (var package = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
             {
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
                 {
@@ -1288,8 +1287,6 @@ namespace Raven.Server.Documents
 
                 BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), package, compressionLevel,
                     infoNotify: infoNotify, cancellationToken: cancellationToken);
-
-                file.Flush(true); // make sure that we fully flushed to disk
             }
 
             return smugglerResult;

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -11,13 +11,14 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.Documents.PeriodicBackup.Restore;
 using Sparrow;
 using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.PeriodicBackup.Aws
 {
-    public class RavenAwsS3Client : IDisposable
+    public class RavenAwsS3Client : IDirectUploader, IDisposable
     {
         private readonly Progress _progress;
         private readonly CancellationToken _cancellationToken;
@@ -103,6 +104,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             AsyncHelpers.RunSync(() => PutObjectAsync(key, stream, metadata));
         }
 
+        public AwsS3MultiPartUploader GetUploader(string key, Dictionary<string, string> metadata)
+        {
+            return new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
+        }
+
         public async Task PutObjectAsync(string key, Stream stream, Dictionary<string, string> metadata)
         {
             //TestConnection();
@@ -120,43 +126,19 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 {
                     _progress?.UploadProgress.ChangeType(UploadType.Chunked);
 
-                    var multipartRequest = new InitiateMultipartUploadRequest { Key = key, BucketName = _bucketName };
+                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
 
-                    FillMetadata(multipartRequest.Metadata, metadata);
-
-                    var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
-                    var partNumber = 1;
-                    var partEtags = new List<PartETag>();
+                    await multiPartUploader.InitializeAsync();
 
                     while (stream.Position < streamLength)
                     {
                         var leftToUpload = streamLength - stream.Position;
                         var toUpload = Math.Min(MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes), leftToUpload);
 
-                        var uploadResponse = await _client
-                            .UploadPartAsync(new UploadPartRequest
-                            {
-                                Key = key,
-                                BucketName = _bucketName,
-                                InputStream = stream,
-                                PartNumber = partNumber++,
-                                PartSize = toUpload,
-                                UploadId = initiateResponse.UploadId,
-                                StreamTransferProgress = (_, args) =>
-                                {
-                                    _progress?.UploadProgress.ChangeState(UploadState.Uploading);
-                                    _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
-                                    _progress?.OnUploadProgress?.Invoke();
-                                }
-                            }, _cancellationToken);
-
-                        partEtags.Add(new PartETag(uploadResponse.PartNumber, uploadResponse.ETag));
+                        await multiPartUploader.UploadPartAsync(stream, toUpload);
                     }
 
-                    await _client.CompleteMultipartUploadAsync(
-                        new CompleteMultipartUploadRequest { UploadId = initiateResponse.UploadId, BucketName = _bucketName, Key = key, PartETags = partEtags },
-                        _cancellationToken);
-
+                    await multiPartUploader.CompleteUploadAsync();
                     return;
                 }
 
@@ -377,7 +359,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             }
         }
 
-        private static void FillMetadata(MetadataCollection collection, IDictionary<string, string> metadata)
+        public static void FillMetadata(MetadataCollection collection, IDictionary<string, string> metadata)
         {
             if (metadata == null)
                 return;

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -640,7 +640,6 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                             EnsureSnapshotProcessed(databaseSummary, smugglerResult, indexesCount);
                         }
-                        
 
                         AddInfo($"Backed up {_backupResult.SnapshotBackup.ReadCount} files, " +
                                 $"took: {totalSw.ElapsedMilliseconds:#,#;;0}ms");
@@ -906,6 +905,12 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         private void UploadToServer(string backupPath, string folderName, string fileName)
         {
+            if (_directUploadDestination != DirectUploadDestination.Disabled)
+            {
+                // already uploaded during the creation of the backup
+                return;
+            }
+
             var s3Settings = GetBackupConfigurationFromScript(_configuration.S3Settings, x => JsonDeserializationServer.S3Settings(x),
                 settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForS3(settings, _database.Name));
             var glacierSettings = GetBackupConfigurationFromScript(_configuration.GlacierSettings, x => JsonDeserializationServer.GlacierSettings(x),

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -675,7 +675,13 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_backupToLocalFolder)
             {
                 // we'll do the local backup and then upload it
-                return GetForLocalBackup();
+                return GetStreamForLocalBackup();
+            }
+
+            if (_database.Configuration.Backup.DisableDirectUpload)
+            {
+                // disabled by configuration
+                return GetStreamForLocalBackup();
             }
 
             var hasAws = BackupConfiguration.CanBackupUsing(_configuration.S3Settings);
@@ -688,7 +694,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (destinations.Count(x => x) != 1)
             {
                 // direct upload is supported only for 1 destination
-                return GetForLocalBackup();
+                return GetStreamForLocalBackup();
             }
 
             if (hasAws)
@@ -709,9 +715,9 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
 
             // all other destinations are currently not supported
-            return GetForLocalBackup();
+            return GetStreamForLocalBackup();
 
-            FileStream GetForLocalBackup()
+            FileStream GetStreamForLocalBackup()
             {
                 return SafeFileStream.Create(filePath, FileMode.Create);
             }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -188,8 +188,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                         FileName = fileName
                     };
 
-                    // if user did not specify local folder we delete the temporary file
-                    if (_backupToLocalFolder == false)
+                    // if user did not specify local folder and it's isn't a direct upload, we delete the temporary file
+                    if (_backupToLocalFolder == false && _directUploadDestination == DirectUploadDestination.Disabled)
                     {
                         DeleteFile(backupFilePath);
                     }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -645,7 +645,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                                 $"took: {totalSw.ElapsedMilliseconds:#,#;;0}ms");
                     }
 
-                    IOExtensions.RenameFile(tempBackupFilePath, backupFilePath);
+                    if (_directUploadDestination == DirectUploadDestination.Disabled)
+                        IOExtensions.RenameFile(tempBackupFilePath, backupFilePath);
 
                     status.LocalBackup.Exception = null;
                 }
@@ -653,8 +654,11 @@ namespace Raven.Server.Documents.PeriodicBackup
                 {
                     status.LocalBackup.Exception = e.ToString();
 
-                    // deleting the temp backup file if the backup failed
-                    DeleteFile(tempBackupFilePath);
+                    if (_directUploadDestination == DirectUploadDestination.Disabled)
+                    {
+                        // deleting the temp backup file if the backup failed
+                        DeleteFile(tempBackupFilePath);
+                    }
                     throw;
                 }
             }
@@ -691,7 +695,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                             FolderName = folderName,
                             FileName = fileName,
                             RetentionPolicyParameters = _retentionPolicyParameters,
-                            OnProgress = AddInfo
+                            OnProgress = AddInfo,
+                            CancellationToken = TaskCancelToken.Token
                         });
 
                 default:

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -710,6 +710,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     IsFullBackup = _isFullBackup,
                     FolderName = folderName,
                     FileName = fileName,
+                    RetentionPolicyParameters = _retentionPolicyParameters,
                     OnProgress = AddInfo
                 });
             }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -695,6 +695,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                             FolderName = folderName,
                             FileName = fileName,
                             RetentionPolicyParameters = _retentionPolicyParameters,
+                            CloudUploadStatus = _backupResult.S3Backup,
                             OnProgress = AddInfo,
                             CancellationToken = TaskCancelToken.Token
                         });

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
@@ -241,19 +241,24 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         private string CombinePathAndKey(string path)
         {
+            return CombinePathAndKey(path, _settings.FolderName, _settings.FileName);
+        }
+
+        public static string CombinePathAndKey(string path, string folderName, string fileName)
+        {
             if (path?.EndsWith('/') == true)
                 path = path[..^1];
 
             var prefix = string.IsNullOrWhiteSpace(path) == false ? $"{path}/" : string.Empty;
 
-            return $"{prefix}{_settings.FolderName}/{_settings.FileName}";
+            return $"{prefix}{folderName}/{fileName}";
         }
 
         private void CreateUploadTaskIfNeeded<S, T>(S settings, Action<S, FileStream, Progress> uploadToServer, T uploadStatus, string targetName)
             where S : BackupSettings
             where T : CloudUploadStatus
         {
-            if (Client.Documents.Operations.Backups.BackupConfiguration.CanBackupUsing(settings) == false)
+            if (BackupConfiguration.CanBackupUsing(settings) == false)
                 return;
 
             Debug.Assert(uploadStatus != null);
@@ -380,8 +385,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             if (backupType.HasValue)
             {
-                var fullBackupText = backupType == BackupType.Backup ? "Full backup" : "A snapshot";
-                description = _isFullBackup ? fullBackupText : "Incremental backup";
+                description = GetBackupDescription(backupType.Value, _isFullBackup);
             }
             else
             {
@@ -389,6 +393,12 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
 
             return $"{description} for db {_settings.DatabaseName} at {SystemTime.UtcNow}";
+        }
+
+        public static string GetBackupDescription(BackupType backupType, bool isFullBackup)
+        {
+            var fullBackupText = backupType == BackupType.Backup ? "Full backup" : "A snapshot";
+            return isFullBackup ? fullBackupText : "Incremental backup";
         }
 
         private static string MsToHumanReadableString(long milliseconds)

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -18,7 +18,7 @@ public class AwsS3DirectUploadStream : DirectUploadStream
 
     protected override long MaxPartSizeInBytes { get; }
 
-    public AwsS3DirectUploadStream(Parameters parameters) : base(parameters.OnProgress)
+    public AwsS3DirectUploadStream(Parameters parameters) : base(parameters.IsFullBackup, parameters.CloudUploadStatus, parameters.OnProgress)
     {
         _client = new RavenAwsS3Client(parameters.Settings, parameters.Configuration, cancellationToken: parameters.CancellationToken);
         _retentionPolicyParameters = parameters.RetentionPolicyParameters;
@@ -60,6 +60,8 @@ public class AwsS3DirectUploadStream : DirectUploadStream
         public string FileName { get; set; }
 
         public RetentionPolicyBaseParameters RetentionPolicyParameters { get; set; }
+
+        public UploadToS3 CloudUploadStatus { get; set; }
 
         public Action<string> OnProgress { get; set; }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Documents.PeriodicBackup.Retention;
@@ -19,7 +20,7 @@ public class AwsS3DirectUploadStream : DirectUploadStream
 
     public AwsS3DirectUploadStream(Parameters parameters) : base(parameters.OnProgress)
     {
-        _client = new RavenAwsS3Client(parameters.Settings, parameters.Configuration);
+        _client = new RavenAwsS3Client(parameters.Settings, parameters.Configuration, cancellationToken: parameters.CancellationToken);
         _retentionPolicyParameters = parameters.RetentionPolicyParameters;
 
         var key = BackupUploader.CombinePathAndKey(parameters.Settings.RemoteFolderName, parameters.FolderName, parameters.FileName);
@@ -61,5 +62,7 @@ public class AwsS3DirectUploadStream : DirectUploadStream
         public RetentionPolicyBaseParameters RetentionPolicyParameters { get; set; }
 
         public Action<string> OnProgress { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow;
+using BackupConfiguration = Raven.Server.Config.Categories.BackupConfiguration;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public class AwsS3DirectUploadStream : DirectUploadStream
+{
+    private readonly RavenAwsS3Client _client;
+
+    protected override IMultiPartUploader MultiPartUploader { get; }
+
+    protected override long MaxPartSizeInBytes { get; }
+
+    public AwsS3DirectUploadStream(Parameters parameters)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            { "Description", BackupUploader.GetBackupDescription(parameters.BackupType, parameters.IsFullBackup) }
+        };
+
+        _client = new RavenAwsS3Client(parameters.Settings, parameters.Configuration);
+
+        var key = BackupUploader.CombinePathAndKey(parameters.Settings.RemoteFolderName, parameters.FolderName, parameters.FileName);
+        MultiPartUploader = _client.GetUploader(key, metadata);
+        MaxPartSizeInBytes = _client.MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes);
+
+        //TODO:
+        //var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, client);
+        //runner.Execute();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        _client.Dispose();
+    }
+
+    public class Parameters
+    {
+        public S3Settings Settings { get; set; }
+
+        public BackupConfiguration Configuration { get; set; }
+
+        public BackupType BackupType { get; set; }
+
+        public bool IsFullBackup { get; set; }
+
+        public string FolderName { get; set; }
+
+        public string FileName { get; set; }
+
+        public Action<string> OnProgress { get; set; }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -17,18 +17,19 @@ public class AwsS3DirectUploadStream : DirectUploadStream
 
     protected override long MaxPartSizeInBytes { get; }
 
-    public AwsS3DirectUploadStream(Parameters parameters)
+    public AwsS3DirectUploadStream(Parameters parameters) : base(parameters.OnProgress)
     {
-        var metadata = new Dictionary<string, string>
-        {
-            { "Description", BackupUploader.GetBackupDescription(parameters.BackupType, parameters.IsFullBackup) }
-        };
-
         _client = new RavenAwsS3Client(parameters.Settings, parameters.Configuration);
         _retentionPolicyParameters = parameters.RetentionPolicyParameters;
 
         var key = BackupUploader.CombinePathAndKey(parameters.Settings.RemoteFolderName, parameters.FolderName, parameters.FileName);
-        MultiPartUploader = _client.GetUploader(key, metadata);
+        MultiPartUploader = _client.GetUploader(key, new Dictionary<string, string>
+        {
+            {
+                "Description", BackupUploader.GetBackupDescription(parameters.BackupType, parameters.IsFullBackup)
+            }
+        });
+
         MaxPartSizeInBytes = _client.MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes);
     }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Sparrow;
+using Size = Sparrow.Size;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public class AwsS3MultiPartUploader : IMultiPartUploader
+{
+    private readonly AmazonS3Client _client;
+    private readonly string _bucketName;
+    private readonly Progress _progress;
+    private readonly string _key;
+    private readonly Dictionary<string, string> _metadata;
+    private readonly CancellationToken _cancellationToken;
+
+    private string _uploadId;
+    private int _partNumber;
+    private List<PartETag> _partEtags;
+
+    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, Progress progress, string key, Dictionary<string, string> metadata, CancellationToken cancellationToken)
+    {
+        _client = client;
+        _bucketName = bucketName;
+        _progress = progress;
+        _key = key;
+        _metadata = metadata;
+        _cancellationToken = cancellationToken;
+    }
+
+    public void Initialize()
+    {
+        AsyncHelpers.RunSync(InitializeAsync);
+    }
+
+    public async Task InitializeAsync()
+    {
+        var multipartRequest = new InitiateMultipartUploadRequest
+        {
+            Key = _key,
+            BucketName = _bucketName
+        };
+
+        RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
+
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        _uploadId = initiateResponse.UploadId;
+        _partNumber = 1;
+        _partEtags = new List<PartETag>();
+    }
+
+    public void UploadPart(Stream stream, long size)
+    {
+        AsyncHelpers.RunSync(() => UploadPartAsync(stream, size));
+    }
+
+    public async Task UploadPartAsync(Stream stream, long size)
+    {
+        if (_uploadId == null)
+            throw new InvalidOperationException($"You must call Initialize before uploading a part");
+
+        var uploadResponse = await _client
+            .UploadPartAsync(new UploadPartRequest
+            {
+                Key = _key,
+                BucketName = _bucketName,
+                InputStream = stream,
+                PartNumber = _partNumber++,
+                PartSize = size,
+                UploadId = _uploadId,
+                StreamTransferProgress = (_, args) =>
+                {
+                    _progress?.UploadProgress.ChangeState(UploadState.Uploading);
+                    _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
+                    _progress?.OnUploadProgress?.Invoke();
+                }
+            }, _cancellationToken);
+
+        _partEtags.Add(new PartETag(uploadResponse.PartNumber, uploadResponse.ETag));
+    }
+
+    public void CompleteUpload()
+    {
+        AsyncHelpers.RunSync(CompleteUploadAsync);
+    }
+
+    public async Task CompleteUploadAsync()
+    {
+        await _client.CompleteMultipartUploadAsync(
+            new CompleteMultipartUploadRequest
+            {
+                UploadId = _uploadId,
+                BucketName = _bucketName,
+                Key = _key,
+                PartETags = _partEtags
+            },
+            _cancellationToken);
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Util;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public abstract class DirectUploadStream : Stream
+{
+    protected abstract IMultiPartUploader MultiPartUploader { get; }
+    protected abstract long MaxPartSizeInBytes { get; }
+
+    private long _position;
+    private bool _initialized;
+    private MemoryStream _writeStream = new();
+    private MemoryStream _uploadStream = new();
+    private Task _uploadTask;
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        if (_initialized == false)
+        {
+            _initialized = true;
+            MultiPartUploader.Initialize();
+        }
+
+        _position += count;
+
+        _writeStream.Write(buffer, offset, count);
+
+        if (_writeStream.Position > MaxPartSizeInBytes)
+        {
+            if (_uploadTask != null && (_uploadTask.IsCompleted == false || _uploadTask.IsCompletedSuccessfully == false))
+                AsyncHelpers.RunSync(() => _uploadTask);
+
+            (_writeStream, _uploadStream) = (_uploadStream, _writeStream);
+
+            _writeStream.Position = _uploadStream.Position = 0;
+            _uploadTask = MultiPartUploader.UploadPartAsync(_uploadStream, _uploadStream.Length);
+        }
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (_initialized == false)
+        {
+            _initialized = true;
+            await MultiPartUploader.InitializeAsync();
+        }
+
+        _position += count;
+
+        await _writeStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+        if (_writeStream.Position > MaxPartSizeInBytes)
+        {
+            if (_uploadTask != null)
+            {
+                if (_uploadTask.IsCompleted == false || _uploadTask.IsCompletedSuccessfully == false)
+                    await _uploadTask;
+
+                //TODO
+                //_backupResult.AddInfo(message);
+                //_onProgress.Invoke(_backupResult.Progress);
+            }
+
+            (_writeStream, _uploadStream) = (_uploadStream, _writeStream);
+
+            _writeStream.Position = _uploadStream.Position = 0;
+            _uploadTask = MultiPartUploader.UploadPartAsync(_uploadStream, _uploadStream.Length);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        using (_uploadStream)
+        using (_writeStream)
+        {
+            if (_uploadTask != null && _uploadTask.IsCompleted == false)
+                AsyncHelpers.RunSync(() => _uploadTask);
+
+            if (_writeStream.Position > 0)
+            {
+                _writeStream.Position = 0;
+                MultiPartUploader.UploadPart(_writeStream, _writeStream.Length);
+            }
+        }
+
+        MultiPartUploader.CompleteUpload();
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public interface IDirectUploader
+{
+    public AwsS3MultiPartUploader GetUploader(string key, Dictionary<string, string> metadata);
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IMultiPartUploader.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public interface IMultiPartUploader
+{
+    void Initialize();
+
+    Task InitializeAsync();
+
+    void UploadPart(Stream stream, long size);
+
+    Task UploadPartAsync(Stream stream, long size);
+
+    void CompleteUpload();
+
+    Task CompleteUploadAsync();
+}

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 using Xunit;
 using Voron.Impl.Backup;
 using Voron.Util.Settings;
@@ -79,7 +80,9 @@ namespace FastTests.Voron.Backups
 
                 var voronTempFileName = new VoronPathSetting(tempFileName);
 
-                database.FullBackupTo(voronTempFileName.Combine("backup-test.backup").FullPath);
+                using (var fileStream = SafeFileStream.Create(voronTempFileName.Combine("backup-test.backup").FullPath, FileMode.Create))
+                    database.FullBackupTo(fileStream);
+
                 BackupMethods.Full.Restore(voronTempFileName.Combine("backup-test.backup"), voronTempFileName.Combine("backup-test.data"));
             }
             using (CreatePersistentDocumentDatabase(Path.Combine(tempFileName, "backup-test.data"), out var database))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

- Upload a backup directly to the storage provider without saving a temp backup file on the disk.
- Supported only when only one destination is defined.
- Currently only `S3` is supported.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing