### PR TITLE
RavenDB-13970 : adding certificate late for external replication 

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1484,9 +1484,11 @@ namespace Raven.Server
             public X509Certificate2 Certificate;
             public CertificateDefinition Definition;
             public int WrittenToAuditLog;
+            public readonly DateTime CreatedAt;
 
             public AuthenticateConnection()
             {
+                CreatedAt = SystemTime.UtcNow;
             }
 
             public bool CanAccess(string database, bool requireAdmin, bool requireWrite)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -13,7 +13,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Lucene.Net.Search;
-using Microsoft.Extensions.Caching.Memory;
 using NCrontab.Advanced;
 using NCrontab.Advanced.Extensions;
 using Raven.Client;
@@ -50,7 +49,6 @@ using Raven.Server.Documents.Indexes.Sorting;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Indexing;
 using Raven.Server.Integrations.PostgreSQL.Commands;
 using Raven.Server.Json;
 using Raven.Server.Monitoring;
@@ -149,6 +147,8 @@ namespace Raven.Server.ServerWide
         public Operations Operations { get; }
 
         public CatastrophicFailureNotification CatastrophicFailureNotification { get; }
+
+        public DateTime? LastCertificateUpdateTime { get; private set; }
 
         public ServerStore(RavenConfiguration configuration, RavenServer server)
         {
@@ -1217,6 +1217,9 @@ namespace Raven.Server.ServerWide
                     LicenseManager.ReloadLicenseLimits();
                     ConcurrentBackupsCounter.ModifyMaxConcurrentBackups();
                     NotifyAboutClusterTopologyAndConnectivityChanges();
+                    break;
+                case nameof(PutCertificateCommand):
+                    LastCertificateUpdateTime = SystemTime.UtcNow;
                     break;
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13970/Validate-adding-cert-late-for-external-replication

### Additional description

- when adding certificate late for external replication (i.e. source cert is registered in destination only after the external replication task was created), replication doesn't start immediately after registering the certificate.
- it takes 19 minutes from the time that the replication task was created until it starts sending data,
and until then the source keeps getting an `AuthorizationException` 
- this happens because we're using the same connection for 19 minutes : https://github.com/ravendb/ravendb/blob/v5.4/src/Raven.Client/Documents/Conventions/DocumentConventions.cs#L50
- when a connection starts `HttpsConnectionMiddleware.OnConnectionAsync`  is triggered, which checks the certificate of the incoming connection and saves the authentication status in the connection context. 
- if the source certificate was unknown to the destination at that time, then all future requests that are using this connection will fail 

fix :
- add `LastCertificateUpdateTime` to server store, and update it after every `PutCertificateCommand`
- add `CreatedAt` date time to `RavenServer.AuthenticateConnection` 
- in `RequestRouter.TryAuthorizeAsync` - retry to authenticate a connection with unfamiliar certificate if a new certificate was added to the server since the last time we authenticated this connection

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
