### PR TITLE
RavenDB-21417 OLAP ETL View: Remove Document ID Postfix + fix popup

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskElasticSearchEtlTransformationModel.ts
@@ -17,8 +17,6 @@ class ongoingTaskElasticSearchTransformationModel {
     canAddCollection: KnockoutComputed<boolean>;
     applyScriptForAllCollections = ko.observable<boolean>(false);
 
-    documentIdPostfix = ko.observable<string>();
-    
     validationGroup: KnockoutValidationGroup;
 
     dirtyFlag: () => DirtyFlag;
@@ -46,7 +44,6 @@ class ongoingTaskElasticSearchTransformationModel {
             this.resetScript,
             this.applyScriptForAllCollections,
             this.transformScriptCollections,
-            this.documentIdPostfix
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -58,7 +55,7 @@ class ongoingTaskElasticSearchTransformationModel {
                 Disabled: false,
                 Name: name || "",
                 Script: "",
-                DocumentIdPostfix: ""
+                DocumentIdPostfix: null
             }, true, false);
     }
 
@@ -69,7 +66,7 @@ class ongoingTaskElasticSearchTransformationModel {
             Disabled: false,
             Name: this.name(),
             Script: this.script(),
-            DocumentIdPostfix: this.documentIdPostfix()
+            DocumentIdPostfix: null
         }
     }
 
@@ -127,7 +124,6 @@ class ongoingTaskElasticSearchTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean): void {
         this.name(dto.Name);
         this.script(dto.Script);
-        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskOlapEtlTransformationModel.ts
@@ -20,8 +20,6 @@ class ongoingTaskOlapEtlTransformationModel {
     isNew = ko.observable<boolean>(true);
     resetScript = ko.observable<boolean>(false);
 
-    documentIdPostfix = ko.observable<string>();
-    
     validationGroup: KnockoutValidationGroup;
     dirtyFlag: () => DirtyFlag;
     
@@ -48,7 +46,6 @@ class ongoingTaskOlapEtlTransformationModel {
             this.resetScript,
             this.applyScriptForAllCollections,
             this.transformScriptCollections,
-            this.documentIdPostfix
        ], false, jsonUtil.newLineNormalizingHashFunction);
     }
    
@@ -60,7 +57,7 @@ class ongoingTaskOlapEtlTransformationModel {
                 Disabled: false,
                 Name: name || "",
                 Script: "",
-                DocumentIdPostfix: ""
+                DocumentIdPostfix: null
             }, true, false);
     }
 
@@ -71,7 +68,7 @@ class ongoingTaskOlapEtlTransformationModel {
             Disabled: false,
             Name: this.name(),
             Script: this.script(),
-            DocumentIdPostfix: this.documentIdPostfix()
+            DocumentIdPostfix: null
         }
     }
 
@@ -149,7 +146,6 @@ class ongoingTaskOlapEtlTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
         this.name(dto.Name);
         this.script(dto.Script);
-        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueEtlTransformationModel.ts
@@ -16,8 +16,6 @@ class ongoingTaskQueueEtlTransformationModel {
     inputCollection = ko.observable<string>();
     canAddCollection: KnockoutComputed<boolean>;
 
-    documentIdPostfix = ko.observable<string>();
-
     validationGroup: KnockoutValidationGroup; 
     
     dirtyFlag: () => DirtyFlag;
@@ -33,7 +31,6 @@ class ongoingTaskQueueEtlTransformationModel {
             this.resetScript,
             this.applyScriptForAllCollections,
             this.transformScriptCollections,
-            this.documentIdPostfix
             ], 
         false, jsonUtil.newLineNormalizingHashFunction);
     }
@@ -54,7 +51,7 @@ class ongoingTaskQueueEtlTransformationModel {
                 Disabled: false,
                 Name: name || "",
                 Script: "",
-                DocumentIdPostfix: ""
+                DocumentIdPostfix: null
             }, true, false);
     }
 
@@ -65,7 +62,7 @@ class ongoingTaskQueueEtlTransformationModel {
             Disabled: false,
             Name: this.name(),
             Script: this.script(),
-            DocumentIdPostfix: this.documentIdPostfix()
+            DocumentIdPostfix: null
         }
     }
 
