### PR TITLE
RavenDB-19957: fix concurrently connecting subscription connections in ConcurrentSubscription

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -22,7 +22,9 @@ namespace Raven.Client.Documents.Subscriptions
         public string NodeTag { get; set; }
         public DateTime? LastBatchAckTime { get; set; }  // Last time server made some progress with the subscriptions docs  
         public DateTime? LastClientConnectionTime { get; set; } // Last time any client has connected to server (connection dead or alive)
-        
+        // raft index used to create or update subscription task
+        public long RaftCommandIndex { get; set; }
+
         public bool Disabled { get; set; }
 
         public ulong GetTaskKey()
@@ -68,8 +70,9 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(NodeTag)] = NodeTag,
                 [nameof(LastBatchAckTime)] = LastBatchAckTime,
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,
-                [nameof(Disabled)] = Disabled
-            };
+                [nameof(Disabled)] = Disabled,
+                [nameof(RaftCommandIndex)] = RaftCommandIndex
+        };
 
             return djv;
         }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1936,6 +1936,7 @@ namespace Raven.Server.Documents
 
             internal Action Subscription_ActionToCallDuringWaitForChangedDocuments;
             internal Action<long> Subscription_ActionToCallAfterRegisterSubscriptionConnection;
+            internal Action<ConcurrentSet<SubscriptionConnection>> ConcurrentSubscription_ActionToCallDuringWaitForSubscribe;
 
             internal IDisposable CallDuringWaitForChangedDocuments(Action action)
             {
@@ -1948,6 +1949,12 @@ namespace Raven.Server.Documents
                 Subscription_ActionToCallAfterRegisterSubscriptionConnection = action;
 
                 return new DisposableAction(() => Subscription_ActionToCallAfterRegisterSubscriptionConnection = null);
+            }
+            internal IDisposable CallDuringWaitForSubscribe(Action<ConcurrentSet<SubscriptionConnection>> action)
+            {
+                ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = action;
+
+                return new DisposableAction(() => ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = null);
             }
 
             internal ManualResetEvent DatabaseRecordLoadHold;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -4,6 +4,7 @@ using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
@@ -58,7 +59,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 return new UpdatedValue(UpdatedValueActionType.Noop, value: null);
             }
 
-            var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
+            var subscription = JsonDeserializationClient.SubscriptionState(existingValue);
             AssertSubscriptionState(record, subscription, subscriptionName);
 
             if (IsLegacyCommand())

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -2,19 +2,18 @@
 using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Voron;
 using Voron.Data.Tables;
-using Raven.Server.Documents.Replication;
-using Raven.Server.Rachis;
-using Voron.Impl.Paging;
-using Raven.Client.Json.Serialization;
-using Raven.Server.Documents.Subscriptions;
 
 namespace Raven.Server.ServerWide.Commands.Subscriptions
 {
@@ -115,7 +114,8 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                         Disabled = Disabled,
                         MentorNode = MentorNode,
                         PinToMentorNode = PinToMentorNode,
-                        LastClientConnectionTime = null
+                        LastClientConnectionTime = null,
+                        RaftCommandIndex = index
                     }.ToJson(), SubscriptionName))
                     {
                         ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, receivedSubscriptionState);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -2,8 +2,8 @@
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
-using Raven.Server.Rachis;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -32,7 +32,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             if (existingValue == null)
                 throw new SubscriptionDoesNotExistException($"Subscription with id '{itemId}' does not exist");
 
