### PR TITLE
RavenDB-21593 Using HTTP2 for connections created by the server

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -47,9 +47,10 @@ namespace Raven.Client.Documents.Conventions
             SendApplicationIdentifier = false,
             MaxContextSizeToKeep = new Size(PlatformDetails.Is32Bits == false ? 8 : 2, SizeUnit.Megabytes),
 #if NETCOREAPP3_1_OR_GREATER
-            HttpPooledConnectionLifetime = TimeSpan.FromMinutes(19)
+            HttpPooledConnectionLifetime = TimeSpan.FromMinutes(19),
+            HttpVersion = System.Net.HttpVersion.Version20
 #endif
-        };
+    };
 
         private static readonly bool DefaultDisableTcpCompression = false;
 
@@ -163,6 +164,22 @@ namespace Raven.Client.Documents.Conventions
                 DefaultForServer.HttpPooledConnectionLifetime = httpPooledConnectionLifetime < 0
                     ? null
                     : TimeSpan.FromSeconds(httpPooledConnectionLifetime);
+            }
+
+            var httpVersionAsString = Environment.GetEnvironmentVariable("RAVEN_HTTP_VERSION");
+            if (httpVersionAsString != null)
+            {
+                Version httpVersion;
+                try
+                {
+                    httpVersion = Version.Parse(httpVersionAsString);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException($"Could not parse 'RAVEN_HTTP_VERSION' env variable with value '{httpVersionAsString}'.", e);
+                }
+
+                DefaultForServer.HttpVersion = httpVersion;
             }
 #endif
 


### PR DESCRIPTION
It applies to cluster request executor and a request executor used by Raven ETL. Introducing env variable that will allow to change it if needed.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21593

### Additional description

This mostly applies to sending raft commands from a non leader node to a leader. In particular this might affect users using heavily the cluster wide transactions. The benefit is that we take advantage of HTTP2 multiplexing feature.  We don't create large number of connections so we reduce the number of ssl context creations `System.Net.Security!Interop+Ssl.SslCtxCreate(int)`:

```
"System.Net.Security!Interop+Ssl.SslCtxCreate(int)",
        "System.Net.Security!Interop+OpenSsl.AllocateSslContext(class System.Net.Security.SslAuthenticationOptions,value class System.Security.Authentication.SslProtocols,bool)",
        "System.Net.Security!Interop+OpenSsl.AllocateSslHandle(class System.Net.Security.SslAuthenticationOptions)",
        "System.Net.Security!System.Net.Security.SslStreamPal.HandshakeInternal(class System.Net.Security.SafeDeleteSslContext&,value class System.ReadOnlySpan`1<unsigned int8>,unsigned int8[]&,class System.Net.Security.SslAuthenticationOptions,class System.Net.Security.SelectClientCertificate)",
"System.Net.Security!System.Net.Security.SslStream.GenerateToken(value class System.ReadOnlySpan`1<unsigned int8>,unsigned int8[]&)",
        "System.Net.Security!System.Net.Security.SslStream.NextMessage(value class System.ReadOnlySpan`1<unsigned int8>)",
        "System.Net.Security!System.Net.Security.SslStream+<ForceAuthenticationAsync>d__146`1[System.Net.Security.AsyncReadWriteAdapter].MoveNext()",
        "System.Private.CoreLib!System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&)",
        "System.Net.Http!System.Net.Http.ConnectHelper+<EstablishSslConnectionAsync>d__2.MoveNext()",
        "System.Private.CoreLib!System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start(!!0&)",
        "System.Net.Http!System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(class System.Net.Security.SslClientAuthenticationOptions,class System.Net.Http.HttpRequestMessage,bool,class System.IO.Stream,value class System.Threading.CancellationToken)",
        "System.Net.Http!System.Net.Http.HttpConnectionPool+<ConnectAsync>d__100.MoveNext()"
```

On the server side we use two types of request executors - cluster request executor and request executors used by Raven ETLs. This change will modify both.

In version 6.0 we already use HTTP2 since it's the default there - https://github.com/ravendb/ravendb/pull/13932

There is `RAVEN_HTTP_VERSION` env variable which allows to modify the default.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team
 - This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
