### PR TITLE
RavenDB-21484 Corax: Highlighting will return results even if the highlighted field isn't projected

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3389,7 +3389,7 @@ namespace Raven.Server.Documents.Indexes
                                 IncludeTimeSeriesCommand includeTimeSeriesCommand = null;
                                 IncludeRevisionsCommand includeRevisionsCommand = new(DocumentDatabase, queryContext.Documents, query.Metadata.RevisionIncludes);
 
-                                var fieldsToFetch = new FieldsToFetch(query, Definition, Type, SearchEngineType);
+                                var fieldsToFetch = new FieldsToFetch(query, Definition, Type);
 
                                 var includeDocumentsCommand = new IncludeDocumentsCommand(
                                     DocumentDatabase.DocumentsStorage, queryContext.Documents,

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Queries.Results
             CoraxIndexSearcher = null;
         }
 
-        public RetrieverInput(IndexSearcher searcher, IndexFieldsMapping knownFields, EntryTermsReader reader, string id, float? score = null, Corax.Utils.Spatial.SpatialResult? distance = null)
+        public RetrieverInput(IndexSearcher searcher, IndexFieldsMapping knownFields, in EntryTermsReader reader, string id, float? score = null, Corax.Utils.Spatial.SpatialResult? distance = null)
         {
             CoraxTermsReader = reader;
             KnownFields = knownFields;

--- a/test/SlowTests/Issues/RavenDB_21484.cs
+++ b/test/SlowTests/Issues/RavenDB_21484.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Highlighting;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public sealed class RavenDB_21484 : RavenTestBase
+    {
+        public RavenDB_21484(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private interface ISearchable
+        {
+            string Slug { get; set; }
+            string Title { get; set; }
+            string Content { get; set; }
+        }
+
+        private class EventsItem : ISearchable
+        {
+            public string Id { get; set; }
+            public string Title { get; set; }
+            public string Slug { get; set; }
+            public string Content { get; set; }
+        }
+
+        private class SearchResults
+        {
+            public ISearchable Result { get; set; }
+            public List<string> Highlights { get; set; }
+            public string Title { get; set; }
+        }
+
+        private class ContentSearchIndex : AbstractMultiMapIndexCreationTask<ISearchable>
+        {
+            public ContentSearchIndex()
+            {
+                AddMap<EventsItem>(docs => from doc in docs
+                    let slug = doc.Id.ToString().Substring(doc.Id.ToString().IndexOf('/') + 1)
+                    select new { Slug = slug, doc.Title, doc.Content });
+
+
+                Index(x => x.Slug, FieldIndexing.Search);
+                Store(x => x.Slug, FieldStorage.Yes);
+                TermVector(x => x.Slug, FieldTermVector.WithPositionsAndOffsets);
+
+                Index(x => x.Title, FieldIndexing.Search);
+                Store(x => x.Title, FieldStorage.Yes);
+                TermVector(x => x.Title, FieldTermVector.WithPositionsAndOffsets);
+
+                Index(x => x.Content, FieldIndexing.Search);
+                Store(x => x.Content, FieldStorage.Yes);
+                TermVector(x => x.Content, FieldTermVector.WithPositionsAndOffsets);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Highlighting)]
+        [RavenData("session", SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+        public void SearchWithHighlightsThatAreNotIncluded(Options options, string q)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new EventsItem
+                    {
+                        Slug = "ravendb-indexes-explained",
+                        Title = "RavenDB indexes explained",
+                        Content = "Itamar Syn-Hershko: Afraid of Map/Reduce? In this session, core RavenDB developer Itamar Syn-Hershko will walk through the RavenDB indexing process, grok it and much more.",
+                    });
+                    session.SaveChanges();
+                }
+
+                new ContentSearchIndex().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var highlightingOptions = new HighlightingOptions
+                    {
+                        PreTags = new[] { "<span style='background: yellow'>" },
+                        PostTags = new[] { "</span>" }
+                    };
+
+                    var results = session.Advanced.DocumentQuery<ISearchable>("ContentSearchIndex")
+                        .WaitForNonStaleResults()
+                        .Highlight("Content", 128, 2, highlightingOptions, out Highlightings contentHighlighting)
+                        .Search("Content", q).Boost(15)
+                        .SelectFields<dynamic>(new[] {"id()"} )
+                        .ToArray();
+
+                    Assert.Equal(1, results.Length);
+                    Assert.Equal(1, contentHighlighting.ResultIndents.Count());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21484

### Additional description

This is PR https://github.com/ravendb/ravendb/pull/17435 squashed into single commit.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