-            var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
+            var subscription = JsonDeserializationClient.SubscriptionState(existingValue);
 
             var topology = record.Topology;
             var lastResponsibleNode = AcknowledgeSubscriptionBatchCommand.GetLastResponsibleNode(HasHighlyAvailableTasks, topology, NodeTag);

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -14,7 +14,6 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries.Sorting;
-using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
@@ -44,8 +43,6 @@ namespace Raven.Server.ServerWide
         public static readonly Func<BlittableJsonReaderObject, IncrementClusterIdentityCommand> IncrementClusterIdentityCommand = GenerateJsonDeserializationRoutine<IncrementClusterIdentityCommand>();
 
         public static readonly Func<BlittableJsonReaderObject, IncrementClusterIdentitiesBatchCommand> IncrementClusterIdentitiesBatchCommand = GenerateJsonDeserializationRoutine<IncrementClusterIdentitiesBatchCommand>();
-
-        public static readonly Func<BlittableJsonReaderObject, SubscriptionState> SubscriptionState = GenerateJsonDeserializationRoutine<SubscriptionState>();
 
         public static readonly Func<BlittableJsonReaderObject, DeleteValueCommand> DeleteValueCommand = GenerateJsonDeserializationRoutine<DeleteValueCommand>();
 

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSubscriptionEditModel.ts
@@ -160,7 +160,8 @@ class ongoingTaskSubscriptionEditModel extends ongoingTaskEditModel {
                 LastBatchAckTime: null,
                 MentorNode: null,
                 PinToMentorNode: false,
-                NodeTag: null
+                NodeTag: null,
+                RaftCommandIndex: 0
             });
     }
 }

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -1018,6 +1018,279 @@ namespace SlowTests.Client.Subscriptions
             }
         }
 
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnections(int count)
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>();
+                var docs = new HashSet<string>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User(), $"users/{i}");
+                        session.SaveChanges();
+                    }
+
+                    var workers = new List<SubscriptionWorker<User>>();
+                    for (int j = 0; j < count; j++)
+                    {
+                        workers.Add(store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        }));
+                    }
+
+                    try
+                    {
+                        foreach (var worker in workers)
+                        {
+                            var t = worker.Run(x =>
+                            {
+                                foreach (var item in x.Items)
+                                {
+                                    docs.Add(item.Id);
+                                }
+                            });
+                        }
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                    finally
+                    {
+                        foreach (var w in workers)
+                        {
+                            await w.DisposeAsync();
+                        }
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnectionsAfterUpdate(int count)
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions<User>()
+                {
+                    Filter = user => user.Age == 0
+                });
+
+                var docs = new HashSet<string>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    if (i > 0)
+                    {
+                        await store.Subscriptions.UpdateAsync(options: new SubscriptionUpdateOptions()
+                        {
+                            Name = id,
+                            Query = @$"declare function predicate() {{ return this.Age==={i} }}
+from 'Users' as doc
+where predicate.call(doc)"
+                        });
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User()
+                        {
+                            Age = i
+                        }, $"users/{i}");
+                        session.SaveChanges();
+                    }
+
+                    var workers = new List<SubscriptionWorker<User>>();
+                    for (int j = 0; j < count; j++)
+                    {
+                        workers.Add(store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        }));
+                    }
+
+                    try
+                    {
+                        foreach (var worker in workers)
+                        {
+                            var t = worker.Run(x =>
+                            {
+                                foreach (var item in x.Items)
+                                {
+                                    docs.Add(item.Id);
+                                }
+                            });
+                        }
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                    finally
+                    {
+                        foreach (var w in workers)
+                        {
+                            await w.DisposeAsync();
+                        }
+                    }
+                }
+
+                var subs = await store.Subscriptions.GetSubscriptionsAsync(0, 1024);
+                Assert.Equal(1, subs.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnectionsAfterUpdate_AndDisposeWhileConnecting()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions<User>()
+                {
+                    Filter = user => user.Age == 0
+                });
+
+                var docs = new HashSet<string>();
+                var workers = new List<SubscriptionWorker<User>>();
+                try
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i > 0)
+                        {
+                            // we update the subscription on each iteration
+                            // so it will process only the new created document
+                            await store.Subscriptions.UpdateAsync(options: new SubscriptionUpdateOptions()
+                            {
+                                Name = id,
+                                Query = @$"declare function predicate() {{ return this.Age==={i} }}
+from 'Users' as doc
+where predicate.call(doc)"
+                            });
+                        }
+
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User()
+                            {
+                                Age = i
+                            }, $"users/{i}");
+                            session.SaveChanges();
+                        }
+
+                        var w = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        });
+                        workers.Add(w);
+
+                        var t2 = w.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                docs.Add(item.Id);
+                                Thread.Sleep(1000);
+                            }
+                        });
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                }
+                finally
+                {
+                    foreach (var w in workers)
+                    {
+                        await w.DisposeAsync();
+                    }
+                }
+
+                var subs = await store.Subscriptions.GetSubscriptionsAsync(0, 1024);
+                Assert.Equal(1, subs.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task ConcurrentSubscriptionsShouldProcessWhen_2_ConnectionsAreSubscribingConcurrently()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>();
+
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var testingStuff = db.ForTestingPurposesOnly();
+
+                using (testingStuff.CallDuringWaitForSubscribe(connections =>
+                {
+                    while (connections.Count < 2)
+                    {
+                        Thread.Sleep(111);
+                    }
+                }))
+                {
+                    await using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        MaxDocsPerBatch = 2
+                    }))
+                    await using (var secondSubscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
+                        MaxDocsPerBatch = 2
+                    }))
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User(), "user/1");
+                            session.Store(new User(), "user/2");
+                            session.Store(new User(), "user/3");
+                            session.Store(new User(), "user/4");
+                            session.Store(new User(), "user/5");
+                            session.Store(new User(), "user/6");
+                            session.SaveChanges();
+                        }
+
+                        var con1Docs = new List<string>();
+                        var con2Docs = new List<string>();
+
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                            }
+                        });
+
+                        var _ = secondSubscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con2Docs.Add(item.Id);
+                            }
+                        });
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(con1Docs.Count + con2Docs.Count == 6), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                }
+            }
+        }
+
         private class GetSubscriptionResendListCommand : RavenCommand<ResendListResults>
         {
             private readonly string _database;
@@ -1072,6 +1345,7 @@ namespace SlowTests.Client.Subscriptions
         private class User
         {
             public string Name;
+            public int Age;
         }
     }
 }

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -6,7 +6,6 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.Replication;
-using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Server;
@@ -65,7 +64,7 @@ namespace SlowTests.Client.Subscriptions
                 Assert.True(await signalWhenStartedProcessingDoc.WaitAsync(_reasonableWaitTime));
                 var database = await GetDatabase(store.Database);
 
