### PR TITLE
RavenDB-21521 & RavenDB-21596: Properly handle term reference count.

### DIFF
--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -78,7 +78,7 @@ public struct DoubleLookupKey : ILookupKey
     {
     }
 
-    public void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    public void PreventTermRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey
     {
     }
 

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -25,7 +25,7 @@ public interface ILookupKey
 
     void OnKeyRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey;
     
-    void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey;
+    void PreventTermRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey;
     
     string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey;
 }

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -77,7 +77,7 @@ public struct Int64LookupKey : ILookupKey
     {
     }
 
-    public void IncreaseReferenceCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    public void PreventTermRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey
     {
     }
 

--- a/test/SlowTests/Issues/RavenDB-21399-2.cs
+++ b/test/SlowTests/Issues/RavenDB-21399-2.cs
@@ -1,9 +1,14 @@
-﻿using FastTests.Voron;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
+using Voron.Impl;
 using Xunit;
 using Xunit.Abstractions;
+using Random = System.Random;
 
 namespace SlowTests.Issues;
 
@@ -87,6 +92,8 @@ public class RavenDB_21399_2 : StorageTest
             lookup.Add(k++, 0);
         }
 
+
+        lookup.Render();
         // here we wait to add *another* page to the right most branch, so we'll have:
         // * Root
         // * * Branch - min value
@@ -122,7 +129,7 @@ public class RavenDB_21399_2 : StorageTest
         CompactTree tree = wtx.CompactTreeFor($"test");
         var lookup = tree._inner;
         long k = 1;
-        
+
         while (lookup.State.BranchPages < 4)
         {
             tree.Add($"{k}", k++);
@@ -132,5 +139,88 @@ public class RavenDB_21399_2 : StorageTest
         {
             tree.TryRemove($"{--k}", out _);
         }
+    }
+
+   [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Corax)]
+   [InlineData(1274580600)]
+    public void RemoveBranchAndMoveAllItemsIntoAnother(int seed)
+    {
+        using var wtx = Env.WriteTransaction();
+        CompactTree tree = wtx.CompactTreeFor($"test");
+        var lookup = tree._inner;
+        long k = 0;
+        while (lookup.State.BranchPages < 4)
+        {
+            tree.Add($"{k}", k++);
+        }
+
+        var list = Enumerable.Range(0, (int)k).ToList();
+        var random = new Random(seed);
+        
+        while (list.Count > 0)
+        {
+            var index = random.Next(0, list.Count);
+            var elementToRemove = list[index];
+            Assert.True(tree.TryRemove($"{elementToRemove}", out _));
+            list.RemoveAt(index);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Corax)]
+    [InlineData(228422771, 2000, 5_834_460)]
+    public void TermWillNotHitMaximumReferenceCount(int seed, int maximumElements, long operationCount)
+    {
+        Transaction wtx = null;
+        try
+        {
+            wtx = Env.WriteTransaction();
+            CompactTree tree = wtx.CompactTreeFor($"test");
+            var lookup = tree._inner;
+            var buffer = new long[maximumElements];
+            List<int> currentIndex = new();
+            List<int> freeElements = Enumerable.Range(0, maximumElements).Select(x => x).ToList();
+            var random = new Random(seed);
+            var counter = operationCount;
+            while (counter >= 0)
+            {
+                counter--;
+
+                var action = (Action)(Math.Abs(random.Next()) % 2);
+                if (action is Action.Add && freeElements.Count > 0)
+                {
+                    var indexOfElementToUpdate = random.Next(0, freeElements.Count);
+                    var elementToInsert = freeElements[indexOfElementToUpdate];
+                    freeElements.RemoveAt(indexOfElementToUpdate);
+                    tree.Add($"{elementToInsert}", elementToInsert);
+                    currentIndex.Add(elementToInsert);
+                }
+                else if (action is Action.Remove && currentIndex.Count > 0)
+                {
+                    var indexOfElementToRemove = random.Next(0, currentIndex.Count);
+                    var elementToRemove = currentIndex[indexOfElementToRemove];
+                    currentIndex.RemoveAt(indexOfElementToRemove);
+                    freeElements.Add(elementToRemove);
+                    Assert.True(tree.TryRemove($"{elementToRemove}", out var value));
+                }
+
+                if (lookup.CheckTreeStructureChanges().Changed)
+                {
+                    wtx.Commit();
+                    wtx = Env.WriteTransaction();
+                    tree = wtx.CompactTreeFor($"test");
+                    lookup = tree._inner;
+                }
+            }
+        }
+        finally
+        {
+            wtx?.Dispose();
+        }
+    }
+
+    private enum Action : int
+    {
+        Add = 0,
+        Remove = 1
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21521
https://issues.hibernatingrhinos.com/issue/RavenDB-21596

### Additional description

Contains two fixes:
- when removing a branch and moving all its leaves into another we've to increase the first term counter since it will be an identifier of a new leaf.

- case of RavenDB-21596: increase term counter only if it's equal to 1. This way we prevent deletion when moving the term to another leaf but we are not invalidating data if the term is used more than 1 (like it's also in a branch e.g.) 

### Type of change

- Bug fix
- Regression bug fix

### How risky is the change?


- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
