### PR TITLE
RavenDB-21523 fixing zstd with no compression

### DIFF
--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -73,7 +73,7 @@ internal static class BackupUtils
                 return new GZipStream(stream, compressionLevel, leaveOpen: true);
             case ExportCompressionAlgorithm.Zstd:
                 if (compressionLevel == CompressionLevel.NoCompression)
-                    return stream;
+                    return new LeaveOpenStream(stream);
 
                 return ZstdStream.Compress(stream, compressionLevel, leaveOpen: true);
             default:

--- a/src/Raven.Server/Utils/LeaveOpenStream.cs
+++ b/src/Raven.Server/Utils/LeaveOpenStream.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Raven.Server.Utils;
+
+public sealed class LeaveOpenStream : Stream
+{
+    private readonly Stream _inner;
+
+    public LeaveOpenStream(Stream inner)
+    {
+        _inner = inner;
+    }
+
+    public override void Flush()
+    {
+        throw new NotSupportedException();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        return _inner.FlushAsync(cancellationToken);
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        return _inner.Read(buffer);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return _inner.Read(buffer, offset, count);
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        return _inner.ReadAsync(buffer, cancellationToken);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        return _inner.Seek(offset, origin);
+    }
+
+    public override void SetLength(long value)
+    {
+        _inner.SetLength(value);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _inner.Write(buffer);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _inner.Write(buffer, offset, count);
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return _inner.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = new CancellationToken())
+    {
+        return _inner.WriteAsync(buffer, cancellationToken);
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => _inner.CanWrite;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+
+        set => _inner.Position = value;
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21523.cs
+++ b/test/SlowTests/Issues/RavenDB_21523.cs
@@ -15,6 +15,7 @@ using Sparrow.Backups;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 using Tests.Infrastructure;
+using Voron.Impl.Backup;
 using Xunit;
 using Xunit.Abstractions;
 using BackupUtils = Raven.Server.Utils.BackupUtils;
@@ -28,7 +29,6 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
-    [InlineData(null, null)]
     [InlineData(null, null)]
     [InlineData(ExportCompressionAlgorithm.Gzip, null)]
     [InlineData(ExportCompressionAlgorithm.Zstd, null)]
@@ -170,6 +170,7 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
+    [InlineData(null, null)]
     [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.Optimal)]
     [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.Optimal)]
     [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.Fastest)]
@@ -177,6 +178,7 @@ public class RavenDB_21523 : RavenTestBase
     [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.SmallestSize)]
     [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.SmallestSize)]
     [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.NoCompression)]
+    [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.NoCompression)]
     public async Task CanBackupRestore(BackupCompressionAlgorithm algorithm, CompressionLevel compressionLevel)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -207,7 +209,10 @@ public class RavenDB_21523 : RavenTestBase
                                 Assert.IsType<GZipStream>(backupStream);
                                 break;
                             case BackupCompressionAlgorithm.Zstd:
-                                Assert.IsType<ZstdStream>(backupStream);
+                                if (compressionLevel == CompressionLevel.NoCompression)
+                                    Assert.IsType<BackupStream>(backupStream);
+                                else
+                                    Assert.IsType<ZstdStream>(backupStream);
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null);
@@ -219,14 +224,16 @@ public class RavenDB_21523 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.BackupExportImport)]
-    [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.Optimal)]
-    [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.Optimal)]
-    [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.Fastest)]
-    [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.Fastest)]
-    [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.SmallestSize)]
-    [InlineData(BackupCompressionAlgorithm.Zstd, CompressionLevel.SmallestSize)]
-    [InlineData(BackupCompressionAlgorithm.Gzip, CompressionLevel.NoCompression)]
-    public async Task CanSnapshotRestore(SnapshotBackupCompressionAlgorithm algorithm, CompressionLevel compressionLevel)
+    [InlineData(null, null)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate, CompressionLevel.Optimal)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel.Optimal)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate, CompressionLevel.Fastest)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel.Fastest)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate, CompressionLevel.SmallestSize)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel.SmallestSize)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate, CompressionLevel.NoCompression)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel.NoCompression)]
+    public async Task CanSnapshotRestore(SnapshotBackupCompressionAlgorithm? algorithm, CompressionLevel? compressionLevel)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
         IOExtensions.DeleteDirectory(backupPath);
@@ -235,8 +242,8 @@ public class RavenDB_21523 : RavenTestBase
         {
             ModifyDatabaseRecord = record =>
             {
-                record.Settings[RavenConfiguration.GetKey(x => x.Backup.SnapshotCompressionAlgorithm)] = algorithm.ToString();
-                record.Settings[RavenConfiguration.GetKey(x => x.Backup.SnapshotCompressionLevel)] = compressionLevel.ToString();
+                record.Settings[RavenConfiguration.GetKey(x => x.Backup.SnapshotCompressionAlgorithm)] = algorithm?.ToString();
+                record.Settings[RavenConfiguration.GetKey(x => x.Backup.SnapshotCompressionLevel)] = compressionLevel?.ToString();
             }
         }))
         {
@@ -246,26 +253,24 @@ public class RavenDB_21523 : RavenTestBase
                 {
                     foreach (var entry in zip.Entries)
                     {
-                        var buffer = new byte[4];
-
                         await using (var entryStream = entry.Open())
+                        await using (var backupStream = FullBackup.GetDecompressionStream(entryStream))
                         {
-                            var read = await entryStream.ReadAsync(buffer, 0, buffer.Length);
-                            if (read == 0)
-                                throw new InvalidOperationException("Empty stream");
-
-                            if (read == buffer.Length)
+                            switch (algorithm)
                             {
-                                const uint zstdMagicNumber = 0xFD2FB528;
-                                var readMagicNumber = BitConverter.ToUInt32(buffer);
-                                if (readMagicNumber == zstdMagicNumber)
-                                {
-                                    Assert.True(SnapshotBackupCompressionAlgorithm.Zstd == algorithm, $"Name: {entry.Name}");
-                                    continue;
-                                }
+                                case SnapshotBackupCompressionAlgorithm.Deflate:
+                                    Assert.IsType<BackupStream>(backupStream);
+                                    break;
+                                case null:
+                                case SnapshotBackupCompressionAlgorithm.Zstd:
+                                    if (compressionLevel == CompressionLevel.NoCompression)
+                                        Assert.IsType<BackupStream>(backupStream);
+                                    else
+                                        Assert.IsType<ZstdStream>(backupStream);
+                                    break;
+                                default:
+                                    throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm, null);
                             }
-
-                            Assert.True(SnapshotBackupCompressionAlgorithm.Deflate == algorithm, $"Name: {entry.Name}");
                         }
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21523

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