-                SubscriptionStorage.SubscriptionGeneralDataAndStats subscriptionState;
+                SubscriptionState subscriptionState;
                 using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -26,7 +26,6 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
-using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.System;
 using Raven.Tests.Core.Utils.Entities;
@@ -341,7 +340,7 @@ namespace SlowTests.Client.Subscriptions
 
                     Assert.True(await ackFirstCV.WaitAsync(_reasonableWaitTime));
 
-                    SubscriptionStorage.SubscriptionGeneralDataAndStats subscriptionState;
+                    SubscriptionState subscriptionState;
                     using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19957

### Additional description

There was an assertion for connection count which is wrong for concurrent subscriptions.
When connections were concurrently connecting, they could end not registering `RegisterForNotificationOnNewDocuments` event so no documents were processed by this particular subscription.

### Type of change

- Regression bug fix (https://github.com/ravendb/ravendb/pull/13694) (https://github.com/ravendb/ravendb/commit/1ecd43f3682b934c0950e0d8aa08847891d01f0b)

### How risky is the change?

- Low 


### Backward compatibility

- Ensured. Please explain how has it been implemented?
There is new `SubscriptionStateWithRaftIndex` added with raft index, made sure each time we write SubscriptionState to storage its using the new one with raft index
In case we get connection for subscription that was create in older version, it will have raft index of 0

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
