### PR TITLE
RavenDB-21242 - Add server side validation for adding unused database ids

### DIFF
--- a/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.Documents.Operations
             return new GetStatisticsCommand(_debugTag, _nodeTag);
         }
 
-        private class GetStatisticsCommand : RavenCommand<DatabaseStatistics>
+        internal class GetStatisticsCommand : RavenCommand<DatabaseStatistics>
         {
             private readonly string _debugTag;
 

--- a/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
@@ -26,6 +26,11 @@ namespace Raven.Client.ServerWide.Operations
             };
         }
 
+        public UpdateUnusedDatabasesOperation(string database, HashSet<string> unusedDatabaseIds, bool validate) : this(database, unusedDatabaseIds)
+        {
+            _parameters.Validate = validate;
+        }
+
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
             return new UpdateUnusedDatabasesCommand(_database, _parameters);
@@ -45,6 +50,8 @@ namespace Raven.Client.ServerWide.Operations
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/admin/databases/unused-ids?name={_database}";
+                if (_parameters.Validate.HasValue)
+                    url += $"&validate={_parameters.Validate}";
 
                 return new HttpRequestMessage
                 {
@@ -59,6 +66,7 @@ namespace Raven.Client.ServerWide.Operations
         internal class Parameters
         {
             public HashSet<string> DatabaseIds { get; set; }
+            public bool? Validate { get; set; } = null;
         }
     }
 }

