### PR TITLE
RavenDB-21611: register client certificate setup wizard only if needed

### DIFF
--- a/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
@@ -115,7 +115,8 @@ public static class SetupWizardUtils
                 throw new InvalidOperationException($"Failed to generate a client certificate for '{domain}'.", e);
             }
 
-            parameters.RegisterClientCertInOs?.Invoke(parameters.OnProgress, parameters.Progress, clientCert);
+            if (parameters.SetupInfo.RegisterClientCert)
+                parameters.RegisterClientCertInOs?.Invoke(parameters.OnProgress, parameters.Progress, clientCert);
 
             return new CompleteClusterConfigurationResult
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21611

### Additional description
we have a lot of certificates stack up on the eagle machines, it appears to be regression

### Type of change

- Regression bug fix
https://github.com/ravendb/ravendb/pull/13563

### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
