### PR TITLE
RavenDB-21599 : fix failing interversion test CanExportFromCurrentAndImportTo54X

### DIFF
--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -297,7 +297,8 @@ namespace InterversionTests
             using var store54 = await GetDocumentStoreAsync(Server54Version);
             using var storeCurrent = GetDocumentStore(options);
 
-            await InsertDataAndExecuteExportImportAsync(storeCurrent, store54);
+            var exportOptions = new DatabaseSmugglerExportOptions { CompressionAlgorithm = ExportCompressionAlgorithm.Gzip };
+            await InsertDataAndExecuteExportImportAsync(storeCurrent, store54, exportOptions);
             await GetStatsAndAssertAsync(storeCurrent, store54);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21599/InterversionTests.SmugglerTests.CanExportFromCurrentAndImportTo54Xoptions-DatabaseMode-Single-SearchEngineMode-Lucene

### Additional description

export using `gzip` compression algorithm

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 