--- a/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/UpdateUnusedDatabasesOperation.cs
@@ -50,8 +50,8 @@ namespace Raven.Client.ServerWide.Operations
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/admin/databases/unused-ids?name={_database}";
-                if (_parameters.Validate.HasValue)
-                    url += $"&validate={_parameters.Validate}";
+                if (_parameters.Validate)
+                    url += $"&validate=true";
 
                 return new HttpRequestMessage
                 {
@@ -66,7 +66,7 @@ namespace Raven.Client.ServerWide.Operations
         internal class Parameters
         {
             public HashSet<string> DatabaseIds { get; set; }
-            public bool? Validate { get; set; } = null;
+            public bool Validate { get; set; }
         }
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1202,18 +1202,71 @@ namespace Raven.Server.Web.System
         public async Task SetUnusedDatabaseIds()
         {
             var database = GetStringQueryString("name");
+            var validate = GetBoolValueQueryString("validate", required: false);
+
             await ServerStore.EnsureNotPassiveAsync();
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var json = await context.ReadForDiskAsync(RequestBodyStream(), "unused-databases-ids"))
             {
                 var parameters = JsonDeserializationServer.Parameters.UnusedDatabaseParameters(json);
+                if (validate.HasValue && validate.Value)
+                {
+                    var token = CreateHttpRequestBoundTimeLimitedOperationToken(ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                    await ValidateUnusedIdsAsync(parameters.DatabaseIds, database, token.Token);
+                }
+
                 var command = new UpdateUnusedDatabaseIdsCommand(database, parameters.DatabaseIds, GetRaftRequestIdFromQuery());
                 await ServerStore.SendToLeaderAsync(command);
             }
 
             NoContentStatus();
         }
+
+        private async Task ValidateUnusedIdsAsync(HashSet<string> unusedIds, string databaseName, CancellationToken token)
+        {
+            DatabaseTopology topology;
+            ClusterTopology clusterTopology;
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            using (var rawRecord = ServerStore.Cluster.ReadRawDatabaseRecord(context, databaseName))
+            {
+                topology = rawRecord.Topology;
+                clusterTopology = ServerStore.GetClusterTopology(context);
+            }
+
+            if(unusedIds.Contains(topology.DatabaseTopologyIdBase64))
+                throw new InvalidOperationException($"'DatabaseTopologyIdBase64' ({topology.DatabaseTopologyIdBase64}) cannot be added to the 'unused ids' list (of '{databaseName}').");
+
+            if(unusedIds.Contains(topology.ClusterTransactionIdBase64))
+                throw new InvalidOperationException($"'ClusterTransactionIdBase64' ({topology.ClusterTransactionIdBase64}) cannot be added to the 'unused ids' list (of '{databaseName}').");
+
+            var nodesUrls = clusterTopology.AllNodes
+                .Where((kvp) => topology.AllNodes.Contains(kvp.Key))
+                .Select(kvp => kvp.Value)
+            .ToArray();
+
+            using var requestExecutor = RequestExecutor.Create(nodesUrls, databaseName, Server.Certificate.Certificate, DocumentConventions.Default);
+
+            foreach (var nodeTag in topology.AllNodes)
+            {
+                using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
+                {
+                    var cmd = new GetStatisticsOperation.GetStatisticsCommand(null, nodeTag);
+                    await requestExecutor.ExecuteAsync(cmd, context); //, token: token);
+                    var stats = cmd.Result;
+
+                    if (unusedIds.Contains(stats.DatabaseId))
+                    {
+                        throw new InvalidOperationException(
+                            $"'{stats.DatabaseId}' cannot be added to the 'unused ids' list (of '{databaseName}'), because it's the database id of '{databaseName}' on node {nodeTag}.");
+                    }
+                }
+            }
+
+        }
+
+
 
         [RavenAction("/admin/migrate", "POST", AuthorizationStatus.Operator, DisableOnCpuCreditsExhaustion = true)]
         public async Task MigrateDatabases()

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1202,7 +1202,7 @@ namespace Raven.Server.Web.System
         public async Task SetUnusedDatabaseIds()
         {
             var database = GetStringQueryString("name");
-            var validate = GetBoolValueQueryString("validate", required: false);
+            var validate = GetBoolValueQueryString("validate", required: false) ?? false;
 
             await ServerStore.EnsureNotPassiveAsync();
 
@@ -1210,7 +1210,7 @@ namespace Raven.Server.Web.System
             using (var json = await context.ReadForDiskAsync(RequestBodyStream(), "unused-databases-ids"))
             {
                 var parameters = JsonDeserializationServer.Parameters.UnusedDatabaseParameters(json);
-                if (validate.HasValue && validate.Value)
+                if (validate)
                 {
                     using (var token = CreateHttpRequestBoundTimeLimitedOperationToken(ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan))
                         await ValidateUnusedIdsAsync(parameters.DatabaseIds, database, token.Token);

--- a/src/Raven.Studio/typescript/commands/database/settings/saveUnusedDatabaseIDsCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/saveUnusedDatabaseIDsCommand.ts
@@ -9,7 +9,8 @@ class saveUnusedDatabaseIDsCommand extends commandBase {
 
     execute(): JQueryPromise<void> {
         const args = {
-            name: this.dbName
+            name: this.dbName,
+            validate: true
         }
 
         const url = endpoints.global.adminDatabases.adminDatabasesUnusedIds + this.urlEncodeArgs(args);

--- a/src/Raven.Studio/typescript/viewmodels/database/advanced/databaseIDs.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/advanced/databaseIDs.ts
@@ -130,7 +130,9 @@ class databaseIDs extends viewModelBase {
     }
 
     addInputToUnusedList() {
-        this.addWithBlink(this.inputDatabaseId());
+        const databaseId = this.inputDatabaseId().trim();
+        this.addWithBlink(databaseId);
+        this.inputDatabaseId("");
     }
     
     addToUnusedList(cvEntry: string) {

--- a/test/SlowTests/Issues/RavenDB-21242.cs
+++ b/test/SlowTests/Issues/RavenDB-21242.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Monitoring.Snmp;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21242 : ClusterTestBase
+    {
+        public RavenDB_21242(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task ShouldValidateUnusedIds()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+            using var store = GetDocumentStore(new Options()
+            {
+                Server = leader,
+                ReplicationFactor = 3
+            });
+            var database = store.Database;
+
+            // WaitForUserToContinueTheTest(store);
+
+            var unusedIds = new List<string>();
+
+            foreach (var node in nodes)
+            {
+                var dbId = await GetDbId(node, database);
+                unusedIds.Add(dbId);
+            }
+            using (leader.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            using (var rawRecord = leader.ServerStore.Cluster.ReadRawDatabaseRecord(context, database))
+            {
+                var topology = rawRecord.Topology;
+                unusedIds.Add(topology.DatabaseTopologyIdBase64);
+                unusedIds.Add(topology.ClusterTransactionIdBase64);
+            }
+
+            foreach(var dbId in unusedIds)
+            {
+                var cmd = new UpdateUnusedDatabasesOperation(store.Database,
+                    new HashSet<string> { dbId }, validate: true);
+
+                var e = await Assert.ThrowsAsync<RavenException>(() => store.Maintenance.Server.SendAsync(cmd));
+                Assert.True(e.InnerException is InvalidOperationException);
+            }
+        }
+
+        private async Task<string> GetDbId(RavenServer ravenServer, string database)
+        {
+            var db = await ravenServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            return db.DocumentsStorage.Environment.Base64Id;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21242/Add-server-side-validation-for-adding-unused-database-ids

### Additional description

Add server side (optional) validation for adding unused database ids.
We validate that the unused ids arent ids of the db instances (in all of the nodes in the database topology).
We also need to valid not to add the IDs of DatabaseTopologyIdBase64 & the ClusterTransactionIdBase64.

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- UI work is needed
