### PR TITLE
RavenDB-21566 Replace `GetValueOrDefault()` with null coalescence in `ExpressionStringBuilder`

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1532,8 +1532,15 @@ namespace Raven.Client.Documents.Indexes
 
             if (node.Method.Name == "GetValueOrDefault" && Nullable.GetUnderlyingType(node.Method.DeclaringType) != null)
             {
+                if (TypeExistsOnServer(node.Type) == false)
+                    throw new InvalidOperationException($"Type {node.Type} does not exist on server, default value cannot be assigned");
+                
+                var underlyingType = Nullable.GetUnderlyingType(node.Method.DeclaringType);
+                
                 Visit(node.Object);
-                return node; // we don't do anything here on the server
+                Out($" ?? default({underlyingType.Name})");
+                
+                return node; // we don't have more to handle
             }
 
             var isExtension = false;

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1533,7 +1533,7 @@ namespace Raven.Client.Documents.Indexes
             if (node.Method.Name == "GetValueOrDefault" && Nullable.GetUnderlyingType(node.Method.DeclaringType) != null)
             {
                 if (TypeExistsOnServer(node.Type) == false)
-                    throw new InvalidOperationException($"Type {node.Type} does not exist on server, default value cannot be assigned");
+                    throw new InvalidOperationException($"Type {node.Type} does not exist on server, default value cannot be assigned. Did you intend to register it via {nameof(DocumentConventions.TypeIsKnownServerSide)} convention?");
                 
                 var underlyingType = Nullable.GetUnderlyingType(node.Method.DeclaringType);
                 

--- a/test/SlowTests/Issues/RavenDB-21566.cs
+++ b/test/SlowTests/Issues/RavenDB-21566.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21566 : RavenTestBase
+{
+    public RavenDB_21566(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfGetValueOrDefaultIsReplacedWithNullCoalescence()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto();
+                
+                session.Store(d1);
+                
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                var res = session.Query<DummyIndex.IndexResult>(index.IndexName).ProjectInto<DummyIndex.IndexResult>().ToList();
+
+                var firstResult = res.First();
+                
+                Assert.Equal(default, firstResult.NonNullableBool);
+                Assert.Equal(default, firstResult.NonNullableInt);
+                Assert.Equal(default, firstResult.NonNullableDecimal);
+                Assert.Equal(default, firstResult.NonNullableDouble);
+                Assert.Equal(default, firstResult.NonNullableFloat);
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfTypeAddedThroughAdditionalSourcesWorksCorrectly()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new DtoWithNullableEnum();
+                
+                session.Store(d1);
+                
+                session.SaveChanges();
+                
+                var conventions = new DocumentConventions
+                {
+                    TypeIsKnownServerSide = t => t == typeof(DummyEnum)
+                };
+
+                var index = new DummyIndexWithNullableEnum() { Conventions = conventions };
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var res = session.Query<DummyIndexWithNullableEnum.IndexResult>(index.IndexName).ProjectInto<DummyIndexWithNullableEnum.IndexResult>().ToList();
+                
+                var firstResult = res.First();
+                
+                Assert.Equal(default, firstResult.NonNullableEnum);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfTypeThatDoesNotExistOnServerThrows()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new DtoWithNullableEnum();
+                
+                session.Store(d1);
+                
+                session.SaveChanges();
+
+                // We don't register DummyEnum type on server
+                var index = new DummyIndexWithNullableEnum();
+                
+                var exception = Assert.Throws<IndexCompilationException>(() => index.Execute(store));
+
+                var innerException = exception.InnerException;
+                
+                Assert.IsType<InvalidOperationException>(innerException);
+
+                Assert.Contains("Type SlowTests.Issues.RavenDB_21566+DummyEnum does not exist on server, default value cannot be assigned", innerException.Message);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckIfNullableDateTypesAreEvaluatedCorrectly()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new DtoWithNullableDates();
+                
+                session.Store(d1);
+                
+                session.SaveChanges();
+
+                var index = new DummyIndexWithNullableDates();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var res = session.Query<DummyIndexWithNullableDates.IndexResult>(index.IndexName).ProjectInto<DummyIndexWithNullableDates.IndexResult>().ToList();
+                
+                var firstResult = res.First();
+                
+                WaitForUserToContinueTheTest(store);
+                
+                Assert.Equal(default, firstResult.NonNullableDateOnly);
+                Assert.Equal(default, firstResult.NonNullableTimeSpan);
+                Assert.Equal(default, firstResult.NonNullableDateTimeOffset);
+                Assert.Equal(default, firstResult.NonNullableDateOnly);
+                Assert.Equal(default, firstResult.NonNullableTimeOnly);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public bool? NullableBool { get; set; }
+        public int? NullableInt { get; set; }
+        public decimal? NullableDecimal { get; set; }
+        public double? NullableDouble { get; set; }
+        public float? NullableFloat { get; set; }
+    }
+
+    private class DtoWithNullableEnum
+    {
+        public DummyEnum? NullableEnum { get; set; }
+    }
+
+    private class DtoWithNullableDates
+    {
+        public DateTime? NullableDateTime { get; set; }
+        public TimeSpan? NullableTimeSpan { get; set; }
+        public DateTimeOffset? NullableDateTimeOffset { get; set; }
+        public DateOnly? NullableDateOnly { get; set; }
+        public TimeOnly? NullableTimeOnly { get; set; }
+    }
+    
+    private enum DummyEnum
+    {
+        Value1,
+        Value2
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public class IndexResult
+        {
+            public string Id { get; set; }
+            public bool NonNullableBool { get; set; }
+            public int NonNullableInt { get; set; }
+            public decimal NonNullableDecimal { get; set; }
+            public double NonNullableDouble { get; set; }
+            public float NonNullableFloat { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexResult()
+                {
+                    Id = dto.Id, 
+                    NonNullableBool = dto.NullableBool.GetValueOrDefault(),
+                    NonNullableInt = dto.NullableInt.GetValueOrDefault(),
+                    NonNullableDecimal = dto.NullableDecimal.GetValueOrDefault(),
+                    NonNullableDouble = dto.NullableDouble.GetValueOrDefault(),
+                    NonNullableFloat = dto.NullableFloat.GetValueOrDefault()
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class DummyIndexWithNullableEnum : AbstractIndexCreationTask<DtoWithNullableEnum>
+    {
+        public class IndexResult
+        {
+            public DummyEnum NonNullableEnum { get; set; }
+        }
+        
+        public DummyIndexWithNullableEnum()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexResult()
+                {
+                    NonNullableEnum = dto.NullableEnum.GetValueOrDefault()
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+            
+            AdditionalSources = new Dictionary<string, string>
+            {
+                {
+                    "DummyAdditionalSource", 
+                    @"
+                    using System;
+
+                    namespace Temp 
+                    {
+                        public enum DummyEnum 
+                        {
+                            Value1,
+                            Value2
+                        }
+                    }"
+                }
+            };
+        }
+    }
+    private class DummyIndexWithNullableDates : AbstractIndexCreationTask<DtoWithNullableDates>
+    {
+        public class IndexResult
+        {
+            public DateTime NonNullableDateTime { get; set; }
+            public TimeSpan NonNullableTimeSpan { get; set; }
+            public DateTimeOffset NonNullableDateTimeOffset { get; set; }
+            public DateOnly NonNullableDateOnly { get; set; }
+            public TimeOnly NonNullableTimeOnly { get; set; }
+        }
+        
+        public DummyIndexWithNullableDates()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexResult()
+                {
+                    NonNullableDateTime = dto.NullableDateTime.GetValueOrDefault(),
+                    NonNullableTimeSpan = dto.NullableTimeSpan.GetValueOrDefault(),
+                    NonNullableDateTimeOffset = dto.NullableDateTimeOffset.GetValueOrDefault(),
+                    NonNullableDateOnly = dto.NullableDateOnly.GetValueOrDefault(),
+                    NonNullableTimeOnly = dto.NullableTimeOnly.GetValueOrDefault()
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-21566.cs
+++ b/test/SlowTests/Issues/RavenDB-21566.cs
@@ -104,7 +104,7 @@ public class RavenDB_21566 : RavenTestBase
                 
                 Assert.IsType<InvalidOperationException>(innerException);
 
-                Assert.Contains("Type SlowTests.Issues.RavenDB_21566+DummyEnum does not exist on server, default value cannot be assigned", innerException.Message);
+                Assert.Contains($"Type SlowTests.Issues.RavenDB_21566+DummyEnum does not exist on server, default value cannot be assigned. Did you intend to register it via {nameof(DocumentConventions.TypeIsKnownServerSide)} convention?", innerException.Message);
             }
         }
     }
@@ -131,8 +131,6 @@ public class RavenDB_21566 : RavenTestBase
                 var res = session.Query<DummyIndexWithNullableDates.IndexResult>(index.IndexName).ProjectInto<DummyIndexWithNullableDates.IndexResult>().ToList();
                 
                 var firstResult = res.First();
-                
-                WaitForUserToContinueTheTest(store);
                 
                 Assert.Equal(default, firstResult.NonNullableDateOnly);
                 Assert.Equal(default, firstResult.NonNullableTimeSpan);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21566/Support-GetValueOrDefault-in-index-definition

### Additional description

We want to replace `GetValueOrDefault()` call with null coalescence operator for types that are known for server. Currently we just get rid of this call in `ExpressionStringBuilder`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change
Currently we remove `GetValueOrDefault()` call in `ExpressionStringBuilder`. This change will throw an exception if user calls this method on type that doesn't exist on server (own nullable enum), even if it's provided in additional sources.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
