### PR TITLE
RavenDB-21251 Queue Sink Views: Remove validation for topic and queue names in Test Area

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueSinkScriptModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueSinkScriptModel.ts
@@ -14,6 +14,7 @@ class ongoingTaskQueueSinkScriptModel {
     documentIdPostfix = ko.observable<string>();
 
     validationGroup: KnockoutValidationGroup;
+    testValidationGroup: KnockoutValidationGroup;
     
     dirtyFlag: () => DirtyFlag;
   
@@ -79,6 +80,11 @@ class ongoingTaskQueueSinkScriptModel {
         this.validationGroup = ko.validatedObservable({
             name: this.name,
             queues: this.queues,
+            script: this.script
+        });
+
+        this.testValidationGroup = ko.validatedObservable({
+            name: this.name,
             script: this.script
         });
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editKafkaSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editKafkaSinkTask.ts
@@ -281,7 +281,7 @@ class editKafkaSinkTask extends viewModelBase {
         
         
         this.test = new kafkaTaskTestMode(this.activeDatabase, () => {
-            return this.isValid(this.editedKafkaSink().editedScriptSandbox().validationGroup);
+            return this.isValid(this.editedKafkaSink().editedScriptSandbox().testValidationGroup);
         }, dtoProvider);
 
         this.test.initObservables();

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqSinkTask.ts
@@ -273,7 +273,7 @@ class editRabbitMqSinkTask extends viewModelBase {
         
         
         this.test = new rabbitMqTaskTestMode(this.activeDatabase, () => {
-            return this.isValid(this.editedRabbitMqSink().editedScriptSandbox().validationGroup);
+            return this.isValid(this.editedRabbitMqSink().editedScriptSandbox().testValidationGroup);
         }, dtoProvider);
 
         this.test.initObservables();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21251/Queue-Sink-Views-Remove-validation-for-topic-and-queue-names-in-Test-Area

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
