### PR TITLE
RavenDB-13397 Better error message when opening encrypted data with the usage of unencrypted storage

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -514,6 +514,9 @@ namespace Voron.Impl.Journal
             }
             else
             {
+                if ((current->Flags & TransactionPersistenceModeFlags.Encrypted) == TransactionPersistenceModeFlags.Encrypted)
+                    throw new InvalidOperationException("Encountered an encrypted transaction when opening a non encrypted storage. Did you forget to provide the encryption key?");
+
                 hashIsValid = ValidatePagesHash(options, current);
             }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13397

### Additional description

Detecting earlier that we have an encrypted transaction but we don't have encryption key so we might throw better error

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
