### PR TITLE
RavenDB-21313 Copy button for the change vector in the stats page

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -2,11 +2,12 @@
 import React from "react";
 import genUtils from "common/generalUtils";
 import changeVectorUtils from "common/changeVectorUtils";
-import { Card, PopoverBody, Table, UncontrolledPopover } from "reactstrap";
+import { Button, Card, PopoverBody, Table, UncontrolledPopover } from "reactstrap";
 import { LazyLoad } from "components/common/LazyLoad";
 import { useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import { statisticsViewSelectors } from "components/pages/database/status/statistics/store/statisticsViewSlice";
+import copyToClipboard = require("common/copyToClipboard");
 
 interface DetailsBlockProps {
     children: (data: DetailedDatabaseStatistics, location: databaseLocationSpecifier) => JSX.Element;
@@ -14,6 +15,12 @@ interface DetailsBlockProps {
 
 export function DetailedDatabaseStats() {
     const perNodeStats = useAppSelector(statisticsViewSelectors.allDatabaseDetails);
+    const copyChangeVector = (formattedChangeVector: changeVectorItem[]) => {
+        copyToClipboard.copy(
+            formattedChangeVector.map((cv) => cv.fullFormat).join("\r\n"),
+            "Copied error message to clipboard"
+        );
+    };
 
     function DetailsBlock(props: DetailsBlockProps): JSX.Element {
         const { children } = props;
@@ -89,6 +96,14 @@ export function DetailedDatabaseStats() {
                                     return (
                                         <>
                                             <div id={id} className="d-inline-flex flex-wrap gap-1">
+                                                <Button
+                                                    color="primary"
+                                                    size="xs"
+                                                    title="Copy to clipboard"
+                                                    onClick={() => copyChangeVector(formattedChangeVector)}
+                                                >
+                                                    <Icon icon="copy-to-clipboard" margin="m-0" />
+                                                </Button>
                                                 {formattedChangeVector.map((cv) => (
                                                     <div
                                                         key={cv.fullFormat}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21313/Copy-button-for-the-change-vector-in-the-stats-page

### Additional description

Add copy button for the change vector in the stats page

_Please delete below the options that are not relevant_

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
