### PR TITLE
RavneDB-21553 - Starting speed test when the toplogy nodes didn't change

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
@@ -9,7 +10,7 @@ namespace Raven.Client.Http
 {
     public class NodeSelector : IDisposable
     {
-        private class NodeSelectorState
+        internal class NodeSelectorState
         {
             public readonly Topology Topology;
             public readonly List<ServerNode> Nodes;
@@ -28,6 +29,43 @@ namespace Raven.Client.Http
                 UnlikelyEveryoneFaultedChoiceIndex = 0;
             }
 
+            public NodeSelectorState(Topology topology, NodeSelectorState prevState)
+            {
+                Topology = topology;
+                Nodes = topology.Nodes;
+                Failures = new int[topology.Nodes.Count];
+                FastestRecords = new int[topology.Nodes.Count];
+                UnlikelyEveryoneFaultedChoiceIndex = 0;
+
+                var fastestNode = prevState.Nodes.ElementAt(Fastest);
+                int index = 0;
+                foreach (var node in topology.Nodes)
+                {
+                    if (node.ClusterTag == fastestNode.ClusterTag)
+                    {
+                        Fastest = index;
+                        break;
+                    }
+
+                    index++;
+                }
+                
+                // fastest node was not found in the new topology. enable speed tests
+                if (index >= topology.Nodes.Count)
+                {
+                    SpeedTestMode = 2;
+                }
+                else
+                {
+                    // we might be in the process of finding fastest node when we reorder the nodes, we don't want the tests to stop until we reach 10
+                    // otherwise, we want to stop the tests and they may be scheduled later on relevant topology change
+                    if (Fastest < prevState.FastestRecords.Length && prevState.FastestRecords[Fastest] < 10)
+                    {
+                        SpeedTestMode = prevState.SpeedTestMode;
+                    }
+                }
+            }
+
             public ValueTuple<int, ServerNode> GetNodeWhenEveryoneMarkedAsFaulted()
             {
                 int index = UnlikelyEveryoneFaultedChoiceIndex;
@@ -40,7 +78,7 @@ namespace Raven.Client.Http
 
         private Timer _updateFastestNodeTimer;
 
-        private NodeSelectorState _state;
+        internal NodeSelectorState _state;
 
         public NodeSelector(Topology topology)
         {
@@ -64,8 +102,8 @@ namespace Raven.Client.Http
             if (_state.Topology.Etag >= topology.Etag && forceUpdate == false)
                 return false;
 
-            var state = new NodeSelectorState(topology);
-
+            var state = new NodeSelectorState(topology, _state);
+            
             Interlocked.Exchange(ref _state, state);
 
             return true;
@@ -233,6 +271,7 @@ namespace Raven.Client.Http
             if (Interlocked.Increment(ref stateFastest[index]) >= 10)
             {
                 SelectFastest(state, index);
+                return;
             }
 
             if (Interlocked.Increment(ref state.SpeedTestMode) <= state.Nodes.Count * 10)

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -29,14 +29,14 @@ namespace Raven.Client.Http
                 UnlikelyEveryoneFaultedChoiceIndex = 0;
             }
 
-            public NodeSelectorState(Topology topology, NodeSelectorState prevState)
+            public NodeSelectorState(Topology topology, NodeSelectorState prevState) : this(topology)
             {
-                Topology = topology;
-                Nodes = topology.Nodes;
-                Failures = new int[topology.Nodes.Count];
-                FastestRecords = new int[topology.Nodes.Count];
-                UnlikelyEveryoneFaultedChoiceIndex = 0;
-                
+                if (prevState.Fastest < 0 || prevState.Fastest >= prevState.Nodes.Count)
+                {
+                    Debug.Assert(false, "Fastest is out of range of Nodes in NodeSelectorState");
+                    return;
+                }
+
                 var fastestNode = prevState.Nodes.ElementAt(prevState.Fastest);
                 int index = 0;
                 foreach (var node in topology.Nodes)

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -36,8 +36,8 @@ namespace Raven.Client.Http
                 Failures = new int[topology.Nodes.Count];
                 FastestRecords = new int[topology.Nodes.Count];
                 UnlikelyEveryoneFaultedChoiceIndex = 0;
-
-                var fastestNode = prevState.Nodes.ElementAt(Fastest);
+                
+                var fastestNode = prevState.Nodes.ElementAt(prevState.Fastest);
                 int index = 0;
                 foreach (var node in topology.Nodes)
                 {

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -102,7 +102,7 @@ namespace Raven.Client.Http
 
         private Timer _updateTopologyTimer;
 
-        protected NodeSelector _nodeSelector;
+        protected internal NodeSelector _nodeSelector;
 
         private TimeSpan? _defaultTimeout;
 
@@ -540,7 +540,7 @@ namespace Raven.Client.Http
             else if (_nodeSelector.OnUpdateTopology(topology, forceUpdate))
             {
                 DisposeAllFailedNodesTimers();
-                if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
+                if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode && _nodeSelector.InSpeedTestPhase)
                 {
                     _nodeSelector.ScheduleSpeedTest();
                 }

--- a/test/SlowTests/Issues/RavenDB_21553.cs
+++ b/test/SlowTests/Issues/RavenDB_21553.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21553 : ClusterTestBase
+    {
+        public RavenDB_21553(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task Topology_Change_Shouldnt_Trigger_SpeedTest()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+
+            using (var leaderStore = GetDocumentStore(new Options
+            {
+                ReplicationFactor = 3,
+                ModifyDocumentStore = s => s.Conventions.ReadBalanceBehavior = ReadBalanceBehavior.FastestNode,
+                Server = leader
+            }))
+            {
+                List<string> originalNodesOrder = new() { "A", "B", "C" };
+                originalNodesOrder.Shuffle();
+                
+                var speedTestsCount = 0;
+                int scheduledSpeedTestsBeforeStopping;
+                var re = leaderStore.GetRequestExecutor();
+
+                await leaderStore.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(leaderStore.Database, originalNodesOrder));
+
+                re.ForTestingPurposesOnly().ExecuteOnAllToFigureOutTheFastestOnBeforeWait = t => Interlocked.Increment(ref speedTestsCount);
+               
+                using (var session = leaderStore.OpenAsyncSession())
+                {
+                    // first node to reach 10 winning speed tests is the fastest. at that point we stop scheduling any more
+                    for (var i = 0; i <= 10 * 3; i++)
+                    {
+                        await session.Query<object>().ToListAsync();
+                        if (re._nodeSelector?._state?.FastestRecords.Any(x => x >= 10) == true)
+                        {
+                            break;
+                        }
+                    }
+                    
+                    Assert.True(speedTestsCount >= 10);
+                    scheduledSpeedTestsBeforeStopping = speedTestsCount;
+                }
+                
+                // speed tests should no longer happen
+                using (var session = leaderStore.OpenAsyncSession())
+                {
+                    await session.Query<object>().ToListAsync();
+                    Assert.Equal(scheduledSpeedTestsBeforeStopping, speedTestsCount);
+                }
+                
+                //reordering should not trigger new speed tests any more since we check the fastest node still exists in the topology
+                originalNodesOrder.Shuffle();
+                await leaderStore.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(leaderStore.Database, originalNodesOrder));
+                
+                using (var session = leaderStore.OpenAsyncSession())
+                {
+                    await session.Query<object>().ToListAsync();
+                    Assert.Equal(scheduledSpeedTestsBeforeStopping, speedTestsCount);
+                }
+                
+                originalNodesOrder.Shuffle();
+                await leaderStore.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(leaderStore.Database, originalNodesOrder));
+                
+                using (var session = leaderStore.OpenAsyncSession())
+                {
+                    await session.Query<object>().ToListAsync();
+                    Assert.Equal(scheduledSpeedTestsBeforeStopping, speedTestsCount);
+                }
+
+                var state = re._nodeSelector._state;
+                var fastestNode = state.Nodes[state.Fastest];
+                
+                //will trigger new speed tests
+                await leaderStore.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(leaderStore.Database, true, fromNode: fastestNode.ClusterTag));
+
+                //wait until db is fully removed from node
+                var removedServer = nodes.Single(x => x.ServerStore.NodeTag == fastestNode.ClusterTag);
+                await AssertWaitForTrueAsync(async () =>
+                {
+                    try
+                    {
+                        await Databases.GetDocumentDatabaseInstanceFor(removedServer, leaderStore);
+                    }
+                    catch (DatabaseNotRelevantException)
+                    {
+                        return true;
+                    }
+                    return false;
+                });
+                
+                using (var session = leaderStore.OpenAsyncSession())
+                {
+                    await session.Query<object>().ToListAsync();
+                    await session.Query<object>().ToListAsync();
+                    
+                    await AssertWaitForTrueAsync(() => Task.FromResult(re._nodeSelector._state.Nodes.Count == 2));
+
+                    await AssertWaitForTrueAsync(() => Task.FromResult(speedTestsCount > scheduledSpeedTestsBeforeStopping));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21553

### Additional description

Issue: Speed tests would run anew on every topology change even if the topology change was irrelevant - fastest node still existed in the changed topology (if we reorder nodes for example).

Changed so on the topology node update we check if the current fastest node exists in the new topology.
If it does not exists we set `SpeedTestMode = 2` which will enable the testing.
If we are in the middle of running tests (haven't reached 10 tests yet), we will set `SpeedTestMode` to be its previous state (no change).
Otherwise we can assume the topology change is irrelevant, we set `SpeedTestMode = 0` and the test will be enabled if needed further down the line (or when the speed test timer activates).

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