@@ -130,7 +127,6 @@ class ongoingTaskQueueEtlTransformationModel {
     private update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean) {
         this.name(dto.Name);
         this.script(dto.Script);
-        this.documentIdPostfix(dto.DocumentIdPostfix);
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);
         

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueSinkScriptModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskQueueSinkScriptModel.ts
@@ -11,8 +11,6 @@ class ongoingTaskQueueSinkScriptModel {
     inputQueue = ko.observable<string>();
     canAddQueue: KnockoutComputed<boolean>;
 
-    documentIdPostfix = ko.observable<string>();
-
     validationGroup: KnockoutValidationGroup;
     
     dirtyFlag: () => DirtyFlag;
@@ -26,7 +24,6 @@ class ongoingTaskQueueSinkScriptModel {
                 this.name,
                 this.script,
                 this.queues,
-                this.documentIdPostfix
             ],
             false, jsonUtil.newLineNormalizingHashFunction);
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlTransformationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlTransformationModel.ts
@@ -17,8 +17,6 @@ class ongoingTaskSqlEtlTransformationModel {
     canAddCollection: KnockoutComputed<boolean>;
     applyScriptForAllCollections = ko.observable<boolean>(false);
 
-    documentIdPostfix = ko.observable<string>();
-    
     validationGroup: KnockoutValidationGroup; 
   
     dirtyFlag: () => DirtyFlag;
@@ -46,7 +44,6 @@ class ongoingTaskSqlEtlTransformationModel {
             this.resetScript,
             this.applyScriptForAllCollections,
             this.transformScriptCollections,
-            this.documentIdPostfix
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
    
@@ -58,7 +55,7 @@ class ongoingTaskSqlEtlTransformationModel {
                 Disabled: false,
                 Name: name || "",
                 Script: "",
-                DocumentIdPostfix: ""
+                DocumentIdPostfix: null
             }, true, false);
     }
 
@@ -69,7 +66,7 @@ class ongoingTaskSqlEtlTransformationModel {
             Disabled: false,
             Name: this.name(),
             Script: this.script(),
-            DocumentIdPostfix: this.documentIdPostfix()
+            DocumentIdPostfix: null
         }
     }
 
@@ -127,7 +124,6 @@ class ongoingTaskSqlEtlTransformationModel {
     update(dto: Raven.Client.Documents.Operations.ETL.Transformation, isNew: boolean, resetScript: boolean): void {
         this.name(dto.Name);
         this.script(dto.Script);
-        this.documentIdPostfix(dto.DocumentIdPostfix);
         
         this.transformScriptCollections(dto.Collections || []);
         this.applyScriptForAllCollections(dto.ApplyToAllDocuments);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -254,13 +254,6 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
-                    <div class="flex-horizontal margin-bottom-sm margin-top-sm" data-bind="validationElement: documentIdPostfix">
-                        <label class="control-label"><strong>Document ID postfix:</strong></label>
-                        <div class="flex-grow margin-left">
-                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
-                        </div>
-                    </div>
                     <div class="margin-bottom-sm margin-top-sm">
                         <div class="flex-horizontal margin-bottom-sm">
                             <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -241,13 +241,6 @@
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
                         </div>
-                        <div class="flex-horizontal margin-bottom-sm margin-top-sm" data-bind="validationElement: documentIdPostfix">
-                            <label class="control-label"><strong>Document ID postfix:</strong></label>
-                            <div class="flex-grow margin-left">
-                                <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
-                            </div>
-                        </div>
                         <div class="margin-bottom-sm margin-top-sm">
                             <div class="flex-horizontal">
                                 <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -271,13 +271,6 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
-                    <div class="flex-horizontal margin-bottom-sm margin-top-sm" data-bind="validationElement: documentIdPostfix">
-                        <label class="control-label"><strong>Document ID postfix:</strong></label>
-                        <div class="flex-grow margin-left">
-                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
-                        </div>
-                    </div>
                     <div class="margin-bottom-sm margin-top-sm">
                         <div class="flex-horizontal margin-bottom-sm">
                             <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -243,13 +243,6 @@
                                 <div class="help-block" data-bind="validationMessage: script"></div>
                             </div>
                         </div>
-                        <div class="flex-horizontal margin-bottom-sm margin-top-sm" data-bind="validationElement: documentIdPostfix">
-                            <label class="control-label"><strong>Document ID postfix:</strong></label>
-                            <div class="flex-grow margin-left">
-                                <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
-                            </div>
-                        </div>
                         <div class="margin-bottom-sm margin-top-sm">
                             <div class="flex-horizontal">
                                 <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -315,13 +315,6 @@
                             <div class="help-block" data-bind="validationMessage: script"></div>
                         </div>
                     </div>
-                    <div class="flex-horizontal margin-bottom-sm margin-top-sm" data-bind="validationElement: documentIdPostfix">
-                        <label class="control-label"><strong>Document ID postfix:</strong></label>
-                        <div class="flex-grow margin-left">
-                            <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                   data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
-                        </div>
-                    </div>
                     <div class="margin-bottom-sm margin-top-sm">
                         <div class="flex-horizontal margin-bottom-sm">
                             <div class="flex-grow">

--- a/src/Raven.Studio/wwwroot/Content/css/bootstrap/popovers.less
+++ b/src/Raven.Studio/wwwroot/Content/css/bootstrap/popovers.less
@@ -41,6 +41,7 @@
 
 .popover-content {
   padding: 9px 14px;
+  word-wrap: break-word;
 }
 
 // Arrows


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21417/OLAP-ETL-View-Remove-Document-ID-Postfix-fix-popup

### Additional description

I decided to replace the values ​​with null rather than modifying the nested types in multiple places

- fixes tooltip word overflow
- removes Document ID postfix everywhere except RavenDB ETL

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/322c9ab3-2453-4b9b-85df-650964643e84)

