### PR TITLE
RavenDB-21378 Cluster dashboard: cluster widget issue when node is down

### DIFF
--- a/src/Raven.Studio/typescript/components/common/LazyLoad.tsx
+++ b/src/Raven.Studio/typescript/components/common/LazyLoad.tsx
@@ -1,7 +1,5 @@
 ﻿import React, { ReactNode } from "react";
 
-import "./LazyLoad.scss";
-
 interface LazyLoadProps {
     children?: ReactNode | ReactNode[];
     active?: boolean;

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/clusterOverviewWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/clusterOverviewWidget.html
@@ -16,17 +16,20 @@
                     <div class="flex-grow">
                         <div class="node-tag">
                             <i class="icon-node-leader text-node" 
-                               data-bind="attr: { class: 'text-node ' + (nodeState() === 'Leader' ? 'icon-node-leader' : 'icon-node') }"></i> 
+                               data-bind="attr: { class: (nodeState() ? 'text-node ' : 'text-muted ') + (nodeState() === 'Leader' ? 'icon-node-leader' : 'icon-node') }"></i> 
                             <span data-bind="text: nodeTag"></span>
+                            
                         </div>
-                        <div class="small-label" data-bind="text: nodeState() ?? '-', css: { 'text-warning' : nodeState() === 'Leader' }"></div>
+                        <div class="small-label d-flex align-items-center">
+                            <span class="global-spinner spinner-xs" data-bind="css:{'hidden': nodeState()}"></span> <span data-bind="text: nodeState() ?? 'Connecting...', css: { 'text-warning' : nodeState() === 'Leader' }"></span>
+                        </div>
                     </div>
-                    <div class="node-type">
+                    <div class="node-type" data-bind="css:{'lazy-load': !nodeType()}">
                         <i data-bind="attr: { class: 'icon-' + iconClass(nodeType()) }"></i>
                         <div class="small-label" data-bind="text: nodeType() ?? '-'"></div>
                     </div>
-                    <div class="node-os" data-toggle="tooltip" data-placement="bottom" data-bind="attr: { title: osName() ?? '-', 'data-original-title': osName() ?? '-' }">
-                        <i data-bind="attr: { class: osIcon() }"></i>
+                    <div class="node-os" data-toggle="tooltip" data-placement="bottom" data-bind="css:{'lazy-load': !osName()},attr: { title: osName() ?? '-', 'data-original-title': osName() ?? '-' }">
+                        <i data-bind="attr: { class: osIcon() ? osIcon() : 'icon-circle' }"></i>
                         <div class="small-label" data-bind="text: osType() ?? '-'"></div>
                     </div>
                     <a class="node-url" target="_blank"
@@ -38,11 +41,15 @@
                 <div class="node-item-details p-3 pt-2">
                     <div class="detail-item" data-bind="attr: { title: 'Start time: ' + (formattedStartTime() ?? '-') }">
                         <div class="detail-label">Uptime:</div>
-                        <div class="detail-value" data-bind="text: formattedUpTime() ?? '-'"></div>
+                        <div class="detail-value" data-bind="css: {'lazy-load': !formattedUpTime() }">
+                            <div data-bind="text: formattedUpTime() ?? '-'"></div>
+                        </div>
                     </div>
                     <div class="detail-item" title="Server version">
                         <div class="detail-label">Version:</div>
-                        <div class="detail-value" data-bind="text: serverVersion() ?? '-'"></div>
+                        <div class="detail-value" data-bind="css: {'lazy-load': !serverVersion() }">
+                            <div data-bind="text: serverVersion() ?? '-'"></div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/Content/css/_bs5.scss
+++ b/src/Raven.Studio/wwwroot/Content/css/_bs5.scss
@@ -57,7 +57,7 @@
 }
 
 @import "../scss/pages/cluster-dashboard.scss";
-
+@import "../../../typescript/components/common/LazyLoad";
 @import "../scss/custom-properties";
 @import "../scss/fonts";
 @import "../scss/main-menu";

--- a/src/Raven.Studio/wwwroot/Content/scss/pages/_cluster-dashboard.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/pages/_cluster-dashboard.scss
@@ -11,6 +11,12 @@
                 display: flex;
                 align-items: flex-end;
 
+                .global-spinner {
+                    margin-top: -4px;
+                    margin-bottom: -3px;
+                    margin-right: $gutter-xxs;
+                }
+
                 .node-tag {
                     flex-grow: 1;
                     font-size: $font-size-lg;
@@ -42,9 +48,14 @@
             }
 
             .node-item-details {
+                display: flex;
+                flex-direction: column;
+                gap: $gutter-xxs;
                 .detail-item {
                     font-size: $font-size-xs;
+                    line-height: $font-size-xs;
                     display: flex;
+                    gap: $gutter-xs;
 
                     .detail-label {
                         font-weight: bold;
@@ -53,7 +64,7 @@
                     }
 
                     .detail-value {
-                        flex-grow: 1;
+                        flex-grow: 0.3;
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21378/Cluster-dashboard-cluster-widget-issue-when-node-is-down

### Additional description

add lazy-loading and spinner, move lazy-load css from component to general bootstrap 5 scss to enable usage in bootstrap 3

_Please delete below the options that are not relevant_

### Type of change

- New feature

### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
