### PR TITLE
RavenDB-21313 Copy button for the change vector in the stats page

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/statistics.ts
@@ -7,6 +7,7 @@ import indexStalenessReasons = require("viewmodels/database/indexes/indexStalene
 import getStorageReportCommand = require("commands/database/debug/getStorageReportCommand");
 import statsModel = require("models/database/stats/statistics");
 import popoverUtils = require("common/popoverUtils");
+import copyToClipboard = require("common/copyToClipboard");
 
 class statistics extends viewModelBase {
 
@@ -23,7 +24,7 @@ class statistics extends viewModelBase {
     constructor() {
         super();
         
-        this.bindToCurrentInstance("showStaleReasons");
+        this.bindToCurrentInstance("showStaleReasons", "copyChangeVectorToClipboard");
 
         this.rawJsonUrl = ko.pureComputed(() => {
             const activeDatabase = this.activeDatabase();
@@ -138,6 +139,13 @@ class statistics extends viewModelBase {
 
     refreshStats() {
         this.fetchStats();
+    }
+
+    copyChangeVectorToClipboard() { 
+        copyToClipboard.copy(
+            this.stats().databaseChangeVector.map(cv => `${cv.fullFormat}`).join("\r\n"),
+            "Change vector was copied to clipboard"
+        )
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/statistics.html
@@ -50,7 +50,15 @@
             </div>
             <div class="col-sm-6 col-lg-4 col-xl-3">
                 <div class="stats-item js-cv-tooltip">
-                    <div class="name"><i class="icon-vector"></i><span>Database Change Vector</span></div>
+                    <div class="name">
+                        <i class="icon-vector"></i><span>Database Change Vector</span>
+                        <button
+                            class="btn btn-default btn-xs margin-left"
+                            data-bind="click: $root.copyChangeVectorToClipboard"
+                            title="Copy to clipboard">
+                                <i class="icon-copy-to-clipboard"></i>
+                        </button>
+                    </div>
                     <div class="value">
                         <span data-bind="foreach: databaseChangeVector">
                             <span class="badge badge-default" data-bind="text: shortFormat"></span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21313/Copy-button-for-the-change-vector-in-the-stats-page

### Additional description

add copy to clipboard button

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
