### PR TITLE
RavenDB-21595 Can't select responsible node for periodic backup

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editPeriodicBackupTask.ts
@@ -119,7 +119,7 @@ class editPeriodicBackupTask extends shardViewModelBase {
                 });
         };
 
-        return $.when<any>(this.loadServerSideConfiguration())
+        return $.when<any>(this.loadPossibleMentors(), this.loadServerSideConfiguration())
             .then(backupLoader);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21595/Cant-select-responsible-node-for-periodic-backup

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
