### PR TITLE
RavenDB-21487 Refresh button doesn’t work in Stats window

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/store/statisticsViewSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/store/statisticsViewSlice.ts
@@ -242,26 +242,33 @@ export const statisticsViewSlice = createSlice({
             ) => {
                 state.ui.detailsVisible = false;
 
-                if (state.databaseName !== action.payload.databaseName) {
-                    state.essentialStats = initialState.essentialStats;
-                    state.databaseName = action.payload.databaseName;
+                const payloadLocationIds = action.payload.locations.map((x) => selectId(x));
+                const isForCurrentLocations = _.isEqual(state.databaseDetails.ids, payloadLocationIds);
 
-                    databaseStatsAdapter.setAll(
-                        state.databaseDetails,
-                        action.payload.locations.map((location) => ({
-                            location,
-                            ...createIdleState(),
-                        }))
-                    );
+                const isForCurrentDatabase = state.databaseName === action.payload.databaseName;
 
-                    state.indexDetailsLoadStatus = action.payload.locations.map((location) => ({
-                        location,
-                        loadError: null,
-                        status: "idle",
-                    }));
-
-                    state.indexDetails = indexStatsAdapter.getInitialState();
+                if (isForCurrentDatabase && isForCurrentLocations) {
+                    return;
                 }
+
+                state.essentialStats = initialState.essentialStats;
+                state.databaseName = action.payload.databaseName;
+
+                databaseStatsAdapter.setAll(
+                    state.databaseDetails,
+                    action.payload.locations.map((location) => ({
+                        location,
+                        ...createIdleState(),
+                    }))
+                );
+
+                state.indexDetailsLoadStatus = action.payload.locations.map((location) => ({
+                    location,
+                    loadError: null,
+                    status: "idle",
+                }));
+
+                state.indexDetails = indexStatsAdapter.getInitialState();
             },
             prepare: (databaseName: string, locations: databaseLocationSpecifier[]) => {
                 return {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21487/Refresh-button-doesnt-work-in-Stats-window

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
