### PR TITLE
RavenDB-21604 fix NRE when ClusterState is null

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexStateCommand.cs
@@ -31,12 +31,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.State = State;
+                autoIndex.ClusterState ??= new IndexDefinitionClusterState();
                 autoIndex.ClusterState.LastIndex = etag;
                 autoIndex.ClusterState.LastStateIndex = etag;
             }
             else if (record.Indexes.TryGetValue(IndexName, out IndexDefinition indexDefinition))
             {
                 indexDefinition.State = State;
+                indexDefinition.ClusterState ??= new IndexDefinitionClusterState();
                 indexDefinition.ClusterState.LastIndex = etag;
                 indexDefinition.ClusterState.LastStateIndex = etag;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21604

### Additional description

regression from https://github.com/ravendb/ravendb/pull/15844
So modifying an old index which doesn't `ClusterState` in the definition can cause NRE in 6.0


### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
